### PR TITLE
Remove obsolete .beads entry from .gitignore (bedrock-qep)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,7 +41,6 @@ bedrock-*.tar
 .claude/
 CLAUDE.md
 AGENTS.md
-.beads
 .gitattributes
 
 # Local env/tooling


### PR DESCRIPTION
Legacy bd (beads) tooling has been fully removed in favor of bw (beadwork). The `.beads/` directory and bd git hooks no longer exist, so the ignore entry is dead. Closes bedrock-qep.