### PR TITLE
fix: harden fresh bedrock transaction semantics

### DIFF
--- a/lib/bedrock/data_plane/log/shale/long_pulls.ex
+++ b/lib/bedrock/data_plane/log/shale/long_pulls.ex
@@ -13,7 +13,9 @@ defmodule Bedrock.DataPlane.Log.Shale.LongPulls do
   @spec notify_waiting_pullers(WaitingList.t(), Bedrock.version(), Bedrock.transaction()) ::
           WaitingList.t()
   def notify_waiting_pullers(waiting_pullers, version, transaction) do
-    {new_map, entries} = WaitingList.remove_all(waiting_pullers, version)
+    {new_map, exact_entries} = WaitingList.remove_all(waiting_pullers, version)
+    {new_map, older_entries} = WaitingList.remove_all_less_than(new_map, version)
+    entries = exact_entries ++ older_entries
 
     Enum.each(entries, fn {_deadline, reply_to_fn, _opts} ->
       reply_to_fn.({:ok, [transaction]})

--- a/lib/bedrock/internal/repo.ex
+++ b/lib/bedrock/internal/repo.ex
@@ -276,6 +276,10 @@ defmodule Bedrock.Internal.Repo do
       try_to_rollback(failed_txn)
       {:error, reason}
 
+    {__MODULE__, :rollback, reason} ->
+      try_to_rollback(txn(repo))
+      {:error, reason}
+
     {__MODULE__, failed_txn, :transaction_error, reason, operation, key} ->
       try_to_rollback(failed_txn)
       raise RuntimeError, "Transaction operation #{operation} failed for key #{inspect(key)}: #{inspect(reason)}"

--- a/lib/bedrock/internal/transaction_builder/point_reads.ex
+++ b/lib/bedrock/internal/transaction_builder/point_reads.ex
@@ -131,6 +131,13 @@ defmodule Bedrock.Internal.TransactionBuilder.PointReads do
         {state, {:failure, failures_by_reason}}
 
       {state, {:ok, {nil, _shard_range}}} ->
+        state =
+          if snapshot do
+            state
+          else
+            %{state | tx: Tx.merge_storage_read(state.tx, racing_key, :not_found)}
+          end
+
         {state, {:error, :not_found}}
 
       {state, {:ok, {{key, nil}, _shard_range}}} ->

--- a/test/bedrock/control_plane/director/recovery/materializer_bootstrap_phase_test.exs
+++ b/test/bedrock/control_plane/director/recovery/materializer_bootstrap_phase_test.exs
@@ -403,11 +403,13 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhaseTest 
       materializer_pid = spawn(fn -> Process.sleep(:infinity) end)
       durable_version = Version.from_integer(100)
 
-      # Logs with different shard assignments
-      # log_1 handles shard 0 (system), log_2 handles shard 1 (user)
+      # Logs with different shard assignments.
+      # log_1 handles shard 0 (system), log_2 handles shard 1 (user), and
+      # log_all is untagged so it applies to every shard.
       logs = %{
         "log_1" => [0],
-        "log_2" => [1]
+        "log_2" => [1],
+        "log_all" => []
       }
 
       recovery_attempt =
@@ -446,9 +448,9 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhaseTest 
           assert {_updated_attempt, CommitProxyStartupPhase} =
                    MaterializerBootstrapPhase.execute(recovery_attempt, context)
 
-          # Verify that only system shard logs were passed to unlock
+          # Verify that only system shard logs and untagged logs were passed to unlock.
           [{:tsl, tsl}] = :ets.lookup(received_tsl, :tsl)
-          assert Map.keys(tsl.logs) == ["log_1"]
+          assert tsl.logs |> Map.keys() |> Enum.sort() == ["log_1", "log_all"]
           refute Map.has_key?(tsl.logs, "log_2")
         end)
 

--- a/test/bedrock/data_plane/log/shale/long_pulls_test.exs
+++ b/test/bedrock/data_plane/log/shale/long_pulls_test.exs
@@ -32,6 +32,27 @@ defmodule Bedrock.DataPlane.Log.Shale.LongPullsTest do
       assert remaining_waiting_pullers == %{}
     end
 
+    test "notifies exact and older pullers while keeping newer pullers waiting" do
+      test_pid = self()
+      older_reply = fn message -> send(test_pid, {:older, message}) end
+      exact_reply = fn message -> send(test_pid, {:exact, message}) end
+      newer_reply = fn message -> send(test_pid, {:newer, message}) end
+
+      waiting_pullers = %{
+        1 => [{0, older_reply, []}],
+        2 => [{0, exact_reply, []}],
+        3 => [{0, newer_reply, []}]
+      }
+
+      remaining_waiting_pullers =
+        LongPulls.notify_waiting_pullers(waiting_pullers, 2, :transaction)
+
+      assert_received {:older, {:ok, [:transaction]}}
+      assert_received {:exact, {:ok, [:transaction]}}
+      refute_received {:newer, _}
+      assert remaining_waiting_pullers == %{3 => [{0, newer_reply, []}]}
+    end
+
     test "does nothing if no pullers are waiting" do
       waiting_pullers = %{}
       version = 1

--- a/test/bedrock/data_plane/materializer/olivine/genserver_integration_test.exs
+++ b/test/bedrock/data_plane/materializer/olivine/genserver_integration_test.exs
@@ -666,13 +666,20 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.GenServerIntegrationTest do
       {:ok, pid} = start_supervised(child_spec)
       wait_for_health_report(worker_id, pid)
 
-      # Test timeout scenarios - should either succeed or timeout gracefully
-      result = GenServer.call(pid, {:info, :kind}, 1)
+      # Test timeout scenarios - should either succeed or timeout without
+      # killing the materializer. The 1ms deadline is intentionally tight, so
+      # capture the caller exit instead of making the test itself flaky.
+      result =
+        try do
+          GenServer.call(pid, {:info, :kind}, 1)
+        catch
+          :exit, {:timeout, _call} -> :timeout
+          :exit, :timeout -> :timeout
+        end
 
       case result do
         {:ok, :materializer} -> :ok
-        # Process should survive timeout
-        _ -> assert Process.alive?(pid)
+        :timeout -> assert Process.alive?(pid)
       end
 
       # Test malformed messages - process should survive all of these

--- a/test/bedrock/internal/repo_test.exs
+++ b/test/bedrock/internal/repo_test.exs
@@ -168,6 +168,25 @@ defmodule Bedrock.Internal.RepoSimpleTest do
       assert type == :rollback
       assert reason == "test_reason"
     end
+
+    test "transact normalizes explicit rollback to error tuple" do
+      transaction_system_layout = %{
+        epoch: 1,
+        sequencer: self(),
+        proxies: [],
+        services: %{},
+        shard_layout: %{},
+        shard_materializers: %{}
+      }
+
+      assert {:error, :rejected} =
+               TestRepo.transact(
+                 fn ->
+                   TestRepo.rollback(:rejected)
+                 end,
+                 transaction_system_layout: transaction_system_layout
+               )
+    end
   end
 
   describe "range/4" do

--- a/test/bedrock/internal/transaction_builder_test.exs
+++ b/test/bedrock/internal/transaction_builder_test.exs
@@ -56,6 +56,14 @@ defmodule Bedrock.Internal.TransactionBuilderTest do
     end
   end
 
+  defp readable_transaction_system_layout(read_version) do
+    read_version
+    |> create_test_transaction_system_layout_with_mock_sequencer()
+    |> Map.put(:metadata_materializer, self())
+    |> Map.put(:shard_layout, %{Bedrock.end_of_keyspace() => {0, ""}})
+    |> Map.put(:shard_materializers, %{})
+  end
+
   # Helper functions for common test patterns
   defp get_transaction_mutations(pid) do
     pid
@@ -197,6 +205,38 @@ defmodule Bedrock.Internal.TransactionBuilderTest do
 
       result = GenServer.call(pid, {:get, "test_key"})
       assert result == {:ok, "test_value"}
+    end
+
+    test ":fetch missing key records read conflict" do
+      pid =
+        start_transaction_builder(
+          read_version: 42,
+          transaction_system_layout: readable_transaction_system_layout(42)
+        )
+
+      storage_get_key_fn = fn _storage_pid, _key, _version, _opts -> {:error, :not_found} end
+
+      assert GenServer.call(pid, {:get, "missing", storage_get_key_fn: storage_get_key_fn}) ==
+               {:error, :not_found}
+
+      state = :sys.get_state(pid)
+      assert state.tx.reads["missing"] == :clear
+    end
+
+    test ":fetch missing key with snapshot option does not record read conflict" do
+      pid =
+        start_transaction_builder(
+          read_version: 42,
+          transaction_system_layout: readable_transaction_system_layout(42)
+        )
+
+      storage_get_key_fn = fn _storage_pid, _key, _version, _opts -> {:error, :not_found} end
+
+      assert GenServer.call(pid, {:get, "missing", storage_get_key_fn: storage_get_key_fn, snapshot: true}) ==
+               {:error, :not_found}
+
+      state = :sys.get_state(pid)
+      refute Map.has_key?(state.tx.reads, "missing")
     end
 
     test ":commit call succeeds for empty transaction with version 0" do


### PR DESCRIPTION
## Summary

- include untagged fresh-cluster logs when assigning materializers to shards
- wake exact-version and older Shale long-pull waiters when appending a transaction
- normalize explicit repo rollbacks to error tuples in transaction execution
- add read-conflict tracking for point-read misses so idempotency-key inserts conflict correctly
- add regression coverage for each behavior above

## Verification

- `mix test test/bedrock/data_plane/log/shale/long_pulls_test.exs test/bedrock/control_plane/director/recovery/materializer_bootstrap_phase_test.exs test/bedrock/internal/transaction_builder_test.exs test/bedrock/internal/repo_test.exs`
- `mix test`
