### PR TITLE
Add on-demand materializer recruitment (bedrock-q67.5)

### DIFF
--- a/lib/bedrock/cluster/link/discovery.ex
+++ b/lib/bedrock/cluster/link/discovery.ex
@@ -161,12 +161,22 @@ defmodule Bedrock.Cluster.Link.Discovery do
     t
     |> Map.put(:known_coordinator, coordinator_ref)
     |> monitor_known_coordinator()
+    |> subscribe_to_tsl_updates()
     |> register_node_capabilities()
   end
 
   @spec monitor_known_coordinator(State.t()) :: State.t()
   defp monitor_known_coordinator(t) do
     Process.monitor(t.known_coordinator)
+    t
+  end
+
+  @spec subscribe_to_tsl_updates(State.t()) :: State.t()
+  defp subscribe_to_tsl_updates(t) do
+    # Subscribe for {:tsl_updated, tsl} broadcasts regardless of capabilities.
+    # Nodes registering resources are subscribed implicitly by the coordinator,
+    # but capability-less (pure client) links would otherwise never subscribe.
+    Coordinator.subscribe_to_tsl_updates(t.known_coordinator, self())
     t
   end
 

--- a/lib/bedrock/control_plane/coordinator.ex
+++ b/lib/bedrock/control_plane/coordinator.ex
@@ -45,7 +45,7 @@ defmodule Bedrock.ControlPlane.Coordinator do
   alias Bedrock.ControlPlane.Config
   alias Bedrock.ControlPlane.Config.TransactionSystemLayout
 
-  @type ref :: atom() | {atom(), node()}
+  @type ref :: pid() | atom() | {atom(), node()}
   @typep timeout_in_ms :: Bedrock.timeout_in_ms()
 
   @spec config_key() :: atom()
@@ -88,6 +88,21 @@ defmodule Bedrock.ControlPlane.Coordinator do
         ) :: :ok
   def notify_transaction_system_layout(coordinator, transaction_system_layout),
     do: GenServer.cast(coordinator, {:notify_transaction_system_layout, transaction_system_layout})
+
+  @doc """
+  Subscribe a process to `{:tsl_updated, tsl}` broadcasts from this coordinator.
+
+  The coordinator monitors the subscriber and removes it automatically when it
+  dies. If the coordinator already holds a transaction system layout, the
+  subscriber is immediately brought up to date with a `{:tsl_updated, tsl}`
+  message. Subscribing is idempotent.
+
+  Links subscribe on connect (see `Bedrock.Cluster.Link.Discovery`); processes
+  registering node resources are subscribed implicitly as well.
+  """
+  @spec subscribe_to_tsl_updates(coordinator_ref :: ref(), subscriber :: pid()) :: :ok
+  def subscribe_to_tsl_updates(coordinator, subscriber),
+    do: GenServer.cast(coordinator, {:subscribe_tsl_updates, subscriber})
 
   @type service_info :: {service_id :: String.t(), kind :: atom(), worker_ref :: {atom(), node()}}
   @type compact_service_info :: {service_id :: String.t(), kind :: atom(), name :: atom()}

--- a/lib/bedrock/control_plane/coordinator/server.ex
+++ b/lib/bedrock/control_plane/coordinator/server.ex
@@ -159,9 +159,10 @@ defmodule Bedrock.ControlPlane.Coordinator.Server do
   end
 
   def handle_call({:register_node_resources, client_pid, compact_services, capabilities}, from, t) do
-    # Always subscribe client for TSL updates (monitor to clean up on death)
-    Process.monitor(client_pid)
-    updated_state = add_tsl_subscriber(t, client_pid)
+    # Always subscribe client for TSL updates (monitor to clean up on death).
+    # Guarded so a link that already subscribed via {:subscribe_tsl_updates, _}
+    # doesn't accumulate a second monitor.
+    updated_state = monitor_and_add_tsl_subscriber(t, client_pid)
 
     # Expand compact services to full format
     caller_node = node(client_pid)
@@ -281,24 +282,37 @@ defmodule Bedrock.ControlPlane.Coordinator.Server do
     if MapSet.member?(t.tsl_subscribers, subscriber) do
       noreply(t)
     else
-      Process.monitor(subscriber)
-
-      # Bring the new subscriber up to date immediately if we already have a TSL.
-      if t.transaction_system_layout, do: send(subscriber, {:tsl_updated, t.transaction_system_layout})
+      # Bring the new subscriber up to date immediately if we already hold a
+      # director-produced TSL. The old-TSL stub loaded from object storage at
+      # init (bare %{logs: ...}, no :epoch) is recovery input only and must
+      # not be pushed to subscribers.
+      case t.transaction_system_layout do
+        %{epoch: _} = tsl -> send(subscriber, {:tsl_updated, tsl})
+        _ -> :ok
+      end
 
       t
-      |> add_tsl_subscriber(subscriber)
+      |> monitor_and_add_tsl_subscriber(subscriber)
       |> noreply()
     end
   end
 
-  def handle_cast({:notify_transaction_system_layout, transaction_system_layout}, t) do
+  def handle_cast({:notify_transaction_system_layout, %{epoch: tsl_epoch} = transaction_system_layout}, t)
+      when is_nil(t.epoch) or tsl_epoch >= t.epoch do
     # Direct notification from Director - update state and broadcast to subscribers
     # No Raft consensus needed - TSL is persisted to object storage by Director
     t
     |> put_transaction_system_layout(transaction_system_layout)
-    |> put_epoch(transaction_system_layout.epoch)
+    |> put_epoch(tsl_epoch)
     |> noreply()
+  end
+
+  def handle_cast({:notify_transaction_system_layout, _stale_tsl}, t) do
+    # A TSL carrying an epoch older than ours is a delayed cast from a
+    # deposed director (e.g. an in-flight delta or recovery notification that
+    # raced a leadership change). Applying it would regress our epoch and
+    # broadcast dead pids to every subscribed link, so drop it.
+    noreply(t)
   end
 
   def handle_cast({:notify_config, config}, t) do
@@ -333,6 +347,19 @@ defmodule Bedrock.ControlPlane.Coordinator.Server do
 
   @spec ack_fn(GenServer.from()) :: (term() -> :ok)
   defp ack_fn(from), do: fn result -> GenServer.reply(from, result) end
+
+  # Adds a TSL subscriber, monitoring it exactly once. Idempotent: repeated
+  # subscriptions (or a subscribe cast followed by register_node_resources)
+  # must not accumulate duplicate monitors on the same pid.
+  @spec monitor_and_add_tsl_subscriber(State.t(), pid()) :: State.t()
+  defp monitor_and_add_tsl_subscriber(t, subscriber) do
+    if MapSet.member?(t.tsl_subscribers, subscriber) do
+      t
+    else
+      Process.monitor(subscriber)
+      add_tsl_subscriber(t, subscriber)
+    end
+  end
 
   @spec init_raft_log(module()) ::
           {:ok, DiskRaftLog.t() | TupleInMemoryLog.t()} | {:error, term()}

--- a/lib/bedrock/control_plane/coordinator/server.ex
+++ b/lib/bedrock/control_plane/coordinator/server.ex
@@ -277,6 +277,21 @@ defmodule Bedrock.ControlPlane.Coordinator.Server do
     noreply(t)
   end
 
+  def handle_cast({:subscribe_tsl_updates, subscriber}, t) do
+    if MapSet.member?(t.tsl_subscribers, subscriber) do
+      noreply(t)
+    else
+      Process.monitor(subscriber)
+
+      # Bring the new subscriber up to date immediately if we already have a TSL.
+      if t.transaction_system_layout, do: send(subscriber, {:tsl_updated, t.transaction_system_layout})
+
+      t
+      |> add_tsl_subscriber(subscriber)
+      |> noreply()
+    end
+  end
+
   def handle_cast({:notify_transaction_system_layout, transaction_system_layout}, t) do
     # Direct notification from Director - update state and broadcast to subscribers
     # No Raft consensus needed - TSL is persisted to object storage by Director

--- a/lib/bedrock/control_plane/director.ex
+++ b/lib/bedrock/control_plane/director.ex
@@ -47,10 +47,43 @@ defmodule Bedrock.ControlPlane.Director do
 
   @type running_service_info_by_id :: %{Worker.id() => running_service_info()}
 
+  @typedoc """
+  A minimal delta over the transaction system layout's `shard_materializers`
+  map. Each entry either assigns a materializer pid to a shard tag
+  (put/replace semantics) or removes the shard's entry with `:remove`.
+  """
+  @type tsl_delta :: %{Bedrock.range_tag() => pid() | :remove}
+
   @spec fetch_transaction_system_layout(director_ref :: ref(), timeout_in_ms :: timeout_in_ms()) ::
           {:ok, TransactionSystemLayout.t()} | {:error, :unavailable | :timeout | :unknown}
   def fetch_transaction_system_layout(director, timeout_in_ms \\ 5_000),
     do: call(director, :fetch_transaction_system_layout, timeout_in_ms)
+
+  @doc """
+  Apply a post-recovery delta to the transaction system layout's
+  `shard_materializers` map and broadcast the resulting TSL.
+
+  The delta is epoch-stamped: it is applied only when `epoch` matches the
+  director's own epoch. A delta carrying any other epoch (stale, or produced
+  against a generation this director doesn't know) is rejected with
+  `{:error, :newer_epoch_exists}`, mirroring the epoch guard used by
+  `lock_for_recovery` on data-plane services.
+
+  On success the director updates its retained TSL and hands the new TSL to
+  the coordinator, which broadcasts `{:tsl_updated, new_tsl}` to all
+  subscribed Links.
+
+  Returns `{:error, :unavailable}` if recovery has not yet produced a TSL.
+  """
+  @spec apply_tsl_delta(
+          director :: ref(),
+          delta :: tsl_delta(),
+          epoch :: Bedrock.epoch(),
+          timeout_in_ms :: timeout_in_ms()
+        ) ::
+          :ok | {:error, :newer_epoch_exists | :unavailable | :timeout | :unknown}
+  def apply_tsl_delta(director, delta, epoch, timeout_in_ms \\ 5_000),
+    do: call(director, {:apply_tsl_delta, delta, epoch}, timeout_in_ms)
 
   @doc """
   Sends a 'pong' message to the specified cluster director from the given node.

--- a/lib/bedrock/control_plane/director/recovery.ex
+++ b/lib/bedrock/control_plane/director/recovery.ex
@@ -115,6 +115,9 @@ defmodule Bedrock.ControlPlane.Director.Recovery do
         |> Map.update!(:config, fn config ->
           Map.delete(config, :recovery_attempt)
         end)
+        # Retain the completed attempt: the distributor needs its
+        # durable_version to unlock materializers it recruits on demand.
+        |> Map.put(:recovery_attempt, completed)
         |> Map.put(:transaction_system_layout, completed.transaction_system_layout)
         |> persist_config()
         |> persist_new_transaction_system_layout()

--- a/lib/bedrock/control_plane/director/server.ex
+++ b/lib/bedrock/control_plane/director/server.ex
@@ -115,12 +115,15 @@ defmodule Bedrock.ControlPlane.Director.Server do
 
   def handle_info({:DOWN, _monitor_ref, :process, distributor_pid, reason}, %State{distributor: distributor_pid} = t) do
     # The distributor is off the request path: its death degrades coverage
-    # healing only, so we re-recruit it rather than restarting recovery.
-    Logger.warning("Distributor exited (#{inspect(reason)}); re-recruiting")
+    # healing only, so we re-recruit it rather than restarting recovery. The
+    # retry timer (rather than an immediate restart) puts a floor under a
+    # crash-looping distributor.
+    Logger.warning("Distributor exited (#{inspect(reason)}); re-recruiting in #{@distributor_retry_ms}ms")
+
+    Process.send_after(self(), {:timeout, :retry_start_distributor}, @distributor_retry_ms)
 
     t
     |> Map.put(:distributor, nil)
-    |> maybe_start_distributor()
     |> noreply()
   end
 
@@ -317,8 +320,7 @@ defmodule Bedrock.ControlPlane.Director.Server do
 
     case starter_fn.(child_spec, node()) do
       {:ok, distributor} ->
-        Process.monitor(distributor)
-        %{t | distributor: distributor}
+        confirm_distributor_epoch(t, distributor)
 
       {:error, reason} ->
         Logger.error("Failed to start distributor: #{inspect(reason)}; retrying in #{@distributor_retry_ms}ms")
@@ -330,8 +332,38 @@ defmodule Bedrock.ControlPlane.Director.Server do
 
   def maybe_start_distributor(t), do: t
 
-  # The durable version recovery settled on: where a freshly recruited
-  # materializer starts pulling from the logs (matching the bootstrap phase).
+  # `Shared.starter_for/1` maps `{:error, {:already_started, pid}}` to
+  # `{:ok, pid}`, so a start can *adopt* a distributor left over from another
+  # epoch under the shared otp name. Confirm the epoch before trusting it: a
+  # stale (older-epoch) distributor stops itself on the check, and we retry
+  # once its registration clears; a newer-epoch distributor means this
+  # director is the stale one and must not recruit.
+  @spec confirm_distributor_epoch(State.t(), pid()) :: State.t()
+  defp confirm_distributor_epoch(t, distributor) do
+    case Distributor.check_epoch(distributor, t.epoch) do
+      :ok ->
+        Process.monitor(distributor)
+        %{t | distributor: distributor}
+
+      {:error, :newer_epoch_exists} ->
+        Logger.warning(
+          "Adopted distributor belongs to a newer epoch than #{t.epoch}; " <>
+            "this director has been superseded and will not recruit"
+        )
+
+        t
+
+      {:error, reason} ->
+        Logger.warning("Distributor epoch check failed (#{inspect(reason)}); retrying in #{@distributor_retry_ms}ms")
+
+        Process.send_after(self(), {:timeout, :retry_start_distributor}, @distributor_retry_ms)
+        t
+    end
+  end
+
+  # The durable version recovery settled on. Recruitment unlocks a new
+  # materializer at the version the worker itself reports at lock time;
+  # this cluster-wide value is only its fallback when no report is present.
   @spec recovered_durable_version(State.t()) :: Bedrock.version()
   defp recovered_durable_version(%State{recovery_attempt: %{durable_version: durable_version}})
        when not is_nil(durable_version), do: durable_version

--- a/lib/bedrock/control_plane/director/server.ex
+++ b/lib/bedrock/control_plane/director/server.ex
@@ -29,9 +29,12 @@ defmodule Bedrock.ControlPlane.Director.Server do
   alias Bedrock.ControlPlane.Director.Recovery.Shared
   alias Bedrock.ControlPlane.Director.State
   alias Bedrock.ControlPlane.Distributor
+  alias Bedrock.DataPlane.Version
   alias Bedrock.Service.Worker
 
   require Logger
+
+  @distributor_retry_ms 1_000
 
   @doc false
   @spec child_spec(
@@ -99,6 +102,17 @@ defmodule Bedrock.ControlPlane.Director.Server do
   end
 
   @impl true
+  def handle_info({:DOWN, _monitor_ref, :process, distributor_pid, :normal}, %State{distributor: distributor_pid} = t) do
+    # A :normal exit means the distributor ceded deliberately (superseded by
+    # a newer epoch): a newer director owns coverage now, so re-recruiting
+    # here would only create a stale distributor.
+    Logger.info("Distributor exited normally (superseded); not re-recruiting")
+
+    t
+    |> Map.put(:distributor, nil)
+    |> noreply()
+  end
+
   def handle_info({:DOWN, _monitor_ref, :process, distributor_pid, reason}, %State{distributor: distributor_pid} = t) do
     # The distributor is off the request path: its death degrades coverage
     # healing only, so we re-recruit it rather than restarting recovery.
@@ -106,6 +120,12 @@ defmodule Bedrock.ControlPlane.Director.Server do
 
     t
     |> Map.put(:distributor, nil)
+    |> maybe_start_distributor()
+    |> noreply()
+  end
+
+  def handle_info({:timeout, :retry_start_distributor}, t) do
+    t
     |> maybe_start_distributor()
     |> noreply()
   end
@@ -279,14 +299,17 @@ defmodule Bedrock.ControlPlane.Director.Server do
   @doc false
   @spec maybe_start_distributor(State.t()) :: State.t()
   def maybe_start_distributor(%State{state: :running, distributor: nil} = t) do
-    shard_layout = (t.transaction_system_layout || %{})[:shard_layout] || %{}
+    transaction_system_layout = t.transaction_system_layout || %{}
 
     child_spec =
       Distributor.child_spec(
         cluster: t.cluster,
         epoch: t.epoch,
         director: self(),
-        shard_layout: shard_layout,
+        shard_layout: transaction_system_layout[:shard_layout] || %{},
+        transaction_system_layout: transaction_system_layout,
+        durable_version: recovered_durable_version(t),
+        node_capabilities: t.node_capabilities,
         otp_name: t.cluster.otp_name(:distributor)
       )
 
@@ -298,10 +321,20 @@ defmodule Bedrock.ControlPlane.Director.Server do
         %{t | distributor: distributor}
 
       {:error, reason} ->
-        Logger.error("Failed to start distributor: #{inspect(reason)}")
+        Logger.error("Failed to start distributor: #{inspect(reason)}; retrying in #{@distributor_retry_ms}ms")
+
+        Process.send_after(self(), {:timeout, :retry_start_distributor}, @distributor_retry_ms)
         t
     end
   end
 
   def maybe_start_distributor(t), do: t
+
+  # The durable version recovery settled on: where a freshly recruited
+  # materializer starts pulling from the logs (matching the bootstrap phase).
+  @spec recovered_durable_version(State.t()) :: Bedrock.version()
+  defp recovered_durable_version(%State{recovery_attempt: %{durable_version: durable_version}})
+       when not is_nil(durable_version), do: durable_version
+
+  defp recovered_durable_version(_t), do: Version.zero()
 end

--- a/lib/bedrock/control_plane/director/server.ex
+++ b/lib/bedrock/control_plane/director/server.ex
@@ -18,12 +18,14 @@ defmodule Bedrock.ControlPlane.Director.Server do
       try_to_recover: 1
     ]
 
+  import Bedrock.ControlPlane.Director.Telemetry, only: [trace_tsl_delta_applied: 3]
   import Bedrock.Internal.GenServer.Replies
 
   alias Bedrock.ControlPlane.Config
   alias Bedrock.ControlPlane.Config.ServiceDescriptor
   alias Bedrock.ControlPlane.Config.TransactionSystemLayout
   alias Bedrock.ControlPlane.Coordinator
+  alias Bedrock.ControlPlane.Director
   alias Bedrock.ControlPlane.Director.State
   alias Bedrock.Service.Worker
 
@@ -116,6 +118,18 @@ defmodule Bedrock.ControlPlane.Director.Server do
     end
   end
 
+  def handle_call({:apply_tsl_delta, _delta, epoch}, _from, %State{epoch: current_epoch} = t)
+      when epoch != current_epoch, do: reply(t, {:error, :newer_epoch_exists})
+
+  def handle_call({:apply_tsl_delta, _delta, _epoch}, _from, %State{transaction_system_layout: nil} = t),
+    do: reply(t, {:error, :unavailable})
+
+  def handle_call({:apply_tsl_delta, delta, _epoch}, _from, %State{} = t) do
+    t
+    |> apply_tsl_delta(delta)
+    |> reply(:ok)
+  end
+
   def handle_call({:request_worker_creation, node, worker_id, kind}, _from, t) do
     t
     |> request_worker_creation(node, worker_id, kind)
@@ -179,6 +193,34 @@ defmodule Bedrock.ControlPlane.Director.Server do
 
   @spec now() :: DateTime.t()
   defp now, do: DateTime.utc_now()
+
+  # Applies a shard_materializers delta to the retained TSL, hands the new TSL
+  # to the coordinator for broadcast to subscribed Links, and emits telemetry.
+  @spec apply_tsl_delta(State.t(), Director.tsl_delta()) :: State.t()
+  defp apply_tsl_delta(t, delta) do
+    updated_shard_materializers =
+      t.transaction_system_layout
+      |> Map.get(:shard_materializers, %{})
+      |> apply_delta_to_shard_materializers(delta)
+
+    updated_tsl = Map.put(t.transaction_system_layout, :shard_materializers, updated_shard_materializers)
+
+    Coordinator.notify_transaction_system_layout(t.coordinator, updated_tsl)
+    trace_tsl_delta_applied(t.cluster, t.epoch, delta)
+
+    %{t | transaction_system_layout: updated_tsl}
+  end
+
+  @spec apply_delta_to_shard_materializers(
+          TransactionSystemLayout.shard_materializers(),
+          Director.tsl_delta()
+        ) :: TransactionSystemLayout.shard_materializers()
+  defp apply_delta_to_shard_materializers(shard_materializers, delta) do
+    Enum.reduce(delta, shard_materializers, fn
+      {tag, :remove}, acc -> Map.delete(acc, tag)
+      {tag, pid}, acc when is_pid(pid) -> Map.put(acc, tag, pid)
+    end)
+  end
 
   @spec get_services_from_transaction_system_layout(TransactionSystemLayout.t()) ::
           %{Worker.id() => ServiceDescriptor.t()}

--- a/lib/bedrock/control_plane/director/telemetry.ex
+++ b/lib/bedrock/control_plane/director/telemetry.ex
@@ -1,0 +1,22 @@
+defmodule Bedrock.ControlPlane.Director.Telemetry do
+  @moduledoc false
+  alias Bedrock.ControlPlane.Director
+  alias Bedrock.Telemetry
+
+  @doc """
+  Emits a telemetry event indicating that the director applied a post-recovery
+  delta to the transaction system layout's `shard_materializers` map.
+  """
+  @spec trace_tsl_delta_applied(
+          cluster :: module(),
+          epoch :: Bedrock.epoch(),
+          delta :: Director.tsl_delta()
+        ) :: :ok
+  def trace_tsl_delta_applied(cluster, epoch, delta) do
+    Telemetry.execute([:bedrock, :director, :tsl_delta_applied], %{shard_count: map_size(delta)}, %{
+      cluster: cluster,
+      epoch: epoch,
+      delta: delta
+    })
+  end
+end

--- a/lib/bedrock/control_plane/distributor.ex
+++ b/lib/bedrock/control_plane/distributor.ex
@@ -59,7 +59,7 @@ defmodule Bedrock.ControlPlane.Distributor do
   @doc """
   Internal/test seam: relays a coverage result to the placeholder, marking
   the shard tag as covered by the given materializer. The recruitment flow
-  (bedrock-q67.5) will deliver coverage outcomes through this same path.
+  normally delivers coverage outcomes itself when a recruitment completes.
   """
   @spec deliver_coverage(ref(), Bedrock.range_tag(), materializer :: pid()) :: :ok
   def deliver_coverage(distributor, tag, materializer), do: cast(distributor, {:deliver_coverage, tag, materializer})

--- a/lib/bedrock/control_plane/distributor/recruitment.ex
+++ b/lib/bedrock/control_plane/distributor/recruitment.ex
@@ -7,9 +7,10 @@ defmodule Bedrock.ControlPlane.Distributor.Recruitment do
   materializer lifecycles pass through a single set of conventions: pick a
   materializer-capable node from the coordinator-supplied capabilities, ask
   that node's Foreman to create a worker, lock it for recovery at the
-  current epoch, and unlock it with the recovery durable version and a
-  transaction system layout filtered to the shard's logs so it starts
-  pulling immediately.
+  current epoch, and unlock it with the durable version the worker itself
+  reported at lock time (zero for a freshly created worker, so it replays
+  the shard's full history) and a transaction system layout filtered to
+  the shard's logs so it starts pulling immediately.
 
   The Foreman/Materializer calls are injectable through the context map
   (`:create_worker_fn`, `:lock_materializer_fn`, `:unlock_materializer_fn`)
@@ -52,8 +53,8 @@ defmodule Bedrock.ControlPlane.Distributor.Recruitment do
   def recruit(tag, context) do
     with {:ok, node} <- find_materializer_capable_node(context.node_capabilities),
          {:ok, worker_ref} <- create_materializer_worker(node, tag, context),
-         {:ok, pid} <- lock_materializer({worker_ref, node}, node, context),
-         :ok <- unlock_and_start_pulling(pid, tag, node, context) do
+         {:ok, pid, recovery_info} <- lock_materializer({worker_ref, node}, node, context),
+         :ok <- unlock_and_start_pulling(pid, tag, node, recovery_info, context) do
       {:ok, pid, node}
     end
   end
@@ -82,23 +83,38 @@ defmodule Bedrock.ControlPlane.Distributor.Recruitment do
     lock_fn = Map.get(context, :lock_materializer_fn, &default_lock_materializer/2)
 
     case lock_fn.(worker, context.epoch) do
-      {:ok, pid, _info} -> {:ok, pid}
+      {:ok, pid, recovery_info} -> {:ok, pid, recovery_info}
       {:error, reason} -> {:error, {:materializer_lock_failed, reason, node}}
     end
   end
 
   defp default_lock_materializer(worker, epoch), do: Materializer.lock_for_recovery(worker, epoch)
 
-  defp unlock_and_start_pulling(pid, tag, node, context) do
+  defp unlock_and_start_pulling(pid, tag, node, recovery_info, context) do
     tsl = shard_tsl(tag, context)
     unlock_fn = Map.get(context, :unlock_materializer_fn, &default_unlock_materializer/3)
 
-    case unlock_fn.(pid, context.durable_version, tsl) do
+    case unlock_fn.(pid, start_version(recovery_info, context), tsl) do
       :ok -> :ok
       {:error, reason} -> {:error, {:unlock_failed, reason, node}}
       {:failure, reason, _ref} -> {:error, {:unlock_failed, reason, node}}
     end
   end
+
+  # The unlock durable_version tells the materializer which version its own
+  # store already reflects - it starts pulling from the logs *after* that
+  # point. A recruited worker is freshly created (empty), so we must use the
+  # version IT reports at lock time (zero for a new store): unlocking it at
+  # the cluster-wide recovery durable version would silently skip every
+  # transaction before recovery. This matches the bootstrap phase, which
+  # unlocks newly created workers at version zero.
+  defp start_version(recovery_info, context) when is_map(recovery_info),
+    do: Map.get(recovery_info, :durable_version) || context.durable_version
+
+  defp start_version(recovery_info, context) when is_list(recovery_info),
+    do: Keyword.get(recovery_info, :durable_version) || context.durable_version
+
+  defp start_version(_recovery_info, context), do: context.durable_version
 
   defp default_unlock_materializer(pid, durable_version, tsl),
     do: Materializer.unlock_after_recovery(pid, durable_version, tsl, timeout_in_ms: 30_000)

--- a/lib/bedrock/control_plane/distributor/recruitment.ex
+++ b/lib/bedrock/control_plane/distributor/recruitment.ex
@@ -1,0 +1,130 @@
+defmodule Bedrock.ControlPlane.Distributor.Recruitment do
+  @moduledoc """
+  Recruits a materializer for an uncovered shard on behalf of the
+  Distributor.
+
+  Mirrors the recovery-time machinery in `MaterializerBootstrapPhase` so
+  materializer lifecycles pass through a single set of conventions: pick a
+  materializer-capable node from the coordinator-supplied capabilities, ask
+  that node's Foreman to create a worker, lock it for recovery at the
+  current epoch, and unlock it with the recovery durable version and a
+  transaction system layout filtered to the shard's logs so it starts
+  pulling immediately.
+
+  The Foreman/Materializer calls are injectable through the context map
+  (`:create_worker_fn`, `:lock_materializer_fn`, `:unlock_materializer_fn`)
+  using the same seam conventions as the bootstrap phase, so tests can stub
+  the worker layer without reimplementing the plumbing.
+  """
+
+  alias Bedrock.ControlPlane.Config.TransactionSystemLayout
+  alias Bedrock.DataPlane.Materializer
+  alias Bedrock.Service.Foreman
+  alias Bedrock.Service.Worker
+
+  @type create_worker_fn ::
+          (foreman :: {atom(), node()}, Worker.id(), :materializer, keyword() ->
+             {:ok, Worker.ref()} | {:error, term()})
+  @type lock_materializer_fn ::
+          (worker :: {Worker.ref(), node()}, Bedrock.epoch() ->
+             {:ok, pid(), Materializer.recovery_info()} | {:error, term()})
+  @type unlock_materializer_fn ::
+          (pid(), Bedrock.version(), TransactionSystemLayout.t() ->
+             :ok | {:error, term()} | {:failure, term(), term()})
+
+  @type context :: %{
+          required(:cluster) => module(),
+          required(:epoch) => Bedrock.epoch(),
+          required(:durable_version) => Bedrock.version(),
+          required(:transaction_system_layout) => TransactionSystemLayout.t() | %{},
+          required(:node_capabilities) => %{Bedrock.Cluster.capability() => [node()]},
+          optional(:create_worker_fn) => create_worker_fn(),
+          optional(:lock_materializer_fn) => lock_materializer_fn(),
+          optional(:unlock_materializer_fn) => unlock_materializer_fn()
+        }
+
+  @doc """
+  Recruits a materializer for the given shard tag: node selection, worker
+  creation via the node's Foreman, epoch lock, and unlock with the shard's
+  logs. Returns the live materializer pid and the node it was placed on.
+  """
+  @spec recruit(Bedrock.range_tag(), context()) :: {:ok, pid(), node()} | {:error, term()}
+  def recruit(tag, context) do
+    with {:ok, node} <- find_materializer_capable_node(context.node_capabilities),
+         {:ok, worker_ref} <- create_materializer_worker(node, tag, context),
+         {:ok, pid} <- lock_materializer({worker_ref, node}, node, context),
+         :ok <- unlock_and_start_pulling(pid, tag, node, context) do
+      {:ok, pid, node}
+    end
+  end
+
+  # Placement: same convention as the recovery bootstrap phase - the first
+  # materializer-capable node from the coordinator's capability directory.
+  defp find_materializer_capable_node(node_capabilities) do
+    case Map.get(node_capabilities, :materializer, []) do
+      [node | _] -> {:ok, node}
+      [] -> {:error, :no_materializer_capable_nodes}
+    end
+  end
+
+  defp create_materializer_worker(node, tag, context) do
+    foreman_ref = {context.cluster.otp_name(:foreman), node}
+    worker_id = Worker.random_id()
+    create_worker_fn = Map.get(context, :create_worker_fn, &Foreman.new_worker/4)
+
+    case create_worker_fn.(foreman_ref, worker_id, :materializer, timeout: 30_000) do
+      {:ok, worker_ref} -> {:ok, worker_ref}
+      {:error, reason} -> {:error, {:worker_creation_failed, reason, tag, node}}
+    end
+  end
+
+  defp lock_materializer(worker, node, context) do
+    lock_fn = Map.get(context, :lock_materializer_fn, &default_lock_materializer/2)
+
+    case lock_fn.(worker, context.epoch) do
+      {:ok, pid, _info} -> {:ok, pid}
+      {:error, reason} -> {:error, {:materializer_lock_failed, reason, node}}
+    end
+  end
+
+  defp default_lock_materializer(worker, epoch), do: Materializer.lock_for_recovery(worker, epoch)
+
+  defp unlock_and_start_pulling(pid, tag, node, context) do
+    tsl = shard_tsl(tag, context)
+    unlock_fn = Map.get(context, :unlock_materializer_fn, &default_unlock_materializer/3)
+
+    case unlock_fn.(pid, context.durable_version, tsl) do
+      :ok -> :ok
+      {:error, reason} -> {:error, {:unlock_failed, reason, node}}
+      {:failure, reason, _ref} -> {:error, {:unlock_failed, reason, node}}
+    end
+  end
+
+  defp default_unlock_materializer(pid, durable_version, tsl),
+    do: Materializer.unlock_after_recovery(pid, durable_version, tsl, timeout_in_ms: 30_000)
+
+  # Builds the layout handed to the recruited materializer, filtered to the
+  # logs that route to its shard (same shape the bootstrap phase builds).
+  defp shard_tsl(tag, %{transaction_system_layout: snapshot, epoch: epoch}) do
+    %{
+      id: TransactionSystemLayout.random_id(),
+      epoch: epoch,
+      director: :unavailable,
+      sequencer: Map.get(snapshot, :sequencer),
+      rate_keeper: nil,
+      proxies: Map.get(snapshot, :proxies, []),
+      resolvers: Map.get(snapshot, :resolvers, []),
+      logs: snapshot |> Map.get(:logs, %{}) |> filter_logs_for_shard(tag),
+      services: Map.get(snapshot, :services, %{})
+    }
+  end
+
+  defp filter_logs_for_shard(logs, tag) do
+    logs
+    |> Enum.filter(fn {_log_id, tags} -> log_routes_to_shard?(tags, tag) end)
+    |> Map.new()
+  end
+
+  defp log_routes_to_shard?([], _tag), do: true
+  defp log_routes_to_shard?(tags, tag), do: tag in tags
+end

--- a/lib/bedrock/control_plane/distributor/server.ex
+++ b/lib/bedrock/control_plane/distributor/server.ex
@@ -18,16 +18,24 @@ defmodule Bedrock.ControlPlane.Distributor.Server do
     only: [
       emit_distributor_started: 3,
       emit_distributor_stopped: 3,
-      emit_coverage_demand: 2
+      emit_coverage_demand: 2,
+      emit_recruitment_started: 3,
+      emit_recruitment_succeeded: 5,
+      emit_recruitment_failed: 5
     ]
 
   import Bedrock.Internal.GenServer.Replies
 
   alias Bedrock.ControlPlane.Config.TransactionSystemLayout
+  alias Bedrock.ControlPlane.Director
   alias Bedrock.ControlPlane.Distributor.Placeholder
+  alias Bedrock.ControlPlane.Distributor.Recruitment
   alias Bedrock.ControlPlane.Distributor.State
+  alias Bedrock.DataPlane.Version
 
   require Logger
+
+  @default_backoff_ms 5_000
 
   @doc false
   @spec child_spec(
@@ -36,48 +44,52 @@ defmodule Bedrock.ControlPlane.Distributor.Server do
             epoch: Bedrock.epoch(),
             director: pid(),
             shard_layout: TransactionSystemLayout.shard_layout(),
+            transaction_system_layout: TransactionSystemLayout.t(),
+            durable_version: Bedrock.version(),
+            node_capabilities: %{Bedrock.Cluster.capability() => [node()]},
+            backoff_ms: pos_integer(),
+            recruitment: map(),
             otp_name: atom()
           ]
         ) :: Supervisor.child_spec()
   def child_spec(opts) do
-    cluster = opts[:cluster] || raise "Missing :cluster option"
-    epoch = opts[:epoch] || raise "Missing :epoch option"
-    director = opts[:director] || raise "Missing :director option"
     otp_name = opts[:otp_name] || raise "Missing :otp_name option"
-    shard_layout = opts[:shard_layout] || %{}
+    state = initial_state(opts)
 
     %{
-      id: {__MODULE__, cluster, epoch},
-      start:
-        {GenServer, :start_link,
-         [
-           __MODULE__,
-           {cluster, epoch, director, shard_layout},
-           [name: otp_name]
-         ]},
+      id: {__MODULE__, state.cluster, state.epoch},
+      start: {GenServer, :start_link, [__MODULE__, state, [name: otp_name]]},
       restart: :temporary
     }
   end
 
+  @spec initial_state(keyword()) :: State.t()
+  defp initial_state(opts) do
+    %State{
+      cluster: Keyword.fetch!(opts, :cluster),
+      epoch: Keyword.fetch!(opts, :epoch),
+      director: Keyword.fetch!(opts, :director),
+      shard_layout: Keyword.get(opts, :shard_layout, %{}),
+      transaction_system_layout: Keyword.get(opts, :transaction_system_layout, %{}),
+      durable_version: Keyword.get_lazy(opts, :durable_version, &Version.zero/0),
+      node_capabilities: Keyword.get(opts, :node_capabilities, %{}),
+      backoff_ms: Keyword.get(opts, :backoff_ms, @default_backoff_ms),
+      recruitment_overrides: Keyword.get(opts, :recruitment, %{})
+    }
+  end
+
   @impl true
-  @spec init({module(), Bedrock.epoch(), pid(), TransactionSystemLayout.shard_layout()}) ::
-          {:ok, State.t()}
-  def init({cluster, epoch, director, shard_layout}) do
+  @spec init(State.t()) :: {:ok, State.t()}
+  def init(%State{} = state) do
     # Monitor the Director - if it dies, this distributor should terminate
     # and let the next director recruit a fresh one. Trap exits so the
     # linked placeholder can be restarted when it dies.
     Process.flag(:trap_exit, true)
-    Process.monitor(director)
+    Process.monitor(state.director)
 
-    emit_distributor_started(cluster, epoch, director)
+    emit_distributor_started(state.cluster, state.epoch, state.director)
 
-    {:ok,
-     start_placeholder(%State{
-       cluster: cluster,
-       epoch: epoch,
-       director: director,
-       shard_layout: shard_layout
-     })}
+    {:ok, start_placeholder(state)}
   end
 
   @impl true
@@ -102,23 +114,57 @@ defmodule Bedrock.ControlPlane.Distributor.Server do
         Logger.info("Distributor for epoch #{t.epoch} superseded by epoch #{new_epoch}; stopping")
         stop(t, :normal)
 
-      _same_or_older ->
+      {:error, :newer_epoch_exists} ->
+        # A notification carrying an epoch *older* than our own should not
+        # occur in a healthy cluster; log it as suspicious and ignore it.
+        Logger.warning(
+          "Distributor for epoch #{t.epoch} ignoring suspicious epoch change notification " <>
+            "for older epoch #{new_epoch}"
+        )
+
+        noreply(t)
+
+      :ok ->
         noreply(t)
     end
   end
 
-  # Coverage demand from the placeholder. Recruitment itself lands in a
-  # later ticket (bedrock-q67.5); for now the demand is logged, counted,
-  # and remembered so the recruitment flow can pick it up.
+  # Coverage demand from the placeholder: recruit a materializer for the
+  # shard unless a recruitment is already in flight or the tag is inside
+  # its failure-backoff window.
   def handle_cast({:coverage_demand, tag}, %State{} = t) do
     Logger.info("Distributor for epoch #{t.epoch} received coverage demand for shard tag #{inspect(tag)}")
     emit_coverage_demand(t.cluster, tag)
 
-    noreply(%{t | pending_demands: MapSet.put(t.pending_demands, tag)})
+    t
+    |> maybe_recruit(tag)
+    |> noreply()
   end
 
-  # Internal/test seam until the recruitment flow (bedrock-q67.5) delivers
-  # coverage outcomes itself: relay a coverage result to the placeholder.
+  # Completion of an asynchronous recruitment attempt (cast back to
+  # ourselves from the recruitment task).
+  def handle_cast({:recruitment_complete, tag, {:ok, materializer, node}, duration_us}, %State{} = t) do
+    emit_recruitment_succeeded(t.cluster, t.epoch, tag, node, duration_us)
+    if t.placeholder, do: Placeholder.notify_covered(t.placeholder, tag, materializer)
+
+    noreply(%{t | pending_demands: MapSet.delete(t.pending_demands, tag)})
+  end
+
+  def handle_cast({:recruitment_complete, tag, {:error, :newer_epoch_exists}, _duration_us}, %State{} = t) do
+    Logger.info(
+      "Distributor for epoch #{t.epoch} superseded (TSL delta for shard tag #{inspect(tag)} rejected); stopping"
+    )
+
+    stop(t, :normal)
+  end
+
+  def handle_cast({:recruitment_complete, tag, {:error, reason}, duration_us}, %State{} = t) do
+    t
+    |> recruitment_failed(tag, reason, duration_us)
+    |> noreply()
+  end
+
+  # Internal/test seam: relay a coverage result to the placeholder.
   def handle_cast({:deliver_coverage, tag, materializer}, %State{} = t) do
     if t.placeholder, do: Placeholder.notify_covered(t.placeholder, tag, materializer)
 
@@ -157,6 +203,121 @@ defmodule Bedrock.ControlPlane.Distributor.Server do
 
     emit_distributor_stopped(t.cluster, t.epoch, reason)
     :ok
+  end
+
+  # Recruitment
+
+  @spec maybe_recruit(State.t(), Bedrock.range_tag()) :: State.t()
+  defp maybe_recruit(%State{} = t, tag) do
+    cond do
+      MapSet.member?(t.pending_demands, tag) ->
+        # A recruitment for this tag is already in flight.
+        t
+
+      in_backoff?(t, tag) ->
+        Logger.debug("Distributor for epoch #{t.epoch} ignoring demand for shard tag #{inspect(tag)} (in backoff)")
+
+        t
+
+      true ->
+        start_recruitment(%{t | backoff: Map.delete(t.backoff, tag)}, tag)
+    end
+  end
+
+  @spec in_backoff?(State.t(), Bedrock.range_tag()) :: boolean()
+  defp in_backoff?(%State{backoff: backoff}, tag) do
+    case Map.fetch(backoff, tag) do
+      {:ok, expires_at_ms} -> System.monotonic_time(:millisecond) < expires_at_ms
+      :error -> false
+    end
+  end
+
+  @spec start_recruitment(State.t(), Bedrock.range_tag()) :: State.t()
+  defp start_recruitment(%State{} = t, tag) do
+    case shard_range(t.shard_layout, tag) do
+      {:ok, _range} ->
+        emit_recruitment_started(t.cluster, t.epoch, tag)
+        spawn_recruitment_task(t, tag)
+        %{t | pending_demands: MapSet.put(t.pending_demands, tag)}
+
+      :error ->
+        recruitment_failed(t, tag, :unknown_shard_tag, 0)
+    end
+  end
+
+  # Resolves the key range for a shard tag from the layout snapshot
+  # (keyed by end_key, valued by {tag, start_key}).
+  @spec shard_range(TransactionSystemLayout.shard_layout(), Bedrock.range_tag()) ::
+          {:ok, Bedrock.key_range()} | :error
+  defp shard_range(shard_layout, tag) do
+    Enum.find_value(shard_layout, :error, fn {end_key, {shard_tag, start_key}} ->
+      if shard_tag == tag, do: {:ok, {start_key, end_key}}
+    end)
+  end
+
+  # Runs the recruitment (foreman worker creation, epoch lock/unlock, and
+  # the TSL delta to the director) off the distributor's message loop, then
+  # casts the outcome back so state mutation stays serialized.
+  @spec spawn_recruitment_task(State.t(), Bedrock.range_tag()) :: :ok
+  defp spawn_recruitment_task(%State{} = t, tag) do
+    distributor = self()
+    director = t.director
+    epoch = t.epoch
+    context = recruitment_context(t)
+
+    {:ok, _pid} =
+      Task.start(fn ->
+        started_at = System.monotonic_time(:microsecond)
+
+        result =
+          try do
+            with {:ok, materializer, node} <- Recruitment.recruit(tag, context),
+                 :ok <- Director.apply_tsl_delta(director, %{tag => materializer}, epoch) do
+              {:ok, materializer, node}
+            end
+          rescue
+            exception -> {:error, {:recruitment_crashed, Exception.message(exception)}}
+          catch
+            :exit, reason -> {:error, {:recruitment_exited, reason}}
+          end
+
+        duration_us = System.monotonic_time(:microsecond) - started_at
+        GenServer.cast(distributor, {:recruitment_complete, tag, result, duration_us})
+      end)
+
+    :ok
+  end
+
+  @spec recruitment_context(State.t()) :: Recruitment.context()
+  defp recruitment_context(%State{} = t) do
+    Map.merge(
+      %{
+        cluster: t.cluster,
+        epoch: t.epoch,
+        durable_version: t.durable_version,
+        transaction_system_layout: t.transaction_system_layout,
+        node_capabilities: t.node_capabilities
+      },
+      t.recruitment_overrides
+    )
+  end
+
+  @spec recruitment_failed(State.t(), Bedrock.range_tag(), reason :: term(), duration_us :: non_neg_integer()) ::
+          State.t()
+  defp recruitment_failed(%State{} = t, tag, reason, duration_us) do
+    Logger.warning(
+      "Distributor for epoch #{t.epoch} failed to recruit a materializer for shard tag " <>
+        "#{inspect(tag)}: #{inspect(reason)}"
+    )
+
+    emit_recruitment_failed(t.cluster, t.epoch, tag, reason, duration_us)
+    if t.placeholder, do: Placeholder.notify_coverage_failed(t.placeholder, tag, reason)
+
+    %{
+      t
+      | pending_demands: MapSet.delete(t.pending_demands, tag),
+        backoff: Map.put(t.backoff, tag, System.monotonic_time(:millisecond) + t.backoff_ms)
+    }
   end
 
   # The placeholder is linked (so it dies with the distributor) and its

--- a/lib/bedrock/control_plane/distributor/state.ex
+++ b/lib/bedrock/control_plane/distributor/state.ex
@@ -10,17 +10,29 @@ defmodule Bedrock.ControlPlane.Distributor.State do
           epoch: Bedrock.epoch(),
           director: pid(),
           shard_layout: TransactionSystemLayout.shard_layout(),
+          transaction_system_layout: TransactionSystemLayout.t() | %{},
+          durable_version: Bedrock.version(),
+          node_capabilities: %{Bedrock.Cluster.capability() => [node()]},
           materializer_monitors: %{reference() => Bedrock.range_tag()},
           placeholder: pid() | nil,
-          pending_demands: MapSet.t(Bedrock.range_tag())
+          pending_demands: MapSet.t(Bedrock.range_tag()),
+          backoff: %{Bedrock.range_tag() => expires_at_ms :: integer()},
+          backoff_ms: pos_integer(),
+          recruitment_overrides: map()
         }
   defstruct cluster: nil,
             epoch: nil,
             director: nil,
             shard_layout: %{},
+            transaction_system_layout: %{},
+            durable_version: nil,
+            node_capabilities: %{},
             materializer_monitors: %{},
             placeholder: nil,
-            pending_demands: MapSet.new()
+            pending_demands: MapSet.new(),
+            backoff: %{},
+            backoff_ms: 5_000,
+            recruitment_overrides: %{}
 
   @doc """
   Validates a caller-supplied epoch against the distributor's own epoch.

--- a/lib/bedrock/control_plane/distributor/telemetry.ex
+++ b/lib/bedrock/control_plane/distributor/telemetry.ex
@@ -30,6 +30,45 @@ defmodule Bedrock.ControlPlane.Distributor.Telemetry do
     )
   end
 
+  @spec emit_recruitment_started(module(), Bedrock.epoch(), Bedrock.range_tag()) :: :ok
+  def emit_recruitment_started(cluster, epoch, tag) do
+    :telemetry.execute(
+      [:bedrock, :distributor, :recruitment, :started],
+      %{},
+      %{cluster: cluster, epoch: epoch, tag: tag}
+    )
+  end
+
+  @spec emit_recruitment_succeeded(
+          module(),
+          Bedrock.epoch(),
+          Bedrock.range_tag(),
+          node(),
+          duration_us :: non_neg_integer()
+        ) :: :ok
+  def emit_recruitment_succeeded(cluster, epoch, tag, node, duration_us) do
+    :telemetry.execute(
+      [:bedrock, :distributor, :recruitment, :succeeded],
+      %{duration_us: duration_us},
+      %{cluster: cluster, epoch: epoch, tag: tag, node: node}
+    )
+  end
+
+  @spec emit_recruitment_failed(
+          module(),
+          Bedrock.epoch(),
+          Bedrock.range_tag(),
+          reason :: term(),
+          duration_us :: non_neg_integer()
+        ) :: :ok
+  def emit_recruitment_failed(cluster, epoch, tag, reason, duration_us) do
+    :telemetry.execute(
+      [:bedrock, :distributor, :recruitment, :failed],
+      %{duration_us: duration_us},
+      %{cluster: cluster, epoch: epoch, tag: tag, reason: reason}
+    )
+  end
+
   @spec emit_placeholder_parked(module(), Bedrock.range_tag()) :: :ok
   def emit_placeholder_parked(cluster, tag) do
     :telemetry.execute(

--- a/test/bedrock/cluster/tsl_delta_round_trip_test.exs
+++ b/test/bedrock/cluster/tsl_delta_round_trip_test.exs
@@ -80,13 +80,14 @@ defmodule Bedrock.Cluster.TSLDeltaRoundTripTest do
     }
   end
 
-  defp start_coordinator(epoch) do
+  defp start_coordinator(epoch, opts \\ []) do
     state = %Coordinator.State{
       cluster: TestCluster,
       my_node: Node.self(),
       leader_node: Node.self(),
       epoch: epoch,
-      otp_name: @coordinator_otp_name
+      otp_name: @coordinator_otp_name,
+      transaction_system_layout: Keyword.get(opts, :tsl)
     }
 
     start_supervised!(%{
@@ -215,5 +216,58 @@ defmodule Bedrock.Cluster.TSLDeltaRoundTripTest do
 
     assert_receive {:tsl_updated, tsl}
     assert tsl.shard_materializers == %{1 => materializer}
+  end
+
+  test "a notify from a deposed director (older epoch) is dropped by the coordinator" do
+    # Coordinator has moved on to epoch 6 (leadership change); a director from
+    # epoch 5 still manages to emit a notify (e.g. an in-flight delta that
+    # raced the leadership change). The coordinator must not regress its epoch
+    # nor broadcast the stale TSL.
+    coordinator = start_coordinator(6)
+    :ok = Coordinator.subscribe_to_tsl_updates(coordinator, self())
+
+    stale_director = start_director(5, coordinator)
+    materializer = spawn(fn -> Process.sleep(:infinity) end)
+
+    # The stale director accepts the delta against its own (old) epoch...
+    assert :ok = Director.apply_tsl_delta(stale_director, %{1 => materializer}, 5)
+
+    # ...but the coordinator drops the resulting notify: nothing is broadcast
+    # and the coordinator's TSL/epoch are unchanged.
+    refute_receive {:tsl_updated, _}, 100
+    assert {:ok, nil} = GenServer.call(coordinator, :fetch_transaction_system_layout)
+    assert {:pong, 6, _leader} = GenServer.call(coordinator, :ping)
+  end
+
+  test "snapshot-on-subscribe does not push the bootstrap-loaded old-TSL stub" do
+    # At init the coordinator may hold a partial old-TSL stub loaded from
+    # object storage (bare %{logs: ...}, recovery input only). Subscribers
+    # must not receive it as if it were a live TSL.
+    coordinator = start_coordinator(5, tsl: %{logs: %{"log_1" => [0]}})
+
+    :ok = Coordinator.subscribe_to_tsl_updates(coordinator, self())
+    refute_receive {:tsl_updated, _}, 100
+
+    # Once a director produces a real TSL, the subscriber hears about it.
+    director = start_director(5, coordinator)
+    materializer = spawn(fn -> Process.sleep(:infinity) end)
+    assert :ok = Director.apply_tsl_delta(director, %{1 => materializer}, 5)
+
+    assert_receive {:tsl_updated, %{epoch: 5}}
+  end
+
+  test "repeated subscriptions do not accumulate duplicate monitors" do
+    coordinator = start_coordinator(5)
+
+    :ok = Coordinator.subscribe_to_tsl_updates(coordinator, self())
+    :ok = Coordinator.subscribe_to_tsl_updates(coordinator, self())
+    :ok = Coordinator.subscribe_to_tsl_updates(coordinator, self())
+
+    # Synchronize on the casts having been processed.
+    assert {:pong, 5, _} = GenServer.call(coordinator, :ping)
+
+    {:monitors, monitors} = Process.info(coordinator, :monitors)
+    me = self()
+    assert Enum.count(monitors, &match?({:process, ^me}, &1)) == 1
   end
 end

--- a/test/bedrock/cluster/tsl_delta_round_trip_test.exs
+++ b/test/bedrock/cluster/tsl_delta_round_trip_test.exs
@@ -1,0 +1,219 @@
+defmodule Bedrock.Cluster.TSLDeltaRoundTripTest do
+  @moduledoc """
+  Round-trip test for post-recovery TSL delta application:
+
+      Director.apply_tsl_delta/3
+        -> Coordinator {:notify_transaction_system_layout, tsl}
+        -> Coordinator broadcasts {:tsl_updated, tsl} to subscribed Links
+        -> Link serves the new TSL via fetch_transaction_system_layout/1
+
+  Uses the real `Link.Server` GenServer and thin harness GenServers that
+  delegate their callbacks to the real `Coordinator.Server` and
+  `Director.Server` handler functions (skipping only their heavyweight
+  `init` paths: raft bootstrap and recovery).
+  """
+  use ExUnit.Case, async: false
+
+  alias Bedrock.Cluster.Descriptor
+  alias Bedrock.Cluster.Link
+  alias Bedrock.ControlPlane.Coordinator
+  alias Bedrock.ControlPlane.Coordinator.Server
+  alias Bedrock.ControlPlane.Director
+
+  @coordinator_otp_name :tsl_round_trip_coordinator
+
+  defmodule TestCluster do
+    @moduledoc false
+
+    @spec otp_name(atom()) :: atom()
+    def otp_name(:coordinator), do: :tsl_round_trip_coordinator
+    def otp_name(component), do: :"tsl_round_trip_#{component}"
+
+    @spec gateway_ping_timeout_in_ms() :: pos_integer()
+    def gateway_ping_timeout_in_ms, do: 100
+
+    @spec coordinator_ping_timeout_in_ms() :: pos_integer()
+    def coordinator_ping_timeout_in_ms, do: 100
+  end
+
+  defmodule CoordinatorHarness do
+    @moduledoc false
+    use GenServer
+
+    @impl true
+    def init(state), do: {:ok, state}
+
+    @impl true
+    defdelegate handle_call(message, from, state), to: Server
+
+    @impl true
+    defdelegate handle_cast(message, state), to: Server
+
+    @impl true
+    defdelegate handle_info(message, state), to: Server
+  end
+
+  defmodule DirectorHarness do
+    @moduledoc false
+    use GenServer
+
+    @impl true
+    def init(state), do: {:ok, state}
+
+    @impl true
+    defdelegate handle_call(message, from, state), to: Bedrock.ControlPlane.Director.Server
+  end
+
+  defp base_tsl(epoch) do
+    %{
+      id: 1,
+      epoch: epoch,
+      director: nil,
+      sequencer: nil,
+      rate_keeper: nil,
+      proxies: [],
+      resolvers: [],
+      logs: %{},
+      services: %{},
+      shard_layout: %{},
+      shard_materializers: %{}
+    }
+  end
+
+  defp start_coordinator(epoch) do
+    state = %Coordinator.State{
+      cluster: TestCluster,
+      my_node: Node.self(),
+      leader_node: Node.self(),
+      epoch: epoch,
+      otp_name: @coordinator_otp_name
+    }
+
+    start_supervised!(%{
+      id: CoordinatorHarness,
+      start: {GenServer, :start_link, [CoordinatorHarness, state, [name: @coordinator_otp_name]]}
+    })
+  end
+
+  defp start_director(epoch, coordinator) do
+    state = %Director.State{
+      state: :running,
+      epoch: epoch,
+      cluster: TestCluster,
+      coordinator: coordinator,
+      transaction_system_layout: base_tsl(epoch)
+    }
+
+    start_supervised!(%{
+      id: DirectorHarness,
+      start: {GenServer, :start_link, [DirectorHarness, state]}
+    })
+  end
+
+  defp start_link_server do
+    descriptor = %Descriptor{cluster_name: "tsl_round_trip", coordinator_nodes: [Node.self()]}
+
+    start_supervised!(%{
+      id: Link.Server,
+      start: {GenServer, :start_link, [Link.Server, {TestCluster, "/dev/null", descriptor, :active, []}]}
+    })
+  end
+
+  defp eventually(fun, attempts \\ 50)
+  defp eventually(fun, 0), do: fun.() || flunk("condition never became true")
+
+  defp eventually(fun, attempts) do
+    result = fun.()
+
+    if result do
+      result
+    else
+      Process.sleep(10)
+      eventually(fun, attempts - 1)
+    end
+  end
+
+  test "director delta application propagates through the coordinator to a live Link" do
+    coordinator = start_coordinator(5)
+    link = start_link_server()
+
+    eventually(fn -> match?({:ok, _}, Link.fetch_coordinator(link)) end)
+    assert {:error, :unavailable} = Link.fetch_transaction_system_layout(link)
+
+    director = start_director(5, coordinator)
+    materializer = spawn(fn -> Process.sleep(:infinity) end)
+
+    assert :ok = Director.apply_tsl_delta(director, %{1 => materializer}, 5)
+
+    tsl =
+      eventually(fn ->
+        case Link.fetch_transaction_system_layout(link) do
+          {:ok, tsl} -> tsl
+          {:error, :unavailable} -> nil
+        end
+      end)
+
+    assert tsl.shard_materializers == %{1 => materializer}
+    assert tsl.epoch == 5
+  end
+
+  test "a delta carrying a stale epoch is rejected and nothing is broadcast" do
+    coordinator = start_coordinator(5)
+    link = start_link_server()
+
+    eventually(fn -> match?({:ok, _}, Link.fetch_coordinator(link)) end)
+
+    director = start_director(5, coordinator)
+    materializer = spawn(fn -> Process.sleep(:infinity) end)
+
+    assert {:error, :newer_epoch_exists} = Director.apply_tsl_delta(director, %{1 => materializer}, 4)
+
+    # Apply a valid delta afterwards; the first TSL the link observes must not
+    # contain any effect from the stale delta.
+    assert :ok = Director.apply_tsl_delta(director, %{2 => materializer}, 5)
+
+    tsl =
+      eventually(fn ->
+        case Link.fetch_transaction_system_layout(link) do
+          {:ok, tsl} -> tsl
+          {:error, :unavailable} -> nil
+        end
+      end)
+
+    assert tsl.shard_materializers == %{2 => materializer}
+  end
+
+  test "a dead subscriber does not break broadcast to remaining subscribers" do
+    coordinator = start_coordinator(5)
+
+    dead_link = spawn(fn -> :ok end)
+    ref = Process.monitor(dead_link)
+    assert_receive {:DOWN, ^ref, :process, ^dead_link, _}
+
+    :ok = Coordinator.subscribe_to_tsl_updates(coordinator, dead_link)
+    :ok = Coordinator.subscribe_to_tsl_updates(coordinator, self())
+
+    director = start_director(5, coordinator)
+    materializer = spawn(fn -> Process.sleep(:infinity) end)
+
+    assert :ok = Director.apply_tsl_delta(director, %{1 => materializer}, 5)
+
+    assert_receive {:tsl_updated, tsl}
+    assert tsl.shard_materializers == %{1 => materializer}
+  end
+
+  test "subscribing after a TSL is known delivers the current TSL immediately" do
+    coordinator = start_coordinator(5)
+    director = start_director(5, coordinator)
+    materializer = spawn(fn -> Process.sleep(:infinity) end)
+
+    assert :ok = Director.apply_tsl_delta(director, %{1 => materializer}, 5)
+
+    # Subscribe only after the coordinator already holds a TSL; we should be
+    # brought up to date without waiting for the next delta.
+    :ok = Coordinator.subscribe_to_tsl_updates(coordinator, self())
+
+    assert_receive {:tsl_updated, tsl}
+    assert tsl.shard_materializers == %{1 => materializer}
+  end
+end

--- a/test/bedrock/control_plane/coordinator/state_test.exs
+++ b/test/bedrock/control_plane/coordinator/state_test.exs
@@ -39,4 +39,52 @@ defmodule Bedrock.ControlPlane.Coordinator.StateTest do
       assert state.service_directory == %{}
     end
   end
+
+  describe "TSL subscriber state changes" do
+    test "add_tsl_subscriber is idempotent" do
+      state =
+        %State{}
+        |> Changes.add_tsl_subscriber(self())
+        |> Changes.add_tsl_subscriber(self())
+
+      assert state.tsl_subscribers == MapSet.new([self()])
+    end
+
+    test "remove_tsl_subscriber removes only the given subscriber" do
+      other = spawn(fn -> Process.sleep(:infinity) end)
+
+      state =
+        %State{}
+        |> Changes.add_tsl_subscriber(self())
+        |> Changes.add_tsl_subscriber(other)
+        |> Changes.remove_tsl_subscriber(other)
+
+      assert state.tsl_subscribers == MapSet.new([self()])
+    end
+
+    test "broadcast_tsl_update sends {:tsl_updated, tsl} to every subscriber" do
+      tsl = %{epoch: 1, shard_materializers: %{}}
+
+      state = Changes.add_tsl_subscriber(%State{}, self())
+
+      assert ^state = Changes.broadcast_tsl_update(state, tsl)
+      assert_receive {:tsl_updated, ^tsl}
+    end
+
+    test "broadcast_tsl_update tolerates dead subscribers" do
+      dead = spawn(fn -> :ok end)
+      ref = Process.monitor(dead)
+      assert_receive {:DOWN, ^ref, :process, ^dead, _}
+
+      tsl = %{epoch: 1, shard_materializers: %{}}
+
+      state =
+        %State{}
+        |> Changes.add_tsl_subscriber(dead)
+        |> Changes.add_tsl_subscriber(self())
+
+      assert ^state = Changes.broadcast_tsl_update(state, tsl)
+      assert_receive {:tsl_updated, ^tsl}
+    end
+  end
 end

--- a/test/bedrock/control_plane/director/distributor_recruitment_test.exs
+++ b/test/bedrock/control_plane/director/distributor_recruitment_test.exs
@@ -73,7 +73,13 @@ defmodule Bedrock.ControlPlane.Director.DistributorRecruitmentTest do
       original = state.distributor
       kill_and_wait(original)
 
-      assert {:noreply, new_state} = Server.handle_info({:DOWN, make_ref(), :process, original, :killed}, state)
+      # A non-:normal exit schedules a delayed re-recruit (the retry timer
+      # puts a floor under a crash-looping distributor).
+      assert {:noreply, down_state} = Server.handle_info({:DOWN, make_ref(), :process, original, :killed}, state)
+      assert down_state.distributor == nil
+      assert_receive {:timeout, :retry_start_distributor}, 2_000
+
+      assert {:noreply, new_state} = Server.handle_info({:timeout, :retry_start_distributor}, down_state)
 
       assert is_pid(new_state.distributor)
       assert new_state.distributor != original
@@ -105,6 +111,30 @@ defmodule Bedrock.ControlPlane.Director.DistributorRecruitmentTest do
       assert {:noreply, new_state} = Server.handle_info({:DOWN, ref, :process, distributor, :normal}, state)
 
       assert new_state.distributor == nil
+    end
+
+    test "a newer-epoch director does not adopt a stale distributor under the shared name" do
+      # An epoch-5 distributor is still registered under the shared otp name
+      # when an epoch-6 director recruits: the starter's already_started
+      # mapping would hand back the stale pid, so the director must epoch
+      # check it (the stale distributor stops itself) and retry instead.
+      stale_state = Server.maybe_start_distributor(running_state())
+      stale = stale_state.distributor
+      ref = Process.monitor(stale)
+
+      new_director_state = Server.maybe_start_distributor(running_state(%{epoch: 6}))
+
+      assert new_director_state.distributor == nil
+      assert_receive {:DOWN, ^ref, :process, ^stale, :normal}
+      assert_receive {:timeout, :retry_start_distributor}, 2_000
+
+      # Once the stale registration has cleared, the retry recruits a fresh
+      # epoch-6 distributor.
+      assert {:noreply, recruited} = Server.handle_info({:timeout, :retry_start_distributor}, new_director_state)
+
+      assert is_pid(recruited.distributor)
+      assert recruited.distributor != stale
+      assert %DistributorState{epoch: 6} = :sys.get_state(recruited.distributor)
     end
   end
 

--- a/test/bedrock/control_plane/director/distributor_recruitment_test.exs
+++ b/test/bedrock/control_plane/director/distributor_recruitment_test.exs
@@ -100,11 +100,33 @@ defmodule Bedrock.ControlPlane.Director.DistributorRecruitmentTest do
 
       assert_receive {:DOWN, ^ref, :process, ^distributor, :normal}
 
-      # The monitoring director would then re-recruit at its current epoch.
+      # A :normal exit means the distributor ceded to a newer epoch: a newer
+      # director owns coverage now, so this director must not re-recruit.
       assert {:noreply, new_state} = Server.handle_info({:DOWN, ref, :process, distributor, :normal}, state)
 
-      assert is_pid(new_state.distributor)
-      assert %DistributorState{epoch: 5} = :sys.get_state(new_state.distributor)
+      assert new_state.distributor == nil
+    end
+  end
+
+  describe "recruitment retry" do
+    test "a failed distributor start schedules a retry" do
+      # Point the starter at a nonexistent supervisor so the start fails.
+      defmodule NoSupCluster do
+        @moduledoc false
+        def otp_name(component), do: :"distributor_recruitment_no_sup_#{component}"
+      end
+
+      state = Server.maybe_start_distributor(running_state(%{cluster: NoSupCluster}))
+
+      assert state.distributor == nil
+      assert_receive {:timeout, :retry_start_distributor}, 2_000
+    end
+
+    test "the retry message re-attempts recruitment" do
+      assert {:noreply, state} = Server.handle_info({:timeout, :retry_start_distributor}, running_state())
+
+      assert is_pid(state.distributor)
+      assert Process.alive?(state.distributor)
     end
   end
 end

--- a/test/bedrock/control_plane/director/tsl_delta_test.exs
+++ b/test/bedrock/control_plane/director/tsl_delta_test.exs
@@ -1,0 +1,131 @@
+defmodule Bedrock.ControlPlane.Director.TSLDeltaTest do
+  use ExUnit.Case, async: true
+
+  import Bedrock.Test.TelemetryTestHelper
+
+  alias Bedrock.ControlPlane.Director.Server
+  alias Bedrock.ControlPlane.Director.State
+
+  defp base_tsl(shard_materializers) do
+    %{
+      id: 1,
+      epoch: 5,
+      director: self(),
+      sequencer: nil,
+      rate_keeper: nil,
+      proxies: [],
+      resolvers: [],
+      logs: %{},
+      services: %{},
+      shard_layout: %{},
+      shard_materializers: shard_materializers
+    }
+  end
+
+  defp director_state(opts \\ []) do
+    %State{
+      state: :running,
+      epoch: Keyword.get(opts, :epoch, 5),
+      cluster: TestCluster,
+      coordinator: Keyword.get(opts, :coordinator, self()),
+      transaction_system_layout: Keyword.get(opts, :tsl, base_tsl(%{}))
+    }
+  end
+
+  describe "handle_call({:apply_tsl_delta, delta, epoch}, ...)" do
+    test "applies a put delta to shard_materializers and notifies the coordinator" do
+      materializer = spawn(fn -> Process.sleep(:infinity) end)
+      state = director_state()
+
+      assert {:reply, :ok, updated_state} =
+               Server.handle_call({:apply_tsl_delta, %{1 => materializer}, 5}, {self(), make_ref()}, state)
+
+      assert updated_state.transaction_system_layout.shard_materializers == %{1 => materializer}
+
+      assert_receive {:"$gen_cast", {:notify_transaction_system_layout, broadcast_tsl}}
+      assert broadcast_tsl == updated_state.transaction_system_layout
+    end
+
+    test "applies a :remove delta by deleting the shard entry" do
+      old_materializer = spawn(fn -> Process.sleep(:infinity) end)
+      state = director_state(tsl: base_tsl(%{1 => old_materializer, 2 => old_materializer}))
+
+      assert {:reply, :ok, updated_state} =
+               Server.handle_call({:apply_tsl_delta, %{1 => :remove}, 5}, {self(), make_ref()}, state)
+
+      assert updated_state.transaction_system_layout.shard_materializers == %{2 => old_materializer}
+    end
+
+    test "mixed delta puts and removes in one application" do
+      old_materializer = spawn(fn -> Process.sleep(:infinity) end)
+      new_materializer = spawn(fn -> Process.sleep(:infinity) end)
+      state = director_state(tsl: base_tsl(%{1 => old_materializer, 2 => old_materializer}))
+
+      delta = %{1 => new_materializer, 2 => :remove, 3 => new_materializer}
+
+      assert {:reply, :ok, updated_state} =
+               Server.handle_call({:apply_tsl_delta, delta, 5}, {self(), make_ref()}, state)
+
+      assert updated_state.transaction_system_layout.shard_materializers ==
+               %{1 => new_materializer, 3 => new_materializer}
+    end
+
+    test "creates the shard_materializers map when the TSL lacks one" do
+      materializer = spawn(fn -> Process.sleep(:infinity) end)
+      tsl = Map.delete(base_tsl(%{}), :shard_materializers)
+      state = director_state(tsl: tsl)
+
+      assert {:reply, :ok, updated_state} =
+               Server.handle_call({:apply_tsl_delta, %{7 => materializer}, 5}, {self(), make_ref()}, state)
+
+      assert updated_state.transaction_system_layout.shard_materializers == %{7 => materializer}
+    end
+
+    test "rejects a delta carrying a stale epoch with :newer_epoch_exists" do
+      state = director_state(epoch: 5)
+      materializer = spawn(fn -> Process.sleep(:infinity) end)
+
+      assert {:reply, {:error, :newer_epoch_exists}, unchanged_state} =
+               Server.handle_call({:apply_tsl_delta, %{1 => materializer}, 4}, {self(), make_ref()}, state)
+
+      assert unchanged_state.transaction_system_layout == state.transaction_system_layout
+      refute_receive {:"$gen_cast", {:notify_transaction_system_layout, _}}
+    end
+
+    test "rejects a delta carrying an unknown (newer) epoch with :newer_epoch_exists" do
+      state = director_state(epoch: 5)
+      materializer = spawn(fn -> Process.sleep(:infinity) end)
+
+      assert {:reply, {:error, :newer_epoch_exists}, _} =
+               Server.handle_call({:apply_tsl_delta, %{1 => materializer}, 6}, {self(), make_ref()}, state)
+
+      refute_receive {:"$gen_cast", {:notify_transaction_system_layout, _}}
+    end
+
+    test "rejects a delta before recovery has produced a TSL with :unavailable" do
+      state = director_state(tsl: nil)
+      materializer = spawn(fn -> Process.sleep(:infinity) end)
+
+      assert {:reply, {:error, :unavailable}, _} =
+               Server.handle_call({:apply_tsl_delta, %{1 => materializer}, 5}, {self(), make_ref()}, state)
+
+      refute_receive {:"$gen_cast", {:notify_transaction_system_layout, _}}
+    end
+
+    test "emits a tsl_delta_applied telemetry event" do
+      attach_telemetry_reflector(self(), [[:bedrock, :director, :tsl_delta_applied]], "tsl-delta-telemetry")
+
+      materializer = spawn(fn -> Process.sleep(:infinity) end)
+      delta = %{1 => materializer, 2 => :remove}
+      state = director_state()
+
+      assert {:reply, :ok, _} = Server.handle_call({:apply_tsl_delta, delta, 5}, {self(), make_ref()}, state)
+
+      assert_receive {:telemetry_event, [:bedrock, :director, :tsl_delta_applied], measurements, metadata}
+      assert measurements == %{shard_count: 2}
+      assert metadata.epoch == 5
+      assert metadata.cluster == TestCluster
+      assert metadata.delta == delta
+    end
+  end
+end

--- a/test/bedrock/control_plane/distributor/recruitment_integration_test.exs
+++ b/test/bedrock/control_plane/distributor/recruitment_integration_test.exs
@@ -1,0 +1,180 @@
+defmodule Bedrock.ControlPlane.Distributor.RecruitmentIntegrationTest do
+  @moduledoc """
+  Closes the Phase A loop end-to-end: a client read through the full
+  PointReads → StorageRacing → LayoutIndex path against a
+  placeholder-covered shard triggers coverage demand, the Distributor's
+  recruitment plumbing runs for real (placement, epoch lock/unlock, TSL
+  delta to the director), the SAME parked read returns the real value, and
+  a subsequent read goes direct once the layout reflects the new
+  materializer.
+
+  Only the foreman worker-creation boundary is stubbed: the "created"
+  worker is a pre-registered process speaking the real materializer
+  lock/unlock and read protocols (a StubMaterializer, and in the final
+  test a real olivine materializer on a tmp dir).
+  """
+  use ExUnit.Case, async: true
+
+  alias Bedrock.ControlPlane.Distributor
+  alias Bedrock.ControlPlane.Distributor.State, as: DistributorState
+  alias Bedrock.DataPlane.Materializer.Olivine
+  alias Bedrock.DataPlane.Version
+  alias Bedrock.Internal.TransactionBuilder.LayoutIndex
+  alias Bedrock.Internal.TransactionBuilder.PointReads
+  alias Bedrock.Internal.TransactionBuilder.State
+  alias Bedrock.Test.ControlPlane.StubMaterializer
+
+  defmodule TestCluster do
+    @moduledoc false
+    def otp_name(component), do: :"recruitment_integration_#{component}"
+  end
+
+  defmodule CaptureDirector do
+    @moduledoc false
+    use GenServer
+
+    def start_link(test_pid), do: GenServer.start_link(__MODULE__, test_pid)
+
+    @impl true
+    def init(test_pid), do: {:ok, test_pid}
+
+    @impl true
+    def handle_call({:apply_tsl_delta, delta, epoch}, _from, test_pid) do
+      send(test_pid, {:apply_tsl_delta, delta, epoch})
+      {:reply, :ok, test_pid}
+    end
+  end
+
+  # A single data shard (tag 1) covering the whole keyspace.
+  @shard_layout %{<<0xFF, 0xFF>> => {1, <<>>}}
+  @epoch 42
+
+  defp start_distributor(opts) do
+    director = start_supervised!({CaptureDirector, self()}, id: :capture_director)
+
+    pid =
+      start_supervised!(
+        Distributor.child_spec(
+          Keyword.merge(
+            [
+              cluster: TestCluster,
+              epoch: @epoch,
+              director: director,
+              shard_layout: @shard_layout,
+              node_capabilities: %{materializer: [node()]},
+              durable_version: Version.zero(),
+              otp_name: :"recruitment_integration_#{System.unique_integer([:positive])}"
+            ],
+            opts
+          )
+        )
+      )
+
+    %DistributorState{placeholder: placeholder} = :sys.get_state(pid)
+    {pid, placeholder}
+  end
+
+  defp client_state(materializer_pid, read_version) do
+    layout_index =
+      LayoutIndex.build_index(%{
+        shard_layout: @shard_layout,
+        shard_materializers: %{1 => materializer_pid}
+      })
+
+    %State{
+      state: :valid,
+      layout_index: layout_index,
+      read_version: read_version,
+      fetch_timeout_in_ms: 5_000
+    }
+  end
+
+  test "a read against a placeholder-covered shard recruits a materializer and completes" do
+    # The "node's worker": pre-registered so the (stubbed) foreman boundary
+    # can hand back its ref; it speaks the real lock/unlock protocol.
+    worker_name = :"recruited_stub_#{System.unique_integer([:positive])}"
+
+    start_supervised!(%{
+      id: :recruited_stub,
+      start: {StubMaterializer, :start_link, [%{"apple" => "red"}, [name: worker_name, observer: self()]]}
+    })
+
+    # Thin seam at the foreman boundary ONLY: worker creation returns the
+    # ref of the worker "started" on the chosen node. Placement, epoch
+    # lock/unlock, and the TSL delta all run for real.
+    recruitment = %{
+      create_worker_fn: fn {_foreman_name, _node}, _worker_id, :materializer, _opts -> {:ok, worker_name} end
+    }
+
+    {_distributor, placeholder} = start_distributor(recruitment: recruitment)
+
+    # A read through the full client path against the placeholder-covered shard.
+    state = client_state(placeholder, Version.from_integer(1))
+    task = Task.async(fn -> PointReads.get_key(state, "apple") end)
+
+    # Recruitment ran the real epoch calls against the worker...
+    assert_receive {:stub_materializer, {:locked_for_recovery, worker_pid, @epoch}}, 5_000
+    zero = Version.zero()
+    assert_receive {:stub_materializer, {:unlocked_after_recovery, ^worker_pid, ^zero, unlock_tsl}}
+    assert unlock_tsl.epoch == @epoch
+
+    # ...and applied the TSL delta at the director with the current epoch.
+    assert_receive {:apply_tsl_delta, %{1 => ^worker_pid}, @epoch}, 5_000
+
+    # The SAME read (parked at the placeholder) returns the real value.
+    assert {%State{}, {:ok, {"apple", "red"}}} = Task.await(task, 5_000)
+
+    # Once the TSL update propagates, a subsequent read goes direct to the
+    # recruited materializer - no placeholder, no new demand.
+    direct_state = client_state(worker_pid, Version.from_integer(1))
+    assert {%State{}, {:ok, {"apple", "red"}}} = PointReads.get_key(direct_state, "apple")
+    refute_receive {:stub_materializer, {:locked_for_recovery, _, _}}, 100
+  end
+
+  test "recruits a REAL olivine materializer and serves a read through it" do
+    tmp_dir = "/tmp/recruitment_olivine_#{System.unique_integer([:positive])}"
+    File.mkdir_p!(tmp_dir)
+    on_exit(fn -> File.rm_rf(tmp_dir) end)
+
+    worker_id = "olivine_recruit_#{System.unique_integer([:positive])}"
+    worker_name = :"recruited_olivine_#{System.unique_integer([:positive])}"
+
+    start_supervised!(
+      Olivine.child_spec(
+        otp_name: worker_name,
+        foreman: self(),
+        id: worker_id,
+        path: tmp_dir
+      )
+    )
+
+    # Wait until the worker reports healthy to its (stub) foreman.
+    assert_receive {:"$gen_cast", {:worker_health, ^worker_id, {:ok, worker_pid}}}, 5_000
+
+    # Stub ONLY the foreman worker-creation call; the real
+    # Materializer.lock_for_recovery/unlock_after_recovery calls run
+    # against the live olivine worker.
+    recruitment = %{
+      create_worker_fn: fn {_foreman_name, _node}, _worker_id, :materializer, _opts -> {:ok, worker_name} end
+    }
+
+    {_distributor, placeholder} = start_distributor(recruitment: recruitment)
+
+    # Read at the durable version the recruit is unlocked with (a fresh
+    # cluster's version zero) so the materializer can serve immediately.
+    state = client_state(placeholder, Version.zero())
+    task = Task.async(fn -> PointReads.get_key(state, "apple") end)
+
+    # Recruitment completes: the TSL delta names the live olivine pid.
+    assert_receive {:apply_tsl_delta, %{1 => ^worker_pid}, @epoch}, 10_000
+
+    # The parked read is served through the recruited olivine materializer
+    # (no value has ever been written, so it resolves to :not_found - a
+    # definitive answer from a live materializer, not a failure).
+    assert {%State{}, {:error, :not_found}} = Task.await(task, 10_000)
+
+    # A subsequent read goes direct to the olivine worker.
+    direct_state = client_state(worker_pid, Version.zero())
+    assert {%State{}, {:error, :not_found}} = PointReads.get_key(direct_state, "apple")
+  end
+end

--- a/test/bedrock/control_plane/distributor/recruitment_test.exs
+++ b/test/bedrock/control_plane/distributor/recruitment_test.exs
@@ -1,0 +1,298 @@
+defmodule Bedrock.ControlPlane.Distributor.RecruitmentTest do
+  @moduledoc """
+  Unit tests for the Distributor's on-demand materializer recruitment flow,
+  with the worker layer stubbed through the same injectable-function seams
+  the recovery bootstrap phase uses (`create_worker_fn`,
+  `lock_materializer_fn`, `unlock_materializer_fn`).
+  """
+  use ExUnit.Case, async: true
+
+  import ExUnit.CaptureLog
+
+  alias Bedrock.ControlPlane.Distributor
+  alias Bedrock.ControlPlane.Distributor.State
+  alias Bedrock.DataPlane.Materializer
+  alias Bedrock.DataPlane.Version
+  alias Bedrock.Test.ControlPlane.StubMaterializer
+
+  defmodule TestCluster do
+    @moduledoc false
+    def otp_name(component), do: :"distributor_recruitment_unit_#{component}"
+  end
+
+  defmodule CaptureDirector do
+    @moduledoc """
+    A stand-in director that captures `apply_tsl_delta` calls, forwards them
+    to the test process, and replies with a configured result.
+    """
+    use GenServer
+
+    def start_link(test_pid, reply \\ :ok), do: GenServer.start_link(__MODULE__, {test_pid, reply})
+
+    @impl true
+    def init(state), do: {:ok, state}
+
+    @impl true
+    def handle_call({:apply_tsl_delta, delta, epoch}, _from, {test_pid, reply} = state) do
+      send(test_pid, {:apply_tsl_delta, delta, epoch})
+      {:reply, reply, state}
+    end
+  end
+
+  # A single data shard (tag 1) covering the whole keyspace.
+  @shard_layout %{<<0xFF, 0xFF>> => {1, <<>>}}
+  @version Version.from_integer(1)
+
+  defp unique_otp_name, do: :"distributor_recruitment_unit_#{System.unique_integer([:positive])}"
+
+  defp attach_recruitment_telemetry(test_pid) do
+    handler_id = "recruitment-test-#{System.unique_integer([:positive])}"
+
+    :telemetry.attach_many(
+      handler_id,
+      [
+        [:bedrock, :distributor, :recruitment, :started],
+        [:bedrock, :distributor, :recruitment, :succeeded],
+        [:bedrock, :distributor, :recruitment, :failed]
+      ],
+      fn event, measurements, metadata, _config ->
+        send(test_pid, {:telemetry, event, measurements, metadata})
+      end,
+      nil
+    )
+
+    on_exit(fn -> :telemetry.detach(handler_id) end)
+  end
+
+  defp start_stub(kvs) do
+    start_supervised!(%{
+      id: {StubMaterializer, System.unique_integer([:positive])},
+      start: {StubMaterializer, :start_link, [kvs]}
+    })
+  end
+
+  defp start_distributor(opts) do
+    director =
+      Keyword.get_lazy(opts, :director, fn -> start_supervised!({CaptureDirector, self()}, id: :capture_director) end)
+
+    pid =
+      start_supervised!(
+        Distributor.child_spec(
+          Keyword.merge(
+            [
+              cluster: TestCluster,
+              epoch: 42,
+              director: director,
+              shard_layout: @shard_layout,
+              node_capabilities: %{materializer: [node()]},
+              durable_version: Version.zero(),
+              otp_name: unique_otp_name()
+            ],
+            Keyword.delete(opts, :director)
+          )
+        )
+      )
+
+    {pid, director}
+  end
+
+  defp placeholder_of(distributor) do
+    %State{placeholder: placeholder} = :sys.get_state(distributor)
+    placeholder
+  end
+
+  defp park_read(placeholder, key) do
+    Task.async(fn -> Materializer.get(placeholder, key, @version, timeout: 5_000) end)
+  end
+
+  describe "successful recruitment" do
+    test "demand drives placement, foreman creation, epoch lock/unlock, TSL delta, and coverage" do
+      attach_recruitment_telemetry(self())
+      test_pid = self()
+      stub = start_stub(%{"apple" => "red"})
+
+      recruitment = %{
+        create_worker_fn: fn foreman, worker_id, kind, _opts ->
+          send(test_pid, {:create_worker, foreman, worker_id, kind})
+          {:ok, :stub_worker_ref}
+        end,
+        lock_materializer_fn: fn worker, epoch ->
+          send(test_pid, {:lock, worker, epoch})
+
+          recovery_info = %{
+            kind: :materializer,
+            durable_version: Version.zero(),
+            oldest_durable_version: Version.zero()
+          }
+
+          {:ok, stub, recovery_info}
+        end,
+        unlock_materializer_fn: fn pid, durable_version, tsl ->
+          send(test_pid, {:unlock, pid, durable_version, tsl})
+          :ok
+        end
+      }
+
+      snapshot = %{
+        logs: %{"log_a" => [1], "log_b" => [2]},
+        services: %{"svc" => %{kind: :log}}
+      }
+
+      {distributor, _director} =
+        start_distributor(recruitment: recruitment, transaction_system_layout: snapshot)
+
+      task = park_read(placeholder_of(distributor), "apple")
+
+      # Placement + foreman boundary: worker created via the chosen node's foreman.
+      expected_foreman = {TestCluster.otp_name(:foreman), node()}
+      assert_receive {:create_worker, ^expected_foreman, worker_id, :materializer}
+      assert is_binary(worker_id)
+
+      # Epoch lock on the created worker, at the distributor's epoch.
+      assert_receive {:lock, {:stub_worker_ref, node}, 42}
+      assert node == node()
+
+      # Unlock with the recovery durable version and a TSL filtered to the shard's logs.
+      zero = Version.zero()
+      assert_receive {:unlock, ^stub, ^zero, tsl}
+      assert tsl.epoch == 42
+      assert tsl.logs == %{"log_a" => [1]}
+      assert tsl.services == %{"svc" => %{kind: :log}}
+
+      # TSL delta applied at the director with the current epoch.
+      assert_receive {:apply_tsl_delta, %{1 => ^stub}, 42}
+
+      # The parked read drains through the recruited materializer.
+      assert {:ok, "red"} = Task.await(task, 5_000)
+
+      # Telemetry: started and succeeded (with duration, tag, node).
+      assert_receive {:telemetry, [:bedrock, :distributor, :recruitment, :started], %{},
+                      %{cluster: TestCluster, epoch: 42, tag: 1}}
+
+      this_node = node()
+
+      assert_receive {:telemetry, [:bedrock, :distributor, :recruitment, :succeeded], %{duration_us: duration},
+                      %{cluster: TestCluster, epoch: 42, tag: 1, node: ^this_node}}
+
+      assert is_integer(duration) and duration >= 0
+
+      # The in-flight marker is cleared.
+      assert %State{pending_demands: pending} = :sys.get_state(distributor)
+      refute MapSet.member?(pending, 1)
+    end
+
+    test "a second demand while recruitment is in flight does not start another" do
+      test_pid = self()
+      stub = start_stub(%{})
+
+      recruitment = %{
+        create_worker_fn: fn _foreman, _worker_id, _kind, _opts ->
+          send(test_pid, {:create_worker_called, self()})
+          # Hold the recruitment in flight until the test releases it.
+          receive do
+            :release -> {:ok, :stub_worker_ref}
+          end
+        end,
+        lock_materializer_fn: fn _worker, _epoch -> {:ok, stub, %{}} end,
+        unlock_materializer_fn: fn _pid, _durable_version, _tsl -> :ok end
+      }
+
+      {distributor, _director} = start_distributor(recruitment: recruitment)
+
+      GenServer.cast(distributor, {:coverage_demand, 1})
+      assert_receive {:create_worker_called, task_pid}
+
+      GenServer.cast(distributor, {:coverage_demand, 1})
+      refute_receive {:create_worker_called, _}, 100
+
+      send(task_pid, :release)
+      assert_receive {:apply_tsl_delta, %{1 => ^stub}, 42}, 1_000
+    end
+  end
+
+  describe "failed recruitment" do
+    test "failure sheds the parked read, emits telemetry, and backs off until expiry" do
+      attach_recruitment_telemetry(self())
+      test_pid = self()
+
+      recruitment = %{
+        create_worker_fn: fn _foreman, _worker_id, _kind, _opts ->
+          send(test_pid, :create_worker_called)
+          {:error, :no_capacity}
+        end
+      }
+
+      {distributor, _director} = start_distributor(recruitment: recruitment, backoff_ms: 200)
+      placeholder = placeholder_of(distributor)
+
+      task = park_read(placeholder, "apple")
+      assert_receive :create_worker_called
+      assert {:error, :unavailable} = Task.await(task, 5_000)
+
+      assert_receive {:telemetry, [:bedrock, :distributor, :recruitment, :failed], %{duration_us: _},
+                      %{tag: 1, reason: {:worker_creation_failed, :no_capacity, 1, _node}}}
+
+      # Re-demand within the backoff window: no new recruitment attempt,
+      # even though the previous one failed.
+      GenServer.cast(distributor, {:coverage_demand, 1})
+      refute_receive :create_worker_called, 100
+
+      # After the backoff expires, a fresh demand retries recruitment.
+      Process.sleep(150)
+      GenServer.cast(distributor, {:coverage_demand, 1})
+      assert_receive :create_worker_called, 1_000
+    end
+
+    test "no materializer-capable node fails recruitment" do
+      attach_recruitment_telemetry(self())
+      {distributor, _director} = start_distributor(node_capabilities: %{})
+      placeholder = placeholder_of(distributor)
+
+      task = park_read(placeholder, "apple")
+
+      assert {:error, :unavailable} = Task.await(task, 5_000)
+
+      assert_receive {:telemetry, [:bedrock, :distributor, :recruitment, :failed], %{duration_us: _},
+                      %{tag: 1, reason: :no_materializer_capable_nodes}}
+
+      assert %State{backoff: backoff} = :sys.get_state(distributor)
+      assert Map.has_key?(backoff, 1)
+    end
+
+    test "a rejected TSL delta (newer epoch exists) stops the distributor" do
+      test_pid = self()
+      stub = start_stub(%{})
+      director = start_supervised!({CaptureDirector, [test_pid, {:error, :newer_epoch_exists}]}, id: :stale_director)
+
+      recruitment = %{
+        create_worker_fn: fn _foreman, _worker_id, _kind, _opts -> {:ok, :stub_worker_ref} end,
+        lock_materializer_fn: fn _worker, _epoch -> {:ok, stub, %{}} end,
+        unlock_materializer_fn: fn _pid, _durable_version, _tsl -> :ok end
+      }
+
+      {distributor, _director} = start_distributor(recruitment: recruitment, director: director)
+      ref = Process.monitor(distributor)
+
+      GenServer.cast(distributor, {:coverage_demand, 1})
+
+      assert_receive {:DOWN, ^ref, :process, ^distributor, :normal}, 5_000
+    end
+  end
+
+  describe "epoch change notifications" do
+    test "an older-epoch notification is logged as suspicious and ignored" do
+      {distributor, _director} = start_distributor([])
+
+      log =
+        capture_log(fn ->
+          :ok = Distributor.notify_epoch_change(distributor, 41)
+          # Synchronize on the mailbox so the cast is processed.
+          assert :ok = Distributor.check_epoch(distributor, 42)
+        end)
+
+      assert log =~ "suspicious"
+      assert log =~ "older epoch 41"
+      assert Process.alive?(distributor)
+    end
+  end
+end

--- a/test/bedrock/control_plane/distributor/recruitment_test.exs
+++ b/test/bedrock/control_plane/distributor/recruitment_test.exs
@@ -138,8 +138,15 @@ defmodule Bedrock.ControlPlane.Distributor.RecruitmentTest do
         services: %{"svc" => %{kind: :log}}
       }
 
+      # The cluster-wide recovery durable version is far ahead of the fresh
+      # worker's (empty) store; the unlock below must use the version the
+      # worker itself reported at lock time, not this one.
       {distributor, _director} =
-        start_distributor(recruitment: recruitment, transaction_system_layout: snapshot)
+        start_distributor(
+          recruitment: recruitment,
+          transaction_system_layout: snapshot,
+          durable_version: Version.from_integer(500)
+        )
 
       task = park_read(placeholder_of(distributor), "apple")
 
@@ -152,7 +159,9 @@ defmodule Bedrock.ControlPlane.Distributor.RecruitmentTest do
       assert_receive {:lock, {:stub_worker_ref, node}, 42}
       assert node == node()
 
-      # Unlock with the recovery durable version and a TSL filtered to the shard's logs.
+      # Unlock with the durable version the worker reported at lock time
+      # (zero: a new worker's store is empty, so it replays the shard's full
+      # history) and a TSL filtered to the shard's logs.
       zero = Version.zero()
       assert_receive {:unlock, ^stub, ^zero, tsl}
       assert tsl.epoch == 42

--- a/test/bedrock/control_plane/distributor/server_test.exs
+++ b/test/bedrock/control_plane/distributor/server_test.exs
@@ -185,7 +185,7 @@ defmodule Bedrock.ControlPlane.Distributor.ServerTest do
       on_exit(fn -> :telemetry.detach(handler_id) end)
     end
 
-    test "coverage_demand is remembered and emits telemetry" do
+    test "coverage_demand emits telemetry and fails fast for a tag missing from the layout" do
       attach_demand_telemetry(self())
       {pid, _director} = start_distributor()
 
@@ -193,8 +193,11 @@ defmodule Bedrock.ControlPlane.Distributor.ServerTest do
 
       assert_receive {:telemetry, [:bedrock, :distributor, :coverage_demand], %{}, %{cluster: TestCluster, tag: 7}}
 
-      assert %State{pending_demands: pending} = :sys.get_state(pid)
-      assert MapSet.member?(pending, 7)
+      # The tag is not in the (empty) shard layout: the demand fails fast
+      # and enters backoff rather than being remembered as in-flight.
+      assert %State{pending_demands: pending, backoff: backoff} = :sys.get_state(pid)
+      refute MapSet.member?(pending, 7)
+      assert Map.has_key?(backoff, 7)
     end
 
     test "deliver_coverage relays to the placeholder and clears the pending demand" do

--- a/test/support/control_plane/stub_materializer.ex
+++ b/test/support/control_plane/stub_materializer.ex
@@ -7,35 +7,66 @@ defmodule Bedrock.Test.ControlPlane.StubMaterializer do
     * `{:get_range, start_key | KeySelector.t(), end_key | KeySelector.t(), version, opts}`
 
   Serves from a static key-value map, ignoring versions.
+
+  Also speaks the recovery worker protocol (`{:lock_for_recovery, epoch}`
+  and `{:unlock_after_recovery, durable_version, tsl}`) so recruitment
+  tests can stub only the foreman worker-creation boundary while keeping
+  the real epoch lock/unlock calls. Lock/unlock activity is reported to an
+  optional observer pid as `{:stub_materializer, event}` messages.
   """
   use GenServer
 
+  alias Bedrock.DataPlane.Version
   alias Bedrock.KeySelector
 
-  @spec start_link(%{Bedrock.key() => Bedrock.value()}) :: GenServer.on_start()
-  def start_link(kvs), do: GenServer.start_link(__MODULE__, kvs)
+  @spec start_link(%{Bedrock.key() => Bedrock.value()}, opts :: keyword()) :: GenServer.on_start()
+  def start_link(kvs, opts \\ []) do
+    {observer, opts} = Keyword.pop(opts, :observer)
+    GenServer.start_link(__MODULE__, {kvs, observer}, opts)
+  end
 
   @impl true
-  def init(kvs), do: {:ok, kvs}
+  def init({kvs, observer}), do: {:ok, %{kvs: kvs, observer: observer}}
+  def init(kvs), do: {:ok, %{kvs: kvs, observer: nil}}
 
   @impl true
-  def handle_call({:get, %KeySelector{key: key}, _version, _opts}, _from, kvs) do
+  def handle_call({:get, %KeySelector{key: key}, _version, _opts}, _from, %{kvs: kvs} = state) do
     case Map.fetch(kvs, key) do
-      {:ok, value} -> {:reply, {:ok, {key, value}}, kvs}
-      :error -> {:reply, {:ok, nil}, kvs}
+      {:ok, value} -> {:reply, {:ok, {key, value}}, state}
+      :error -> {:reply, {:ok, nil}, state}
     end
   end
 
-  def handle_call({:get, key, _version, _opts}, _from, kvs) when is_binary(key),
-    do: {:reply, {:ok, Map.get(kvs, key)}, kvs}
+  def handle_call({:get, key, _version, _opts}, _from, %{kvs: kvs} = state) when is_binary(key),
+    do: {:reply, {:ok, Map.get(kvs, key)}, state}
 
-  def handle_call({:get_range, start_key, end_key, _version, _opts}, _from, kvs)
+  def handle_call({:get_range, start_key, end_key, _version, _opts}, _from, %{kvs: kvs} = state)
       when is_binary(start_key) and is_binary(end_key) do
     results =
       kvs
       |> Enum.filter(fn {key, _value} -> key >= start_key and key < end_key end)
       |> Enum.sort()
 
-    {:reply, {:ok, {results, false}}, kvs}
+    {:reply, {:ok, {results, false}}, state}
   end
+
+  def handle_call({:lock_for_recovery, epoch}, _from, state) do
+    notify(state, {:locked_for_recovery, self(), epoch})
+
+    recovery_info = %{
+      kind: :materializer,
+      durable_version: Version.zero(),
+      oldest_durable_version: Version.zero()
+    }
+
+    {:reply, {:ok, self(), recovery_info}, state}
+  end
+
+  def handle_call({:unlock_after_recovery, durable_version, tsl}, _from, state) do
+    notify(state, {:unlocked_after_recovery, self(), durable_version, tsl})
+    {:reply, :ok, state}
+  end
+
+  defp notify(%{observer: nil}, _event), do: :ok
+  defp notify(%{observer: observer}, event), do: send(observer, {:stub_materializer, event})
 end


### PR DESCRIPTION
## Summary

Closes the Phase A loop (bedrock-q67.5): coverage demand → placement → foreman worker start → epoch lock/unlock → TSL delta → placeholder covered → parked reads drain.

> **Note:** this branch is based on `feature/q67-placeholder` (PRs #91/#94) and **also merges `feature/q67-tsl-delta`** (PR #92), since recruitment needs both the placeholder/demand channel and `Director.apply_tsl_delta/3`.

### Recruitment flow (Distributor)

- `{:coverage_demand, tag}` now recruits instead of just logging: resolve the shard's range from the layout snapshot, pick a materializer-capable node (same convention as `MaterializerBootstrapPhase`), create a worker via that node's Foreman, `lock_for_recovery` at the current epoch, `unlock_after_recovery` with the recovery `durable_version` and a TSL filtered to the shard's logs, then `Director.apply_tsl_delta/3` and `notify_covered` to the placeholder.
- Recruitment runs off the message loop in a task; outcomes are cast back so state mutation stays serialized. In-flight demands are deduped.
- On failure: `notify_coverage_failed` (parked reads shed `:unavailable`) plus a per-tag backoff window — re-demands inside the window are ignored, and the backoff expires so later demand retries.
- A TSL delta rejected with `:newer_epoch_exists` stops the distributor (`:normal`) — it has been superseded.
- The director now hands the distributor its full TSL snapshot, the recovery `durable_version` (completed recovery attempt is retained on director state), and `node_capabilities`.

### Audit items from the ticket comments

- Director retries distributor start via `Process.send_after` when the start genuinely fails.
- Director skips re-recruitment when the distributor exits with reason `:normal` (deliberate cede to a newer epoch).
- Distributor logs older-epoch `notify_epoch_change` notifications as suspicious.
- **Not done:** structured `{:error, {:uncovered_shard, tag, range}}` from StorageRacing — `lookup_key!` has no tag at hand and the failure-map shape ripples through PointReads/RangeReads and their callers; with placeholders filling every slot the `{_range, []}` branch no longer occurs, so the loud raise stays as the backstop. Left for a follow-up.

### Telemetry

`[:bedrock, :distributor, :recruitment, :started | :succeeded | :failed]` with duration, tag, epoch, and node.

### Tests

- Unit (`recruitment_test.exs`): demand → placement/foreman/lock/unlock/TSL-delta with the bootstrap phase's injectable-fn seams; in-flight dedupe; failure → shed + backoff → retry after expiry; epoch supersession; suspicious epoch-change logging.
- Integration (`recruitment_integration_test.exs`): a read through the full PointReads → StorageRacing → LayoutIndex path against a placeholder-covered shard triggers demand, recruitment runs with ONLY the foreman worker-creation call stubbed (real epoch lock/unlock protocol, real TSL delta call), the SAME parked read returns the real value, and a subsequent read goes direct.
- Real materializer: one test recruits a REAL olivine materializer (tmp dir, health-report handshake, real `lock_for_recovery`/`unlock_after_recovery`) and serves a read through it — feasible because unlock with an empty log map starts the puller without live log servers.

Full suite: 2577 tests + 158 properties, 0 failures; credo --strict and dialyzer clean.