### PR TITLE
Abort transactions whose read version predates pruned conflict history (bedrock-qzr.1)

### DIFF
--- a/lib/bedrock/data_plane/resolver/conflicts.ex
+++ b/lib/bedrock/data_plane/resolver/conflicts.ex
@@ -13,19 +13,29 @@ defmodule Bedrock.DataPlane.Resolver.Conflicts do
   alias Bedrock.DataPlane.Resolver.Tree
 
   @type t :: %__MODULE__{
-          versions: [{Bedrock.version(), MapSet.t(binary()), Tree.t() | nil}]
+          versions: [{Bedrock.version(), MapSet.t(binary()), Tree.t() | nil}],
+          oldest_version: Bedrock.version() | nil
         }
 
-  defstruct versions: []
+  defstruct versions: [], oldest_version: nil
 
   @doc """
-  Creates a new empty versioned conflicts structure.
+  Creates a new empty versioned conflicts structure with no floor: reads at
+  any version check cleanly against the (complete, empty) history.
   """
-  @spec new() :: %__MODULE__{
-          versions: []
-        }
+  @spec new() :: t()
   def new do
     %__MODULE__{versions: []}
+  end
+
+  @doc """
+  Creates a new empty versioned conflicts structure floored at
+  `oldest_version`: history before it is unknown (not empty), so reads below
+  it abort.
+  """
+  @spec new(Bedrock.version()) :: t()
+  def new(oldest_version) do
+    %__MODULE__{versions: [], oldest_version: oldest_version}
   end
 
   @doc """
@@ -48,8 +58,14 @@ defmodule Bedrock.DataPlane.Resolver.Conflicts do
   @doc """
   Checks if any of the given conflicts overlap with existing conflicts
   at versions greater than the specified version.
+
+  Aborts outright when the version is below `oldest_version`: entries in that
+  range have been pruned, so absence of overlap proves nothing.
   """
   @spec check_conflicts(t(), [Bedrock.key_range()], Bedrock.version()) :: :ok | :abort
+  def check_conflicts(%__MODULE__{oldest_version: floor}, _conflicts, version)
+      when not is_nil(floor) and version < floor, do: :abort
+
   def check_conflicts(%__MODULE__{versions: versions}, conflicts, version) do
     {points, ranges} = separate_conflicts(conflicts)
     do_check_conflicts(versions, points, ranges, version, [])
@@ -115,12 +131,15 @@ defmodule Bedrock.DataPlane.Resolver.Conflicts do
   end
 
   @doc """
-  Removes conflicts older than the specified version.
+  Removes conflicts older than the specified version and advances the floor
+  to it (monotonically), so reads below the pruned horizon abort instead of
+  checking against incomplete history.
   """
   @spec remove_old_conflicts(t(), Bedrock.version()) :: t()
-  def remove_old_conflicts(%__MODULE__{versions: versions} = conflicts, min_version) do
+  def remove_old_conflicts(%__MODULE__{versions: versions, oldest_version: floor} = conflicts, min_version) do
     new_versions = keep_recent_versions(versions, min_version, [])
-    %{conflicts | versions: new_versions}
+    new_floor = if is_nil(floor) or min_version > floor, do: min_version, else: floor
+    %{conflicts | versions: new_versions, oldest_version: new_floor}
   end
 
   # Keep this version and continue

--- a/lib/bedrock/data_plane/resolver/server.ex
+++ b/lib/bedrock/data_plane/resolver/server.ex
@@ -82,8 +82,7 @@ defmodule Bedrock.DataPlane.Resolver.Server do
     then(
       %State{
         lock_token: lock_token,
-        conflicts: Conflicts.new(),
-        oldest_version: last_version,
+        conflicts: Conflicts.new(last_version),
         last_version: last_version,
         waiting: %{},
         mode: :running,

--- a/lib/bedrock/data_plane/resolver/state.ex
+++ b/lib/bedrock/data_plane/resolver/state.ex
@@ -22,7 +22,6 @@ defmodule Bedrock.DataPlane.Resolver.State do
 
   @type t :: %__MODULE__{
           conflicts: Conflicts.t(),
-          oldest_version: Bedrock.version(),
           last_version: Bedrock.version(),
           waiting: Bedrock.Internal.WaitingList.t(),
           mode: mode(),
@@ -36,7 +35,6 @@ defmodule Bedrock.DataPlane.Resolver.State do
           metadata_window: MetadataAccumulator.t()
         }
   defstruct conflicts: nil,
-            oldest_version: nil,
             last_version: nil,
             waiting: %{},
             mode: :running,

--- a/test/bedrock/data_plane/resolver/conflicts_test.exs
+++ b/test/bedrock/data_plane/resolver/conflicts_test.exs
@@ -1,0 +1,57 @@
+defmodule Bedrock.DataPlane.Resolver.ConflictsTest do
+  use ExUnit.Case, async: true
+
+  alias Bedrock.DataPlane.Resolver.Conflicts
+  alias Bedrock.DataPlane.Version
+
+  defp v(i), do: Version.from_integer(i)
+
+  describe "oldest_version floor" do
+    test "new/0 has no floor: any read version checks cleanly against empty history" do
+      assert :ok = Conflicts.check_conflicts(Conflicts.new(), [{"a", "a\0"}], v(0))
+    end
+
+    test "new/1 seeds the floor: reads below it abort even with empty history" do
+      conflicts = Conflicts.new(v(100))
+
+      assert :abort = Conflicts.check_conflicts(conflicts, [{"a", "a\0"}], v(99))
+      assert :ok = Conflicts.check_conflicts(conflicts, [{"a", "a\0"}], v(100))
+    end
+
+    test "remove_old_conflicts advances the floor to the prune horizon" do
+      conflicts =
+        Conflicts.new()
+        |> Conflicts.add_conflicts([{"k", "k\0"}], v(100))
+        |> Conflicts.remove_old_conflicts(v(200))
+
+      # The write at v100 was pruned; a read below the horizon can no longer be
+      # validated and must abort rather than silently pass.
+      assert :abort = Conflicts.check_conflicts(conflicts, [{"k", "k\0"}], v(50))
+
+      # Even for keys never written: history below the floor is unknowable.
+      assert :abort = Conflicts.check_conflicts(conflicts, [{"other", "other\0"}], v(199))
+
+      # At or above the horizon all surviving entries are visible.
+      assert :ok = Conflicts.check_conflicts(conflicts, [{"k", "k\0"}], v(200))
+    end
+
+    test "floor never regresses" do
+      conflicts =
+        Conflicts.new()
+        |> Conflicts.remove_old_conflicts(v(200))
+        |> Conflicts.remove_old_conflicts(v(100))
+
+      assert :abort = Conflicts.check_conflicts(conflicts, [{"a", "a\0"}], v(150))
+      assert :ok = Conflicts.check_conflicts(conflicts, [{"a", "a\0"}], v(200))
+    end
+
+    test "conflicts at or above the floor are still detected" do
+      conflicts =
+        Conflicts.new()
+        |> Conflicts.add_conflicts([{"k", "k\0"}], v(300))
+        |> Conflicts.remove_old_conflicts(v(200))
+
+      assert :abort = Conflicts.check_conflicts(conflicts, [{"k", "k\0"}], v(250))
+    end
+  end
+end

--- a/test/bedrock/data_plane/resolver/server_test.exs
+++ b/test/bedrock/data_plane/resolver/server_test.exs
@@ -562,6 +562,53 @@ defmodule Bedrock.DataPlane.Resolver.ServerTest do
     end
   end
 
+  describe "MVCC floor enforcement after sweep (bedrock-qzr.1)" do
+    setup do
+      start_test_server(sweep_interval_ms: 100, version_retention_ms: 200)
+    end
+
+    test "aborts transactions whose read version predates pruned conflict history", %{server: server} do
+      # T1 writes "hot_key" at version-time 1s.
+      write_version = Version.from_integer(1_000_000)
+
+      t1 =
+        Transaction.encode(%{
+          mutations: [{:set, "hot_key", "value"}],
+          read_conflicts: [],
+          write_conflicts: [{"hot_key", "hot_key\0"}]
+        })
+
+      assert {:ok, [], _} =
+               Resolver.resolve_transactions(server, 1, Version.zero(), write_version, [t1], [[]], timeout: 1000)
+
+      # Advance version-time to 10s so the retention horizon (10s - 200ms)
+      # passes T1's entry, then let the sweep fire.
+      advanced_version = Version.from_integer(10_000_000)
+
+      assert {:ok, [], _} =
+               Resolver.resolve_transactions(server, 1, write_version, advanced_version, [], [], timeout: 1000)
+
+      Process.sleep(150)
+      send(server, :timeout)
+      wait_until(fn -> :sys.get_state(server).conflicts.versions == [] end)
+
+      # T2 read "hot_key" at a version below T1's write. That write is now
+      # pruned, so the conflict is invisible — T2 must be aborted, not
+      # silently committed.
+      t2 =
+        Transaction.encode(%{
+          mutations: [{:set, "other_key", "value"}],
+          read_conflicts: {Version.from_integer(500_000), [{"hot_key", "hot_key\0"}]},
+          write_conflicts: [{"other_key", "other_key\0"}]
+        })
+
+      next_version = Version.from_integer(10_000_001)
+
+      assert {:ok, [0], _} =
+               Resolver.resolve_transactions(server, 1, advanced_version, next_version, [t2], [[]], timeout: 1000)
+    end
+  end
+
   describe "property-based testing" do
     setup do
       start_test_server()


### PR DESCRIPTION
## Summary

Fixes a silent serializability violation in the resolver (bedrock-qzr.1).

The resolver sweeps conflict entries older than `version_retention_ms` (default 6s), but `Conflicts.check_conflicts/3` had no floor: a transaction arriving with a read version below the pruned horizon found no overlapping entries and **committed**, even when a conflicting write in the pruned range existed. `State.oldest_version` was set at init and never advanced or consulted.

## Fix

- `Conflicts` now carries an `oldest_version` floor (`nil` = unbounded, preserving existing unit-test/bench behavior of `new/0`).
- `remove_old_conflicts/2` advances the floor to the prune horizon (monotonic), so sweeping and floor-advancement are inseparable by construction.
- `check_conflicts/3` aborts any read version below the floor before walking entries — FDB `transaction_too_old` parity. The client sees a normal abort and retries with a fresh read version.
- The resolver seeds the floor with its recovery `last_version` (it has no history before that either). The dead `State.oldest_version` field is removed; the floor lives in `Conflicts`, where it is enforced.

## Tests

- New `conflicts_test.exs` covers floor semantics: seeded floor, advancement on prune, monotonicity, unknowable-history aborts, and that at-or-above-floor conflicts still detect.
- New server-level regression drives the exact ticket repro through the GenServer: commit a write, let the sweep prune it, then submit a conflicting old-read-version transaction — previously `{:ok, [], _}` (committed), now aborted.

Full suite: 2530 tests, 0 failures; credo --strict, dialyzer, and --warnings-as-errors clean.

Follow-up filed as bedrock-b28: the existing conflict_resolution property test encodes read conflicts in a flat map shape that `Transaction.encode` silently drops, making its read-abort assertions vacuous.