### PR TITLE
Add Distributor singleton skeleton (bedrock-q67.2)

### DIFF
--- a/lib/bedrock/control_plane/director/server.ex
+++ b/lib/bedrock/control_plane/director/server.ex
@@ -24,7 +24,9 @@ defmodule Bedrock.ControlPlane.Director.Server do
   alias Bedrock.ControlPlane.Config.ServiceDescriptor
   alias Bedrock.ControlPlane.Config.TransactionSystemLayout
   alias Bedrock.ControlPlane.Coordinator
+  alias Bedrock.ControlPlane.Director.Recovery.Shared
   alias Bedrock.ControlPlane.Director.State
+  alias Bedrock.ControlPlane.Distributor
   alias Bedrock.Service.Worker
 
   require Logger
@@ -83,7 +85,7 @@ defmodule Bedrock.ControlPlane.Director.Server do
     # Services are already provided by coordinator from service directory
     t
     |> ping_all_coordinators()
-    |> try_to_recover()
+    |> advance_recovery()
     |> noreply()
   end
 
@@ -95,6 +97,17 @@ defmodule Bedrock.ControlPlane.Director.Server do
   end
 
   @impl true
+  def handle_info({:DOWN, _monitor_ref, :process, distributor_pid, reason}, %State{distributor: distributor_pid} = t) do
+    # The distributor is off the request path: its death degrades coverage
+    # healing only, so we re-recruit it rather than restarting recovery.
+    Logger.warning("Distributor exited (#{inspect(reason)}); re-recruiting")
+
+    t
+    |> Map.put(:distributor, nil)
+    |> maybe_start_distributor()
+    |> noreply()
+  end
+
   def handle_info({:DOWN, _monitor_ref, :process, failed_pid, reason}, t) do
     t
     |> Map.put(:state, :stopped)
@@ -126,7 +139,7 @@ defmodule Bedrock.ControlPlane.Director.Server do
     {:ok, updated_t} = request_to_rejoin(t, node, capabilities, Map.values(running_services), now())
 
     updated_t
-    |> try_to_recover()
+    |> advance_recovery()
     |> reply(:ok)
   end
 
@@ -147,7 +160,7 @@ defmodule Bedrock.ControlPlane.Director.Server do
   def handle_cast({:node_added_worker, node, worker_info}, %State{} = t) do
     t
     |> node_added_worker(node, worker_info, now())
-    |> try_to_recover()
+    |> advance_recovery()
     |> noreply()
   end
 
@@ -201,11 +214,52 @@ defmodule Bedrock.ControlPlane.Director.Server do
   def try_to_recover_if_stalled(%{state: :recovery} = t) do
     # If we're in recovery state, new services might resolve insufficient_nodes
     # So we should retry recovery
-    try_to_recover(t)
+    advance_recovery(t)
   end
 
   def try_to_recover_if_stalled(t) do
     # If not in recovery state, no need to retry
     t
   end
+
+  @doc false
+  @spec advance_recovery(State.t()) :: State.t()
+  def advance_recovery(t) do
+    t
+    |> try_to_recover()
+    |> maybe_start_distributor()
+  end
+
+  # Recruits the Distributor once recovery has completed (FDB: the cluster
+  # controller recruits the data distributor only after the cluster is
+  # accepting commits). The distributor is monitored and re-recruited on
+  # death; it never participates in recovery itself.
+  @doc false
+  @spec maybe_start_distributor(State.t()) :: State.t()
+  def maybe_start_distributor(%State{state: :running, distributor: nil} = t) do
+    shard_layout = (t.transaction_system_layout || %{})[:shard_layout] || %{}
+
+    child_spec =
+      Distributor.child_spec(
+        cluster: t.cluster,
+        epoch: t.epoch,
+        director: self(),
+        shard_layout: shard_layout,
+        otp_name: t.cluster.otp_name(:distributor)
+      )
+
+    starter_fn = :sup |> t.cluster.otp_name() |> Shared.starter_for()
+
+    case starter_fn.(child_spec, node()) do
+      {:ok, distributor} ->
+        Process.monitor(distributor)
+        %{t | distributor: distributor}
+
+      {:error, reason} ->
+        Logger.error("Failed to start distributor: #{inspect(reason)}")
+        t
+    end
+  end
+
+  def maybe_start_distributor(t), do: t
 end

--- a/lib/bedrock/control_plane/director/state.ex
+++ b/lib/bedrock/control_plane/director/state.ex
@@ -23,7 +23,8 @@ defmodule Bedrock.ControlPlane.Director.State do
           timers: timer_registry() | nil,
           services: %{Worker.id() => {atom(), {atom(), node()}}},
           lock_token: binary(),
-          recovery_attempt: Config.RecoveryAttempt.t() | nil
+          recovery_attempt: Config.RecoveryAttempt.t() | nil,
+          distributor: pid() | nil
         }
   defstruct state: :starting,
             epoch: nil,
@@ -36,7 +37,8 @@ defmodule Bedrock.ControlPlane.Director.State do
             timers: nil,
             services: %{},
             lock_token: nil,
-            recovery_attempt: nil
+            recovery_attempt: nil,
+            distributor: nil
 
   defmodule Changes do
     @moduledoc false

--- a/lib/bedrock/control_plane/distributor.ex
+++ b/lib/bedrock/control_plane/distributor.ex
@@ -1,0 +1,58 @@
+defmodule Bedrock.ControlPlane.Distributor do
+  @moduledoc """
+  The distributor is a cluster singleton that owns shard-coverage policy:
+  on-demand materializer recruitment, placeholder supervision, and
+  materializer-death healing (with shard split/merge and rebalancing to
+  follow). It is the analogue of FoundationDB's Data Distributor.
+
+  ## Lifecycle
+
+  The distributor is recruited by the director *after* recovery completes
+  (FDB: the cluster controller recruits the data distributor once the
+  cluster is accepting commits) and is handed the current epoch along with
+  a snapshot of the shard layout. The director monitors the distributor
+  and re-recruits it if it dies.
+
+  The distributor is deliberately off the request path: its death degrades
+  coverage healing but never blocks reads or writes.
+
+  ## Epoch Validation
+
+  Every shard-map mutation the distributor initiates is epoch-validated
+  (the analogue of FDB's `moveKeysLock`). When the distributor learns that
+  the cluster has moved to a newer epoch - via `check_epoch/3` from a
+  caller carrying a newer epoch, or via `notify_epoch_change/2` - it stops
+  itself with reason `:normal`, ceding to the distributor of the new epoch.
+  """
+
+  use Bedrock.Internal.GenServerApi, for: __MODULE__.Server
+
+  @type ref :: pid() | atom() | {atom(), node()}
+
+  @doc """
+  Validates the caller's epoch against the distributor's own epoch.
+
+  This is the guard that all shard-map mutations pass through. Returns
+  `:ok` when the epochs match. If the caller carries a *newer* epoch, the
+  distributor has been superseded: it replies `{:error, :epoch_superseded}`
+  and stops itself with reason `:normal`. If the caller carries an *older*
+  epoch, the caller is stale and receives `{:error, :newer_epoch_exists}`.
+  """
+  @spec check_epoch(ref(), Bedrock.epoch(), opts :: [timeout_in_ms: Bedrock.timeout_in_ms()]) ::
+          :ok
+          | {:error, :epoch_superseded | :newer_epoch_exists}
+          | {:error, :unavailable | :timeout | :unknown}
+  def check_epoch(distributor, epoch, opts \\ []),
+    do: call(distributor, {:check_epoch, epoch}, opts[:timeout_in_ms] || 5_000)
+
+  @doc """
+  Notifies the distributor that the cluster epoch has changed.
+
+  If the new epoch is greater than the distributor's own epoch, the
+  distributor stops itself with reason `:normal` (a newer epoch's director
+  will recruit its own distributor). Signals for the same or an older
+  epoch are ignored.
+  """
+  @spec notify_epoch_change(ref(), Bedrock.epoch()) :: :ok
+  def notify_epoch_change(distributor, new_epoch), do: cast(distributor, {:epoch_changed, new_epoch})
+end

--- a/lib/bedrock/control_plane/distributor/server.ex
+++ b/lib/bedrock/control_plane/distributor/server.ex
@@ -1,0 +1,123 @@
+defmodule Bedrock.ControlPlane.Distributor.Server do
+  @moduledoc """
+  GenServer implementation of the Distributor singleton.
+
+  Holds the epoch it was recruited under, a reference to the recruiting
+  director, and a snapshot of the shard layout. Monitors the director and
+  stops (`:normal`) when the director exits or when a newer epoch is
+  signaled - the next director recruits a fresh distributor.
+
+  This is the Phase A skeleton: coverage tracking, recruitment, and
+  placeholder supervision arrive in later tickets and will all pass
+  through the epoch guard implemented here.
+  """
+
+  use GenServer
+
+  import Bedrock.ControlPlane.Distributor.Telemetry,
+    only: [
+      emit_distributor_started: 3,
+      emit_distributor_stopped: 3
+    ]
+
+  import Bedrock.Internal.GenServer.Replies
+
+  alias Bedrock.ControlPlane.Config.TransactionSystemLayout
+  alias Bedrock.ControlPlane.Distributor.State
+
+  require Logger
+
+  @doc false
+  @spec child_spec(
+          opts :: [
+            cluster: module(),
+            epoch: Bedrock.epoch(),
+            director: pid(),
+            shard_layout: TransactionSystemLayout.shard_layout(),
+            otp_name: atom()
+          ]
+        ) :: Supervisor.child_spec()
+  def child_spec(opts) do
+    cluster = opts[:cluster] || raise "Missing :cluster option"
+    epoch = opts[:epoch] || raise "Missing :epoch option"
+    director = opts[:director] || raise "Missing :director option"
+    otp_name = opts[:otp_name] || raise "Missing :otp_name option"
+    shard_layout = opts[:shard_layout] || %{}
+
+    %{
+      id: {__MODULE__, cluster, epoch},
+      start:
+        {GenServer, :start_link,
+         [
+           __MODULE__,
+           {cluster, epoch, director, shard_layout},
+           [name: otp_name]
+         ]},
+      restart: :temporary
+    }
+  end
+
+  @impl true
+  @spec init({module(), Bedrock.epoch(), pid(), TransactionSystemLayout.shard_layout()}) ::
+          {:ok, State.t()}
+  def init({cluster, epoch, director, shard_layout}) do
+    # Monitor the Director - if it dies, this distributor should terminate
+    # and let the next director recruit a fresh one.
+    Process.monitor(director)
+
+    emit_distributor_started(cluster, epoch, director)
+
+    {:ok,
+     %State{
+       cluster: cluster,
+       epoch: epoch,
+       director: director,
+       shard_layout: shard_layout
+     }}
+  end
+
+  @impl true
+  def handle_call({:check_epoch, epoch}, _from, %State{} = t) do
+    case State.check_epoch(t, epoch) do
+      :ok ->
+        reply(t, :ok)
+
+      {:error, :epoch_superseded} = error ->
+        Logger.info("Distributor for epoch #{t.epoch} superseded by epoch #{epoch}; stopping")
+        {:stop, :normal, error, t}
+
+      {:error, :newer_epoch_exists} = error ->
+        reply(t, error)
+    end
+  end
+
+  @impl true
+  def handle_cast({:epoch_changed, new_epoch}, %State{} = t) do
+    case State.check_epoch(t, new_epoch) do
+      {:error, :epoch_superseded} ->
+        Logger.info("Distributor for epoch #{t.epoch} superseded by epoch #{new_epoch}; stopping")
+        stop(t, :normal)
+
+      _same_or_older ->
+        noreply(t)
+    end
+  end
+
+  @impl true
+  def handle_info({:DOWN, _ref, :process, director, reason}, %State{director: director} = t) do
+    Logger.info("Distributor for epoch #{t.epoch} stopping: director exited (#{inspect(reason)})")
+
+    stop(t, :normal)
+  end
+
+  def handle_info(message, %State{} = t) do
+    Logger.debug("Distributor ignoring unexpected message: #{inspect(message)}")
+    noreply(t)
+  end
+
+  @impl true
+  def terminate(reason, %State{} = t) do
+    emit_distributor_stopped(t.cluster, t.epoch, reason)
+    :ok
+  end
+end

--- a/lib/bedrock/control_plane/distributor/state.ex
+++ b/lib/bedrock/control_plane/distributor/state.ex
@@ -1,0 +1,39 @@
+defmodule Bedrock.ControlPlane.Distributor.State do
+  @moduledoc """
+  Internal state structure for the Distributor process.
+  """
+
+  alias Bedrock.ControlPlane.Config.TransactionSystemLayout
+
+  @type t :: %__MODULE__{
+          cluster: module(),
+          epoch: Bedrock.epoch(),
+          director: pid(),
+          shard_layout: TransactionSystemLayout.shard_layout(),
+          materializer_monitors: %{reference() => Bedrock.range_tag()},
+          placeholder: pid() | nil
+        }
+  defstruct cluster: nil,
+            epoch: nil,
+            director: nil,
+            shard_layout: %{},
+            materializer_monitors: %{},
+            placeholder: nil
+
+  @doc """
+  Validates a caller-supplied epoch against the distributor's own epoch.
+
+  Returns `:ok` when they match, `{:error, :epoch_superseded}` when the
+  caller carries a newer epoch (this distributor is stale and must stop),
+  and `{:error, :newer_epoch_exists}` when the caller carries an older
+  epoch (the caller is stale).
+  """
+  @spec check_epoch(t(), Bedrock.epoch()) ::
+          :ok | {:error, :epoch_superseded | :newer_epoch_exists}
+  def check_epoch(%__MODULE__{epoch: epoch}, epoch), do: :ok
+
+  def check_epoch(%__MODULE__{epoch: own_epoch}, caller_epoch) when caller_epoch > own_epoch,
+    do: {:error, :epoch_superseded}
+
+  def check_epoch(%__MODULE__{}, _caller_epoch), do: {:error, :newer_epoch_exists}
+end

--- a/lib/bedrock/control_plane/distributor/telemetry.ex
+++ b/lib/bedrock/control_plane/distributor/telemetry.ex
@@ -1,0 +1,23 @@
+defmodule Bedrock.ControlPlane.Distributor.Telemetry do
+  @moduledoc """
+  Telemetry utilities for distributor lifecycle events.
+  """
+
+  @spec emit_distributor_started(module(), Bedrock.epoch(), pid()) :: :ok
+  def emit_distributor_started(cluster, epoch, director) do
+    :telemetry.execute(
+      [:bedrock, :distributor, :started],
+      %{},
+      %{cluster: cluster, epoch: epoch, director: director}
+    )
+  end
+
+  @spec emit_distributor_stopped(module(), Bedrock.epoch(), reason :: term()) :: :ok
+  def emit_distributor_stopped(cluster, epoch, reason) do
+    :telemetry.execute(
+      [:bedrock, :distributor, :stopped],
+      %{},
+      %{cluster: cluster, epoch: epoch, reason: reason}
+    )
+  end
+end

--- a/test/bedrock/control_plane/director/distributor_recruitment_test.exs
+++ b/test/bedrock/control_plane/director/distributor_recruitment_test.exs
@@ -1,0 +1,110 @@
+defmodule Bedrock.ControlPlane.Director.DistributorRecruitmentTest do
+  use ExUnit.Case, async: true
+
+  alias Bedrock.ControlPlane.Director.Server
+  alias Bedrock.ControlPlane.Director.State
+  alias Bedrock.ControlPlane.Distributor
+  alias Bedrock.ControlPlane.Distributor.State, as: DistributorState
+
+  defmodule TestCluster do
+    @moduledoc false
+    def otp_name, do: :distributor_recruitment_test
+    def otp_name(component), do: :"distributor_recruitment_test_#{component}"
+  end
+
+  setup do
+    start_supervised!({DynamicSupervisor, name: TestCluster.otp_name(:sup), strategy: :one_for_one})
+    :ok
+  end
+
+  defp running_state(overrides \\ %{}) do
+    Map.merge(
+      %State{
+        state: :running,
+        cluster: TestCluster,
+        epoch: 5,
+        transaction_system_layout: %{shard_layout: %{<<0xFF>> => {0, <<>>}}}
+      },
+      overrides
+    )
+  end
+
+  defp kill_and_wait(pid) do
+    ref = Process.monitor(pid)
+    Process.exit(pid, :kill)
+    assert_receive {:DOWN, ^ref, :process, ^pid, :killed}
+  end
+
+  describe "recruitment after recovery completes" do
+    test "advance_recovery recruits a distributor once the director is running" do
+      state = Server.advance_recovery(running_state())
+
+      assert is_pid(state.distributor)
+      assert Process.alive?(state.distributor)
+
+      # The distributor is handed the current epoch and TSL shard layout snapshot.
+      assert %DistributorState{
+               cluster: TestCluster,
+               epoch: 5,
+               shard_layout: %{<<0xFF>> => {0, <<>>}}
+             } = :sys.get_state(state.distributor)
+
+      # Registered under the cluster's otp_name convention.
+      assert Process.whereis(TestCluster.otp_name(:distributor)) == state.distributor
+    end
+
+    test "no distributor is recruited while recovery has not completed" do
+      state = Server.maybe_start_distributor(%State{state: :recovery, cluster: TestCluster, epoch: 5})
+
+      assert state.distributor == nil
+      assert Process.whereis(TestCluster.otp_name(:distributor)) == nil
+    end
+
+    test "an already-recruited distributor is left alone" do
+      state = Server.maybe_start_distributor(running_state())
+      assert %{distributor: distributor} = Server.maybe_start_distributor(state)
+      assert distributor == state.distributor
+    end
+  end
+
+  describe "distributor death" do
+    test "director re-recruits the distributor on :DOWN without stopping itself" do
+      state = Server.maybe_start_distributor(running_state())
+      original = state.distributor
+      kill_and_wait(original)
+
+      assert {:noreply, new_state} = Server.handle_info({:DOWN, make_ref(), :process, original, :killed}, state)
+
+      assert is_pid(new_state.distributor)
+      assert new_state.distributor != original
+      assert Process.alive?(new_state.distributor)
+      assert %DistributorState{epoch: 5} = :sys.get_state(new_state.distributor)
+    end
+
+    test "a :DOWN from any other component still stops the director" do
+      state = Server.maybe_start_distributor(running_state())
+      other_pid = spawn(fn -> :ok end)
+
+      assert {:stop, {:shutdown, {:component_failure, ^other_pid, :boom}}, _} =
+               Server.handle_info({:DOWN, make_ref(), :process, other_pid, :boom}, state)
+    end
+  end
+
+  describe "epoch guard integration" do
+    test "distributor recruited with epoch N terminates when the director signals epoch N+1" do
+      state = Server.maybe_start_distributor(running_state())
+      distributor = state.distributor
+      ref = Process.monitor(distributor)
+
+      :ok = Distributor.notify_epoch_change(distributor, state.epoch + 1)
+
+      assert_receive {:DOWN, ^ref, :process, ^distributor, :normal}
+
+      # The monitoring director would then re-recruit at its current epoch.
+      assert {:noreply, new_state} = Server.handle_info({:DOWN, ref, :process, distributor, :normal}, state)
+
+      assert is_pid(new_state.distributor)
+      assert %DistributorState{epoch: 5} = :sys.get_state(new_state.distributor)
+    end
+  end
+end

--- a/test/bedrock/control_plane/distributor/server_test.exs
+++ b/test/bedrock/control_plane/distributor/server_test.exs
@@ -1,0 +1,149 @@
+defmodule Bedrock.ControlPlane.Distributor.ServerTest do
+  use ExUnit.Case, async: true
+
+  alias Bedrock.ControlPlane.Distributor
+  alias Bedrock.ControlPlane.Distributor.State
+
+  defmodule TestCluster do
+    @moduledoc false
+    def otp_name(component), do: :"distributor_server_test_#{component}"
+  end
+
+  defp unique_otp_name, do: :"distributor_test_#{System.unique_integer([:positive])}"
+
+  defp attach_telemetry(test_pid) do
+    handler_id = "distributor-test-#{System.unique_integer([:positive])}"
+
+    :telemetry.attach_many(
+      handler_id,
+      [
+        [:bedrock, :distributor, :started],
+        [:bedrock, :distributor, :stopped]
+      ],
+      fn event, measurements, metadata, _config ->
+        send(test_pid, {:telemetry, event, measurements, metadata})
+      end,
+      nil
+    )
+
+    on_exit(fn -> :telemetry.detach(handler_id) end)
+  end
+
+  defp start_director_stub do
+    spawn(fn ->
+      receive do
+        :stop -> :ok
+      end
+    end)
+  end
+
+  defp start_distributor(opts \\ []) do
+    director = Keyword.get_lazy(opts, :director, &start_director_stub/0)
+
+    pid =
+      start_supervised!(
+        Distributor.child_spec(
+          cluster: TestCluster,
+          epoch: Keyword.get(opts, :epoch, 42),
+          director: director,
+          shard_layout: Keyword.get(opts, :shard_layout, %{}),
+          otp_name: unique_otp_name()
+        )
+      )
+
+    {pid, director}
+  end
+
+  describe "lifecycle" do
+    test "starts with the expected state and emits the started telemetry event" do
+      attach_telemetry(self())
+      shard_layout = %{<<0xFF>> => {0, <<>>}}
+
+      {pid, director} = start_distributor(epoch: 42, shard_layout: shard_layout)
+
+      assert %State{
+               cluster: TestCluster,
+               epoch: 42,
+               director: ^director,
+               shard_layout: ^shard_layout,
+               materializer_monitors: %{},
+               placeholder: nil
+             } = :sys.get_state(pid)
+
+      assert_receive {:telemetry, [:bedrock, :distributor, :started], %{},
+                      %{cluster: TestCluster, epoch: 42, director: ^director}}
+    end
+
+    test "stops with :normal and emits the stopped telemetry event when the director exits" do
+      attach_telemetry(self())
+      {pid, director} = start_distributor(epoch: 7)
+      ref = Process.monitor(pid)
+
+      send(director, :stop)
+
+      assert_receive {:DOWN, ^ref, :process, ^pid, :normal}
+
+      assert_receive {:telemetry, [:bedrock, :distributor, :stopped], %{},
+                      %{cluster: TestCluster, epoch: 7, reason: :normal}}
+    end
+  end
+
+  describe "epoch guard" do
+    test "check_epoch with the distributor's own epoch returns :ok" do
+      {pid, _director} = start_distributor(epoch: 42)
+
+      assert :ok = Distributor.check_epoch(pid, 42)
+      assert Process.alive?(pid)
+    end
+
+    test "check_epoch from a stale caller returns an error and leaves the distributor running" do
+      {pid, _director} = start_distributor(epoch: 42)
+
+      assert {:error, :newer_epoch_exists} = Distributor.check_epoch(pid, 41)
+      assert Process.alive?(pid)
+    end
+
+    test "check_epoch with a newer epoch stops the distributor with :normal" do
+      attach_telemetry(self())
+      {pid, _director} = start_distributor(epoch: 42)
+      ref = Process.monitor(pid)
+
+      assert {:error, :epoch_superseded} = Distributor.check_epoch(pid, 43)
+
+      assert_receive {:DOWN, ^ref, :process, ^pid, :normal}
+      assert_receive {:telemetry, [:bedrock, :distributor, :stopped], %{}, %{epoch: 42, reason: :normal}}
+    end
+
+    test "notify_epoch_change with a newer epoch stops the distributor with :normal" do
+      attach_telemetry(self())
+      {pid, _director} = start_distributor(epoch: 42)
+      ref = Process.monitor(pid)
+
+      :ok = Distributor.notify_epoch_change(pid, 43)
+
+      assert_receive {:DOWN, ^ref, :process, ^pid, :normal}
+      assert_receive {:telemetry, [:bedrock, :distributor, :stopped], %{}, %{epoch: 42, reason: :normal}}
+    end
+
+    test "notify_epoch_change with the same or an older epoch is ignored" do
+      {pid, _director} = start_distributor(epoch: 42)
+
+      :ok = Distributor.notify_epoch_change(pid, 42)
+      :ok = Distributor.notify_epoch_change(pid, 41)
+
+      # Synchronize on the mailbox to be sure both casts were processed.
+      assert :ok = Distributor.check_epoch(pid, 42)
+      assert Process.alive?(pid)
+    end
+  end
+
+  describe "State.check_epoch/2" do
+    test "matches, supersedes, and rejects stale callers" do
+      state = %State{epoch: 5}
+
+      assert :ok = State.check_epoch(state, 5)
+      assert {:error, :epoch_superseded} = State.check_epoch(state, 6)
+      assert {:error, :newer_epoch_exists} = State.check_epoch(state, 4)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Adds the **Distributor** — a control-plane cluster singleton that will own shard-coverage policy (on-demand materializer recruitment, placeholder supervision, materializer-death healing, and later split/merge/rebalancing). It is the analogue of FoundationDB's **Data Distributor**: recruited by the director only *after* recovery completes (FDB: the cluster controller recruits DD once the cluster is accepting commits), deliberately **off the request path** — its death degrades coverage healing only, never reads or writes.

Part of the q67 Phase A (Coverage & Distribution) epic.

## What's here

- `Bedrock.ControlPlane.Distributor` (public API) + `Distributor.Server` (GenServer) + `Distributor.State` + `Distributor.Telemetry`
  - State: cluster, epoch, director ref, shard-layout snapshot, materializer monitors (empty for now), placeholder ref (nil for now)
  - Telemetry: `[:bedrock, :distributor, :started]` / `[:bedrock, :distributor, :stopped]`
- **Post-recovery recruitment**: the director's recovery entry points now flow through `advance_recovery/1` (`try_to_recover` + `maybe_start_distributor`); once state reaches `:running`, the director starts the Distributor via the cluster's dynamic supervisor with the current epoch + TSL `shard_layout` snapshot, registered as `cluster.otp_name(:distributor)`
- **Monitoring + re-recruitment**: the director monitors the Distributor pid; a `:DOWN` for it re-recruits at the current epoch instead of tripping the component-failure shutdown path
- **Epoch guard** (`moveKeysLock` analogue): `State.check_epoch/2` is the guard every future shard-map mutation passes through. Two channels for learning the epoch moved on: `check_epoch/3` (call — a caller with a newer epoch supersedes the distributor) and `notify_epoch_change/2` (cast from the director side). Either way the stale distributor logs and stops with `:normal`. It also monitors its director and stops `:normal` when the director exits
- Tests: server lifecycle + epoch guard unit tests; director-level tests for post-recovery recruitment, death → re-recruitment, and epoch N / N+1 supersession

## Deliberately NOT here yet

- **Recruitment logic** (coverage demand handling, node selection via Foreman, TSL deltas) — bedrock-q67.5
- **Placeholder materializer** (bounded parking, fallback coverage endpoint) — bedrock-q67.3
- Service-directory registration and materializer monitoring wiring — arrive with the recruitment flow

## Testing

- New tests green at multiple seeds; full `control_plane` dir green; full suite: 2526 tests, 0 failures
- `mix format`, `credo --strict`, and `dialyzer` clean