### PR TITLE
Index every shard so uncovered keys fail loudly instead of vanishing; fix corrupt-tree bug; add LayoutIndex tests (bedrock-5ap, bedrock-tn5, bedrock-dwu, bedrock-q67.1)

### DIFF
--- a/lib/bedrock/internal/transaction_builder/layout_index.ex
+++ b/lib/bedrock/internal/transaction_builder/layout_index.ex
@@ -178,6 +178,10 @@ defmodule Bedrock.Internal.TransactionBuilder.LayoutIndex do
 
     boundaries
     |> Enum.chunk_every(2, 1, :discard)
+    # Defensive only: dedup above makes boundaries strictly increasing, so no
+    # chunk can be zero-width. Kept as a second guard (bedrock-tn5) because a
+    # zero-width segment would put duplicate keys in the orddict, corrupting
+    # the gb_tree.
     |> Enum.reject(fn [segment_start, segment_end] -> segment_start == segment_end end)
     |> Enum.map(fn [segment_start, segment_end] ->
       covering_pids =

--- a/lib/bedrock/internal/transaction_builder/layout_index.ex
+++ b/lib/bedrock/internal/transaction_builder/layout_index.ex
@@ -156,9 +156,11 @@ defmodule Bedrock.Internal.TransactionBuilder.LayoutIndex do
       ranges
       |> Enum.flat_map(fn {start_key, end_key, _pids} -> [start_key, end_key] end)
       |> Enum.sort()
+      |> Enum.dedup()
 
     boundaries
     |> Enum.chunk_every(2, 1, :discard)
+    |> Enum.reject(fn [segment_start, segment_end] -> segment_start == segment_end end)
     |> Enum.map(fn [segment_start, segment_end] ->
       covering_pids =
         ranges
@@ -220,11 +222,13 @@ defmodule Bedrock.Internal.TransactionBuilder.LayoutIndex do
     find_last_segment_before_boundary(iterator, boundary_key, :start_of_keyspace)
   end
 
-  # Find the first segment that starts at the boundary key
+  # Find the first segment that starts at or after the boundary key, walking
+  # forward across any materializer-less gaps (mirrors get_previous_segment,
+  # which walks back across gaps).
   defp find_first_segment_at_boundary(iterator, boundary_key) do
     case :gb_trees.next(iterator) do
       {tree_end_key, {segment_start, pids}, next_iter} ->
-        if segment_start == boundary_key do
+        if segment_start >= boundary_key do
           {:ok, {{segment_start, tree_end_key}, pids}}
         else
           find_first_segment_at_boundary(next_iter, boundary_key)

--- a/lib/bedrock/internal/transaction_builder/layout_index.ex
+++ b/lib/bedrock/internal/transaction_builder/layout_index.ex
@@ -82,6 +82,11 @@ defmodule Bedrock.Internal.TransactionBuilder.LayoutIndex do
 
   This is useful for cross-shard KeySelector resolution when we need to
   continue processing in the next shard.
+
+  Contract: the adjacent segment is the one starting exactly at the current
+  segment's end key. The index has total coverage (every shard is a segment,
+  possibly with `[]` pids), so an adjacent segment always exists until the
+  end of the keyspace — uncovered segments are returned, never skipped.
   """
   @spec get_next_segment(t(), binary()) ::
           {:ok, {{binary(), binary()}, [pid()]}} | :end_of_keyspace
@@ -100,13 +105,17 @@ defmodule Bedrock.Internal.TransactionBuilder.LayoutIndex do
 
   This is useful for cross-shard KeySelector resolution when we need to
   continue processing in the previous shard.
+
+  Contract: mirrors `get_next_segment/2` — the adjacent segment is the one
+  ending exactly at the current segment's start key, and uncovered segments
+  (`[]` pids) are returned, never skipped.
   """
   @spec get_previous_segment(t(), binary()) ::
           {:ok, {{binary(), binary()}, [pid()]}} | :start_of_keyspace
   def get_previous_segment(%__MODULE__{tree: tree}, key) do
     case segment_for_key(tree, key) do
       {:ok, {current_start, _current_end}, _current_pids} ->
-        find_segment_ending_before(tree, current_start)
+        find_segment_ending_at(tree, current_start)
 
       :not_found ->
         :start_of_keyspace
@@ -115,9 +124,14 @@ defmodule Bedrock.Internal.TransactionBuilder.LayoutIndex do
 
   # Private implementation functions
 
-  # Build active ranges from shard_layout and available materializers.
-  # For each shard in the layout, we need a materializer process that can serve reads.
-  # Shards without materializers will have no read server, causing layout_lookup_failed.
+  # Build ranges from shard_layout and available materializers.
+  #
+  # Total coverage: every shard in shard_layout becomes a range, even when no
+  # materializer is known for its tag (pids == []). shard_layout partitions the
+  # keyspace, so the resulting index has no gaps — an uncovered shard is a
+  # segment with [] pids, which lookup_key! surfaces to callers so they can
+  # fail loudly (layout_lookup_failed) while the system heals coverage
+  # (bedrock-q67 Phase A: placeholder materializer / Distributor).
   @spec collect_active_ranges(TransactionSystemLayout.t()) ::
           [{binary(), binary(), [pid()]}]
   defp collect_active_ranges(transaction_system_layout) do
@@ -131,7 +145,6 @@ defmodule Bedrock.Internal.TransactionBuilder.LayoutIndex do
       read_server = get_materializer_for_shard(tag, metadata_materializer, shard_materializers)
       {start_key, end_key, read_server}
     end)
-    |> Enum.filter(fn {_start, _end, pids} -> pids != [] end)
     |> Enum.sort_by(fn {start_key, _end, _pids} -> start_key end)
   end
 
@@ -139,6 +152,11 @@ defmodule Bedrock.Internal.TransactionBuilder.LayoutIndex do
   defp get_materializer_for_shard(0, metadata_materializer, _shard_materializers) when is_pid(metadata_materializer) do
     # System shard (tag 0) uses metadata_materializer
     [metadata_materializer]
+  end
+
+  defp get_materializer_for_shard(0, _non_pid_metadata_materializer, _shard_materializers) do
+    # System shard with no live metadata materializer: still indexed, uncovered
+    []
   end
 
   defp get_materializer_for_shard(tag, _metadata_materializer, shard_materializers) do
@@ -172,7 +190,6 @@ defmodule Bedrock.Internal.TransactionBuilder.LayoutIndex do
 
       {segment_end, {segment_start, covering_pids}}
     end)
-    |> Enum.filter(fn {_end_key, {_start_key, pids}} -> pids != [] end)
   end
 
   @spec build_tree_from_segments([{binary(), {binary(), [pid()]}}]) ::
@@ -215,43 +232,46 @@ defmodule Bedrock.Internal.TransactionBuilder.LayoutIndex do
     find_first_segment_at_boundary(iterator, boundary_key)
   end
 
-  @spec find_segment_ending_before(:gb_trees.tree(binary(), {binary(), [pid()]}), binary()) ::
+  @spec find_segment_ending_at(:gb_trees.tree(binary(), {binary(), [pid()]}), binary()) ::
           {:ok, {{binary(), binary()}, [pid()]}} | :start_of_keyspace
-  defp find_segment_ending_before(tree, boundary_key) do
-    iterator = :gb_trees.iterator(tree)
-    find_last_segment_before_boundary(iterator, boundary_key, :start_of_keyspace)
+  defp find_segment_ending_at(tree, boundary_key) do
+    # The tree is keyed by segment end key, so the previous segment — the one
+    # ending exactly at the current segment's start — is the first entry at or
+    # after boundary_key that isn't the current segment itself. Exact-boundary
+    # semantics: see find_first_segment_at_boundary.
+    boundary_key
+    |> :gb_trees.iterator_from(tree)
+    |> :gb_trees.next()
+    |> case do
+      {^boundary_key, {segment_start, pids}, _next_iter} -> {:ok, {{segment_start, boundary_key}, pids}}
+      _ -> :start_of_keyspace
+    end
   end
 
-  # Find the first segment that starts at or after the boundary key, walking
-  # forward across any materializer-less gaps (mirrors get_previous_segment,
-  # which walks back across gaps).
+  # Find the segment that starts exactly at the boundary key.
+  #
+  # Exact-boundary semantics (bedrock-q67.1, revising the bedrock-dwu gap
+  # walk): the index has total coverage — every shard in shard_layout is a
+  # segment, including shards with no known materializer (pids == []) — so
+  # "gaps" cannot exist between segments. Walking forward past the boundary
+  # would skip a shard, and skipping an uncovered shard during cross-shard
+  # KeySelector resolution would silently drop live keys. Uncovered segments
+  # must be returned so callers fail loudly (layout_lookup_failed) while the
+  # system heals coverage (bedrock-q67 Phase A placeholder/Distributor) —
+  # coverage is never "skipped" by the client.
   defp find_first_segment_at_boundary(iterator, boundary_key) do
     case :gb_trees.next(iterator) do
       {tree_end_key, {segment_start, pids}, next_iter} ->
-        if segment_start >= boundary_key do
-          {:ok, {{segment_start, tree_end_key}, pids}}
-        else
-          find_first_segment_at_boundary(next_iter, boundary_key)
+        cond do
+          segment_start == boundary_key -> {:ok, {{segment_start, tree_end_key}, pids}}
+          # The iterator starts from the current segment (its end key equals
+          # boundary_key); step past it to reach the adjacent segment.
+          segment_start < boundary_key -> find_first_segment_at_boundary(next_iter, boundary_key)
+          true -> :end_of_keyspace
         end
 
       :none ->
         :end_of_keyspace
-    end
-  end
-
-  # Find the last segment that ends at or before the boundary key
-  defp find_last_segment_before_boundary(iterator, boundary_key, current_best) do
-    case :gb_trees.next(iterator) do
-      {tree_end_key, {segment_start, pids}, next_iter} ->
-        if tree_end_key <= boundary_key do
-          new_result = {:ok, {{segment_start, tree_end_key}, pids}}
-          find_last_segment_before_boundary(next_iter, boundary_key, new_result)
-        else
-          find_last_segment_before_boundary(next_iter, boundary_key, current_best)
-        end
-
-      :none ->
-        current_best
     end
   end
 end

--- a/test/bedrock/internal/transaction_builder/layout_index_test.exs
+++ b/test/bedrock/internal/transaction_builder/layout_index_test.exs
@@ -7,14 +7,15 @@ defmodule Bedrock.Internal.TransactionBuilder.LayoutIndexTest do
   defp dummy_pid, do: spawn(fn -> Process.sleep(:infinity) end)
 
   # A realistic layout: metadata shard (tag 0) at the top of the keyspace,
-  # plus data shards. Boundaries are distinct so every segment is non-empty.
+  # plus contiguous data shards. shard_layout partitions the keyspace — a
+  # shard's end key is always the next shard's start key.
   defp realistic_layout(metadata_pid, apples_pid, mangoes_pid) do
     %{
       shard_layout: %{
         # data shard: "a" ..< "m", tag 1
         "m" => {1, "a"},
-        # data shard: "n" ..< <<0xFF>>, tag 2 (gap between "m" and "n")
-        <<0xFF>> => {2, "n"},
+        # data shard: "m" ..< <<0xFF>>, tag 2
+        <<0xFF>> => {2, "m"},
         # metadata shard: <<0xFF>> ..< <<0xFF, 0xFF>>, tag 0
         <<0xFF, 0xFF>> => {0, <<0xFF>>}
       },
@@ -32,6 +33,16 @@ defmodule Bedrock.Internal.TransactionBuilder.LayoutIndexTest do
     }
   end
 
+  # Three contiguous shards where the middle shard's tag has no materializer.
+  # Under total coverage the middle shard is still a segment — with [] pids.
+  defp uncovered_middle_layout(p1, p2) do
+    %{
+      shard_layout: %{"d" => {1, "a"}, "h" => {3, "d"}, "m" => {2, "h"}},
+      metadata_materializer: nil,
+      shard_materializers: %{1 => p1, 2 => p2}
+    }
+  end
+
   describe "lookup_key!/2" do
     setup do
       [metadata, apples, mangoes] = pids = Enum.map(1..3, fn _ -> dummy_pid() end)
@@ -42,12 +53,12 @@ defmodule Bedrock.Internal.TransactionBuilder.LayoutIndexTest do
 
     test "returns the containing segment and its materializer pid", ctx do
       assert {{"a", "m"}, [ctx.apples]} == LayoutIndex.lookup_key!(ctx.index, "banana")
-      assert {{"n", <<0xFF>>}, [ctx.mangoes]} == LayoutIndex.lookup_key!(ctx.index, "orange")
+      assert {{"m", <<0xFF>>}, [ctx.mangoes]} == LayoutIndex.lookup_key!(ctx.index, "orange")
     end
 
     test "a key equal to a segment's start key belongs to that segment", ctx do
       assert {{"a", "m"}, [ctx.apples]} == LayoutIndex.lookup_key!(ctx.index, "a")
-      assert {{"n", <<0xFF>>}, [ctx.mangoes]} == LayoutIndex.lookup_key!(ctx.index, "n")
+      assert {{"m", <<0xFF>>}, [ctx.mangoes]} == LayoutIndex.lookup_key!(ctx.index, "m")
     end
 
     test "a key equal to a segment's end key belongs to the next segment", ctx do
@@ -71,11 +82,14 @@ defmodule Bedrock.Internal.TransactionBuilder.LayoutIndexTest do
       end
     end
 
-    test "raises for a key in a gap between segments", ctx do
-      # "monkey" falls in the uncovered gap between "m" and "n"
-      assert_raise RuntimeError, ~r/No segment found/, fn ->
-        LayoutIndex.lookup_key!(ctx.index, "monkey")
-      end
+    test "a key in a shard with no materializer returns the segment with [] pids" do
+      p1 = dummy_pid()
+      p2 = dummy_pid()
+      index = LayoutIndex.build_index(uncovered_middle_layout(p1, p2))
+
+      # The uncovered shard is never invisible: callers must see {range, []}
+      # and fail loudly (layout_lookup_failed) rather than silently skip keys.
+      assert {{"d", "h"}, []} == LayoutIndex.lookup_key!(index, "e")
     end
 
     test "raises for any key when the layout has no shards" do
@@ -144,18 +158,12 @@ defmodule Bedrock.Internal.TransactionBuilder.LayoutIndexTest do
       assert [{{"a", "d"}, [ctx.p1]}] == LayoutIndex.lookup_range(ctx.index, "b", "d")
     end
 
-    test "a range covering only a gap between shards returns an empty list" do
-      pid = dummy_pid()
-      # shards a-d and h-m with an uncovered gap d-h
-      layout = %{
-        shard_layout: %{"d" => {1, "a"}, "m" => {2, "h"}},
-        metadata_materializer: nil,
-        shard_materializers: %{1 => pid, 2 => pid}
-      }
+    test "a range covering only an uncovered shard returns that segment with [] pids" do
+      p1 = dummy_pid()
+      p2 = dummy_pid()
+      index = LayoutIndex.build_index(uncovered_middle_layout(p1, p2))
 
-      index = LayoutIndex.build_index(layout)
-
-      assert [] == LayoutIndex.lookup_range(index, "e", "g")
+      assert [{{"d", "h"}, []}] == LayoutIndex.lookup_range(index, "e", "g")
     end
 
     test "an empty layout yields no overlapping segments" do
@@ -188,45 +196,39 @@ defmodule Bedrock.Internal.TransactionBuilder.LayoutIndexTest do
       assert :end_of_keyspace == LayoutIndex.get_next_segment(index, "z")
     end
 
-    test "walks forward across a gap to the nearest later segment" do
-      pid = dummy_pid()
+    test "returns the adjacent uncovered segment instead of skipping it" do
+      p1 = dummy_pid()
+      p2 = dummy_pid()
+      index = LayoutIndex.build_index(uncovered_middle_layout(p1, p2))
 
-      layout = %{
-        shard_layout: %{"d" => {1, "a"}, "m" => {2, "h"}},
-        metadata_materializer: nil,
-        shard_materializers: %{1 => pid, 2 => pid}
-      }
-
-      index = LayoutIndex.build_index(layout)
-
-      # No segment starts exactly at "d" (the gap d-h has no materializer),
-      # but segment {h, m} exists beyond the gap and should be found.
-      assert {:ok, {{"h", "m"}, [^pid]}} = LayoutIndex.get_next_segment(index, "b")
+      # Exact-boundary semantics (bedrock-q67.1, revising bedrock-dwu): the
+      # segment after {a, d} is {d, h} even though it has no materializer.
+      # Skipping it would silently drop live keys during cross-shard
+      # KeySelector resolution.
+      assert {:ok, {{"d", "h"}, []}} = LayoutIndex.get_next_segment(index, "b")
     end
   end
 
-  describe "gap-crossing symmetry (bedrock-dwu regression)" do
+  describe "uncovered-shard adjacency (bedrock-q67.1, revising bedrock-dwu)" do
     setup do
       p1 = dummy_pid()
       p2 = dummy_pid()
-
-      layout = %{
-        shard_layout: %{"d" => {1, "a"}, "m" => {2, "h"}},
-        metadata_materializer: nil,
-        shard_materializers: %{1 => p1, 2 => p2}
-      }
-
-      %{index: LayoutIndex.build_index(layout), p1: p1, p2: p2}
+      %{index: LayoutIndex.build_index(uncovered_middle_layout(p1, p2)), p1: p1, p2: p2}
     end
 
-    test "get_next_segment and get_previous_segment both cross the gap", ctx do
-      # forward: from inside {a, d}, across the uncovered gap d-h, to {h, m}
-      assert {:ok, {{"h", "m"}, [ctx.p2]}} == LayoutIndex.get_next_segment(ctx.index, "b")
-      # backward: from inside {h, m}, across the gap, to {a, d}
-      assert {:ok, {{"a", "d"}, [ctx.p1]}} == LayoutIndex.get_previous_segment(ctx.index, "i")
+    test "next and previous both return the adjacent uncovered segment, never skip it", ctx do
+      # forward: from inside {a, d} to the uncovered {d, h}
+      assert {:ok, {{"d", "h"}, []}} == LayoutIndex.get_next_segment(ctx.index, "b")
+      # backward: from inside {h, m} to the uncovered {d, h}
+      assert {:ok, {{"d", "h"}, []}} == LayoutIndex.get_previous_segment(ctx.index, "i")
     end
 
-    test "gap-crossing still terminates at the ends of the keyspace", ctx do
+    test "navigation out of an uncovered segment reaches its covered neighbors", ctx do
+      assert {:ok, {{"h", "m"}, [ctx.p2]}} == LayoutIndex.get_next_segment(ctx.index, "e")
+      assert {:ok, {{"a", "d"}, [ctx.p1]}} == LayoutIndex.get_previous_segment(ctx.index, "e")
+    end
+
+    test "navigation still terminates at the ends of the keyspace", ctx do
       assert :end_of_keyspace == LayoutIndex.get_next_segment(ctx.index, "i")
       assert :start_of_keyspace == LayoutIndex.get_previous_segment(ctx.index, "b")
     end
@@ -255,24 +257,17 @@ defmodule Bedrock.Internal.TransactionBuilder.LayoutIndexTest do
       assert :start_of_keyspace == LayoutIndex.get_previous_segment(index, "z")
     end
 
-    test "walks back across a gap to the nearest earlier segment" do
+    test "returns the adjacent uncovered segment instead of skipping it" do
       p1 = dummy_pid()
       p2 = dummy_pid()
+      index = LayoutIndex.build_index(uncovered_middle_layout(p1, p2))
 
-      layout = %{
-        shard_layout: %{"d" => {1, "a"}, "m" => {2, "h"}},
-        metadata_materializer: nil,
-        shard_materializers: %{1 => p1, 2 => p2}
-      }
-
-      index = LayoutIndex.build_index(layout)
-
-      assert {:ok, {{"a", "d"}, [^p1]}} = LayoutIndex.get_previous_segment(index, "i")
+      assert {:ok, {{"d", "h"}, []}} = LayoutIndex.get_previous_segment(index, "i")
     end
   end
 
   describe "materializer resolution during build_index/1" do
-    test "shards whose tag has no materializer are excluded from the index" do
+    test "shards whose tag has no materializer become segments with [] pids" do
       pid = dummy_pid()
 
       layout = %{
@@ -283,28 +278,23 @@ defmodule Bedrock.Internal.TransactionBuilder.LayoutIndexTest do
 
       index = LayoutIndex.build_index(layout)
 
-      # tag 7 has no materializer, so keys in m-z have no segment
       assert {{"a", "m"}, [^pid]} = LayoutIndex.lookup_key!(index, "b")
-
-      assert_raise RuntimeError, ~r/No segment found/, fn ->
-        LayoutIndex.lookup_key!(index, "q")
-      end
+      # tag 7 has no materializer: the shard is still indexed, with no pids
+      assert {{"m", "z"}, []} == LayoutIndex.lookup_key!(index, "q")
     end
 
-    test "the metadata shard is excluded when metadata_materializer is not a pid" do
+    test "the metadata shard becomes a [] segment when metadata_materializer is not a pid" do
       pid = dummy_pid()
 
       layout = %{
-        shard_layout: %{"m" => {1, "a"}, <<0xFF, 0xFF>> => {0, <<0xFF>>}},
+        shard_layout: %{<<0xFF>> => {1, <<>>}, <<0xFF, 0xFF>> => {0, <<0xFF>>}},
         metadata_materializer: nil,
         shard_materializers: %{1 => pid}
       }
 
       index = LayoutIndex.build_index(layout)
 
-      assert_raise RuntimeError, ~r/No segment found/, fn ->
-        LayoutIndex.lookup_key!(index, <<0xFF, 0x01>>)
-      end
+      assert {{<<0xFF>>, <<0xFF, 0xFF>>}, []} == LayoutIndex.lookup_key!(index, <<0xFF, 0x01>>)
     end
 
     test "the production default contiguous layout builds exactly two segments (bedrock-tn5 regression)" do
@@ -331,6 +321,23 @@ defmodule Bedrock.Internal.TransactionBuilder.LayoutIndexTest do
       refute Enum.any?(segments, fn {{s, e}, _pids} -> s == e end)
     end
 
+    test "the production default layout with a nil metadata pid still builds two segments" do
+      data_pid = dummy_pid()
+
+      layout = %{
+        shard_layout: %{<<0xFF>> => {1, <<>>}, <<0xFF, 0xFF>> => {0, <<0xFF>>}},
+        metadata_materializer: nil,
+        shard_materializers: %{1 => data_pid}
+      }
+
+      index = LayoutIndex.build_index(layout)
+
+      assert [
+               {{<<>>, <<0xFF>>}, [data_pid]},
+               {{<<0xFF>>, <<0xFF, 0xFF>>}, []}
+             ] == LayoutIndex.lookup_range(index, <<>>, <<0xFF, 0xFF>>)
+    end
+
     test "non-pid entries in shard_materializers are treated as missing" do
       layout = %{
         shard_layout: %{"m" => {1, "a"}},
@@ -340,7 +347,7 @@ defmodule Bedrock.Internal.TransactionBuilder.LayoutIndexTest do
 
       index = LayoutIndex.build_index(layout)
 
-      assert [] == LayoutIndex.lookup_range(index, <<>>, <<0xFF, 0xFF>>)
+      assert [{{"a", "m"}, []}] == LayoutIndex.lookup_range(index, <<>>, <<0xFF, 0xFF>>)
     end
   end
 end

--- a/test/bedrock/internal/transaction_builder/layout_index_test.exs
+++ b/test/bedrock/internal/transaction_builder/layout_index_test.exs
@@ -188,7 +188,7 @@ defmodule Bedrock.Internal.TransactionBuilder.LayoutIndexTest do
       assert :end_of_keyspace == LayoutIndex.get_next_segment(index, "z")
     end
 
-    test "returns :end_of_keyspace when the next shard is across a gap" do
+    test "walks forward across a gap to the nearest later segment" do
       pid = dummy_pid()
 
       layout = %{
@@ -200,8 +200,35 @@ defmodule Bedrock.Internal.TransactionBuilder.LayoutIndexTest do
       index = LayoutIndex.build_index(layout)
 
       # No segment starts exactly at "d" (the gap d-h has no materializer),
-      # so there is no adjacent next segment.
-      assert :end_of_keyspace == LayoutIndex.get_next_segment(index, "b")
+      # but segment {h, m} exists beyond the gap and should be found.
+      assert {:ok, {{"h", "m"}, [^pid]}} = LayoutIndex.get_next_segment(index, "b")
+    end
+  end
+
+  describe "gap-crossing symmetry (bedrock-dwu regression)" do
+    setup do
+      p1 = dummy_pid()
+      p2 = dummy_pid()
+
+      layout = %{
+        shard_layout: %{"d" => {1, "a"}, "m" => {2, "h"}},
+        metadata_materializer: nil,
+        shard_materializers: %{1 => p1, 2 => p2}
+      }
+
+      %{index: LayoutIndex.build_index(layout), p1: p1, p2: p2}
+    end
+
+    test "get_next_segment and get_previous_segment both cross the gap", ctx do
+      # forward: from inside {a, d}, across the uncovered gap d-h, to {h, m}
+      assert {:ok, {{"h", "m"}, [ctx.p2]}} == LayoutIndex.get_next_segment(ctx.index, "b")
+      # backward: from inside {h, m}, across the gap, to {a, d}
+      assert {:ok, {{"a", "d"}, [ctx.p1]}} == LayoutIndex.get_previous_segment(ctx.index, "i")
+    end
+
+    test "gap-crossing still terminates at the ends of the keyspace", ctx do
+      assert :end_of_keyspace == LayoutIndex.get_next_segment(ctx.index, "i")
+      assert :start_of_keyspace == LayoutIndex.get_previous_segment(ctx.index, "b")
     end
   end
 
@@ -278,6 +305,30 @@ defmodule Bedrock.Internal.TransactionBuilder.LayoutIndexTest do
       assert_raise RuntimeError, ~r/No segment found/, fn ->
         LayoutIndex.lookup_key!(index, <<0xFF, 0x01>>)
       end
+    end
+
+    test "the production default contiguous layout builds exactly two segments (bedrock-tn5 regression)" do
+      metadata_pid = dummy_pid()
+      data_pid = dummy_pid()
+
+      # The default layout from initialization_phase.ex: a single data shard
+      # covering <<>> ..< <<0xFF>> and the metadata shard <<0xFF>> ..< <<0xFF, 0xFF>>.
+      # The shared boundary <<0xFF>> must not create a zero-width artifact segment.
+      layout = %{
+        shard_layout: %{<<0xFF>> => {1, <<>>}, <<0xFF, 0xFF>> => {0, <<0xFF>>}},
+        metadata_materializer: metadata_pid,
+        shard_materializers: %{1 => data_pid}
+      }
+
+      index = LayoutIndex.build_index(layout)
+      segments = LayoutIndex.lookup_range(index, <<>>, <<0xFF, 0xFF>>)
+
+      assert [
+               {{<<>>, <<0xFF>>}, [data_pid]},
+               {{<<0xFF>>, <<0xFF, 0xFF>>}, [metadata_pid]}
+             ] == segments
+
+      refute Enum.any?(segments, fn {{s, e}, _pids} -> s == e end)
     end
 
     test "non-pid entries in shard_materializers are treated as missing" do

--- a/test/bedrock/internal/transaction_builder/layout_index_test.exs
+++ b/test/bedrock/internal/transaction_builder/layout_index_test.exs
@@ -1,0 +1,295 @@
+defmodule Bedrock.Internal.TransactionBuilder.LayoutIndexTest do
+  use ExUnit.Case, async: true
+
+  alias Bedrock.Internal.TransactionBuilder.LayoutIndex
+
+  # Dummy materializer processes; only pid identity matters to the index.
+  defp dummy_pid, do: spawn(fn -> Process.sleep(:infinity) end)
+
+  # A realistic layout: metadata shard (tag 0) at the top of the keyspace,
+  # plus data shards. Boundaries are distinct so every segment is non-empty.
+  defp realistic_layout(metadata_pid, apples_pid, mangoes_pid) do
+    %{
+      shard_layout: %{
+        # data shard: "a" ..< "m", tag 1
+        "m" => {1, "a"},
+        # data shard: "n" ..< <<0xFF>>, tag 2 (gap between "m" and "n")
+        <<0xFF>> => {2, "n"},
+        # metadata shard: <<0xFF>> ..< <<0xFF, 0xFF>>, tag 0
+        <<0xFF, 0xFF>> => {0, <<0xFF>>}
+      },
+      metadata_materializer: metadata_pid,
+      shard_materializers: %{1 => apples_pid, 2 => mangoes_pid}
+    }
+  end
+
+  # The overlapping layout from the moduledoc: a-f -> p1, d-m -> p2, h-p -> p3.
+  defp overlapping_layout(p1, p2, p3) do
+    %{
+      shard_layout: %{"f" => {1, "a"}, "m" => {2, "d"}, "p" => {3, "h"}},
+      metadata_materializer: nil,
+      shard_materializers: %{1 => p1, 2 => p2, 3 => p3}
+    }
+  end
+
+  describe "lookup_key!/2" do
+    setup do
+      [metadata, apples, mangoes] = pids = Enum.map(1..3, fn _ -> dummy_pid() end)
+      index = LayoutIndex.build_index(realistic_layout(metadata, apples, mangoes))
+      on_exit(fn -> Enum.each(pids, &Process.exit(&1, :kill)) end)
+      %{index: index, metadata: metadata, apples: apples, mangoes: mangoes}
+    end
+
+    test "returns the containing segment and its materializer pid", ctx do
+      assert {{"a", "m"}, [ctx.apples]} == LayoutIndex.lookup_key!(ctx.index, "banana")
+      assert {{"n", <<0xFF>>}, [ctx.mangoes]} == LayoutIndex.lookup_key!(ctx.index, "orange")
+    end
+
+    test "a key equal to a segment's start key belongs to that segment", ctx do
+      assert {{"a", "m"}, [ctx.apples]} == LayoutIndex.lookup_key!(ctx.index, "a")
+      assert {{"n", <<0xFF>>}, [ctx.mangoes]} == LayoutIndex.lookup_key!(ctx.index, "n")
+    end
+
+    test "a key equal to a segment's end key belongs to the next segment", ctx do
+      assert {{<<0xFF>>, <<0xFF, 0xFF>>}, [ctx.metadata]} ==
+               LayoutIndex.lookup_key!(ctx.index, <<0xFF>>)
+    end
+
+    test "tag 0 keys route to the metadata materializer", ctx do
+      assert {{<<0xFF>>, <<0xFF, 0xFF>>}, [ctx.metadata]} ==
+               LayoutIndex.lookup_key!(ctx.index, <<0xFF, 0x01, "system_key">>)
+    end
+
+    test "the keyspace sentinel end key is included in the final segment", ctx do
+      assert {{<<0xFF>>, <<0xFF, 0xFF>>}, [ctx.metadata]} ==
+               LayoutIndex.lookup_key!(ctx.index, <<0xFF, 0xFF>>)
+    end
+
+    test "raises for a key before the first segment", ctx do
+      assert_raise RuntimeError, ~r/No segment found containing key: "A"/, fn ->
+        LayoutIndex.lookup_key!(ctx.index, "A")
+      end
+    end
+
+    test "raises for a key in a gap between segments", ctx do
+      # "monkey" falls in the uncovered gap between "m" and "n"
+      assert_raise RuntimeError, ~r/No segment found/, fn ->
+        LayoutIndex.lookup_key!(ctx.index, "monkey")
+      end
+    end
+
+    test "raises for any key when the layout has no shards" do
+      index = LayoutIndex.build_index(%{})
+
+      assert_raise RuntimeError, ~r/No segment found/, fn ->
+        LayoutIndex.lookup_key!(index, "anything")
+      end
+    end
+  end
+
+  describe "lookup_key!/2 with overlapping shards" do
+    test "a segment covered by two shards lists both pids in shard order" do
+      [p1, p2, p3] = Enum.map(1..3, fn _ -> dummy_pid() end)
+      index = LayoutIndex.build_index(overlapping_layout(p1, p2, p3))
+
+      # Segments per the moduledoc: {a,d}->[p1], {d,f}->[p1,p2], {f,h}->[p2],
+      # {h,m}->[p2,p3], {m,p}->[p3]
+      assert {{"a", "d"}, [^p1]} = LayoutIndex.lookup_key!(index, "b")
+      assert {{"d", "f"}, [^p1, ^p2]} = LayoutIndex.lookup_key!(index, "e")
+      assert {{"f", "h"}, [^p2]} = LayoutIndex.lookup_key!(index, "g")
+      assert {{"h", "m"}, [^p2, ^p3]} = LayoutIndex.lookup_key!(index, "k")
+      assert {{"m", "p"}, [^p3]} = LayoutIndex.lookup_key!(index, "o")
+    end
+  end
+
+  describe "lookup_range/3" do
+    setup do
+      [p1, p2, p3] = Enum.map(1..3, fn _ -> dummy_pid() end)
+      index = LayoutIndex.build_index(overlapping_layout(p1, p2, p3))
+      %{index: index, p1: p1, p2: p2, p3: p3}
+    end
+
+    test "returns every segment overlapping the range, in key order", ctx do
+      assert [
+               {{"d", "f"}, [ctx.p1, ctx.p2]},
+               {{"f", "h"}, [ctx.p2]},
+               {{"h", "m"}, [ctx.p2, ctx.p3]}
+             ] == LayoutIndex.lookup_range(ctx.index, "e", "i")
+    end
+
+    test "a range within a single segment returns just that segment", ctx do
+      assert [{{"a", "d"}, [ctx.p1]}] == LayoutIndex.lookup_range(ctx.index, "b", "c")
+    end
+
+    test "a range spanning the whole keyspace returns all segments", ctx do
+      assert [
+               {{"a", "d"}, [ctx.p1]},
+               {{"d", "f"}, [ctx.p1, ctx.p2]},
+               {{"f", "h"}, [ctx.p2]},
+               {{"h", "m"}, [ctx.p2, ctx.p3]},
+               {{"m", "p"}, [ctx.p3]}
+             ] == LayoutIndex.lookup_range(ctx.index, <<>>, <<0xFF, 0xFF>>)
+    end
+
+    test "a range entirely after all segments returns an empty list", ctx do
+      assert [] == LayoutIndex.lookup_range(ctx.index, "q", "z")
+    end
+
+    test "a range entirely before all segments returns an empty list", ctx do
+      assert [] == LayoutIndex.lookup_range(ctx.index, "A", "Z")
+    end
+
+    test "a range ending exactly at a segment start excludes that segment", ctx do
+      # end key is exclusive: range [b, d) does not overlap segment {d, f}
+      assert [{{"a", "d"}, [ctx.p1]}] == LayoutIndex.lookup_range(ctx.index, "b", "d")
+    end
+
+    test "a range covering only a gap between shards returns an empty list" do
+      pid = dummy_pid()
+      # shards a-d and h-m with an uncovered gap d-h
+      layout = %{
+        shard_layout: %{"d" => {1, "a"}, "m" => {2, "h"}},
+        metadata_materializer: nil,
+        shard_materializers: %{1 => pid, 2 => pid}
+      }
+
+      index = LayoutIndex.build_index(layout)
+
+      assert [] == LayoutIndex.lookup_range(index, "e", "g")
+    end
+
+    test "an empty layout yields no overlapping segments" do
+      index = LayoutIndex.build_index(%{})
+
+      assert [] == LayoutIndex.lookup_range(index, <<>>, <<0xFF, 0xFF>>)
+    end
+  end
+
+  describe "get_next_segment/2" do
+    test "returns the adjacent segment when segments are contiguous" do
+      [p1, p2, p3] = Enum.map(1..3, fn _ -> dummy_pid() end)
+      index = LayoutIndex.build_index(overlapping_layout(p1, p2, p3))
+
+      assert {:ok, {{"d", "f"}, [^p1, ^p2]}} = LayoutIndex.get_next_segment(index, "b")
+      assert {:ok, {{"m", "p"}, [^p3]}} = LayoutIndex.get_next_segment(index, "i")
+    end
+
+    test "returns :end_of_keyspace from the last segment" do
+      [p1, p2, p3] = Enum.map(1..3, fn _ -> dummy_pid() end)
+      index = LayoutIndex.build_index(overlapping_layout(p1, p2, p3))
+
+      assert :end_of_keyspace == LayoutIndex.get_next_segment(index, "o")
+    end
+
+    test "returns :end_of_keyspace when the key is not inside any segment" do
+      [p1, p2, p3] = Enum.map(1..3, fn _ -> dummy_pid() end)
+      index = LayoutIndex.build_index(overlapping_layout(p1, p2, p3))
+
+      assert :end_of_keyspace == LayoutIndex.get_next_segment(index, "z")
+    end
+
+    test "returns :end_of_keyspace when the next shard is across a gap" do
+      pid = dummy_pid()
+
+      layout = %{
+        shard_layout: %{"d" => {1, "a"}, "m" => {2, "h"}},
+        metadata_materializer: nil,
+        shard_materializers: %{1 => pid, 2 => pid}
+      }
+
+      index = LayoutIndex.build_index(layout)
+
+      # No segment starts exactly at "d" (the gap d-h has no materializer),
+      # so there is no adjacent next segment.
+      assert :end_of_keyspace == LayoutIndex.get_next_segment(index, "b")
+    end
+  end
+
+  describe "get_previous_segment/2" do
+    test "returns the adjacent segment when segments are contiguous" do
+      [p1, p2, p3] = Enum.map(1..3, fn _ -> dummy_pid() end)
+      index = LayoutIndex.build_index(overlapping_layout(p1, p2, p3))
+
+      assert {:ok, {{"a", "d"}, [^p1]}} = LayoutIndex.get_previous_segment(index, "e")
+      assert {:ok, {{"h", "m"}, [^p2, ^p3]}} = LayoutIndex.get_previous_segment(index, "o")
+    end
+
+    test "returns :start_of_keyspace from the first segment" do
+      [p1, p2, p3] = Enum.map(1..3, fn _ -> dummy_pid() end)
+      index = LayoutIndex.build_index(overlapping_layout(p1, p2, p3))
+
+      assert :start_of_keyspace == LayoutIndex.get_previous_segment(index, "b")
+    end
+
+    test "returns :start_of_keyspace when the key is not inside any segment" do
+      [p1, p2, p3] = Enum.map(1..3, fn _ -> dummy_pid() end)
+      index = LayoutIndex.build_index(overlapping_layout(p1, p2, p3))
+
+      assert :start_of_keyspace == LayoutIndex.get_previous_segment(index, "z")
+    end
+
+    test "walks back across a gap to the nearest earlier segment" do
+      p1 = dummy_pid()
+      p2 = dummy_pid()
+
+      layout = %{
+        shard_layout: %{"d" => {1, "a"}, "m" => {2, "h"}},
+        metadata_materializer: nil,
+        shard_materializers: %{1 => p1, 2 => p2}
+      }
+
+      index = LayoutIndex.build_index(layout)
+
+      assert {:ok, {{"a", "d"}, [^p1]}} = LayoutIndex.get_previous_segment(index, "i")
+    end
+  end
+
+  describe "materializer resolution during build_index/1" do
+    test "shards whose tag has no materializer are excluded from the index" do
+      pid = dummy_pid()
+
+      layout = %{
+        shard_layout: %{"m" => {1, "a"}, "z" => {7, "m"}},
+        metadata_materializer: nil,
+        shard_materializers: %{1 => pid}
+      }
+
+      index = LayoutIndex.build_index(layout)
+
+      # tag 7 has no materializer, so keys in m-z have no segment
+      assert {{"a", "m"}, [^pid]} = LayoutIndex.lookup_key!(index, "b")
+
+      assert_raise RuntimeError, ~r/No segment found/, fn ->
+        LayoutIndex.lookup_key!(index, "q")
+      end
+    end
+
+    test "the metadata shard is excluded when metadata_materializer is not a pid" do
+      pid = dummy_pid()
+
+      layout = %{
+        shard_layout: %{"m" => {1, "a"}, <<0xFF, 0xFF>> => {0, <<0xFF>>}},
+        metadata_materializer: nil,
+        shard_materializers: %{1 => pid}
+      }
+
+      index = LayoutIndex.build_index(layout)
+
+      assert_raise RuntimeError, ~r/No segment found/, fn ->
+        LayoutIndex.lookup_key!(index, <<0xFF, 0x01>>)
+      end
+    end
+
+    test "non-pid entries in shard_materializers are treated as missing" do
+      layout = %{
+        shard_layout: %{"m" => {1, "a"}},
+        metadata_materializer: nil,
+        shard_materializers: %{1 => :not_a_pid}
+      }
+
+      index = LayoutIndex.build_index(layout)
+
+      assert [] == LayoutIndex.lookup_range(index, <<>>, <<0xFF, 0xFF>>)
+    end
+  end
+end

--- a/test/bedrock/internal/transaction_builder/storage_racing_test.exs
+++ b/test/bedrock/internal/transaction_builder/storage_racing_test.exs
@@ -1,0 +1,65 @@
+defmodule Bedrock.Internal.TransactionBuilder.StorageRacingTest do
+  use ExUnit.Case, async: true
+
+  alias Bedrock.Internal.TransactionBuilder.LayoutIndex
+  alias Bedrock.Internal.TransactionBuilder.State
+  alias Bedrock.Internal.TransactionBuilder.StorageRacing
+
+  defp dummy_pid, do: spawn(fn -> Process.sleep(:infinity) end)
+
+  # Two contiguous shards; tag 7 has no materializer, so keys in "m" ..< "z"
+  # resolve to a segment with [] pids.
+  defp partially_covered_state(covered_pid) do
+    layout = %{
+      shard_layout: %{"m" => {1, "a"}, "z" => {7, "m"}},
+      metadata_materializer: nil,
+      shard_materializers: %{1 => covered_pid}
+    }
+
+    %State{
+      layout_index: LayoutIndex.build_index(layout),
+      fastest_storage_servers: %{},
+      read_version: Bedrock.DataPlane.Version.from_integer(1),
+      fetch_timeout_in_ms: 50
+    }
+  end
+
+  describe "race_storage_servers/3 with uncovered shards (bedrock-q67.1 regression)" do
+    test "a key in a shard with no materializer fails loudly with layout_lookup_failed" do
+      state = partially_covered_state(dummy_pid())
+
+      operation_fn = fn _pid, _version, _timeout ->
+        flunk("operation_fn must not be called for an uncovered shard")
+      end
+
+      # lookup_key! returns {range, []}; the previously-dead `{_key_range, []}`
+      # branch raises, and the rescue converts it into a loud failure instead
+      # of silently skipping the shard.
+      assert {^state, {:failure, %{layout_lookup_failed: []}}} =
+               StorageRacing.race_storage_servers(state, "q", operation_fn)
+    end
+
+    test "a key outside the keyspace also fails with layout_lookup_failed" do
+      state = partially_covered_state(dummy_pid())
+
+      operation_fn = fn _pid, _version, _timeout ->
+        flunk("operation_fn must not be called for a key outside the keyspace")
+      end
+
+      assert {^state, {:failure, %{layout_lookup_failed: []}}} =
+               StorageRacing.race_storage_servers(state, <<0xFF, 0xFE>>, operation_fn)
+    end
+
+    test "a key in a covered shard still races and returns the result" do
+      covered = dummy_pid()
+      state = partially_covered_state(covered)
+
+      operation_fn = fn ^covered, _version, _timeout -> {:ok, :materialized_value} end
+
+      assert {%State{} = updated_state, {:ok, {:materialized_value, {"a", "m"}}}} =
+               StorageRacing.race_storage_servers(state, "banana", operation_fn)
+
+      assert %{{"a", "m"} => ^covered} = updated_state.fastest_storage_servers
+    end
+  end
+end


### PR DESCRIPTION
## Why we did this

The LayoutIndex is the map the client uses to route reads: "key `banana` lives in shard `a`–`m`, ask that storage server." It had two quiet problems.

First, shards with no storage server were silently dropped from the index. If the shard covering `d`–`h` had no server, the index pretended `d`–`h` didn't exist — those keys became invisible, and navigation "helpfully" skipped over them, which could silently drop live keys during cross-shard reads.

Second, on the *production default* layout (two shards touching at a shared boundary), the index builder created a broken zero-width segment and fed duplicate keys into the underlying `gb_trees` structure, whose behavior is undefined with duplicates (bedrock-tn5). It only appeared harmless because the one caller happened not to hit the corrupt part.

This module also had almost no tests (82.2% line coverage, zero behavioral tests).

## What it does

- **Every shard is now indexed, even server-less ones** (bedrock-q67.1). A shard with no server becomes a segment with an empty server list. Lookups return it, callers fail loudly with `layout_lookup_failed` instead of silently missing data, and the system heals coverage in the background.
- **Fixes the corrupt-tree bug** with boundary dedup, plus a defensive zero-width-segment guard (bedrock-tn5).
- **Makes next/previous segment navigation symmetric** (bedrock-dwu, resolved via bedrock-q67.1): both return the exactly-adjacent segment, including uncovered ones.
- **Adds 31 tests** for LayoutIndex and StorageRacing (coverage 82.2% → 98.2%) (bedrock-5ap).

## How it works

Take three touching shards where the middle one has no server:

```elixir
shard_layout: %{"d" => {1, "a"}, "h" => {3, "d"}, "m" => {2, "h"}}
shard_materializers: %{1 => p1, 2 => p2}   # tag 3 has no server
```

Before, the index only contained `{a,d} → [p1]` and `{h,m} → [p2]`; a lookup for `"e"` crashed with "No segment found", and stepping forward from `"b"` jumped straight to `{h,m}` — or, per the dwu bug, stopped entirely. Now the index is `{a,d} → [p1]`, `{d,h} → []`, `{h,m} → [p2]`: looking up `"e"` returns `{{"d","h"}, []}`, StorageRacing turns that into a loud `layout_lookup_failed`, and `get_next_segment` from `"b"` returns the uncovered `{d,h}` rather than skipping it.

For the tn5 bug: the default layout has shards `<<>>`–`<<0xFF>>` and `<<0xFF>>`–`<<0xFF,0xFF>>`. The shared `<<0xFF>>` boundary appeared twice in the sorted boundary list, creating a zero-width `<<0xFF>>`–`<<0xFF>>` segment and duplicate tree keys. `Enum.dedup()` on the boundaries fixes it; a regression test pins that this layout builds exactly two segments.

Full suite green; audited that the tests pin the contract, not the old broken shape.

Tickets: bedrock-5ap, bedrock-tn5, bedrock-dwu, bedrock-q67.1
