### PR TITLE
Add placeholder materializer with bounded parking (bedrock-q67.3)

### DIFF
--- a/lib/bedrock/control_plane/distributor.ex
+++ b/lib/bedrock/control_plane/distributor.ex
@@ -55,4 +55,20 @@ defmodule Bedrock.ControlPlane.Distributor do
   """
   @spec notify_epoch_change(ref(), Bedrock.epoch()) :: :ok
   def notify_epoch_change(distributor, new_epoch), do: cast(distributor, {:epoch_changed, new_epoch})
+
+  @doc """
+  Internal/test seam: relays a coverage result to the placeholder, marking
+  the shard tag as covered by the given materializer. The recruitment flow
+  (bedrock-q67.5) will deliver coverage outcomes through this same path.
+  """
+  @spec deliver_coverage(ref(), Bedrock.range_tag(), materializer :: pid()) :: :ok
+  def deliver_coverage(distributor, tag, materializer), do: cast(distributor, {:deliver_coverage, tag, materializer})
+
+  @doc """
+  Internal/test seam: relays a coverage failure to the placeholder, which
+  sheds parked requests for the tag with `{:error, :unavailable}` and
+  clears the demand dedupe so a later request re-triggers recruitment.
+  """
+  @spec fail_coverage(ref(), Bedrock.range_tag(), reason :: term()) :: :ok
+  def fail_coverage(distributor, tag, reason), do: cast(distributor, {:fail_coverage, tag, reason})
 end

--- a/lib/bedrock/control_plane/distributor/placeholder.ex
+++ b/lib/bedrock/control_plane/distributor/placeholder.ex
@@ -1,0 +1,58 @@
+defmodule Bedrock.ControlPlane.Distributor.Placeholder do
+  @moduledoc """
+  The placeholder materializer: the cluster's fallback coverage endpoint.
+
+  One placeholder process runs per cluster, started and supervised by the
+  Distributor. Its pid fills every uncovered `shard_materializers` slot in
+  the transaction system layout, so from a client's perspective every shard
+  is always covered: the placeholder speaks the Materializer read API
+  (`{:get, key_or_selector, version, opts}` and
+  `{:get_range, start, end, version, opts}` GenServer calls) and clients
+  cannot distinguish it from a real materializer.
+
+  On each read request the placeholder resolves the shard tag from its own
+  copy of the shard layout, then:
+
+    * If a live materializer is already known for the tag (a `{:covered,
+      tag, pid}` notification arrived, but stale clients still hold the old
+      layout), the request is **forwarded** - re-issued against the live
+      materializer from a task, acting as a staleness shim until layout
+      updates propagate.
+    * Otherwise the request is **parked** in a per-tag waiting list with a
+      deadline of `min(caller timeout, hold_ms)` and a `{:coverage_demand,
+      tag}` signal is cast to the Distributor (at most one demand per tag
+      until the tag is covered or recruitment fails).
+
+  When the Distributor delivers `{:covered, tag, pid}` the tag's parked
+  requests are drained by re-issuing each against the new materializer.
+  When it delivers `{:coverage_failed, tag, reason}` - or a parked
+  request's deadline expires - waiters receive `{:error, :unavailable}`,
+  which clients already handle and retry.
+  """
+
+  use Bedrock.Internal.GenServerApi, for: __MODULE__.Server
+
+  @type ref :: pid() | atom() | {atom(), node()}
+
+  @default_hold_ms 2_000
+
+  @doc "The default maximum time a request may be parked awaiting coverage."
+  @spec default_hold_ms() :: pos_integer()
+  def default_hold_ms, do: @default_hold_ms
+
+  @doc """
+  Notifies the placeholder that a shard tag is now covered by a live
+  materializer. Parked requests for the tag are drained by re-issuing them
+  against the materializer, and subsequent requests are forwarded to it.
+  """
+  @spec notify_covered(ref(), Bedrock.range_tag(), materializer :: pid()) :: :ok
+  def notify_covered(placeholder, tag, materializer), do: cast(placeholder, {:covered, tag, materializer})
+
+  @doc """
+  Notifies the placeholder that recruitment for a shard tag has failed.
+  Parked requests for the tag are shed with `{:error, :unavailable}` and
+  the demand dedupe is cleared so a later request re-triggers recruitment.
+  """
+  @spec notify_coverage_failed(ref(), Bedrock.range_tag(), reason :: term()) :: :ok
+  def notify_coverage_failed(placeholder, tag, reason), do: cast(placeholder, {:coverage_failed, tag, reason})
+end

--- a/lib/bedrock/control_plane/distributor/placeholder/server.ex
+++ b/lib/bedrock/control_plane/distributor/placeholder/server.ex
@@ -1,0 +1,202 @@
+defmodule Bedrock.ControlPlane.Distributor.Placeholder.Server do
+  @moduledoc """
+  GenServer implementation of the placeholder materializer.
+
+  Accepts the exact read-path call shapes that real materializer servers
+  (olivine/basalt) handle - `{:get, key_or_selector, version, opts}` and
+  `{:get_range, start, end, version, opts}` - and either forwards them to a
+  live materializer (when one is known for the shard tag) or parks them in
+  a deadline-bounded waiting list while signaling coverage demand to the
+  Distributor.
+
+  Deadline expiry is timer-driven: every mutation of the waiting list
+  reschedules a `Process.send_after/3` for the earliest deadline, and
+  expired entries are shed with `{:error, :unavailable}`.
+  """
+
+  use GenServer
+
+  import Bedrock.ControlPlane.Distributor.Telemetry,
+    only: [
+      emit_placeholder_parked: 2,
+      emit_placeholder_forwarded: 2,
+      emit_placeholder_shed: 4,
+      emit_placeholder_drained: 3
+    ]
+
+  import Bedrock.Internal.GenServer.Replies
+
+  alias Bedrock.ControlPlane.Config.TransactionSystemLayout
+  alias Bedrock.ControlPlane.Distributor.Placeholder
+  alias Bedrock.ControlPlane.Distributor.Placeholder.State
+  alias Bedrock.DataPlane.Materializer
+  alias Bedrock.Internal.WaitingList
+  alias Bedrock.KeySelector
+
+  @doc false
+  @spec child_spec(
+          opts :: [
+            cluster: module(),
+            distributor: pid(),
+            shard_layout: TransactionSystemLayout.shard_layout(),
+            hold_ms: pos_integer(),
+            otp_name: atom()
+          ]
+        ) :: Supervisor.child_spec()
+  def child_spec(opts) do
+    cluster = opts[:cluster] || raise "Missing :cluster option"
+    distributor = opts[:distributor] || raise "Missing :distributor option"
+    shard_layout = opts[:shard_layout] || %{}
+    hold_ms = opts[:hold_ms] || Placeholder.default_hold_ms()
+
+    start_opts =
+      case opts[:otp_name] do
+        nil -> []
+        otp_name -> [name: otp_name]
+      end
+
+    %{
+      id: {__MODULE__, cluster},
+      start:
+        {GenServer, :start_link,
+         [
+           __MODULE__,
+           {cluster, distributor, shard_layout, hold_ms},
+           start_opts
+         ]},
+      restart: :temporary
+    }
+  end
+
+  @impl true
+  @spec init({module(), pid(), TransactionSystemLayout.shard_layout(), pos_integer()}) ::
+          {:ok, State.t()}
+  def init({cluster, distributor, shard_layout, hold_ms}) do
+    {:ok,
+     %State{
+       cluster: cluster,
+       distributor: distributor,
+       shard_layout: shard_layout,
+       hold_ms: hold_ms
+     }}
+  end
+
+  @impl true
+  def handle_call({:get, key_or_selector, _version, opts} = request, from, %State{} = t),
+    do: handle_read(t, racing_key(key_or_selector), request, opts, from)
+
+  def handle_call({:get_range, start_key_or_selector, _end, _version, opts} = request, from, %State{} = t),
+    do: handle_read(t, racing_key(start_key_or_selector), request, opts, from)
+
+  @impl true
+  def handle_cast({:covered, tag, materializer}, %State{} = t) do
+    {waiting, entries} = WaitingList.remove_all(t.waiting, tag)
+
+    Enum.each(entries, fn {_deadline, reply_fn, request} ->
+      {:ok, _pid} = Task.start(fn -> reply_fn.(reissue(materializer, request)) end)
+    end)
+
+    emit_placeholder_drained(t.cluster, tag, length(entries))
+
+    t =
+      %{
+        t
+        | waiting: waiting,
+          covered: Map.put(t.covered, tag, materializer),
+          demanded: MapSet.delete(t.demanded, tag)
+      }
+
+    t |> reschedule_expiry() |> noreply()
+  end
+
+  def handle_cast({:coverage_failed, tag, reason}, %State{} = t) do
+    {waiting, entries} = WaitingList.remove_all(t.waiting, tag)
+    WaitingList.reply_to_expired(entries, {:error, :unavailable})
+
+    emit_placeholder_shed(t.cluster, tag, length(entries), reason)
+
+    t = %{t | waiting: waiting, demanded: MapSet.delete(t.demanded, tag)}
+    t |> reschedule_expiry() |> noreply()
+  end
+
+  @impl true
+  def handle_info(:expire_waiting, %State{} = t) do
+    {waiting, expired} = WaitingList.expire(t.waiting)
+    WaitingList.reply_to_expired(expired, {:error, :unavailable})
+
+    if expired != [], do: emit_placeholder_shed(t.cluster, nil, length(expired), :deadline_expired)
+
+    %{t | waiting: waiting, expiry_timer: nil} |> reschedule_expiry() |> noreply()
+  end
+
+  def handle_info(_message, %State{} = t), do: noreply(t)
+
+  # Read handling
+
+  defp handle_read(%State{} = t, key, request, opts, from) do
+    case State.resolve_tag(t, key) do
+      {:ok, tag} ->
+        case Map.fetch(t.covered, tag) do
+          {:ok, materializer} -> forward(t, tag, materializer, request, from)
+          :error -> park(t, tag, request, opts, from)
+        end
+
+      {:error, :no_shard} ->
+        reply(t, {:error, :unavailable})
+    end
+  end
+
+  defp forward(%State{} = t, tag, materializer, request, from) do
+    emit_placeholder_forwarded(t.cluster, tag)
+
+    {:ok, _pid} = Task.start(fn -> GenServer.reply(from, reissue(materializer, request)) end)
+
+    noreply(t)
+  end
+
+  defp park(%State{} = t, tag, request, opts, from) do
+    budget_ms = State.parking_budget_ms(t, opts[:timeout])
+    reply_fn = fn result -> GenServer.reply(from, result) end
+    {waiting, _next_timeout} = WaitingList.insert(t.waiting, tag, request, reply_fn, budget_ms)
+
+    emit_placeholder_parked(t.cluster, tag)
+
+    t
+    |> struct!(waiting: waiting)
+    |> signal_demand(tag)
+    |> reschedule_expiry()
+    |> noreply()
+  end
+
+  defp signal_demand(%State{} = t, tag) do
+    if MapSet.member?(t.demanded, tag) do
+      t
+    else
+      # The demand telemetry event is emitted by the Distributor on receipt.
+      GenServer.cast(t.distributor, {:coverage_demand, tag})
+      %{t | demanded: MapSet.put(t.demanded, tag)}
+    end
+  end
+
+  # Re-issue a parked or forwarded request against a live materializer,
+  # using the same client API the original caller used.
+  defp reissue(materializer, {:get, key_or_selector, version, opts}),
+    do: Materializer.get(materializer, key_or_selector, version, opts)
+
+  defp reissue(materializer, {:get_range, start_key_or_selector, end_key_or_selector, version, opts}),
+    do: Materializer.get_range(materializer, start_key_or_selector, end_key_or_selector, version, opts)
+
+  defp racing_key(%KeySelector{key: key}), do: key
+  defp racing_key(key) when is_binary(key), do: key
+
+  # Timer-driven expiry: keep a single timer armed for the earliest deadline
+  # across the waiting list, rescheduling on every mutation.
+  defp reschedule_expiry(%State{} = t) do
+    if t.expiry_timer, do: Process.cancel_timer(t.expiry_timer)
+
+    case WaitingList.next_timeout(t.waiting) do
+      :infinity -> %{t | expiry_timer: nil}
+      timeout_ms -> %{t | expiry_timer: Process.send_after(self(), :expire_waiting, timeout_ms)}
+    end
+  end
+end

--- a/lib/bedrock/control_plane/distributor/placeholder/server.ex
+++ b/lib/bedrock/control_plane/distributor/placeholder/server.ex
@@ -126,7 +126,11 @@ defmodule Bedrock.ControlPlane.Distributor.Placeholder.Server do
 
     if expired != [], do: emit_placeholder_shed(t.cluster, nil, length(expired), :deadline_expired)
 
-    %{t | waiting: waiting, expiry_timer: nil} |> reschedule_expiry() |> noreply()
+    # Note: this message may be stale - a mutation since the timer fired may
+    # have re-armed `expiry_timer` with a new, still-live timer. Keep the ref
+    # so `reschedule_expiry/1` cancels it rather than leaking a duplicate
+    # timer; expiry itself is idempotent (only past-deadline entries shed).
+    %{t | waiting: waiting} |> reschedule_expiry() |> noreply()
   end
 
   def handle_info(_message, %State{} = t), do: noreply(t)

--- a/lib/bedrock/control_plane/distributor/placeholder/state.ex
+++ b/lib/bedrock/control_plane/distributor/placeholder/state.ex
@@ -1,0 +1,57 @@
+defmodule Bedrock.ControlPlane.Distributor.Placeholder.State do
+  @moduledoc """
+  Internal state structure for the placeholder materializer process.
+  """
+
+  alias Bedrock.ControlPlane.Config.TransactionSystemLayout
+  alias Bedrock.Internal.WaitingList
+
+  @unbounded_end_key <<0xFF, 0xFF>>
+
+  @type t :: %__MODULE__{
+          cluster: module(),
+          distributor: pid(),
+          shard_layout: TransactionSystemLayout.shard_layout(),
+          hold_ms: pos_integer(),
+          waiting: WaitingList.t(),
+          covered: %{Bedrock.range_tag() => pid()},
+          demanded: MapSet.t(Bedrock.range_tag()),
+          expiry_timer: reference() | nil
+        }
+  defstruct cluster: nil,
+            distributor: nil,
+            shard_layout: %{},
+            hold_ms: 2_000,
+            waiting: %{},
+            covered: %{},
+            demanded: MapSet.new(),
+            expiry_timer: nil
+
+  @doc """
+  Resolves the shard tag responsible for a key from the placeholder's copy
+  of the shard layout (`%{end_key => {tag, start_key}}`). The end key
+  `<<0xFF, 0xFF>>` is treated as the unbounded sentinel, matching
+  `LayoutIndex` semantics.
+  """
+  @spec resolve_tag(t(), Bedrock.key()) :: {:ok, Bedrock.range_tag()} | {:error, :no_shard}
+  def resolve_tag(%__MODULE__{shard_layout: shard_layout}, key) do
+    shard_layout
+    |> Enum.find(fn {end_key, {_tag, start_key}} ->
+      start_key <= key and (key < end_key or end_key == @unbounded_end_key)
+    end)
+    |> case do
+      {_end_key, {tag, _start_key}} -> {:ok, tag}
+      nil -> {:error, :no_shard}
+    end
+  end
+
+  @doc """
+  Computes the parking budget for a request: the minimum of the
+  caller-supplied timeout (if any and finite) and the configured `hold_ms`.
+  """
+  @spec parking_budget_ms(t(), caller_timeout :: timeout() | nil) :: non_neg_integer()
+  def parking_budget_ms(%__MODULE__{hold_ms: hold_ms}, caller_timeout)
+      when is_integer(caller_timeout) and caller_timeout >= 0, do: min(caller_timeout, hold_ms)
+
+  def parking_budget_ms(%__MODULE__{hold_ms: hold_ms}, _caller_timeout), do: hold_ms
+end

--- a/lib/bedrock/control_plane/distributor/server.ex
+++ b/lib/bedrock/control_plane/distributor/server.ex
@@ -161,6 +161,12 @@ defmodule Bedrock.ControlPlane.Distributor.Server do
 
   # The placeholder is linked (so it dies with the distributor) and its
   # exit is caught via trap_exit above so the distributor can restart it.
+  #
+  # A restarted placeholder loses its `covered` and `demanded` state while
+  # `pending_demands` here survives, so the recruitment flow (bedrock-q67.5)
+  # must tolerate duplicate `{:coverage_demand, tag}` casts for tags already
+  # pending, and should re-deliver coverage if a delivery races a restart
+  # (a `notify_covered` cast to the dead pid is silently dropped).
   @spec start_placeholder(State.t()) :: State.t()
   defp start_placeholder(%State{} = t) do
     {:ok, placeholder} =

--- a/lib/bedrock/control_plane/distributor/server.ex
+++ b/lib/bedrock/control_plane/distributor/server.ex
@@ -17,12 +17,14 @@ defmodule Bedrock.ControlPlane.Distributor.Server do
   import Bedrock.ControlPlane.Distributor.Telemetry,
     only: [
       emit_distributor_started: 3,
-      emit_distributor_stopped: 3
+      emit_distributor_stopped: 3,
+      emit_coverage_demand: 2
     ]
 
   import Bedrock.Internal.GenServer.Replies
 
   alias Bedrock.ControlPlane.Config.TransactionSystemLayout
+  alias Bedrock.ControlPlane.Distributor.Placeholder
   alias Bedrock.ControlPlane.Distributor.State
 
   require Logger
@@ -62,18 +64,20 @@ defmodule Bedrock.ControlPlane.Distributor.Server do
           {:ok, State.t()}
   def init({cluster, epoch, director, shard_layout}) do
     # Monitor the Director - if it dies, this distributor should terminate
-    # and let the next director recruit a fresh one.
+    # and let the next director recruit a fresh one. Trap exits so the
+    # linked placeholder can be restarted when it dies.
+    Process.flag(:trap_exit, true)
     Process.monitor(director)
 
     emit_distributor_started(cluster, epoch, director)
 
     {:ok,
-     %State{
+     start_placeholder(%State{
        cluster: cluster,
        epoch: epoch,
        director: director,
        shard_layout: shard_layout
-     }}
+     })}
   end
 
   @impl true
@@ -103,11 +107,41 @@ defmodule Bedrock.ControlPlane.Distributor.Server do
     end
   end
 
+  # Coverage demand from the placeholder. Recruitment itself lands in a
+  # later ticket (bedrock-q67.5); for now the demand is logged, counted,
+  # and remembered so the recruitment flow can pick it up.
+  def handle_cast({:coverage_demand, tag}, %State{} = t) do
+    Logger.info("Distributor for epoch #{t.epoch} received coverage demand for shard tag #{inspect(tag)}")
+    emit_coverage_demand(t.cluster, tag)
+
+    noreply(%{t | pending_demands: MapSet.put(t.pending_demands, tag)})
+  end
+
+  # Internal/test seam until the recruitment flow (bedrock-q67.5) delivers
+  # coverage outcomes itself: relay a coverage result to the placeholder.
+  def handle_cast({:deliver_coverage, tag, materializer}, %State{} = t) do
+    if t.placeholder, do: Placeholder.notify_covered(t.placeholder, tag, materializer)
+
+    noreply(%{t | pending_demands: MapSet.delete(t.pending_demands, tag)})
+  end
+
+  def handle_cast({:fail_coverage, tag, reason}, %State{} = t) do
+    if t.placeholder, do: Placeholder.notify_coverage_failed(t.placeholder, tag, reason)
+
+    noreply(%{t | pending_demands: MapSet.delete(t.pending_demands, tag)})
+  end
+
   @impl true
   def handle_info({:DOWN, _ref, :process, director, reason}, %State{director: director} = t) do
     Logger.info("Distributor for epoch #{t.epoch} stopping: director exited (#{inspect(reason)})")
 
     stop(t, :normal)
+  end
+
+  def handle_info({:EXIT, placeholder, reason}, %State{placeholder: placeholder} = t) do
+    Logger.warning("Distributor for epoch #{t.epoch} restarting placeholder (exited: #{inspect(reason)})")
+
+    noreply(start_placeholder(t))
   end
 
   def handle_info(message, %State{} = t) do
@@ -117,7 +151,24 @@ defmodule Bedrock.ControlPlane.Distributor.Server do
 
   @impl true
   def terminate(reason, %State{} = t) do
+    # A `:normal` exit signal would be ignored by the linked placeholder,
+    # so shut it down explicitly to avoid orphaning it.
+    if t.placeholder && Process.alive?(t.placeholder), do: Process.exit(t.placeholder, :shutdown)
+
     emit_distributor_stopped(t.cluster, t.epoch, reason)
     :ok
+  end
+
+  # The placeholder is linked (so it dies with the distributor) and its
+  # exit is caught via trap_exit above so the distributor can restart it.
+  @spec start_placeholder(State.t()) :: State.t()
+  defp start_placeholder(%State{} = t) do
+    {:ok, placeholder} =
+      GenServer.start_link(
+        Placeholder.Server,
+        {t.cluster, self(), t.shard_layout, Placeholder.default_hold_ms()}
+      )
+
+    %{t | placeholder: placeholder}
   end
 end

--- a/lib/bedrock/control_plane/distributor/state.ex
+++ b/lib/bedrock/control_plane/distributor/state.ex
@@ -11,14 +11,16 @@ defmodule Bedrock.ControlPlane.Distributor.State do
           director: pid(),
           shard_layout: TransactionSystemLayout.shard_layout(),
           materializer_monitors: %{reference() => Bedrock.range_tag()},
-          placeholder: pid() | nil
+          placeholder: pid() | nil,
+          pending_demands: MapSet.t(Bedrock.range_tag())
         }
   defstruct cluster: nil,
             epoch: nil,
             director: nil,
             shard_layout: %{},
             materializer_monitors: %{},
-            placeholder: nil
+            placeholder: nil,
+            pending_demands: MapSet.new()
 
   @doc """
   Validates a caller-supplied epoch against the distributor's own epoch.

--- a/lib/bedrock/control_plane/distributor/telemetry.ex
+++ b/lib/bedrock/control_plane/distributor/telemetry.ex
@@ -20,4 +20,49 @@ defmodule Bedrock.ControlPlane.Distributor.Telemetry do
       %{cluster: cluster, epoch: epoch, reason: reason}
     )
   end
+
+  @spec emit_coverage_demand(module(), Bedrock.range_tag()) :: :ok
+  def emit_coverage_demand(cluster, tag) do
+    :telemetry.execute(
+      [:bedrock, :distributor, :coverage_demand],
+      %{},
+      %{cluster: cluster, tag: tag}
+    )
+  end
+
+  @spec emit_placeholder_parked(module(), Bedrock.range_tag()) :: :ok
+  def emit_placeholder_parked(cluster, tag) do
+    :telemetry.execute(
+      [:bedrock, :distributor, :placeholder, :parked],
+      %{count: 1},
+      %{cluster: cluster, tag: tag}
+    )
+  end
+
+  @spec emit_placeholder_forwarded(module(), Bedrock.range_tag()) :: :ok
+  def emit_placeholder_forwarded(cluster, tag) do
+    :telemetry.execute(
+      [:bedrock, :distributor, :placeholder, :forwarded],
+      %{count: 1},
+      %{cluster: cluster, tag: tag}
+    )
+  end
+
+  @spec emit_placeholder_drained(module(), Bedrock.range_tag(), count :: non_neg_integer()) :: :ok
+  def emit_placeholder_drained(cluster, tag, count) do
+    :telemetry.execute(
+      [:bedrock, :distributor, :placeholder, :drained],
+      %{count: count},
+      %{cluster: cluster, tag: tag}
+    )
+  end
+
+  @spec emit_placeholder_shed(module(), Bedrock.range_tag() | nil, count :: non_neg_integer(), reason :: term()) :: :ok
+  def emit_placeholder_shed(cluster, tag, count, reason) do
+    :telemetry.execute(
+      [:bedrock, :distributor, :placeholder, :shed],
+      %{count: count},
+      %{cluster: cluster, tag: tag, reason: reason}
+    )
+  end
 end

--- a/lib/bedrock/internal/waiting_list.ex
+++ b/lib/bedrock/internal/waiting_list.ex
@@ -1,9 +1,11 @@
 defmodule Bedrock.Internal.WaitingList do
   @moduledoc """
-  Unified waiting list for version-based out-of-order request handling.
+  Unified waiting list for out-of-order request handling.
 
   Supports both single-waiter (Resolver) and multi-waiter (LongPulls) patterns
-  using a map of deadline-sorted lists.
+  using a map of deadline-sorted lists. Entries are typically keyed by
+  version, but any ordered key works (the Distributor's placeholder keys by
+  shard tag).
 
   Structure: %{version => [{deadline, reply_fn, data}, ...]}
   Lists are sorted by deadline (earliest first).
@@ -11,7 +13,7 @@ defmodule Bedrock.Internal.WaitingList do
 
   alias Bedrock.Internal.Time
 
-  @type version :: Bedrock.version()
+  @type version :: Bedrock.version() | Bedrock.range_tag()
   @type reply_fn :: (any() -> :ok)
   @type timeout_ms :: non_neg_integer()
 

--- a/test/bedrock/control_plane/distributor/placeholder_integration_test.exs
+++ b/test/bedrock/control_plane/distributor/placeholder_integration_test.exs
@@ -1,0 +1,111 @@
+defmodule Bedrock.ControlPlane.Distributor.PlaceholderIntegrationTest do
+  @moduledoc """
+  Drives a read through the whole client path - PointReads/RangeReads →
+  StorageRacing → LayoutIndex → Materializer client API - against a layout
+  whose shard slot holds the placeholder pid, proving that clients cannot
+  tell the placeholder apart from a real materializer: the request parks,
+  coverage arrives, and the client receives the real value.
+  """
+  use ExUnit.Case, async: true
+
+  alias Bedrock.ControlPlane.Distributor.Placeholder
+  alias Bedrock.DataPlane.Version
+  alias Bedrock.Internal.TransactionBuilder.LayoutIndex
+  alias Bedrock.Internal.TransactionBuilder.PointReads
+  alias Bedrock.Internal.TransactionBuilder.RangeReads
+  alias Bedrock.Internal.TransactionBuilder.State
+  alias Bedrock.Test.ControlPlane.StubMaterializer
+
+  defmodule TestCluster do
+    @moduledoc false
+  end
+
+  # A single data shard (tag 1) covering the whole keyspace.
+  @shard_layout %{<<0xFF, 0xFF>> => {1, <<>>}}
+  @version Version.from_integer(1)
+
+  defp start_placeholder(opts \\ []) do
+    start_supervised!(
+      Placeholder.Server.child_spec(
+        cluster: TestCluster,
+        distributor: self(),
+        shard_layout: @shard_layout,
+        hold_ms: Keyword.get(opts, :hold_ms, 2_000)
+      )
+    )
+  end
+
+  defp start_stub(kvs) do
+    start_supervised!(%{
+      id: {StubMaterializer, System.unique_integer([:positive])},
+      start: {StubMaterializer, :start_link, [kvs]}
+    })
+  end
+
+  defp client_state(placeholder, opts \\ []) do
+    layout_index =
+      LayoutIndex.build_index(%{
+        shard_layout: @shard_layout,
+        shard_materializers: %{1 => placeholder}
+      })
+
+    %State{
+      state: :valid,
+      layout_index: layout_index,
+      read_version: @version,
+      fetch_timeout_in_ms: Keyword.get(opts, :fetch_timeout_in_ms, 1_000)
+    }
+  end
+
+  test "a get through the full client path parks, then succeeds after coverage" do
+    placeholder = start_placeholder()
+    state = client_state(placeholder)
+
+    task = Task.async(fn -> PointReads.get_key(state, "apple") end)
+
+    # The client's read is parked; the placeholder signaled coverage demand.
+    assert_receive {:"$gen_cast", {:coverage_demand, 1}}
+
+    stub = start_stub(%{"apple" => "red"})
+    :ok = Placeholder.notify_covered(placeholder, 1, stub)
+
+    assert {%State{}, {:ok, {"apple", "red"}}} = Task.await(task, 2_000)
+  end
+
+  test "a range read through the full client path parks, then succeeds after coverage" do
+    placeholder = start_placeholder()
+    state = client_state(placeholder)
+
+    task = Task.async(fn -> RangeReads.get_range(state, {"a", "c"}, 100) end)
+
+    assert_receive {:"$gen_cast", {:coverage_demand, 1}}
+
+    stub = start_stub(%{"apple" => "red", "banana" => "yellow", "zebra" => "striped"})
+    :ok = Placeholder.notify_covered(placeholder, 1, stub)
+
+    assert {%State{}, {:ok, {[{"apple", "red"}, {"banana", "yellow"}], false}}} = Task.await(task, 2_000)
+  end
+
+  test "a get through the full client path fails with :unavailable when coverage never arrives" do
+    placeholder = start_placeholder(hold_ms: 30)
+    state = client_state(placeholder)
+
+    task = Task.async(fn -> PointReads.get_key(state, "apple") end)
+
+    assert_receive {:"$gen_cast", {:coverage_demand, 1}}
+
+    assert {%State{}, {:failure, %{unavailable: [^placeholder]}}} = Task.await(task, 2_000)
+  end
+
+  test "after coverage, stale clients still racing the placeholder are forwarded" do
+    placeholder = start_placeholder()
+    stub = start_stub(%{"apple" => "red"})
+    :ok = Placeholder.notify_covered(placeholder, 1, stub)
+
+    # This client's layout still points at the placeholder (stale TSL).
+    state = client_state(placeholder)
+
+    assert {%State{}, {:ok, {"apple", "red"}}} = PointReads.get_key(state, "apple")
+    refute_receive {:"$gen_cast", {:coverage_demand, _tag}}, 50
+  end
+end

--- a/test/bedrock/control_plane/distributor/placeholder_test.exs
+++ b/test/bedrock/control_plane/distributor/placeholder_test.exs
@@ -1,0 +1,255 @@
+defmodule Bedrock.ControlPlane.Distributor.PlaceholderTest do
+  use ExUnit.Case, async: true
+
+  alias Bedrock.ControlPlane.Distributor.Placeholder
+  alias Bedrock.DataPlane.Materializer
+  alias Bedrock.DataPlane.Version
+  alias Bedrock.KeySelector
+  alias Bedrock.Test.ControlPlane.StubMaterializer
+
+  defmodule TestCluster do
+    @moduledoc false
+  end
+
+  # Layout: tag 1 covers [<<>>, "m"), tag 2 covers ["m", <<0xFF, 0xFF>>).
+  @shard_layout %{
+    "m" => {1, <<>>},
+    <<0xFF, 0xFF>> => {2, "m"}
+  }
+
+  @version Version.from_integer(1)
+
+  defp start_placeholder(opts \\ []) do
+    start_supervised!(
+      Placeholder.Server.child_spec(
+        cluster: TestCluster,
+        distributor: Keyword.get(opts, :distributor, self()),
+        shard_layout: Keyword.get(opts, :shard_layout, @shard_layout),
+        hold_ms: Keyword.get(opts, :hold_ms, 2_000)
+      )
+    )
+  end
+
+  defp start_stub(kvs) do
+    start_supervised!(%{
+      id: {StubMaterializer, System.unique_integer([:positive])},
+      start: {StubMaterializer, :start_link, [kvs]}
+    })
+  end
+
+  defp async_get(placeholder, key, opts \\ []),
+    do: Task.async(fn -> Materializer.get(placeholder, key, @version, opts) end)
+
+  defp attach_telemetry(test_pid) do
+    handler_id = "placeholder-test-#{System.unique_integer([:positive])}"
+
+    :telemetry.attach_many(
+      handler_id,
+      [
+        [:bedrock, :distributor, :placeholder, :parked],
+        [:bedrock, :distributor, :placeholder, :forwarded],
+        [:bedrock, :distributor, :placeholder, :drained],
+        [:bedrock, :distributor, :placeholder, :shed]
+      ],
+      fn event, measurements, metadata, _config ->
+        send(test_pid, {:telemetry, event, measurements, metadata})
+      end,
+      nil
+    )
+
+    on_exit(fn -> :telemetry.detach(handler_id) end)
+  end
+
+  describe "park then cover" do
+    test "parked get is drained with the real value once coverage arrives" do
+      attach_telemetry(self())
+      placeholder = start_placeholder()
+      stub = start_stub(%{"apple" => "red"})
+
+      task = async_get(placeholder, "apple", timeout: 1_000)
+
+      assert_receive {:"$gen_cast", {:coverage_demand, 1}}
+      assert_receive {:telemetry, [:bedrock, :distributor, :placeholder, :parked], %{count: 1}, %{tag: 1}}
+
+      :ok = Placeholder.notify_covered(placeholder, 1, stub)
+
+      assert {:ok, "red"} = Task.await(task, 1_000)
+      assert_receive {:telemetry, [:bedrock, :distributor, :placeholder, :drained], %{count: 1}, %{tag: 1}}
+    end
+
+    test "parked key-selector get is drained with the resolved key-value" do
+      placeholder = start_placeholder()
+      stub = start_stub(%{"apple" => "red"})
+
+      selector = KeySelector.first_greater_or_equal("apple")
+      task = Task.async(fn -> Materializer.get(placeholder, selector, @version, timeout: 1_000) end)
+
+      assert_receive {:"$gen_cast", {:coverage_demand, 1}}
+      :ok = Placeholder.notify_covered(placeholder, 1, stub)
+
+      assert {:ok, {"apple", "red"}} = Task.await(task, 1_000)
+    end
+
+    test "parked get_range is drained with the shard's key-values" do
+      placeholder = start_placeholder()
+      stub = start_stub(%{"apple" => "red", "banana" => "yellow", "zebra" => "striped"})
+
+      task = Task.async(fn -> Materializer.get_range(placeholder, "a", "c", @version, timeout: 1_000) end)
+
+      assert_receive {:"$gen_cast", {:coverage_demand, 1}}
+      :ok = Placeholder.notify_covered(placeholder, 1, stub)
+
+      assert {:ok, {[{"apple", "red"}, {"banana", "yellow"}], false}} = Task.await(task, 1_000)
+    end
+
+    test "draining multiple parked requests replies to every waiter" do
+      placeholder = start_placeholder()
+      stub = start_stub(%{"apple" => "red", "cherry" => "dark red"})
+
+      task_a = async_get(placeholder, "apple", timeout: 1_000)
+      task_b = async_get(placeholder, "cherry", timeout: 1_000)
+
+      assert_receive {:"$gen_cast", {:coverage_demand, 1}}
+      :ok = Placeholder.notify_covered(placeholder, 1, stub)
+
+      assert {:ok, "red"} = Task.await(task_a, 1_000)
+      assert {:ok, "dark red"} = Task.await(task_b, 1_000)
+    end
+  end
+
+  describe "deadline expiry" do
+    test "parked request is shed with :unavailable when hold_ms expires" do
+      attach_telemetry(self())
+      placeholder = start_placeholder(hold_ms: 30)
+
+      task = async_get(placeholder, "apple", timeout: 1_000)
+
+      assert {:error, :unavailable} = Task.await(task, 1_000)
+
+      assert_receive {:telemetry, [:bedrock, :distributor, :placeholder, :shed], %{count: 1},
+                      %{reason: :deadline_expired}}
+    end
+
+    test "caller-supplied timeout below hold_ms bounds the parking budget" do
+      placeholder = start_placeholder(hold_ms: 5_000)
+
+      # Call directly with a generous GenServer timeout so the placeholder's
+      # budget (opts[:timeout] = 30ms) is what trips, not the client call.
+      task =
+        Task.async(fn ->
+          GenServer.call(placeholder, {:get, "apple", @version, [timeout: 30]}, 1_000)
+        end)
+
+      assert {:error, :unavailable} = Task.await(task, 1_000)
+    end
+
+    test "expiry only sheds entries past their deadline" do
+      placeholder = start_placeholder(hold_ms: 5_000)
+      stub = start_stub(%{"apple" => "red"})
+
+      short_task =
+        Task.async(fn ->
+          GenServer.call(placeholder, {:get, "apple", @version, [timeout: 30]}, 1_000)
+        end)
+
+      long_task = async_get(placeholder, "apple", timeout: 5_000)
+
+      assert {:error, :unavailable} = Task.await(short_task, 1_000)
+
+      # The longer-deadline waiter is still parked and drains on coverage.
+      :ok = Placeholder.notify_covered(placeholder, 1, stub)
+      assert {:ok, "red"} = Task.await(long_task, 1_000)
+    end
+  end
+
+  describe "forwarding" do
+    test "requests for a covered tag are forwarded without parking" do
+      attach_telemetry(self())
+      placeholder = start_placeholder()
+      stub = start_stub(%{"apple" => "red"})
+
+      :ok = Placeholder.notify_covered(placeholder, 1, stub)
+
+      assert {:ok, "red"} = Materializer.get(placeholder, "apple", @version, timeout: 1_000)
+      assert_receive {:telemetry, [:bedrock, :distributor, :placeholder, :forwarded], %{count: 1}, %{tag: 1}}
+      refute_receive {:"$gen_cast", {:coverage_demand, _tag}}, 50
+    end
+
+    test "forwarding is per-tag: uncovered tags still park" do
+      placeholder = start_placeholder()
+      stub = start_stub(%{"apple" => "red"})
+
+      :ok = Placeholder.notify_covered(placeholder, 1, stub)
+
+      task = async_get(placeholder, "pear", timeout: 1_000)
+      assert_receive {:"$gen_cast", {:coverage_demand, 2}}
+
+      :ok = Placeholder.notify_covered(placeholder, 2, start_stub(%{"pear" => "green"}))
+      assert {:ok, "green"} = Task.await(task, 1_000)
+    end
+  end
+
+  describe "demand dedupe" do
+    test "at most one coverage demand per tag until covered" do
+      placeholder = start_placeholder()
+
+      task_a = async_get(placeholder, "apple", timeout: 1_000)
+      task_b = async_get(placeholder, "banana", timeout: 1_000)
+
+      assert_receive {:"$gen_cast", {:coverage_demand, 1}}
+      refute_receive {:"$gen_cast", {:coverage_demand, 1}}, 50
+
+      stub = start_stub(%{"apple" => "red", "banana" => "yellow"})
+      :ok = Placeholder.notify_covered(placeholder, 1, stub)
+      assert {:ok, "red"} = Task.await(task_a, 1_000)
+      assert {:ok, "yellow"} = Task.await(task_b, 1_000)
+    end
+
+    test "distinct tags each signal their own demand" do
+      placeholder = start_placeholder(hold_ms: 30)
+
+      task_a = async_get(placeholder, "apple", timeout: 1_000)
+      task_b = async_get(placeholder, "pear", timeout: 1_000)
+
+      assert_receive {:"$gen_cast", {:coverage_demand, 1}}
+      assert_receive {:"$gen_cast", {:coverage_demand, 2}}
+
+      assert {:error, :unavailable} = Task.await(task_a, 1_000)
+      assert {:error, :unavailable} = Task.await(task_b, 1_000)
+    end
+  end
+
+  describe "coverage failure" do
+    test "sheds parked requests with :unavailable and re-arms the demand" do
+      attach_telemetry(self())
+      placeholder = start_placeholder()
+
+      task = async_get(placeholder, "apple", timeout: 1_000)
+      assert_receive {:"$gen_cast", {:coverage_demand, 1}}
+
+      :ok = Placeholder.notify_coverage_failed(placeholder, 1, :no_capacity)
+
+      assert {:error, :unavailable} = Task.await(task, 1_000)
+
+      assert_receive {:telemetry, [:bedrock, :distributor, :placeholder, :shed], %{count: 1},
+                      %{tag: 1, reason: :no_capacity}}
+
+      # Dedupe was cleared: a later request re-triggers the demand.
+      retry_task = async_get(placeholder, "apple", timeout: 1_000)
+      assert_receive {:"$gen_cast", {:coverage_demand, 1}}
+
+      stub = start_stub(%{"apple" => "red"})
+      :ok = Placeholder.notify_covered(placeholder, 1, stub)
+      assert {:ok, "red"} = Task.await(retry_task, 1_000)
+    end
+  end
+
+  describe "layout misses" do
+    test "keys outside every shard are refused with :unavailable" do
+      placeholder = start_placeholder(shard_layout: %{"m" => {1, "a"}})
+
+      assert {:error, :unavailable} = GenServer.call(placeholder, {:get, "zebra", @version, []}, 1_000)
+      refute_receive {:"$gen_cast", {:coverage_demand, _tag}}, 50
+    end
+  end
+end

--- a/test/bedrock/control_plane/distributor/server_test.exs
+++ b/test/bedrock/control_plane/distributor/server_test.exs
@@ -3,6 +3,8 @@ defmodule Bedrock.ControlPlane.Distributor.ServerTest do
 
   alias Bedrock.ControlPlane.Distributor
   alias Bedrock.ControlPlane.Distributor.State
+  alias Bedrock.DataPlane.Materializer
+  alias Bedrock.Test.ControlPlane.StubMaterializer
 
   defmodule TestCluster do
     @moduledoc false
@@ -67,8 +69,10 @@ defmodule Bedrock.ControlPlane.Distributor.ServerTest do
                director: ^director,
                shard_layout: ^shard_layout,
                materializer_monitors: %{},
-               placeholder: nil
+               placeholder: placeholder
              } = :sys.get_state(pid)
+
+      assert is_pid(placeholder) and Process.alive?(placeholder)
 
       assert_receive {:telemetry, [:bedrock, :distributor, :started], %{},
                       %{cluster: TestCluster, epoch: 42, director: ^director}}
@@ -134,6 +138,119 @@ defmodule Bedrock.ControlPlane.Distributor.ServerTest do
       # Synchronize on the mailbox to be sure both casts were processed.
       assert :ok = Distributor.check_epoch(pid, 42)
       assert Process.alive?(pid)
+    end
+  end
+
+  describe "placeholder supervision" do
+    test "the placeholder dies with the distributor" do
+      {pid, director} = start_distributor()
+      %State{placeholder: placeholder} = :sys.get_state(pid)
+      ref = Process.monitor(placeholder)
+
+      send(director, :stop)
+
+      assert_receive {:DOWN, ^ref, :process, ^placeholder, :shutdown}
+    end
+
+    test "the placeholder is restarted when it dies" do
+      {pid, _director} = start_distributor()
+      %State{placeholder: placeholder} = :sys.get_state(pid)
+      ref = Process.monitor(placeholder)
+
+      Process.exit(placeholder, :kill)
+      assert_receive {:DOWN, ^ref, :process, ^placeholder, :killed}
+
+      # Synchronize on the distributor's mailbox, then check the new pid.
+      assert :ok = Distributor.check_epoch(pid, 42)
+      assert %State{placeholder: new_placeholder} = :sys.get_state(pid)
+      assert is_pid(new_placeholder)
+      assert new_placeholder != placeholder
+      assert Process.alive?(new_placeholder)
+    end
+  end
+
+  describe "coverage demand and delivery" do
+    defp attach_demand_telemetry(test_pid) do
+      handler_id = "distributor-demand-#{System.unique_integer([:positive])}"
+
+      :telemetry.attach(
+        handler_id,
+        [:bedrock, :distributor, :coverage_demand],
+        fn event, measurements, metadata, _config ->
+          send(test_pid, {:telemetry, event, measurements, metadata})
+        end,
+        nil
+      )
+
+      on_exit(fn -> :telemetry.detach(handler_id) end)
+    end
+
+    test "coverage_demand is remembered and emits telemetry" do
+      attach_demand_telemetry(self())
+      {pid, _director} = start_distributor()
+
+      GenServer.cast(pid, {:coverage_demand, 7})
+
+      assert_receive {:telemetry, [:bedrock, :distributor, :coverage_demand], %{}, %{cluster: TestCluster, tag: 7}}
+
+      assert %State{pending_demands: pending} = :sys.get_state(pid)
+      assert MapSet.member?(pending, 7)
+    end
+
+    test "deliver_coverage relays to the placeholder and clears the pending demand" do
+      attach_demand_telemetry(self())
+      shard_layout = %{<<0xFF, 0xFF>> => {1, <<>>}}
+      {pid, _director} = start_distributor(shard_layout: shard_layout)
+      %State{placeholder: placeholder} = :sys.get_state(pid)
+
+      stub =
+        start_supervised!(%{
+          id: {StubMaterializer, System.unique_integer([:positive])},
+          start: {StubMaterializer, :start_link, [%{"apple" => "red"}]}
+        })
+
+      # Park a read against the placeholder, then deliver coverage through
+      # the distributor's internal seam and observe the drain.
+      version = Bedrock.DataPlane.Version.from_integer(1)
+
+      task =
+        Task.async(fn ->
+          Materializer.get(placeholder, "apple", version, timeout: 1_000)
+        end)
+
+      # Wait for the placeholder's demand to be processed by the distributor
+      # before delivering coverage, so the pending set is stable.
+      assert_receive {:telemetry, [:bedrock, :distributor, :coverage_demand], %{}, %{tag: 1}}
+
+      :ok = Distributor.deliver_coverage(pid, 1, stub)
+
+      assert {:ok, "red"} = Task.await(task, 1_000)
+
+      assert %State{pending_demands: pending} = :sys.get_state(pid)
+      refute MapSet.member?(pending, 1)
+    end
+
+    test "fail_coverage relays the failure to the placeholder and clears the pending demand" do
+      attach_demand_telemetry(self())
+      shard_layout = %{<<0xFF, 0xFF>> => {1, <<>>}}
+      {pid, _director} = start_distributor(shard_layout: shard_layout)
+      %State{placeholder: placeholder} = :sys.get_state(pid)
+
+      version = Bedrock.DataPlane.Version.from_integer(1)
+
+      task =
+        Task.async(fn ->
+          Materializer.get(placeholder, "apple", version, timeout: 1_000)
+        end)
+
+      assert_receive {:telemetry, [:bedrock, :distributor, :coverage_demand], %{}, %{tag: 1}}
+
+      :ok = Distributor.fail_coverage(pid, 1, :no_capacity)
+
+      assert {:error, :unavailable} = Task.await(task, 1_000)
+
+      assert %State{pending_demands: pending} = :sys.get_state(pid)
+      refute MapSet.member?(pending, 1)
     end
   end
 

--- a/test/support/control_plane/stub_materializer.ex
+++ b/test/support/control_plane/stub_materializer.ex
@@ -1,0 +1,41 @@
+defmodule Bedrock.Test.ControlPlane.StubMaterializer do
+  @moduledoc """
+  A stub materializer GenServer that implements the real read API call
+  shapes handled by the olivine/basalt materializer servers:
+
+    * `{:get, key | KeySelector.t(), version, opts}`
+    * `{:get_range, start_key | KeySelector.t(), end_key | KeySelector.t(), version, opts}`
+
+  Serves from a static key-value map, ignoring versions.
+  """
+  use GenServer
+
+  alias Bedrock.KeySelector
+
+  @spec start_link(%{Bedrock.key() => Bedrock.value()}) :: GenServer.on_start()
+  def start_link(kvs), do: GenServer.start_link(__MODULE__, kvs)
+
+  @impl true
+  def init(kvs), do: {:ok, kvs}
+
+  @impl true
+  def handle_call({:get, %KeySelector{key: key}, _version, _opts}, _from, kvs) do
+    case Map.fetch(kvs, key) do
+      {:ok, value} -> {:reply, {:ok, {key, value}}, kvs}
+      :error -> {:reply, {:ok, nil}, kvs}
+    end
+  end
+
+  def handle_call({:get, key, _version, _opts}, _from, kvs) when is_binary(key),
+    do: {:reply, {:ok, Map.get(kvs, key)}, kvs}
+
+  def handle_call({:get_range, start_key, end_key, _version, _opts}, _from, kvs)
+      when is_binary(start_key) and is_binary(end_key) do
+    results =
+      kvs
+      |> Enum.filter(fn {key, _value} -> key >= start_key and key < end_key end)
+      |> Enum.sort()
+
+    {:reply, {:ok, {results, false}}, kvs}
+  end
+end


### PR DESCRIPTION
> [!NOTE]
> **Stacked PR** — based on `feature/q67-distributor` (#91, the Distributor skeleton). Merge #91 first; this PR should only be reviewed for its own diff.

## What

The placeholder materializer (bedrock-q67.3): the cluster's fallback coverage endpoint. One process per cluster, started, linked, and restarted-on-death by the Distributor. Its pid is intended to fill every uncovered `shard_materializers` slot so clients can never observe an uncovered shard.

## Design

- **Indistinguishable from a real materializer.** Accepts exactly the GenServer call shapes olivine/basalt handle — `{:get, key | KeySelector, version, opts}` and `{:get_range, start, end, version, opts}` — so `StorageRacing`/`PointReads`/`RangeReads` are unchanged.
- **Park** (`Bedrock.Internal.WaitingList` keyed by shard tag) with budget `min(caller opts[:timeout], hold_ms)` (`hold_ms` default 2,000ms); signals `{:coverage_demand, tag}` to the Distributor, deduped to at most one in-flight demand per tag.
- **Timer-driven expiry** (lesson from bedrock-tvb): a single `Process.send_after` armed for the earliest deadline, rescheduled on every waitlist mutation; expired waiters get `{:error, :unavailable}`.
- **Drain on `{:covered, tag, pid}`:** parked requests are re-issued against the live materializer from one `Task` per request (the placeholder never blocks); the pid is remembered so later stale-layout requests are **forwarded** (staleness shim).
- **Shed on `{:coverage_failed, tag, reason}`:** waiters get `{:error, :unavailable}` and the demand dedupe clears so the next request re-triggers recruitment.
- **Distributor side (minimal — recruitment is bedrock-q67.5):** `{:coverage_demand, tag}` is logged, counted (telemetry), and remembered in `pending_demands`; `deliver_coverage/3` and `fail_coverage/3` are the internal/test seam that relays outcomes to the placeholder. The Distributor traps exits, links the placeholder, restarts it on death, and shuts it down explicitly in `terminate/2` (a `:normal` exit signal would otherwise orphan it).
- `WaitingList`'s key type widened to include `Bedrock.range_tag()`.

## Telemetry

`[:bedrock, :distributor, :placeholder, :parked | :forwarded | :drained | :shed]` and `[:bedrock, :distributor, :coverage_demand]` (emitted by the Distributor on receipt).

## Tests

- Unit: park→cover→drain (binary key, KeySelector, get_range, multi-waiter), park→timeout→`:unavailable`, caller-timeout bounds the budget, partial expiry, forward-when-covered, per-tag demand dedupe, coverage-failed shed + demand re-arm, off-layout keys refused.
- Integration: full client path (`PointReads`/`RangeReads` → `StorageRacing` → `LayoutIndex` with the placeholder pid in the shard slot) parks, then succeeds after coverage; fails `:unavailable` when coverage never arrives; forwards for stale clients.
- Distributor: placeholder lifecycle (start/link/restart/shutdown), demand tracking, coverage delivery/failure seams.

Deterministic: no sleeps; timer expiry uses ≤30ms deadlines with generous `assert_receive`/`Task.await` margins.

Full suite: 13 doctests, 158 properties, 2548 tests, 0 failures. `mix format`, `credo --strict`, and dialyzer clean.

Closes bedrock-q67.3.