### PR TITLE
Exclude dialyzer PLTs from hex package (bedrock-wn6)

### DIFF
--- a/.github/workflows/elixir_ci.yaml
+++ b/.github/workflows/elixir_ci.yaml
@@ -79,14 +79,14 @@ jobs:
     - name: Credo
       run: mix credo --strict
 
-    # Define how to cache the `priv/plts` directory. After the first run,
+    # Define how to cache the `plts` directory. After the first run,
     # this speeds up dialyzer runs a lot.
     - name: Cache PLTs
       id: cache-plts
       uses: actions/cache@v3
       with:
-        path: priv/plts
-        key: ${{ runner.os }}-${{ matrix.elixir }}-${{ matrix.otp }}-plts-v2-${{ hashFiles('**/mix.lock') }}
+        path: plts
+        key: ${{ runner.os }}-${{ matrix.elixir }}-${{ matrix.otp }}-plts-v3-${{ hashFiles('**/mix.lock') }}
 
     - name: Dialyzer
       run: mix dialyzer

--- a/.gitignore
+++ b/.gitignore
@@ -29,7 +29,7 @@ bedrock-*.tar
 /tmp/
 
 # Dialyzer PLT files.
-/priv/plts
+/plts
 
 # MacOS cruft
 .DS_Store

--- a/mix.exs
+++ b/mix.exs
@@ -36,6 +36,7 @@ defmodule Bedrock.MixProject do
   defp package do
     [
       name: "bedrock",
+      files: ~w(lib priv/schemas mix.exs README.md CHANGELOG.md LICENSE .formatter.exs),
       licenses: ["MIT"],
       links: %{
         "GitHub" => "https://github.com/bedrock-kv/bedrock",
@@ -50,8 +51,8 @@ defmodule Bedrock.MixProject do
 
   defp dialyzer do
     [
-      plt_core_path: "priv/plts",
-      plt_file: {:no_warn, "priv/plts/dialyzer.plt"},
+      plt_core_path: "plts",
+      plt_file: {:no_warn, "plts/dialyzer.plt"},
       plt_add_apps: [:ex_unit, :mix],
       # Disable opaque type checks due to OTP 28 issues with structs containing
       # MapSet/queue. See: https://github.com/elixir-lang/elixir/issues/14576


### PR DESCRIPTION
The 0.5.2 hex tarball shipped 8.2MB of local dialyzer PLT artifacts because dialyxir's cache lived in `priv/plts` and hex packages all of `priv/` by default.

- Add an explicit `files:` list to `package()` — `lib`, `priv/schemas`, and doc files only
- Move the PLT cache from `priv/plts` to `/plts` (gitignore + CI cache path updated, cache key bumped to v3)

Package size: **8.2MB → 295KB**. Verified with `mix hex.build`; pre-commit credo + dialyzer pass with the relocated PLT path.

Closes bedrock-wn6.