### PR TITLE
Add post-recovery TSL delta application and broadcast (bedrock-q67.4)

### DIFF
--- a/lib/bedrock/cluster/link/discovery.ex
+++ b/lib/bedrock/cluster/link/discovery.ex
@@ -161,12 +161,22 @@ defmodule Bedrock.Cluster.Link.Discovery do
     t
     |> Map.put(:known_coordinator, coordinator_ref)
     |> monitor_known_coordinator()
+    |> subscribe_to_tsl_updates()
     |> register_node_capabilities()
   end
 
   @spec monitor_known_coordinator(State.t()) :: State.t()
   defp monitor_known_coordinator(t) do
     Process.monitor(t.known_coordinator)
+    t
+  end
+
+  @spec subscribe_to_tsl_updates(State.t()) :: State.t()
+  defp subscribe_to_tsl_updates(t) do
+    # Subscribe for {:tsl_updated, tsl} broadcasts regardless of capabilities.
+    # Nodes registering resources are subscribed implicitly by the coordinator,
+    # but capability-less (pure client) links would otherwise never subscribe.
+    Coordinator.subscribe_to_tsl_updates(t.known_coordinator, self())
     t
   end
 

--- a/lib/bedrock/control_plane/coordinator.ex
+++ b/lib/bedrock/control_plane/coordinator.ex
@@ -45,7 +45,7 @@ defmodule Bedrock.ControlPlane.Coordinator do
   alias Bedrock.ControlPlane.Config
   alias Bedrock.ControlPlane.Config.TransactionSystemLayout
 
-  @type ref :: atom() | {atom(), node()}
+  @type ref :: pid() | atom() | {atom(), node()}
   @typep timeout_in_ms :: Bedrock.timeout_in_ms()
 
   @spec config_key() :: atom()
@@ -88,6 +88,21 @@ defmodule Bedrock.ControlPlane.Coordinator do
         ) :: :ok
   def notify_transaction_system_layout(coordinator, transaction_system_layout),
     do: GenServer.cast(coordinator, {:notify_transaction_system_layout, transaction_system_layout})
+
+  @doc """
+  Subscribe a process to `{:tsl_updated, tsl}` broadcasts from this coordinator.
+
+  The coordinator monitors the subscriber and removes it automatically when it
+  dies. If the coordinator already holds a transaction system layout, the
+  subscriber is immediately brought up to date with a `{:tsl_updated, tsl}`
+  message. Subscribing is idempotent.
+
+  Links subscribe on connect (see `Bedrock.Cluster.Link.Discovery`); processes
+  registering node resources are subscribed implicitly as well.
+  """
+  @spec subscribe_to_tsl_updates(coordinator_ref :: ref(), subscriber :: pid()) :: :ok
+  def subscribe_to_tsl_updates(coordinator, subscriber),
+    do: GenServer.cast(coordinator, {:subscribe_tsl_updates, subscriber})
 
   @type service_info :: {service_id :: String.t(), kind :: atom(), worker_ref :: {atom(), node()}}
   @type compact_service_info :: {service_id :: String.t(), kind :: atom(), name :: atom()}

--- a/lib/bedrock/control_plane/coordinator/director_management.ex
+++ b/lib/bedrock/control_plane/coordinator/director_management.ex
@@ -34,10 +34,15 @@ defmodule Bedrock.ControlPlane.Coordinator.DirectorManagement do
     case start_director_with_monitoring(t) do
       {:ok, new_director} ->
         trace_director_changed(new_director)
-        # Clear cached TSL in all Links so user transactions get :unavailable during recovery
-        # instead of using the stale OLD TSL with dead PIDs
-        State.Changes.broadcast_tsl_update(t, nil)
-        put_director(t, new_director)
+
+        # Clear cached TSL in all Links so user transactions get :unavailable
+        # during recovery instead of using the stale OLD TSL with dead PIDs.
+        # Mark the retained TSL stale as well, so links that subscribe while
+        # recovery is in flight aren't handed it as a snapshot.
+        t
+        |> State.Changes.mark_tsl_stale()
+        |> State.Changes.broadcast_tsl_update(nil)
+        |> put_director(new_director)
 
       {:error, reason} ->
         Logger.warning("Failed to start director: #{inspect(reason)}")

--- a/lib/bedrock/control_plane/coordinator/server.ex
+++ b/lib/bedrock/control_plane/coordinator/server.ex
@@ -159,9 +159,10 @@ defmodule Bedrock.ControlPlane.Coordinator.Server do
   end
 
   def handle_call({:register_node_resources, client_pid, compact_services, capabilities}, from, t) do
-    # Always subscribe client for TSL updates (monitor to clean up on death)
-    Process.monitor(client_pid)
-    updated_state = add_tsl_subscriber(t, client_pid)
+    # Always subscribe client for TSL updates (monitor to clean up on death).
+    # Guarded so a link that already subscribed via {:subscribe_tsl_updates, _}
+    # doesn't accumulate a second monitor.
+    updated_state = monitor_and_add_tsl_subscriber(t, client_pid)
 
     # Expand compact services to full format
     caller_node = node(client_pid)
@@ -281,24 +282,37 @@ defmodule Bedrock.ControlPlane.Coordinator.Server do
     if MapSet.member?(t.tsl_subscribers, subscriber) do
       noreply(t)
     else
-      Process.monitor(subscriber)
-
-      # Bring the new subscriber up to date immediately if we already have a TSL.
-      if t.transaction_system_layout, do: send(subscriber, {:tsl_updated, t.transaction_system_layout})
+      # Bring the new subscriber up to date immediately if we already hold a
+      # director-produced TSL. The old-TSL stub loaded from object storage at
+      # init (bare %{logs: ...}, no :epoch) is recovery input only and must
+      # not be pushed to subscribers.
+      case t.transaction_system_layout do
+        %{epoch: _} = tsl -> send(subscriber, {:tsl_updated, tsl})
+        _ -> :ok
+      end
 
       t
-      |> add_tsl_subscriber(subscriber)
+      |> monitor_and_add_tsl_subscriber(subscriber)
       |> noreply()
     end
   end
 
-  def handle_cast({:notify_transaction_system_layout, transaction_system_layout}, t) do
+  def handle_cast({:notify_transaction_system_layout, %{epoch: tsl_epoch} = transaction_system_layout}, t)
+      when is_nil(t.epoch) or tsl_epoch >= t.epoch do
     # Direct notification from Director - update state and broadcast to subscribers
     # No Raft consensus needed - TSL is persisted to object storage by Director
     t
     |> put_transaction_system_layout(transaction_system_layout)
-    |> put_epoch(transaction_system_layout.epoch)
+    |> put_epoch(tsl_epoch)
     |> noreply()
+  end
+
+  def handle_cast({:notify_transaction_system_layout, _stale_tsl}, t) do
+    # A TSL carrying an epoch older than ours is a delayed cast from a
+    # deposed director (e.g. an in-flight delta or recovery notification that
+    # raced a leadership change). Applying it would regress our epoch and
+    # broadcast dead pids to every subscribed link, so drop it.
+    noreply(t)
   end
 
   def handle_cast({:notify_config, config}, t) do
@@ -333,6 +347,19 @@ defmodule Bedrock.ControlPlane.Coordinator.Server do
 
   @spec ack_fn(GenServer.from()) :: (term() -> :ok)
   defp ack_fn(from), do: fn result -> GenServer.reply(from, result) end
+
+  # Adds a TSL subscriber, monitoring it exactly once. Idempotent: repeated
+  # subscriptions (or a subscribe cast followed by register_node_resources)
+  # must not accumulate duplicate monitors on the same pid.
+  @spec monitor_and_add_tsl_subscriber(State.t(), pid()) :: State.t()
+  defp monitor_and_add_tsl_subscriber(t, subscriber) do
+    if MapSet.member?(t.tsl_subscribers, subscriber) do
+      t
+    else
+      Process.monitor(subscriber)
+      add_tsl_subscriber(t, subscriber)
+    end
+  end
 
   @spec init_raft_log(module()) ::
           {:ok, DiskRaftLog.t() | TupleInMemoryLog.t()} | {:error, term()}

--- a/lib/bedrock/control_plane/coordinator/server.ex
+++ b/lib/bedrock/control_plane/coordinator/server.ex
@@ -277,6 +277,21 @@ defmodule Bedrock.ControlPlane.Coordinator.Server do
     noreply(t)
   end
 
+  def handle_cast({:subscribe_tsl_updates, subscriber}, t) do
+    if MapSet.member?(t.tsl_subscribers, subscriber) do
+      noreply(t)
+    else
+      Process.monitor(subscriber)
+
+      # Bring the new subscriber up to date immediately if we already have a TSL.
+      if t.transaction_system_layout, do: send(subscriber, {:tsl_updated, t.transaction_system_layout})
+
+      t
+      |> add_tsl_subscriber(subscriber)
+      |> noreply()
+    end
+  end
+
   def handle_cast({:notify_transaction_system_layout, transaction_system_layout}, t) do
     # Direct notification from Director - update state and broadcast to subscribers
     # No Raft consensus needed - TSL is persisted to object storage by Director

--- a/lib/bedrock/control_plane/coordinator/server.ex
+++ b/lib/bedrock/control_plane/coordinator/server.ex
@@ -282,12 +282,14 @@ defmodule Bedrock.ControlPlane.Coordinator.Server do
     if MapSet.member?(t.tsl_subscribers, subscriber) do
       noreply(t)
     else
-      # Bring the new subscriber up to date immediately if we already hold a
-      # director-produced TSL. The old-TSL stub loaded from object storage at
-      # init (bare %{logs: ...}, no :epoch) is recovery input only and must
-      # not be pushed to subscribers.
+      # Bring the new subscriber up to date immediately, but only if we hold a
+      # live, director-produced TSL (tsl_live?). Two stale forms are retained
+      # in state as recovery input and must not be pushed to subscribers: the
+      # old-TSL stub loaded from object storage at init (bare %{logs: ...}, no
+      # :epoch), and a full pre-recovery TSL kept while a newly launched
+      # director is still recovering (its component pids may be dead).
       case t.transaction_system_layout do
-        %{epoch: _} = tsl -> send(subscriber, {:tsl_updated, tsl})
+        %{epoch: _} = tsl when t.tsl_live? -> send(subscriber, {:tsl_updated, tsl})
         _ -> :ok
       end
 

--- a/lib/bedrock/control_plane/coordinator/state.ex
+++ b/lib/bedrock/control_plane/coordinator/state.ex
@@ -28,6 +28,7 @@ defmodule Bedrock.ControlPlane.Coordinator.State do
           service_directory: %{String.t() => {atom(), {atom(), node()}}},
           node_capabilities: %{node() => [Cluster.capability()]},
           tsl_subscribers: MapSet.t(pid()),
+          tsl_live?: boolean(),
           leader_startup_state: leader_startup_state(),
           recovery_tracker: RecoveryCapabilityTracker.t()
         }
@@ -46,6 +47,7 @@ defmodule Bedrock.ControlPlane.Coordinator.State do
             service_directory: %{},
             node_capabilities: %{},
             tsl_subscribers: MapSet.new(),
+            tsl_live?: false,
             leader_startup_state: :not_leader,
             recovery_tracker: %RecoveryCapabilityTracker{}
 
@@ -92,9 +94,16 @@ defmodule Bedrock.ControlPlane.Coordinator.State do
     @spec put_transaction_system_layout(t :: State.t(), TransactionSystemLayout.t()) ::
             State.t()
     def put_transaction_system_layout(t, transaction_system_layout) do
-      updated_state = %{t | transaction_system_layout: transaction_system_layout}
+      updated_state = %{t | transaction_system_layout: transaction_system_layout, tsl_live?: true}
       broadcast_tsl_update(updated_state, transaction_system_layout)
     end
+
+    # Marks the retained TSL as stale (recovery input only). Called when a new
+    # director is launched: the TSL is kept in state so a recovery retry can
+    # use it as input, but it must no longer be served to new TSL subscribers
+    # since its component pids may be dead.
+    @spec mark_tsl_stale(t :: State.t()) :: State.t()
+    def mark_tsl_stale(t), do: %{t | tsl_live?: false}
 
     @spec put_service_directory(t :: State.t(), %{String.t() => {atom(), {atom(), node()}}}) ::
             State.t()

--- a/lib/bedrock/control_plane/director.ex
+++ b/lib/bedrock/control_plane/director.ex
@@ -47,10 +47,43 @@ defmodule Bedrock.ControlPlane.Director do
 
   @type running_service_info_by_id :: %{Worker.id() => running_service_info()}
 
+  @typedoc """
+  A minimal delta over the transaction system layout's `shard_materializers`
+  map. Each entry either assigns a materializer pid to a shard tag
+  (put/replace semantics) or removes the shard's entry with `:remove`.
+  """
+  @type tsl_delta :: %{Bedrock.range_tag() => pid() | :remove}
+
   @spec fetch_transaction_system_layout(director_ref :: ref(), timeout_in_ms :: timeout_in_ms()) ::
           {:ok, TransactionSystemLayout.t()} | {:error, :unavailable | :timeout | :unknown}
   def fetch_transaction_system_layout(director, timeout_in_ms \\ 5_000),
     do: call(director, :fetch_transaction_system_layout, timeout_in_ms)
+
+  @doc """
+  Apply a post-recovery delta to the transaction system layout's
+  `shard_materializers` map and broadcast the resulting TSL.
+
+  The delta is epoch-stamped: it is applied only when `epoch` matches the
+  director's own epoch. A delta carrying any other epoch (stale, or produced
+  against a generation this director doesn't know) is rejected with
+  `{:error, :newer_epoch_exists}`, mirroring the epoch guard used by
+  `lock_for_recovery` on data-plane services.
+
+  On success the director updates its retained TSL and hands the new TSL to
+  the coordinator, which broadcasts `{:tsl_updated, new_tsl}` to all
+  subscribed Links.
+
+  Returns `{:error, :unavailable}` if recovery has not yet produced a TSL.
+  """
+  @spec apply_tsl_delta(
+          director :: ref(),
+          delta :: tsl_delta(),
+          epoch :: Bedrock.epoch(),
+          timeout_in_ms :: timeout_in_ms()
+        ) ::
+          :ok | {:error, :newer_epoch_exists | :unavailable | :timeout | :unknown}
+  def apply_tsl_delta(director, delta, epoch, timeout_in_ms \\ 5_000),
+    do: call(director, {:apply_tsl_delta, delta, epoch}, timeout_in_ms)
 
   @doc """
   Sends a 'pong' message to the specified cluster director from the given node.

--- a/lib/bedrock/control_plane/director/server.ex
+++ b/lib/bedrock/control_plane/director/server.ex
@@ -18,12 +18,14 @@ defmodule Bedrock.ControlPlane.Director.Server do
       try_to_recover: 1
     ]
 
+  import Bedrock.ControlPlane.Director.Telemetry, only: [trace_tsl_delta_applied: 3]
   import Bedrock.Internal.GenServer.Replies
 
   alias Bedrock.ControlPlane.Config
   alias Bedrock.ControlPlane.Config.ServiceDescriptor
   alias Bedrock.ControlPlane.Config.TransactionSystemLayout
   alias Bedrock.ControlPlane.Coordinator
+  alias Bedrock.ControlPlane.Director
   alias Bedrock.ControlPlane.Director.State
   alias Bedrock.Service.Worker
 
@@ -116,6 +118,18 @@ defmodule Bedrock.ControlPlane.Director.Server do
     end
   end
 
+  def handle_call({:apply_tsl_delta, _delta, epoch}, _from, %State{epoch: current_epoch} = t)
+      when epoch != current_epoch, do: reply(t, {:error, :newer_epoch_exists})
+
+  def handle_call({:apply_tsl_delta, _delta, _epoch}, _from, %State{transaction_system_layout: nil} = t),
+    do: reply(t, {:error, :unavailable})
+
+  def handle_call({:apply_tsl_delta, delta, _epoch}, _from, %State{} = t) do
+    t
+    |> apply_tsl_delta(delta)
+    |> reply(:ok)
+  end
+
   def handle_call({:request_worker_creation, node, worker_id, kind}, _from, t) do
     t
     |> request_worker_creation(node, worker_id, kind)
@@ -179,6 +193,34 @@ defmodule Bedrock.ControlPlane.Director.Server do
 
   @spec now() :: DateTime.t()
   defp now, do: DateTime.utc_now()
+
+  # Applies a shard_materializers delta to the retained TSL, hands the new TSL
+  # to the coordinator for broadcast to subscribed Links, and emits telemetry.
+  @spec apply_tsl_delta(State.t(), Director.tsl_delta()) :: State.t()
+  defp apply_tsl_delta(t, delta) do
+    updated_shard_materializers =
+      t.transaction_system_layout
+      |> Map.get(:shard_materializers, %{})
+      |> apply_delta_to_shard_materializers(delta)
+
+    updated_tsl = Map.put(t.transaction_system_layout, :shard_materializers, updated_shard_materializers)
+
+    Coordinator.notify_transaction_system_layout(t.coordinator, updated_tsl)
+    trace_tsl_delta_applied(t.cluster, t.epoch, delta)
+
+    %{t | transaction_system_layout: updated_tsl}
+  end
+
+  @spec apply_delta_to_shard_materializers(
+          TransactionSystemLayout.shard_materializers(),
+          Director.tsl_delta()
+        ) :: TransactionSystemLayout.shard_materializers()
+  defp apply_delta_to_shard_materializers(shard_materializers, delta) do
+    Enum.reduce(delta, shard_materializers, fn
+      {tag, :remove}, acc -> Map.delete(acc, tag)
+      {tag, pid}, acc when is_pid(pid) -> Map.put(acc, tag, pid)
+    end)
+  end
 
   @spec get_services_from_transaction_system_layout(TransactionSystemLayout.t()) ::
           %{Worker.id() => ServiceDescriptor.t()}

--- a/lib/bedrock/control_plane/director/telemetry.ex
+++ b/lib/bedrock/control_plane/director/telemetry.ex
@@ -1,0 +1,22 @@
+defmodule Bedrock.ControlPlane.Director.Telemetry do
+  @moduledoc false
+  alias Bedrock.ControlPlane.Director
+  alias Bedrock.Telemetry
+
+  @doc """
+  Emits a telemetry event indicating that the director applied a post-recovery
+  delta to the transaction system layout's `shard_materializers` map.
+  """
+  @spec trace_tsl_delta_applied(
+          cluster :: module(),
+          epoch :: Bedrock.epoch(),
+          delta :: Director.tsl_delta()
+        ) :: :ok
+  def trace_tsl_delta_applied(cluster, epoch, delta) do
+    Telemetry.execute([:bedrock, :director, :tsl_delta_applied], %{shard_count: map_size(delta)}, %{
+      cluster: cluster,
+      epoch: epoch,
+      delta: delta
+    })
+  end
+end

--- a/test/bedrock/cluster/tsl_delta_round_trip_test.exs
+++ b/test/bedrock/cluster/tsl_delta_round_trip_test.exs
@@ -80,13 +80,14 @@ defmodule Bedrock.Cluster.TSLDeltaRoundTripTest do
     }
   end
 
-  defp start_coordinator(epoch) do
+  defp start_coordinator(epoch, opts \\ []) do
     state = %Coordinator.State{
       cluster: TestCluster,
       my_node: Node.self(),
       leader_node: Node.self(),
       epoch: epoch,
-      otp_name: @coordinator_otp_name
+      otp_name: @coordinator_otp_name,
+      transaction_system_layout: Keyword.get(opts, :tsl)
     }
 
     start_supervised!(%{
@@ -215,5 +216,58 @@ defmodule Bedrock.Cluster.TSLDeltaRoundTripTest do
 
     assert_receive {:tsl_updated, tsl}
     assert tsl.shard_materializers == %{1 => materializer}
+  end
+
+  test "a notify from a deposed director (older epoch) is dropped by the coordinator" do
+    # Coordinator has moved on to epoch 6 (leadership change); a director from
+    # epoch 5 still manages to emit a notify (e.g. an in-flight delta that
+    # raced the leadership change). The coordinator must not regress its epoch
+    # nor broadcast the stale TSL.
+    coordinator = start_coordinator(6)
+    :ok = Coordinator.subscribe_to_tsl_updates(coordinator, self())
+
+    stale_director = start_director(5, coordinator)
+    materializer = spawn(fn -> Process.sleep(:infinity) end)
+
+    # The stale director accepts the delta against its own (old) epoch...
+    assert :ok = Director.apply_tsl_delta(stale_director, %{1 => materializer}, 5)
+
+    # ...but the coordinator drops the resulting notify: nothing is broadcast
+    # and the coordinator's TSL/epoch are unchanged.
+    refute_receive {:tsl_updated, _}, 100
+    assert {:ok, nil} = GenServer.call(coordinator, :fetch_transaction_system_layout)
+    assert {:pong, 6, _leader} = GenServer.call(coordinator, :ping)
+  end
+
+  test "snapshot-on-subscribe does not push the bootstrap-loaded old-TSL stub" do
+    # At init the coordinator may hold a partial old-TSL stub loaded from
+    # object storage (bare %{logs: ...}, recovery input only). Subscribers
+    # must not receive it as if it were a live TSL.
+    coordinator = start_coordinator(5, tsl: %{logs: %{"log_1" => [0]}})
+
+    :ok = Coordinator.subscribe_to_tsl_updates(coordinator, self())
+    refute_receive {:tsl_updated, _}, 100
+
+    # Once a director produces a real TSL, the subscriber hears about it.
+    director = start_director(5, coordinator)
+    materializer = spawn(fn -> Process.sleep(:infinity) end)
+    assert :ok = Director.apply_tsl_delta(director, %{1 => materializer}, 5)
+
+    assert_receive {:tsl_updated, %{epoch: 5}}
+  end
+
+  test "repeated subscriptions do not accumulate duplicate monitors" do
+    coordinator = start_coordinator(5)
+
+    :ok = Coordinator.subscribe_to_tsl_updates(coordinator, self())
+    :ok = Coordinator.subscribe_to_tsl_updates(coordinator, self())
+    :ok = Coordinator.subscribe_to_tsl_updates(coordinator, self())
+
+    # Synchronize on the casts having been processed.
+    assert {:pong, 5, _} = GenServer.call(coordinator, :ping)
+
+    {:monitors, monitors} = Process.info(coordinator, :monitors)
+    me = self()
+    assert Enum.count(monitors, &match?({:process, ^me}, &1)) == 1
   end
 end

--- a/test/bedrock/cluster/tsl_delta_round_trip_test.exs
+++ b/test/bedrock/cluster/tsl_delta_round_trip_test.exs
@@ -87,7 +87,8 @@ defmodule Bedrock.Cluster.TSLDeltaRoundTripTest do
       leader_node: Node.self(),
       epoch: epoch,
       otp_name: @coordinator_otp_name,
-      transaction_system_layout: Keyword.get(opts, :tsl)
+      transaction_system_layout: Keyword.get(opts, :tsl),
+      tsl_live?: Keyword.get(opts, :tsl_live?, false)
     }
 
     start_supervised!(%{
@@ -254,6 +255,25 @@ defmodule Bedrock.Cluster.TSLDeltaRoundTripTest do
     assert :ok = Director.apply_tsl_delta(director, %{1 => materializer}, 5)
 
     assert_receive {:tsl_updated, %{epoch: 5}}
+  end
+
+  test "snapshot-on-subscribe does not push a stale pre-recovery TSL while recovery is in flight" do
+    # A director crash keeps the previous (epoch-bearing) TSL in coordinator
+    # state as recovery input, but marks it stale (tsl_live?: false) when the
+    # replacement director is launched. A link that subscribes during that
+    # window must not receive the stale TSL: its component pids may be dead.
+    stale_tsl = Map.put(base_tsl(5), :shard_materializers, %{1 => self()})
+    coordinator = start_coordinator(5, tsl: stale_tsl, tsl_live?: false)
+
+    :ok = Coordinator.subscribe_to_tsl_updates(coordinator, self())
+    refute_receive {:tsl_updated, _}, 100
+
+    # Once the new director's recovery produces a TSL, the subscriber hears it.
+    director = start_director(5, coordinator)
+    materializer = spawn(fn -> Process.sleep(:infinity) end)
+    assert :ok = Director.apply_tsl_delta(director, %{2 => materializer}, 5)
+
+    assert_receive {:tsl_updated, %{shard_materializers: %{2 => ^materializer}}}
   end
 
   test "repeated subscriptions do not accumulate duplicate monitors" do

--- a/test/bedrock/cluster/tsl_delta_round_trip_test.exs
+++ b/test/bedrock/cluster/tsl_delta_round_trip_test.exs
@@ -1,0 +1,219 @@
+defmodule Bedrock.Cluster.TSLDeltaRoundTripTest do
+  @moduledoc """
+  Round-trip test for post-recovery TSL delta application:
+
+      Director.apply_tsl_delta/3
+        -> Coordinator {:notify_transaction_system_layout, tsl}
+        -> Coordinator broadcasts {:tsl_updated, tsl} to subscribed Links
+        -> Link serves the new TSL via fetch_transaction_system_layout/1
+
+  Uses the real `Link.Server` GenServer and thin harness GenServers that
+  delegate their callbacks to the real `Coordinator.Server` and
+  `Director.Server` handler functions (skipping only their heavyweight
+  `init` paths: raft bootstrap and recovery).
+  """
+  use ExUnit.Case, async: false
+
+  alias Bedrock.Cluster.Descriptor
+  alias Bedrock.Cluster.Link
+  alias Bedrock.ControlPlane.Coordinator
+  alias Bedrock.ControlPlane.Coordinator.Server
+  alias Bedrock.ControlPlane.Director
+
+  @coordinator_otp_name :tsl_round_trip_coordinator
+
+  defmodule TestCluster do
+    @moduledoc false
+
+    @spec otp_name(atom()) :: atom()
+    def otp_name(:coordinator), do: :tsl_round_trip_coordinator
+    def otp_name(component), do: :"tsl_round_trip_#{component}"
+
+    @spec gateway_ping_timeout_in_ms() :: pos_integer()
+    def gateway_ping_timeout_in_ms, do: 100
+
+    @spec coordinator_ping_timeout_in_ms() :: pos_integer()
+    def coordinator_ping_timeout_in_ms, do: 100
+  end
+
+  defmodule CoordinatorHarness do
+    @moduledoc false
+    use GenServer
+
+    @impl true
+    def init(state), do: {:ok, state}
+
+    @impl true
+    defdelegate handle_call(message, from, state), to: Server
+
+    @impl true
+    defdelegate handle_cast(message, state), to: Server
+
+    @impl true
+    defdelegate handle_info(message, state), to: Server
+  end
+
+  defmodule DirectorHarness do
+    @moduledoc false
+    use GenServer
+
+    @impl true
+    def init(state), do: {:ok, state}
+
+    @impl true
+    defdelegate handle_call(message, from, state), to: Bedrock.ControlPlane.Director.Server
+  end
+
+  defp base_tsl(epoch) do
+    %{
+      id: 1,
+      epoch: epoch,
+      director: nil,
+      sequencer: nil,
+      rate_keeper: nil,
+      proxies: [],
+      resolvers: [],
+      logs: %{},
+      services: %{},
+      shard_layout: %{},
+      shard_materializers: %{}
+    }
+  end
+
+  defp start_coordinator(epoch) do
+    state = %Coordinator.State{
+      cluster: TestCluster,
+      my_node: Node.self(),
+      leader_node: Node.self(),
+      epoch: epoch,
+      otp_name: @coordinator_otp_name
+    }
+
+    start_supervised!(%{
+      id: CoordinatorHarness,
+      start: {GenServer, :start_link, [CoordinatorHarness, state, [name: @coordinator_otp_name]]}
+    })
+  end
+
+  defp start_director(epoch, coordinator) do
+    state = %Director.State{
+      state: :running,
+      epoch: epoch,
+      cluster: TestCluster,
+      coordinator: coordinator,
+      transaction_system_layout: base_tsl(epoch)
+    }
+
+    start_supervised!(%{
+      id: DirectorHarness,
+      start: {GenServer, :start_link, [DirectorHarness, state]}
+    })
+  end
+
+  defp start_link_server do
+    descriptor = %Descriptor{cluster_name: "tsl_round_trip", coordinator_nodes: [Node.self()]}
+
+    start_supervised!(%{
+      id: Link.Server,
+      start: {GenServer, :start_link, [Link.Server, {TestCluster, "/dev/null", descriptor, :active, []}]}
+    })
+  end
+
+  defp eventually(fun, attempts \\ 50)
+  defp eventually(fun, 0), do: fun.() || flunk("condition never became true")
+
+  defp eventually(fun, attempts) do
+    result = fun.()
+
+    if result do
+      result
+    else
+      Process.sleep(10)
+      eventually(fun, attempts - 1)
+    end
+  end
+
+  test "director delta application propagates through the coordinator to a live Link" do
+    coordinator = start_coordinator(5)
+    link = start_link_server()
+
+    eventually(fn -> match?({:ok, _}, Link.fetch_coordinator(link)) end)
+    assert {:error, :unavailable} = Link.fetch_transaction_system_layout(link)
+
+    director = start_director(5, coordinator)
+    materializer = spawn(fn -> Process.sleep(:infinity) end)
+
+    assert :ok = Director.apply_tsl_delta(director, %{1 => materializer}, 5)
+
+    tsl =
+      eventually(fn ->
+        case Link.fetch_transaction_system_layout(link) do
+          {:ok, tsl} -> tsl
+          {:error, :unavailable} -> nil
+        end
+      end)
+
+    assert tsl.shard_materializers == %{1 => materializer}
+    assert tsl.epoch == 5
+  end
+
+  test "a delta carrying a stale epoch is rejected and nothing is broadcast" do
+    coordinator = start_coordinator(5)
+    link = start_link_server()
+
+    eventually(fn -> match?({:ok, _}, Link.fetch_coordinator(link)) end)
+
+    director = start_director(5, coordinator)
+    materializer = spawn(fn -> Process.sleep(:infinity) end)
+
+    assert {:error, :newer_epoch_exists} = Director.apply_tsl_delta(director, %{1 => materializer}, 4)
+
+    # Apply a valid delta afterwards; the first TSL the link observes must not
+    # contain any effect from the stale delta.
+    assert :ok = Director.apply_tsl_delta(director, %{2 => materializer}, 5)
+
+    tsl =
+      eventually(fn ->
+        case Link.fetch_transaction_system_layout(link) do
+          {:ok, tsl} -> tsl
+          {:error, :unavailable} -> nil
+        end
+      end)
+
+    assert tsl.shard_materializers == %{2 => materializer}
+  end
+
+  test "a dead subscriber does not break broadcast to remaining subscribers" do
+    coordinator = start_coordinator(5)
+
+    dead_link = spawn(fn -> :ok end)
+    ref = Process.monitor(dead_link)
+    assert_receive {:DOWN, ^ref, :process, ^dead_link, _}
+
+    :ok = Coordinator.subscribe_to_tsl_updates(coordinator, dead_link)
+    :ok = Coordinator.subscribe_to_tsl_updates(coordinator, self())
+
+    director = start_director(5, coordinator)
+    materializer = spawn(fn -> Process.sleep(:infinity) end)
+
+    assert :ok = Director.apply_tsl_delta(director, %{1 => materializer}, 5)
+
+    assert_receive {:tsl_updated, tsl}
+    assert tsl.shard_materializers == %{1 => materializer}
+  end
+
+  test "subscribing after a TSL is known delivers the current TSL immediately" do
+    coordinator = start_coordinator(5)
+    director = start_director(5, coordinator)
+    materializer = spawn(fn -> Process.sleep(:infinity) end)
+
+    assert :ok = Director.apply_tsl_delta(director, %{1 => materializer}, 5)
+
+    # Subscribe only after the coordinator already holds a TSL; we should be
+    # brought up to date without waiting for the next delta.
+    :ok = Coordinator.subscribe_to_tsl_updates(coordinator, self())
+
+    assert_receive {:tsl_updated, tsl}
+    assert tsl.shard_materializers == %{1 => materializer}
+  end
+end

--- a/test/bedrock/control_plane/coordinator/state_test.exs
+++ b/test/bedrock/control_plane/coordinator/state_test.exs
@@ -39,4 +39,52 @@ defmodule Bedrock.ControlPlane.Coordinator.StateTest do
       assert state.service_directory == %{}
     end
   end
+
+  describe "TSL subscriber state changes" do
+    test "add_tsl_subscriber is idempotent" do
+      state =
+        %State{}
+        |> Changes.add_tsl_subscriber(self())
+        |> Changes.add_tsl_subscriber(self())
+
+      assert state.tsl_subscribers == MapSet.new([self()])
+    end
+
+    test "remove_tsl_subscriber removes only the given subscriber" do
+      other = spawn(fn -> Process.sleep(:infinity) end)
+
+      state =
+        %State{}
+        |> Changes.add_tsl_subscriber(self())
+        |> Changes.add_tsl_subscriber(other)
+        |> Changes.remove_tsl_subscriber(other)
+
+      assert state.tsl_subscribers == MapSet.new([self()])
+    end
+
+    test "broadcast_tsl_update sends {:tsl_updated, tsl} to every subscriber" do
+      tsl = %{epoch: 1, shard_materializers: %{}}
+
+      state = Changes.add_tsl_subscriber(%State{}, self())
+
+      assert ^state = Changes.broadcast_tsl_update(state, tsl)
+      assert_receive {:tsl_updated, ^tsl}
+    end
+
+    test "broadcast_tsl_update tolerates dead subscribers" do
+      dead = spawn(fn -> :ok end)
+      ref = Process.monitor(dead)
+      assert_receive {:DOWN, ^ref, :process, ^dead, _}
+
+      tsl = %{epoch: 1, shard_materializers: %{}}
+
+      state =
+        %State{}
+        |> Changes.add_tsl_subscriber(dead)
+        |> Changes.add_tsl_subscriber(self())
+
+      assert ^state = Changes.broadcast_tsl_update(state, tsl)
+      assert_receive {:tsl_updated, ^tsl}
+    end
+  end
 end

--- a/test/bedrock/control_plane/coordinator/state_test.exs
+++ b/test/bedrock/control_plane/coordinator/state_test.exs
@@ -71,6 +71,18 @@ defmodule Bedrock.ControlPlane.Coordinator.StateTest do
       assert_receive {:tsl_updated, ^tsl}
     end
 
+    test "put_transaction_system_layout marks the TSL live; mark_tsl_stale clears it" do
+      tsl = %{epoch: 1, shard_materializers: %{}}
+
+      state = Changes.put_transaction_system_layout(%State{}, tsl)
+      assert state.tsl_live?
+
+      state = Changes.mark_tsl_stale(state)
+      refute state.tsl_live?
+      # The TSL itself is retained as recovery input.
+      assert state.transaction_system_layout == tsl
+    end
+
     test "broadcast_tsl_update tolerates dead subscribers" do
       dead = spawn(fn -> :ok end)
       ref = Process.monitor(dead)

--- a/test/bedrock/control_plane/director/tsl_delta_test.exs
+++ b/test/bedrock/control_plane/director/tsl_delta_test.exs
@@ -1,0 +1,131 @@
+defmodule Bedrock.ControlPlane.Director.TSLDeltaTest do
+  use ExUnit.Case, async: true
+
+  import Bedrock.Test.TelemetryTestHelper
+
+  alias Bedrock.ControlPlane.Director.Server
+  alias Bedrock.ControlPlane.Director.State
+
+  defp base_tsl(shard_materializers) do
+    %{
+      id: 1,
+      epoch: 5,
+      director: self(),
+      sequencer: nil,
+      rate_keeper: nil,
+      proxies: [],
+      resolvers: [],
+      logs: %{},
+      services: %{},
+      shard_layout: %{},
+      shard_materializers: shard_materializers
+    }
+  end
+
+  defp director_state(opts \\ []) do
+    %State{
+      state: :running,
+      epoch: Keyword.get(opts, :epoch, 5),
+      cluster: TestCluster,
+      coordinator: Keyword.get(opts, :coordinator, self()),
+      transaction_system_layout: Keyword.get(opts, :tsl, base_tsl(%{}))
+    }
+  end
+
+  describe "handle_call({:apply_tsl_delta, delta, epoch}, ...)" do
+    test "applies a put delta to shard_materializers and notifies the coordinator" do
+      materializer = spawn(fn -> Process.sleep(:infinity) end)
+      state = director_state()
+
+      assert {:reply, :ok, updated_state} =
+               Server.handle_call({:apply_tsl_delta, %{1 => materializer}, 5}, {self(), make_ref()}, state)
+
+      assert updated_state.transaction_system_layout.shard_materializers == %{1 => materializer}
+
+      assert_receive {:"$gen_cast", {:notify_transaction_system_layout, broadcast_tsl}}
+      assert broadcast_tsl == updated_state.transaction_system_layout
+    end
+
+    test "applies a :remove delta by deleting the shard entry" do
+      old_materializer = spawn(fn -> Process.sleep(:infinity) end)
+      state = director_state(tsl: base_tsl(%{1 => old_materializer, 2 => old_materializer}))
+
+      assert {:reply, :ok, updated_state} =
+               Server.handle_call({:apply_tsl_delta, %{1 => :remove}, 5}, {self(), make_ref()}, state)
+
+      assert updated_state.transaction_system_layout.shard_materializers == %{2 => old_materializer}
+    end
+
+    test "mixed delta puts and removes in one application" do
+      old_materializer = spawn(fn -> Process.sleep(:infinity) end)
+      new_materializer = spawn(fn -> Process.sleep(:infinity) end)
+      state = director_state(tsl: base_tsl(%{1 => old_materializer, 2 => old_materializer}))
+
+      delta = %{1 => new_materializer, 2 => :remove, 3 => new_materializer}
+
+      assert {:reply, :ok, updated_state} =
+               Server.handle_call({:apply_tsl_delta, delta, 5}, {self(), make_ref()}, state)
+
+      assert updated_state.transaction_system_layout.shard_materializers ==
+               %{1 => new_materializer, 3 => new_materializer}
+    end
+
+    test "creates the shard_materializers map when the TSL lacks one" do
+      materializer = spawn(fn -> Process.sleep(:infinity) end)
+      tsl = Map.delete(base_tsl(%{}), :shard_materializers)
+      state = director_state(tsl: tsl)
+
+      assert {:reply, :ok, updated_state} =
+               Server.handle_call({:apply_tsl_delta, %{7 => materializer}, 5}, {self(), make_ref()}, state)
+
+      assert updated_state.transaction_system_layout.shard_materializers == %{7 => materializer}
+    end
+
+    test "rejects a delta carrying a stale epoch with :newer_epoch_exists" do
+      state = director_state(epoch: 5)
+      materializer = spawn(fn -> Process.sleep(:infinity) end)
+
+      assert {:reply, {:error, :newer_epoch_exists}, unchanged_state} =
+               Server.handle_call({:apply_tsl_delta, %{1 => materializer}, 4}, {self(), make_ref()}, state)
+
+      assert unchanged_state.transaction_system_layout == state.transaction_system_layout
+      refute_receive {:"$gen_cast", {:notify_transaction_system_layout, _}}
+    end
+
+    test "rejects a delta carrying an unknown (newer) epoch with :newer_epoch_exists" do
+      state = director_state(epoch: 5)
+      materializer = spawn(fn -> Process.sleep(:infinity) end)
+
+      assert {:reply, {:error, :newer_epoch_exists}, _} =
+               Server.handle_call({:apply_tsl_delta, %{1 => materializer}, 6}, {self(), make_ref()}, state)
+
+      refute_receive {:"$gen_cast", {:notify_transaction_system_layout, _}}
+    end
+
+    test "rejects a delta before recovery has produced a TSL with :unavailable" do
+      state = director_state(tsl: nil)
+      materializer = spawn(fn -> Process.sleep(:infinity) end)
+
+      assert {:reply, {:error, :unavailable}, _} =
+               Server.handle_call({:apply_tsl_delta, %{1 => materializer}, 5}, {self(), make_ref()}, state)
+
+      refute_receive {:"$gen_cast", {:notify_transaction_system_layout, _}}
+    end
+
+    test "emits a tsl_delta_applied telemetry event" do
+      attach_telemetry_reflector(self(), [[:bedrock, :director, :tsl_delta_applied]], "tsl-delta-telemetry")
+
+      materializer = spawn(fn -> Process.sleep(:infinity) end)
+      delta = %{1 => materializer, 2 => :remove}
+      state = director_state()
+
+      assert {:reply, :ok, _} = Server.handle_call({:apply_tsl_delta, delta, 5}, {self(), make_ref()}, state)
+
+      assert_receive {:telemetry_event, [:bedrock, :director, :tsl_delta_applied], measurements, metadata}
+      assert measurements == %{shard_count: 2}
+      assert metadata.epoch == 5
+      assert metadata.cluster == TestCluster
+      assert metadata.delta == delta
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Makes the TSL updatable after recovery, with propagation to clients (bedrock-q67.4, Phase A of the shard-centric storage epic). Pure mechanism — no Distributor or placeholder (separate tickets).

### What already existed vs what's new

- The Link receiver for `{:tsl_updated, new_tsl}` already existed (`link/server.ex`).
- A sender **also already existed**: `Coordinator.State.Changes.broadcast_tsl_update/2` fires on every `put_transaction_system_layout`, and the Director already hands the recovery-built TSL to the coordinator via `notify_transaction_system_layout`. So `{:tsl_updated, ...}` was sent — but only once, at recovery completion. The TSL was static thereafter.
- New: a post-recovery **delta path** on the Director, and a subscription fix so capability-less Links actually receive broadcasts.

## Design notes

### Delta shape

```elixir
@type tsl_delta :: %{Bedrock.range_tag() => pid() | :remove}
```

Minimal map-merge semantics over `shard_materializers` only: a pid puts/replaces the shard's entry; `:remove` deletes it. Applied atomically per call; the rest of the TSL is untouched.

### Epoch guard

`Director.apply_tsl_delta(director, delta, epoch)` applies only when `epoch` exactly matches the director's own epoch; any other epoch (stale, or from a generation this director doesn't know) is rejected with `{:error, :newer_epoch_exists}`, mirroring the `lock_for_recovery` guards on data-plane services. `{:error, :unavailable}` before recovery has produced a TSL. On success the director updates its retained TSL (it already keeps it in `State.transaction_system_layout` — no restructuring needed) and reuses the existing `notify_transaction_system_layout` handoff to the coordinator, which broadcasts to all subscribers.

### Subscription mechanism

Piggybacked on existing machinery rather than building a new registry: the coordinator already held a monitored `tsl_subscribers` MapSet, but only populated it as a side effect of `register_node_resources` — which Links skip entirely when they have no capabilities (pure clients). Added an explicit, idempotent `Coordinator.subscribe_to_tsl_updates/2` cast; `Link.Discovery.change_coordinator/2` now calls it unconditionally on connect. New subscribers are immediately sent the current TSL if one is known (snapshot-then-updates), so late-connecting links don't wait for the next delta. Dead subscribers are pruned via the existing `:DOWN` handling; `send/2` to a dead pid is a no-op, so a dead link never breaks a broadcast.

### Telemetry

`[:bedrock, :director, :tsl_delta_applied]` with `%{shard_count: n}` measurements and `%{cluster, epoch, delta}` metadata (`Director.Telemetry.trace_tsl_delta_applied/3`).

### Type fix

`Coordinator.ref()` now includes `pid()` — the Director already stores and calls the coordinator by pid; dialyzer flagged the omission once the new specs landed.

## Tests

- `test/bedrock/cluster/tsl_delta_round_trip_test.exs` — real `Link.Server` GenServer + thin harnesses delegating to the real `Coordinator.Server`/`Director.Server` handlers: director applies delta → coordinator broadcasts → Link observes the new TSL via `fetch_transaction_system_layout`. Plus stale-epoch rejection, dead-subscriber resilience, and snapshot-on-subscribe.
- `test/bedrock/control_plane/director/tsl_delta_test.exs` — put/remove/mixed delta semantics, missing `shard_materializers` map, epoch guards, `:unavailable` pre-recovery, telemetry event.
- Coordinator `state_test.exs` — subscriber add/remove idempotence, broadcast delivery, dead-subscriber tolerance.

Coordinator + director + cluster dirs green at seeds 0 and 424242; full suite green (2528 tests, 158 properties); `mix format`, `credo --strict`, and dialyzer clean.