### PR TITLE
Fix replay cursor preservation (bedrock-qzr.18)

### DIFF
--- a/guides/deep-dives/architecture/implementations/shale.md
+++ b/guides/deep-dives/architecture/implementations/shale.md
@@ -1,127 +1,96 @@
 # Shale
 
-[Shale](../../../glossary.md#shale) is Bedrock's disk-based [log](../../../glossary.md#log) storage engine that provides durable [transaction](../../../glossary.md#transaction) persistence. It implements the Log interface using local storage with write-ahead logging, segment files for large transactions, and efficient streaming capabilities.
+[Shale](../../../glossary.md#shale) is Bedrock's local-disk transaction log.
+It provides ordered, fsync-durable transaction storage, exclusive range pulls
+for log recovery, and a Demux tree that turns the replicated transaction stream
+into per-shard object-storage chunks.
 
-**Location**: [`lib/bedrock/data_plane/log/shale.ex`](../../../lib/bedrock/data_plane/log/shale.ex)
+**Location**: `lib/bedrock/data_plane/log/shale/`
 
-## Design Principles
+## WAL Segments
 
-Shale is built around three core requirements: durability, ordering, and performance. Every committed transaction must survive system failures, transactions must be stored in strict version order, and the system must handle both small frequent transactions and occasional large ones efficiently.
+Shale writes into preallocated 64 MiB segment files. A segment rolls when it is
+full or when a transaction crosses the Demux's deterministic cut boundary. The
+active segment is never trimmed; completed segments can be recycled once their
+last transaction is at or below the replica-local object-storage durability
+floor.
 
-The storage engine uses a multi-file approach because different transaction sizes have different performance characteristics. Small transactions benefit from sequential writes to a single file, while large transactions need dedicated space to avoid fragmenting the main log. This hybrid approach optimizes for the common case while handling edge cases gracefully.
+The versioned `BED1` segment header contains the eight-byte
+`previous_version` that was the WAL tip when the segment was created. Entries
+then contain the commit version, payload length, original encoded transaction,
+and CRC32, followed by an EOF marker. The header is twelve bytes:
 
-## Storage Architecture
+```text
+BED1 | previous_version
+```
 
-Shale organizes data into three types of files, each serving a specific purpose in the overall storage strategy.
+The first append writes the entry and EOF marker and fsyncs them together with
+the header before acknowledging. Thus an older segment cannot become
+trim-eligible before its successor durably records the exact predecessor
+cursor. An empty recovery range explicitly fsyncs the header by itself.
 
-### Write-Ahead Log (WAL) Files
+Headers that predate `BED1` do not contain enough information to reconstruct a
+trimmed exclusive range. Startup rejects them instead of guessing a cursor.
 
-The WAL is the primary storage mechanism for most transactions. It's an append-only file where transactions are written sequentially, which maximizes disk performance by avoiding random seeks. Each transaction is written with its version number, timestamp, and a checksum for integrity verification.
+## Ordered Appends
 
-WAL files have a maximum size limit, typically 64MB. When a file reaches this limit, Shale creates a new WAL file and continues writing to it. This rotation prevents any single file from becoming unwieldy and enables more efficient garbage collection of old transactions.
+A push names the previous committed version. If it matches the WAL tip, Shale
+appends immediately. If it is greater, Shale parks the transaction until its
+predecessor arrives; if it is older, Shale rejects it. Commit versions may have
+arbitrary numeric gaps—the explicit predecessor chain defines order.
 
-The sequential nature of WAL writes means that even on traditional spinning disks, Shale can achieve high write throughput. Modern SSDs make this even faster, but the design doesn't depend on SSD performance.
+An append is acknowledged only after WAL fsync. The exact encoded binary that
+was appended is then passed unchanged to Demux. Demux alone slices mutations by
+shard, so crossing the process boundary does not require rebuilding the
+transaction binary.
 
-### Segment Files
+Known committed version (KCV) is a separate global monotonic watermark. Demux
+accumulates it with `max`, including while a future transaction is parked, but
+does not confuse KCV progress with transaction high-water.
 
-Some transactions are too large to fit efficiently in the WAL without causing performance problems for smaller transactions. These large transactions are stored in separate segment files, with the WAL containing only a reference to the segment file location.
+## Pull and Availability Semantics
 
-Shale pre-allocates segment files during startup to avoid allocation delays during normal operation. When a large transaction needs storage, Shale assigns it to an available segment file and records the location in the WAL. This keeps the WAL flowing smoothly while handling large data efficiently.
+`Log.pull/3` returns transactions in `(start_after, last_inclusive]`. Recovery
+is its only WAL consumer; materializers stream from ShardServers instead.
 
-Empty segment files are recycled, so the system doesn't consume unnecessary disk space over time. The allocation strategy balances having enough pre-allocated space with not wasting storage.
+Shale exposes both:
 
-### Manifest and Metadata
+- `available_after`: the persisted exclusive cursor after which all retained
+  WAL transactions are available;
+- `oldest_version`: informational data about the first retained transaction.
 
-The manifest file tracks Shale's current state, including which WAL file is active, which segment files are allocated, and what version ranges are stored. This metadata enables fast startup and recovery without scanning entire log files.
+They are intentionally different. Using `oldest_version` as an exclusive
+cursor would skip the transaction it names.
 
-During normal operation, the manifest is updated periodically to reflect the current state. During recovery, it provides the starting point for reconstructing the full transaction index.
+## Recovery
 
-## Transaction Storage Process
+Cold start enumerates segment files, reads every `BED1` predecessor, and derives
+`available_after` from the oldest retained segment. The WAL tip is the newest
+transaction, or the header cursor for an empty baseline.
 
-When a transaction arrives for storage, Shale compares the push's predecessor version with the durable WAL tip. A matching predecessor appends immediately; a future predecessor link is parked; an older one is rejected. Commit versions may contain numeric gaps, so correctness comes from following the explicit predecessor chain rather than incrementing a version. When a missing predecessor arrives, Shale appends and acknowledges the entire newly connected chain in order.
-
-For transactions that fit within the WAL size limit, Shale appends them directly to the current WAL file. The transaction data is written with a header containing the version, timestamp, and checksum, followed by the encoded transaction payload. This logic is implemented in [`lib/bedrock/data_plane/log/shale/writer.ex`](../../../lib/bedrock/data_plane/log/shale/writer.ex).
-
-Large transactions follow a different path. Shale allocates a segment file, writes the transaction data there, and then writes a reference entry in the WAL. This keeps the WAL compact while ensuring that all transactions, regardless of size, are recorded in version order. Segment management is handled in [`lib/bedrock/data_plane/log/shale/segment.ex`](../../../lib/bedrock/data_plane/log/shale/segment.ex).
-
-After writing transaction data, Shale forces a disk sync to ensure durability before acknowledging the write. Each successfully appended original encoded binary is then handed unchanged to Demux in predecessor-chain order; Demux alone slices it by shard. Demux delivery remains asynchronous and reconstructible from the WAL, so the client acknowledgment never waits for slicing or object storage.
-
-## Index Management
-
-Shale maintains an in-memory index mapping version numbers to file locations. This index enables fast lookups when serving transaction pull requests without scanning log files.
-
-The index is built incrementally as transactions are written and can be reconstructed from disk files during recovery. For performance, frequently accessed entries are kept in memory, while the complete index can be persisted periodically.
-
-This approach balances memory usage with lookup performance. Recovery pulls proceed in sequential order, so the working set of index entries remains manageable even with millions of stored transactions.
-
-## Transaction Serving
-
-Shale's `pull` interface serves transaction ranges from the WAL using the version index — but recovery is its only remaining consumer (a failed log rebuilding itself from a survivor). This implementation is in [`lib/bedrock/data_plane/log/shale/pulling.ex`](../../../lib/bedrock/data_plane/log/shale/pulling.ex).
-
-Materializers never pull the WAL. Each running Shale instance owns a Demux tree that slices every WAL-appended transaction by shard and feeds per-shard ShardServers; materializers discover their ShardServer through the log (`get_shard_server/2`) and stream from it — object-storage chunks for history, the in-memory buffer for recent data. Every push to Shale carries the KCV from the commit proxies. Immediately appended transactions piggyback it normally. If a future transaction is parked, Shale independently advances Demux's KCV with `max` while leaving transaction `high_water` unchanged; when the chain later drains, Demux's held maximum flows through normal shard currency. No queued transaction stores a private KCV because KCV is a global monotonic watermark, not per-entry metadata.
+Log-to-log recovery has one range: `(replay_after, last_inclusive]`. It resets
+the destination to logical position `replay_after` without appending a sentinel,
+copies each real transaction byte-for-byte, and sends it through a fresh Demux
+exactly once. Success requires observing `last_inclusive`; an empty response
+before it is an error. When the range is empty, Shale persists only a header
+baseline, which survives restart and anchors the next push.
 
 ## WAL Trimming
 
-The WAL is not retained forever: once a shard's data is confirmed written to object storage, the corresponding segments can be recycled. The Demux commands deterministic version-time cuts, ShardServers confirm them after object storage acknowledges the chunk writes, and Shale trims segments strictly behind the confirmed minimum durable version — clamped to the WAL's own bounds, only while `:running`, and never touching a segment that straddles the floor. Trim telemetry reports the floor and its lag; growth is unbounded-with-alerting by default, with an opt-in hard limit that rejects pushes with `{:error, :wal_backpressure}`.
+Each Demux commands version-time cuts gated by KCV. Its ShardServers confirm a
+cut only after their deterministic chunks are present in object storage. The
+minimum confirmation from that log's own children advances its trim floor.
+Shale recycles only completed segments fully behind the floor and recomputes
+`available_after` from the oldest segment that remains.
 
-## Recovery Implementation
-
-Shale recovery begins by reading the manifest to understand the last known state. Then it scans WAL files to rebuild the transaction index and verify data integrity. The recovery logic is implemented in [`lib/bedrock/data_plane/log/shale/recovery.ex`](../../../lib/bedrock/data_plane/log/shale/recovery.ex).
-
-During recovery, Shale can operate in several modes. Cold start recovery rebuilds state from disk files. Log-to-log recovery copies transactions from another Shale instance to restore a failed log server. The recovery mode is determined by what data is available and what the Director requests.
-
-Recovery includes integrity verification, checking that transaction checksums match and that version sequences are complete. If corruption is detected, Shale can attempt to recover valid transactions while reporting problems for manual intervention.
-
-The recovery process is designed to be conservative. If there's any doubt about data integrity, Shale will request complete recovery from another log server rather than risk serving corrupted data.
-
-## Performance Characteristics
-
-Shale's performance comes from several design decisions working together. Sequential writes to WAL files maximize disk throughput. Pre-allocated segment files eliminate allocation delays. In-memory indexing provides fast transaction lookups.
-
-Write performance is primarily limited by disk sync speed, which depends on the storage hardware's durability guarantees. SSDs with power-loss protection can achieve much higher performance than traditional drives because they can complete syncs faster.
-
-Read performance benefits from the sequential nature of recovery pulls. When a recovering log pulls transaction ranges, Shale can read large chunks efficiently and stream results without loading everything into memory.
-
-Memory usage is controlled by limiting index cache size and using streaming for large operations. This allows Shale to handle transaction logs that are much larger than available RAM.
-
-## Error Handling
-
-Shale uses a fail-fast approach to error handling. When it encounters unrecoverable errors like disk corruption or hardware failures, it exits immediately rather than attempting complex recovery logic.
-
-This design relies on the Director to detect failures and coordinate recovery. By failing quickly and cleanly, Shale avoids creating inconsistent state that would complicate recovery.
-
-For recoverable errors like temporary disk space issues, Shale includes cleanup and compaction logic to reclaim space and retry operations. But if these attempts fail, it still chooses to exit rather than continue in a degraded state.
-
-## Configuration and Tuning
-
-Shale's configuration focuses on balancing durability, performance, and resource usage. WAL file sizes affect rotation frequency and recovery time. Segment pre-allocation affects memory usage and large transaction performance.
-
-Sync policies control the trade-off between durability and performance. Immediate sync after every write maximizes durability but limits throughput. Batched sync improves performance but increases the window of potential data loss.
-
-Buffer sizes affect memory usage and I/O efficiency. Larger buffers can improve performance for workloads with many small transactions but use more memory.
-
-The configuration system provides reasonable defaults while allowing operators to tune behavior for specific workloads and hardware characteristics.
-
-## Integration with Bedrock
-
-Shale integrates with the broader Bedrock system through the Log interface. Commit proxies push predecessor-linked transactions to Shale for WAL durability and carry the independent KCV on every push. `Pushing` owns chain scheduling and appends, `Server` forwards every appended binary, and Demux owns slicing and KCV accumulation. Materializers stream their shard from Shale's Demux to update their local data. The main server coordination logic is in [`lib/bedrock/data_plane/log/shale/server.ex`](../../../lib/bedrock/data_plane/log/shale/server.ex).
-
-During recovery, the Director coordinates with Shale to ensure consistent state across the cluster. Shale provides recovery information about what transactions it has stored and can serve transactions to restore other failed components.
-
-This integration allows Shale to focus on its core responsibility—durable transaction storage—while participating in the larger system's reliability and consistency guarantees.
-
-## Related Components
-
-- **[Log System](../data-plane/log.md)**: General log system concepts and interface
-- **[Commit Proxy](../data-plane/commit-proxy.md)**: Pushes committed transactions to Shale
-- **[Storage](../data-plane/storage.md)**: Streams per-shard transactions from Shale's Demux for local updates
-- **[Director](../../control-plane/director.md)**: Control plane component that coordinates Shale recovery processes
+Trim-floor telemetry reports lag and segment counts. Growth is
+unbounded-with-alerting by default; an optional hard limit rejects pushes with
+`{:error, :wal_backpressure}`.
 
 ## Code References
 
-- **Main Implementation**: [`lib/bedrock/data_plane/log/shale.ex`](../../../lib/bedrock/data_plane/log/shale.ex)
-- **Server Logic**: [`lib/bedrock/data_plane/log/shale/server.ex`](../../../lib/bedrock/data_plane/log/shale/server.ex)
-- **Storage Engine**: [`lib/bedrock/data_plane/log/shale/writer.ex`](../../../lib/bedrock/data_plane/log/shale/writer.ex)
-- **Recovery Logic**: [`lib/bedrock/data_plane/log/shale/recovery.ex`](../../../lib/bedrock/data_plane/log/shale/recovery.ex)
-- **File Management**: [`lib/bedrock/data_plane/log/shale/segment.ex`](../../../lib/bedrock/data_plane/log/shale/segment.ex)
-- **Streaming Support**: [`lib/bedrock/data_plane/log/shale/pulling.ex`](../../../lib/bedrock/data_plane/log/shale/pulling.ex)
+- `writer.ex`: versioned headers, entry encoding, fsync
+- `segment.ex` and `cold_starting.ex`: segment metadata and restart
+- `pushing.ex` and `pulling.ex`: predecessor-chain appends and exclusive pulls
+- `recovery.ex`: endpoint-proven log-to-log replay
+- `server.ex`: lifecycle, facts, durability-floor trimming

--- a/guides/deep-dives/recovery.md
+++ b/guides/deep-dives/recovery.md
@@ -18,11 +18,11 @@ Recovery's first line of defense: the recovered Transaction System Layout is che
 
 ## Phase 1: [Service Locking](../quick-reads/recovery/service-locking.md)
 
-Recovery establishes exclusive control by locking the old layout's logs and every advertised materializer. Locking does two jobs at once. It fences: a locked service reports only to this recovery's director, and an older epoch's director can never reclaim it. And it informs: each locked service returns its recovery info — logs report their oldest and newest versions, materializers report their durable version and shard assignment. That information is what lets the later phases reuse survivors instead of discarding them.
+Recovery establishes exclusive control by locking the old layout's logs and every advertised materializer. Locking does two jobs at once. It fences: a locked service reports only to this recovery's director, and an older epoch's director can never reclaim it. And it informs: each locked service returns its recovery info — logs report the persisted exclusive `available_after` cursor, their first retained transaction for inspection, and their inclusive endpoint; materializers report their durable version and shard assignment. That information is what lets the later phases reuse survivors instead of discarding them.
 
 ## Phase 2: [Log Recovery Planning](../quick-reads/recovery/log-recovery-planning.md)
 
-From the locked logs, recovery computes the version vector: the range of transactions guaranteed complete across the surviving majority. The first element is the oldest version any survivor can still supply — the WAL below it has been trimmed, which can only happen after that history became durable in object-storage chunks. The last element is the recovery version: the cluster's rollback point, always at or above the known committed version at the moment of failure, because every log receives every version. This phase also seeds vacancies for a fresh generation of logs: Bedrock does not repair old logs in place, it replaces them and copies the data forward.
+From the locked logs, recovery computes the version vector `{available_after, last_inclusive}`: the common range `(available_after, last_inclusive]` guaranteed complete across the surviving majority. The first element is a cursor persisted in every WAL segment header, not the first transaction. The second is the recovery endpoint. This phase also seeds vacancies for a fresh generation of logs: Bedrock does not repair old logs in place, it replaces them and copies the data forward.
 
 ## Phase 3: [Log Recruitment](../quick-reads/recovery/log-recruitment.md)
 
@@ -30,7 +30,7 @@ The log vacancies are filled: available log workers are reused as candidates, an
 
 ## Phase 4: [Log Replay](../quick-reads/recovery/log-replay.md)
 
-Committed transactions are copied from the surviving logs into the new generation. The copy range starts at the later of the durable floor and the vector's first element, and replay routes every copied transaction through the new log's fresh Demux, so the per-shard buffers and chunk pipeline are rebuilt as a side effect — deterministic cuts reproduce byte-identical chunks, and "already exists" is a truthful confirmation. Because the old WAL was trimmed in normal operation, this copies a few seconds of tail, not the cluster's lifetime; replay cost is independent of cluster age.
+Committed transactions are copied from the surviving logs into the new generation. Object storage is durable through `durable_through`, so replay uses the exclusive cursor `replay_after = max(durable_through, available_after)` and copies `(replay_after, last_inclusive]`. It routes every copied transaction through the new log's fresh Demux, so the per-shard buffers and chunk pipeline are rebuilt as a side effect — deterministic cuts reproduce byte-identical chunks, and "already exists" is a truthful confirmation. No lower-bound sentinel is appended: an empty range persists only its cursor, while a non-empty replay succeeds only after observing the inclusive endpoint. Because the old WAL was trimmed in normal operation, this copies a few seconds of tail, not the cluster's lifetime; replay cost is independent of cluster age.
 
 ## Phase 5: [Sequencer Startup](../quick-reads/recovery/sequencer-startup.md)
 

--- a/guides/durability-foundation.md
+++ b/guides/durability-foundation.md
@@ -61,6 +61,13 @@ the cuts use, so there is always a finished segment for the floor to catch — a
 log's disk footprint stays proportional to a few seconds of traffic, not to
 its lifetime.
 
+Each new WAL segment durably records the prior WAL tip as `previous_version`
+in its header before the preceding segment can become trim-eligible. After a
+cold restart, the oldest retained header therefore preserves `available_after`:
+the exact exclusive replay cursor before retained data. This cursor is distinct
+from the first retained transaction and remains meaningful across numeric
+version gaps.
+
 The commit acknowledgment never waits for any of this. Clients are
 acknowledged on WAL fsync; chunk writes and floor advancement happen behind
 the scenes, and the floor only ever moves forward.

--- a/guides/glossary.md
+++ b/guides/glossary.md
@@ -10,6 +10,13 @@ This glossary defines key terms and concepts used throughout the Bedrock distrib
 
 ## A
 
+### **Available After**
+
+The exclusive WAL cursor after which every retained transaction is available.
+Shale persists it as the `previous_version` in each segment header, so trimming
+and cold restart cannot erase the boundary needed by `Log.pull/3`. It is not the
+same as the first retained transaction.
+
 ### **ACID**
 
 **Atomicity, Consistency, Isolation, Durability** - The four fundamental properties of database transactions that Bedrock guarantees. All operations in a transaction either succeed together (atomicity), maintain data validity (consistency), appear isolated from other transactions (isolation), and survive system failures (durability).

--- a/guides/quick-reads/recovery.md
+++ b/guides/quick-reads/recovery.md
@@ -69,11 +69,11 @@ flowchart TD
    references recovery already holds, so recruitment completes in a single
    attempt.
 4. **[Log Replay](recovery/log-replay.md)** - Copy the surviving WAL tail
-   into the new generation of logs. The copy starts at the later of the
-   durable floor and the oldest version the survivors still hold — history
-   below that is already durable in object-storage chunks, which is the
-   only way it left the WAL — so replay cost is bounded by the untrimmed
-   tail, not the cluster's age.
+   into the new generation of logs. The copy range is
+   `(max(durable_through, available_after), last_inclusive]`; the persisted
+   lower cursor preserves the first retained transaction even after trim and
+   restart. History below it is already durable in object-storage chunks, so
+   replay cost is bounded by the untrimmed tail, not the cluster's age.
 5. **[Sequencer Startup](recovery/sequencer-startup.md)** - Start the
    global version authority at the recovery version.
 6. **Materializer Bootstrap** - Reuse the surviving materializers: hand

--- a/guides/quick-reads/recovery/log-recovery-planning.md
+++ b/guides/quick-reads/recovery/log-recovery-planning.md
@@ -1,67 +1,55 @@
 # Log Recovery Planning
 
-**Determining what committed transaction data can be safely recovered from existing logs.**
+**Determining the common recoverable WAL range without confusing data with a cursor.**
 
-Log recovery planning analyzes surviving logs to identify which [transactions](../transactions.md) can be safely restored. This phase only runs for existing clusters with potentially valuable data—new clusters skip directly to clean infrastructure creation.
+Bedrock writes every committed transaction to every log. Recovery can proceed
+when a majority of the previous generation's logs can be locked. Those
+survivors report three distinct positions:
 
-## Core Strategy
+- `available_after`: an exclusive cursor; every retained transaction after it
+  is available from that WAL.
+- `last_inclusive`: the last transaction version present in the WAL (reported
+  as `last_version`).
+- `minimum_durable_version`: the transient object-storage durability
+  watermark, or `:unavailable` after restart.
 
-Bedrock stores every committed transaction on every [log](../../deep-dives/architecture/data-plane/log.md), creating natural redundancy. During recovery, some logs may be unavailable or contain different data ranges due to failures.
+`oldest_version` remains useful for inspection, but it names retained data and
+is never used as an exclusive pull cursor.
 
-The planning algorithm:
+## Common Range
 
-1. **Groups logs by shard** - Logs serving the same key ranges form analysis groups
-2. **Checks quorum requirements** - Each shard needs sufficient logs for data validation  
-3. **Finds common version range** - Identifies the latest version safely recoverable across all shards
-4. **Selects optimal logs** - Chooses log combinations maximizing recoverable data
-
-## Shard Analysis
-
-For each shard, recovery examines all possible combinations of available logs meeting quorum requirements:
-
-```text
-Shard Alpha: Logs 1, 2, 3 (requires 2 for quorum)
-- Logs 1 & 2 available with data through version 100
-- Log 3 unreachable
-- Result: Can recover through version 100 ✓
-```
-
-## Cross-Shard Consensus
-
-Individual shard analysis isn't enough. Recovery uses the **minimum version across all shards** as the global recovery baseline:
+Across the locked majority, planning computes:
 
 ```text
-Shard Alpha: Max recoverable version 100
-Shard Beta:  Max recoverable version 85  
-Shard Gamma: Max recoverable version 95
-Global recovery baseline: 85 (minimum)
+available_after = max(each survivor's available_after)
+last_inclusive  = min(each survivor's last_version)
+
+common range = (available_after, last_inclusive]
 ```
 
-This conservative approach ensures every recovered transaction achieved full cross-shard replication.
+The lower bound is deliberately exclusive. A survivor whose first retained
+transaction is version 10 can report `available_after = 9`; replay from 9 then
+includes version 10 exactly once. Versions may have arbitrary numeric gaps, so
+the cursor is persisted rather than derived by subtracting from the first
+transaction.
 
-## Data Maximization
+Planning separately takes the minimum available durability watermark. Log
+replay may advance its exclusive cursor to that point because object storage is
+durable through it. The watermark is an optimization, not the WAL's persisted
+availability contract.
 
-Recovery attempts to copy from all available logs within each shard, not just the minimum required. This preserves more transaction history in the rebuilt logs, whose Demux replay re-produces the object-storage chunks that [storage servers](../../deep-dives/architecture/data-plane/storage.md) stream during their own catch-up.
+If the locked logs do not form a majority, or if the aggregated lower cursor is
+greater than the inclusive endpoint, recovery stalls with
+`:unable_to_meet_log_quorum`.
 
-## Failure Handling
+## Outputs
 
-If any shard cannot meet quorum requirements, recovery fails with `:unable_to_meet_log_quorum`. This prevents recovery from proceeding with insufficient data validation guarantees.
+- `survivor_log_ids`: the locked logs that can serve as replay sources.
+- `version_vector`: `{available_after, last_inclusive}`.
+- `durable_version`: the common `durable_through` optimization.
+- Fresh log vacancies for the next generation.
 
-## Algorithm Inputs and Outputs
-
-**Inputs:**
-
-- Previous system configuration (log assignments and ranges)
-- Current log status (availability and version ranges)  
-- Target system requirements (quorum parameters)
-
-**Outputs:**
-
-- `old_log_ids_to_copy` - Which logs to preserve data from
-- `version_vector` - Transaction range bounds for recovery
-
-## Next Phase
-
-Success leads to [vacancy creation](vacancy-creation.md), which uses the established version vector to plan the new system architecture.
+Success leads to [log recruitment](log-recruitment.md), followed by
+[log replay](log-replay.md).
 
 **Implementation**: `lib/bedrock/control_plane/director/recovery/log_recovery_planning_phase.ex`

--- a/guides/quick-reads/recovery/log-replay.md
+++ b/guides/quick-reads/recovery/log-replay.md
@@ -1,41 +1,53 @@
 # Log Replay: Data Migration to Trusted Infrastructure
 
-**Copying committed transactions from potentially compromised logs to verified new infrastructure.**
+**Copying the committed WAL tail into a fresh generation of logs.**
 
-The log replay phase transfers all committed transaction data from old [logs](../../deep-dives/architecture/data-plane/log.md) to newly recruited log services. Rather than attempting to salvage potentially compromised infrastructure, Bedrock systematically copies transaction data to verified, reliable storage before the new system begins operation.
+Each new log receives the locked survivor set and rebuilds from any available
+survivor. Every log holds the same encoded transaction stream, so the source
+transaction binary is appended unchanged; the destination's Demux performs
+normal shard slicing after the WAL append.
 
-## Core Process
+## One Range Convention
 
-**Smart Pairing Algorithm**  
-Recovery pairs each new log with old logs using round-robin distribution. When scaling from 2 to 4 logs:
+Planning supplies `{available_after, last_inclusive}` and object storage is
+known durable through `durable_through`. Replay computes:
 
-- New log 1 ← Old log 1  
-- New log 2 ← Old log 2
-- New log 3 ← Old log 1 (cycles back)
-- New log 4 ← Old log 2
+```text
+replay_after = max(durable_through, available_after)
+copy range   = (replay_after, last_inclusive]
+```
 
-**Selective Data Migration**  
-Only committed transactions within the established [version](../../glossary.md#version) range determined during [version determination](version-determination.md) undergo copying. Uncommitted transactions are deliberately excluded to maintain system consistency.
+Both lower inputs are exclusive cursors. `Log.pull/3` remains exclusive at its
+start and inclusive at `last_version`, so there is no conversion at an API
+boundary. A transaction at the first retained version is copied exactly once,
+including when it is the only retained transaction. Numeric version gaps are
+valid.
 
-**Parallel Execution**  
-Each old-to-new log pairing operates in parallel, maximizing throughput while maintaining strict consistency requirements.
+The destination records `replay_after` as logical WAL position without
+creating a transaction. An empty range persists that baseline in a WAL segment
+header. A non-empty range begins with the first real source transaction and
+routes that exact binary through the fresh Demux.
 
-## Reliability Philosophy
+Recovery succeeds only after observing `last_inclusive`. An empty page before
+that endpoint is an incomplete replay, not evidence of success. Replay never
+assigns the requested endpoint speculatively and never writes an empty
+transaction as a progress marker.
 
-Bedrock chooses data integrity over operational efficiency. Even though old logs contain correct transaction data, recovery copies this information to newly recruited logs rather than reusing potentially compromised storage. This ensures all transaction data resides on verified infrastructure before system startup.
+## Why Restart Preserves the Boundary
 
-The new [transaction system layout](transaction-system-layout.md) often differs significantly—different log services, node assignments, and potentially different durability policies. Complete data migration ensures compatibility between system generations.
+Every WAL segment header stores the `previous_version` current when the segment
+was created. The header and first entry are covered by the same fsync before the
+old segment can become trim-eligible. Consequently, after trim and cold restart,
+the oldest retained segment still states the exact exclusive cursor preceding
+its data. Legacy headers without that fact fail closed.
 
-## Error Handling
+New logs recover in parallel. Source unavailability is reported or retried
+against another survivor; malformed, out-of-order, beyond-endpoint, or
+incomplete data fails recovery.
 
-- **Service Failures**: Controlled stall with detailed diagnostics
-- **Epoch Conflicts**: Immediate termination if `:newer_epoch_exists` indicates a newer recovery attempt
-- **Fail-Fast**: Clean termination enables coordinator restart with fresh state
+**Prerequisites**: [Log recovery planning](log-recovery-planning.md),
+[log recruitment](log-recruitment.md), and [service locking](service-locking.md)
 
-## Phase Integration
+**Next phase**: [Sequencer startup](sequencer-startup.md)
 
-**Prerequisites**: [Log recruitment](log-recruitment.md), [version determination](version-determination.md), [service locking](service-locking.md)  
-**Next Phase**: [Sequencer startup](sequencer-startup.md) with populated transaction data  
 **Implementation**: `lib/bedrock/control_plane/director/recovery/log_replay_phase.ex`
-
-This phase marks the transformation from architectural planning to operational infrastructure capable of serving transaction workloads with complete data integrity confidence.

--- a/lib/bedrock.ex
+++ b/lib/bedrock.ex
@@ -15,7 +15,7 @@ defmodule Bedrock do
   @type key_value :: {key(), value()}
 
   @type version :: Bedrock.DataPlane.Version.t()
-  @type version_vector :: {oldest :: version(), newest :: version()}
+  @type version_vector :: {available_after :: version(), last_inclusive :: version()}
 
   @type transaction :: binary()
 

--- a/lib/bedrock/control_plane/director/recovery/log_recovery_planning_phase.ex
+++ b/lib/bedrock/control_plane/director/recovery/log_recovery_planning_phase.ex
@@ -5,7 +5,9 @@ defmodule Bedrock.ControlPlane.Director.Recovery.LogRecoveryPlanningPhase do
 
   Runs when logs existed in the previous layout. Uses simple majority quorum - if more than half
   of the logs from the previous layout are available (locked), recovery can proceed. The version
-  vector is computed as `{max(oldest), min(newest)}` across all available logs.
+  vector is computed as `{max(available_after), min(last_inclusive)}` across
+  all available logs. Its lower element is an exclusive cursor, not the first
+  retained transaction.
 
   Also calculates `durable_version` as the minimum of all logs' `minimum_durable_version` values,
   representing the highest version guaranteed to be persisted to durable storage (ObjectStorage)
@@ -74,8 +76,8 @@ defmodule Bedrock.ControlPlane.Director.Recovery.LogRecoveryPlanningPhase do
   @doc """
   Computes the version vector from log recovery info.
 
-  Returns `{max(oldest), min(newest)}` across all logs, which represents the
-  range of transactions that are guaranteed to be complete across all survivors.
+  Returns `{max(available_after), min(last_inclusive)}` across all logs, which
+  represents the common recovery range `(available_after, last_inclusive]`.
   """
   @spec compute_version_vector(%{Log.id() => Log.recovery_info()}) ::
           {:ok, Bedrock.version_vector()} | {:error, :invalid_version_range}
@@ -84,44 +86,46 @@ defmodule Bedrock.ControlPlane.Director.Recovery.LogRecoveryPlanningPhase do
   end
 
   def compute_version_vector(log_recovery_info) do
-    {max_oldest, min_newest} =
+    {max_available_after, min_last_inclusive} =
       log_recovery_info
       |> Map.values()
-      |> Enum.reduce({Version.zero(), nil}, fn info, {current_max_oldest, current_min_newest} ->
-        oldest = info[:oldest_version]
-        newest = info[:last_version]
+      |> Enum.reduce({Version.zero(), nil}, fn info, {current_max_available_after, current_min_last_inclusive} ->
+        available_after = info[:available_after]
+        last_inclusive = info[:last_version]
 
-        new_max_oldest = if oldest > current_max_oldest, do: oldest, else: current_max_oldest
+        new_max_available_after =
+          if available_after > current_max_available_after,
+            do: available_after,
+            else: current_max_available_after
 
-        new_min_newest =
+        new_min_last_inclusive =
           cond do
-            current_min_newest == nil -> newest
-            newest < current_min_newest -> newest
-            true -> current_min_newest
+            current_min_last_inclusive == nil -> last_inclusive
+            last_inclusive < current_min_last_inclusive -> last_inclusive
+            true -> current_min_last_inclusive
           end
 
-        {new_max_oldest, new_min_newest}
+        {new_max_available_after, new_min_last_inclusive}
       end)
 
-    # Validate the range
-    if valid_range?({max_oldest, min_newest}) do
-      {:ok, {max_oldest, min_newest}}
+    if valid_range?({max_available_after, min_last_inclusive}) do
+      {:ok, {max_available_after, min_last_inclusive}}
     else
       {:error, :invalid_version_range}
     end
   end
 
   @doc """
-  Validates a version range is valid (oldest <= newest, with special handling for zero).
+  Validates an exclusive/inclusive recovery range (`available_after <= last_inclusive`).
   """
   @spec valid_range?(Bedrock.version_vector()) :: boolean()
-  def valid_range?({oldest, newest}) do
+  def valid_range?({available_after, last_inclusive}) do
     zero_version = Version.zero()
 
     cond do
-      oldest == zero_version -> true
-      newest == zero_version -> false
-      true -> newest >= oldest
+      available_after == zero_version -> true
+      last_inclusive == zero_version -> false
+      true -> last_inclusive >= available_after
     end
   end
 

--- a/lib/bedrock/control_plane/director/recovery/log_replay_phase.ex
+++ b/lib/bedrock/control_plane/director/recovery/log_replay_phase.ex
@@ -38,16 +38,13 @@ defmodule Bedrock.ControlPlane.Director.Recovery.LogReplayPhase do
 
   @impl true
   def execute(recovery_attempt, context) do
-    # Copy only what the new generation actually needs — but never ask a
-    # source for versions below what its WAL can supply. The durable floor
-    # skips the already-chunked prefix when it is ahead, but it regresses
-    # to zero on restart (it is not persisted), while a trimmed WAL begins
-    # at its oldest retained version: everything below the vector's first
-    # element is durable in object-storage chunks — that is the only way
-    # it got trimmed.
-    {oldest_available, last_version} = recovery_attempt.version_vector
-    first_version = max(recovery_attempt.durable_version, oldest_available)
-    optimized_version_vector = {first_version, last_version}
+    # Both lower bounds are exclusive cursors: object storage is durable
+    # through `durable_through`, while every surviving WAL is complete after
+    # `available_after`. Their maximum therefore remains an exclusive cursor.
+    {available_after, last_inclusive} = recovery_attempt.version_vector
+    durable_through = recovery_attempt.durable_version
+    replay_after = max(durable_through, available_after)
+    replay_range = {replay_after, last_inclusive}
 
     # Get survivor log IDs - all logs that were successfully locked during recovery
     survivor_log_ids = Map.get(recovery_attempt, :survivor_log_ids, recovery_attempt.old_log_ids_to_copy)
@@ -55,7 +52,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery.LogReplayPhase do
     survivor_log_ids
     |> replay_into_new_logs(
       Map.keys(recovery_attempt.logs),
-      optimized_version_vector,
+      replay_range,
       recovery_attempt,
       context
     )
@@ -90,7 +87,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery.LogReplayPhase do
   def replay_into_new_logs(
         survivor_log_ids,
         new_log_ids,
-        {first_version, last_version},
+        {replay_after, last_inclusive},
         recovery_attempt,
         context \\ %{}
       ) do
@@ -105,7 +102,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery.LogReplayPhase do
     |> Task.async_stream(
       fn new_log_id ->
         new_log_id
-        |> copy_log_data_fn.(survivor_pids, first_version, last_version, service_pids)
+        |> copy_log_data_fn.(survivor_pids, replay_after, last_inclusive, service_pids)
         |> then(&{new_log_id, &1})
       end,
       ordered: false,
@@ -154,16 +151,16 @@ defmodule Bedrock.ControlPlane.Director.Recovery.LogReplayPhase do
   @spec copy_log_data(
           new_log_id :: Log.id(),
           survivor_pids :: [pid()],
-          first_version :: Bedrock.version(),
-          last_version :: Bedrock.version(),
+          replay_after :: Bedrock.version(),
+          last_inclusive :: Bedrock.version(),
           service_pids :: %{Log.id() => pid()}
         ) :: {:ok, pid()} | {:error, term()}
-  def copy_log_data(new_log_id, survivor_pids, first_version, last_version, service_pids) do
+  def copy_log_data(new_log_id, survivor_pids, replay_after, last_inclusive, service_pids) do
     Log.recover_from(
       Map.fetch!(service_pids, new_log_id),
       survivor_pids,
-      first_version,
-      last_version
+      replay_after,
+      last_inclusive
     )
   end
 

--- a/lib/bedrock/control_plane/director/recovery/materializer_bootstrap_phase.ex
+++ b/lib/bedrock/control_plane/director/recovery/materializer_bootstrap_phase.ex
@@ -202,7 +202,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhase do
     # WAL trim floor — is NOT a rollback target: it regresses to zero on
     # restart by design, and rolling a populated materializer back to it
     # would discard real state.)
-    {_oldest, recovery_version} = recovery_attempt.version_vector
+    {_available_after, recovery_version} = recovery_attempt.version_vector
 
     # Materializers were locked during the locking phase; their recovery
     # info carries their shard assignments. Reuse them — they hold the

--- a/lib/bedrock/control_plane/director/recovery/resolver_startup_phase.ex
+++ b/lib/bedrock/control_plane/director/recovery/resolver_startup_phase.ex
@@ -33,7 +33,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery.ResolverStartupPhase do
       end)
 
     available_resolver_nodes = Map.get(context.node_capabilities, :coordination, [])
-    {_first_version, last_committed_version} = recovery_attempt.version_vector
+    {_available_after, last_committed_version} = recovery_attempt.version_vector
 
     resolver_context = %{
       resolvers: recovery_attempt.resolvers,

--- a/lib/bedrock/control_plane/director/recovery/sequencer_startup_phase.ex
+++ b/lib/bedrock/control_plane/director/recovery/sequencer_startup_phase.ex
@@ -56,7 +56,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery.SequencerStartupPhase do
 
   @spec build_sequencer_child_spec(RecoveryAttempt.t()) :: Supervisor.child_spec()
   defp build_sequencer_child_spec(recovery_attempt) do
-    {_first_version, last_committed_version} = recovery_attempt.version_vector
+    {_available_after, last_committed_version} = recovery_attempt.version_vector
 
     Sequencer.child_spec(
       cluster: recovery_attempt.cluster,

--- a/lib/bedrock/data_plane/log.ex
+++ b/lib/bedrock/data_plane/log.ex
@@ -17,12 +17,14 @@ defmodule Bedrock.DataPlane.Log do
   @type fact_name ::
           Worker.fact_name()
           | :last_version
+          | :available_after
           | :oldest_version
           | :minimum_durable_version
 
   @type recovery_info :: %{
           kind: :log,
           last_version: Bedrock.version(),
+          available_after: Bedrock.version(),
           oldest_version: Bedrock.version(),
           minimum_durable_version: Bedrock.version() | :unavailable
         }
@@ -37,16 +39,18 @@ defmodule Bedrock.DataPlane.Log do
     - A list containing:
       - `:kind`: Identifies the entity as a log.
       - `:last_version`: The latest version present in the log.
-      - `:oldest_version`: The earliest version still available in the log.
-      - `:minimum_durable_version`: The lowest version that is guaranteed to
-        be durable. This could be a specific version or `:unavailable` if
-        not determinable.
+      - `:available_after`: The exclusive cursor after which every retained
+        transaction is available.
+      - `:oldest_version`: Informational first retained transaction version.
+      - `:minimum_durable_version`: The object-storage watermark through which
+        data is durable. This could be a specific version or `:unavailable`
+        after restart.
 
   Useful in scenarios where system recovery needs to consider the current
   state of log versions, ensuring consistency and order.
   """
   @spec recovery_info :: [fact_name()]
-  def recovery_info, do: [:kind, :last_version, :oldest_version, :minimum_durable_version]
+  def recovery_info, do: [:kind, :last_version, :available_after, :oldest_version, :minimum_durable_version]
 
   @doc """
   Apply a new transaction to the log. The previous transaction version is given
@@ -108,7 +112,7 @@ defmodule Bedrock.DataPlane.Log do
     - `{:error, :invalid_last_version}`: The specified `last_version` is invalid.
     - `{:error, :version_too_new}`: The version specified is too recent.
     - `{:error, {:version_too_old, floor}}`: The version specified is below
-      the WAL's trim floor; `floor` is the oldest version still available.
+      the WAL's trim floor; `floor` is the exclusive `available_after` cursor.
       Consumers below it should catch up from object storage chunks.
     - `{:error, :version_not_found}`: The version cannot be found.
     - `{:error, :unavailable}`: Log is unavailable for operation.
@@ -149,9 +153,10 @@ defmodule Bedrock.DataPlane.Log do
   def get_shard_server(log, shard_id), do: call(log, {:get_shard_server, shard_id}, 5_000)
 
   @doc """
-  The initial transaction that is applied to a new log if the current version
-  is set to 0 during a recovery. It is an explicit a directive to clear the
-  entire key range.
+  Encodes an empty transaction at version zero for callers that need one.
+
+  Recovery does not use this as a cursor or progress marker. Empty recovery
+  state is represented by persisted WAL metadata, never by a transaction.
   """
   @spec initial_transaction :: Transaction.encoded()
   def initial_transaction do
@@ -177,6 +182,7 @@ defmodule Bedrock.DataPlane.Log do
            recovery_info :: [
              kind: :log,
              last_version: Bedrock.version(),
+             available_after: Bedrock.version(),
              oldest_version: Bedrock.version(),
              minimum_durable_version: Bedrock.version() | :unavailable
            ]}
@@ -184,10 +190,7 @@ defmodule Bedrock.DataPlane.Log do
   defdelegate lock_for_recovery(storage, epoch), to: Worker
 
   @doc """
-  Initiates a recovery process from the given source log(s) spanning the
-  transactions specified by the given first/last versions. If the first version
-  is 0, a special _initial transaction_ is applied to the log. This transaction
-  is defined by `initial_transaction/0`.
+  Initiates recovery from source logs over `(replay_after, last_inclusive]`.
 
   The function ensures that the transaction log is consistent with the
   source logs by pulling from them and applying the transactions.
@@ -198,18 +201,16 @@ defmodule Bedrock.DataPlane.Log do
     - `source_logs`: List of source log references from which transactions are
       recovered, or a single ref for backward compatibility. Empty list or nil
       is sent for initial recovery when there are no source logs.
-    - `first_version`: The starting point of the recovery. Transactions _after_
-      this version are applied.
-    - `last_version`: The ending point of the recovery. Transactions up to and
-      including this version are applied.
+    - `replay_after`: The exclusive starting cursor. No transaction is created
+      at this version.
+    - `last_inclusive`: The inclusive endpoint that recovery must observe before
+      it can report success.
 
   ## Multi-Source Recovery (Consistent Hashing)
 
-  When multiple source logs are provided, the log pulls transactions from all
-  sources and uses the shard index embedded in each transaction to filter for
-  mutations belonging to shards this log serves (determined by ShardRouter).
-  This supports the consistent hashing model where shard→log mapping is computed
-  rather than stored.
+  When multiple source logs are provided, Shale can try another survivor if a
+  source is unavailable. Every log stores the same encoded transaction stream;
+  the destination appends each binary unchanged and its Demux performs slicing.
 
   ## Return Values:
 
@@ -220,12 +221,12 @@ defmodule Bedrock.DataPlane.Log do
   @spec recover_from(
           log :: ref(),
           source_logs :: [ref()] | ref() | nil,
-          first_version :: Bedrock.version(),
-          last_version :: Bedrock.version()
+          replay_after :: Bedrock.version(),
+          last_inclusive :: Bedrock.version()
         ) ::
           {:ok, pid()} | {:error, :unavailable}
-  def recover_from(log, source_logs, first_version, last_version),
-    do: call(log, {:recover_from, normalize_source_logs(source_logs), first_version, last_version}, :infinity)
+  def recover_from(log, source_logs, replay_after, last_inclusive),
+    do: call(log, {:recover_from, normalize_source_logs(source_logs), replay_after, last_inclusive}, :infinity)
 
   # Normalize source_logs to always be a list for consistent handling
   defp normalize_source_logs(nil), do: []

--- a/lib/bedrock/data_plane/log/shale/cold_starting.ex
+++ b/lib/bedrock/data_plane/log/shale/cold_starting.ex
@@ -2,11 +2,11 @@ defmodule Bedrock.DataPlane.Log.Shale.ColdStarting do
   @moduledoc false
 
   alias Bedrock.DataPlane.Log.Shale.Segment
-  alias Bedrock.DataPlane.Version
 
   @spec reload_segments_at_path(segment_dir :: String.t()) ::
           {:ok, [Segment.t()]}
           | {:error, {:unable_to_list_segments, File.posix()}}
+          | {:error, {:unsupported_wal_format | :invalid_wal_format, String.t()}}
   def reload_segments_at_path(segment_dir) do
     segment_dir
     |> File.ls()
@@ -14,23 +14,17 @@ defmodule Bedrock.DataPlane.Log.Shale.ColdStarting do
       {:ok, files} ->
         files
         |> Enum.filter(&String.starts_with?(&1, Segment.file_prefix()))
-        |> Enum.map(fn file_name ->
-          path = Path.join(segment_dir, file_name)
-
-          min_version =
-            file_name
-            |> String.replace_prefix(Segment.file_prefix(), "")
-            |> String.replace_suffix(".log", "")
-            |> String.to_integer(32)
-            |> Version.from_integer()
-
-          {min_version, path}
+        |> Enum.sort(:desc)
+        |> Enum.reduce_while({:ok, []}, fn file_name, {:ok, segments} ->
+          case Segment.from_path(Path.join(segment_dir, file_name)) do
+            {:ok, segment} -> {:cont, {:ok, [segment | segments]}}
+            {:error, reason} -> {:halt, {:error, reason}}
+          end
         end)
-        |> Enum.sort_by(&elem(&1, 0), :desc)
-        |> Enum.map(fn {min_version, path} ->
-          %Segment{min_version: min_version, path: path}
-        end)
-        |> then(&{:ok, &1})
+        |> case do
+          {:ok, segments} -> {:ok, Enum.sort_by(segments, & &1.min_version, :desc)}
+          error -> error
+        end
 
       {:error, posix} ->
         {:error, {:unable_to_list_segments, posix}}

--- a/lib/bedrock/data_plane/log/shale/facts.ex
+++ b/lib/bedrock/data_plane/log/shale/facts.ex
@@ -21,7 +21,18 @@ defmodule Bedrock.DataPlane.Log.Shale.Facts do
 
   @spec supported_info() :: [Log.fact_name()]
   def supported_info,
-    do: [:id, :kind, :minimum_durable_version, :oldest_version, :last_version, :otp_name, :pid, :state, :supported_info]
+    do: [
+      :id,
+      :kind,
+      :minimum_durable_version,
+      :available_after,
+      :oldest_version,
+      :last_version,
+      :otp_name,
+      :pid,
+      :state,
+      :supported_info
+    ]
 
   @spec gather_info(Log.fact_name(), State.t()) ::
           String.t()
@@ -43,6 +54,7 @@ defmodule Bedrock.DataPlane.Log.Shale.Facts do
   defp gather_info(:minimum_durable_version, %{min_durable_version: nil}), do: :unavailable
   defp gather_info(:minimum_durable_version, %{min_durable_version: v}), do: v
 
+  defp gather_info(:available_after, t), do: t.available_after
   defp gather_info(:oldest_version, t), do: t.oldest_version
   defp gather_info(:last_version, t), do: t.last_version
 

--- a/lib/bedrock/data_plane/log/shale/pulling.ex
+++ b/lib/bedrock/data_plane/log/shale/pulling.ex
@@ -23,11 +23,21 @@ defmodule Bedrock.DataPlane.Log.Shale.Pulling do
           | {:error, {:version_too_old, floor :: Bedrock.version()}}
   def pull(t, from_version, opts \\ [])
 
-  def pull(t, from_version, _) when from_version >= t.last_version, do: {:waiting_for, from_version}
+  def pull(t, from_version, opts) when from_version >= t.last_version do
+    if opts[:recovery] == true and from_version == t.last_version and opts[:last_version] == t.last_version do
+      case check_for_locked_outside_of_recovery(true, t) do
+        :ok -> {:ok, t, []}
+        error -> error
+      end
+    else
+      {:waiting_for, from_version}
+    end
+  end
 
-  # The floor is data, not a wall: a puller below it learns where the WAL
-  # now begins and can re-bootstrap from object storage up to that point.
-  def pull(t, from_version, _) when from_version < t.oldest_version, do: {:error, {:version_too_old, t.oldest_version}}
+  # `available_after` is the persisted exclusive floor. A puller below it
+  # must re-bootstrap from object storage through that cursor.
+  def pull(t, from_version, _) when from_version < t.available_after,
+    do: {:error, {:version_too_old, t.available_after}}
 
   def pull(t, from_version, opts) do
     with :ok <- check_for_locked_outside_of_recovery(opts[:recovery] || false, t),
@@ -57,7 +67,7 @@ defmodule Bedrock.DataPlane.Log.Shale.Pulling do
         end
 
       {:error, :version_too_old} ->
-        {:error, {:version_too_old, t.oldest_version}}
+        {:error, {:version_too_old, t.available_after}}
 
       error ->
         error

--- a/lib/bedrock/data_plane/log/shale/pushing.ex
+++ b/lib/bedrock/data_plane/log/shale/pushing.ex
@@ -91,9 +91,11 @@ defmodule Bedrock.DataPlane.Log.Shale.Pushing do
           raise "Failed to extract version: #{inspect(reason)}"
       end
 
-    case Segment.allocate_from_recycler(t.segment_recycler, t.path, version) do
+    previous_version = t.last_version
+
+    case Segment.allocate_from_recycler(t.segment_recycler, t.path, version, previous_version) do
       {:ok, new_segment} ->
-        case Writer.open(new_segment.path) do
+        case Writer.open(new_segment.path, previous_version) do
           {:ok, new_writer} ->
             write_encoded_transaction(
               %{
@@ -123,9 +125,10 @@ defmodule Bedrock.DataPlane.Log.Shale.Pushing do
           # segment is trim-immune, so a low-traffic log that never fills a
           # segment would otherwise hold its entire history in one
           # untrimmable file — and every recovery would copy that history
-          # from version zero. Rolling per cut bucket keeps oldest_version
-          # chasing the trim floor, which bounds recovery replay to the
-          # untrimmed tail. A roll is a rename from the preallocated pool.
+          # from version zero. Rolling per cut bucket gives trimming a
+          # successor header whose persisted predecessor keeps
+          # `available_after` chasing the untrimmed tail. A roll is a rename
+          # from the preallocated pool.
           case Writer.close(t.writer) do
             :ok -> write_encoded_transaction(%{t | writer: nil}, encoded_transaction)
             {:error, reason} -> {:error, reason, t}
@@ -150,11 +153,22 @@ defmodule Bedrock.DataPlane.Log.Shale.Pushing do
   end
 
   defp append_encoded_transaction(t, encoded_transaction, version) do
+    had_transactions? = wal_has_transactions?(t)
+
     case Writer.append(t.writer, encoded_transaction, version) do
       {:ok, writer} ->
         # Update the active segment's transaction cache to keep it coherent with disk
         updated_active_segment = update_segment_transaction_cache(t.active_segment, encoded_transaction)
-        {:ok, %{t | writer: writer, last_version: version, active_segment: updated_active_segment}}
+        oldest_version = if had_transactions?, do: t.oldest_version, else: version
+
+        {:ok,
+         %{
+           t
+           | writer: writer,
+             last_version: version,
+             oldest_version: oldest_version,
+             active_segment: updated_active_segment
+         }}
 
       {:error, :segment_full} ->
         case Writer.close(t.writer) do
@@ -165,6 +179,12 @@ defmodule Bedrock.DataPlane.Log.Shale.Pushing do
       {:error, reason} ->
         {:error, reason, t}
     end
+  end
+
+  defp wal_has_transactions?(t) do
+    [t.active_segment | t.segments]
+    |> Enum.reject(&is_nil/1)
+    |> Enum.any?(fn segment -> Segment.transactions(segment) != [] end)
   end
 
   @spec update_segment_transaction_cache(Segment.t(), Transaction.encoded()) :: Segment.t()

--- a/lib/bedrock/data_plane/log/shale/recovery.ex
+++ b/lib/bedrock/data_plane/log/shale/recovery.ex
@@ -2,15 +2,9 @@ defmodule Bedrock.DataPlane.Log.Shale.Recovery do
   @moduledoc """
   Recovery logic for Shale log servers.
 
-  Supports multi-source recovery for the consistent hashing model. When multiple
-  source logs are provided, transactions are pulled from available sources to
-  establish the version range. Since all logs receive the same version sequence
-  (with personalized content), pulling from any survivor establishes the correct
-  version boundaries.
-
-  For future optimization, true multi-source coalescing could merge transaction
-  streams and filter by shard index, but for now we use the simpler approach
-  of pulling from available sources.
+  Every log stores the same encoded transaction stream. Recovery pulls from one
+  available survivor, appends each source binary unchanged, and lets the fresh
+  destination Demux perform normal shard slicing.
   """
   import Bedrock.DataPlane.Log.Shale.Pushing, only: [push: 4]
 
@@ -22,43 +16,99 @@ defmodule Bedrock.DataPlane.Log.Shale.Recovery do
   alias Bedrock.DataPlane.Log.Shale.State
   alias Bedrock.DataPlane.Log.Shale.Writer
   alias Bedrock.DataPlane.Transaction
-  alias Bedrock.DataPlane.Version
 
   @spec recover_from(
           State.t(),
           source_logs :: [Log.ref()],
-          first_version :: Bedrock.version(),
-          last_version :: Bedrock.version()
+          replay_after :: Bedrock.version(),
+          last_inclusive :: Bedrock.version()
         ) ::
           {:ok, State.t()}
           | {:error, :lock_required}
           | {:error, {:source_log_unavailable, log_ref :: Log.ref()}}
           | {:error, :no_source_logs_available}
+          | {:error, {:incomplete_replay, Bedrock.version(), Bedrock.version()}}
+          | {:error, term(), State.t()}
   def recover_from(t, _, _, _) when t.mode != :locked, do: {:error, :lock_required}
 
-  def recover_from(t, source_logs, first_version, last_version) do
-    %{t | mode: :recovering}
+  def recover_from(t, _source_logs, replay_after, last_inclusive) when replay_after > last_inclusive,
+    do: {:error, :invalid_version_range, t}
+
+  def recover_from(t, source_logs, replay_after, last_inclusive) do
+    t = prepare_replay(t, replay_after)
+
+    result =
+      if replay_after == last_inclusive do
+        persist_empty_baseline(t, replay_after)
+      else
+        pull_transactions_from_sources(t, source_logs, replay_after, last_inclusive)
+      end
+
+    case result do
+      {:ok, %{last_version: ^last_inclusive} = t} -> {:ok, %{t | mode: :running}}
+      {:ok, t} -> {:error, {:incomplete_replay, t.last_version, last_inclusive}, lock_failed_replay(t)}
+      {:error, reason, t} -> {:error, reason, lock_failed_replay(t)}
+    end
+  end
+
+  defp lock_failed_replay(t) do
+    t = close_writer(t)
+    DemuxControl.teardown(t.demux)
+    %{t | mode: :locked, demux: nil}
+  end
+
+  defp prepare_replay(t, replay_after) do
+    t
+    |> Map.put(:mode, :recovering)
     |> abort_all_waiting_pullers()
+    |> abort_all_pending_pushes()
     |> close_writer()
     |> discard_all_segments()
-    |> ensure_active_segment(first_version)
-    |> open_writer()
+    |> Map.merge(%{
+      active_segment: nil,
+      segments: [],
+      writer: nil,
+      available_after: replay_after,
+      oldest_version: replay_after,
+      last_version: replay_after,
+      pending_pushes: %{}
+    })
     |> reset_demux()
-    |> push_sentinel(first_version)
-    |> pull_transactions_from_sources(source_logs, first_version, last_version)
-    |> case do
-      {:ok, t} ->
-        {oldest, last} =
-          if first_version == last_version do
-            {t.oldest_version, t.last_version}
-          else
-            {first_version, last_version}
-          end
+  end
 
-        {:ok, %{t | mode: :running, oldest_version: oldest, last_version: last}}
+  defp persist_empty_baseline(t, replay_after) do
+    case Segment.allocate_from_recycler(t.segment_recycler, t.path, replay_after, replay_after) do
+      {:ok, segment} ->
+        persist_allocated_baseline(t, segment, replay_after)
 
-      error ->
-        error
+      {:error, reason} ->
+        {:error, {:unable_to_persist_replay_cursor, reason}, t}
+    end
+  end
+
+  defp persist_allocated_baseline(t, segment, replay_after) do
+    case Writer.open(segment.path, replay_after) do
+      {:ok, writer} ->
+        case Writer.sync(writer) do
+          :ok ->
+            :ok = Writer.close(writer)
+
+            {:ok,
+             %{
+               t
+               | active_segment: %{segment | transactions: []},
+                 writer: nil
+             }}
+
+          {:error, reason} ->
+            _ = Writer.close(writer)
+            :ok = Segment.return_to_recycler(segment, t.segment_recycler)
+            {:error, {:unable_to_persist_replay_cursor, reason}, t}
+        end
+
+      {:error, reason} ->
+        :ok = Segment.return_to_recycler(segment, t.segment_recycler)
+        {:error, {:unable_to_persist_replay_cursor, reason}, t}
     end
   end
 
@@ -92,115 +142,115 @@ defmodule Bedrock.DataPlane.Log.Shale.Recovery do
   @spec pull_transactions_from_sources(
           t :: State.t(),
           source_logs :: [Log.ref()],
-          first_version :: Bedrock.version(),
-          last_version :: Bedrock.version()
+          replay_after :: Bedrock.version(),
+          last_inclusive :: Bedrock.version()
         ) ::
           {:ok, State.t()}
           | Log.pull_errors()
           | {:error, {:source_log_unavailable, log_ref :: Log.ref()}}
           | {:error, :no_source_logs_available}
+          | {:error, term(), State.t()}
 
-  # No source logs - this is initial recovery (brand new cluster)
-  def pull_transactions_from_sources(t, [], first_version, last_version) when first_version == last_version do
-    {:ok, %{t | oldest_version: first_version, last_version: first_version}}
-  end
-
-  def pull_transactions_from_sources(_t, [], _first_version, _last_version) do
-    # No source logs available and we have transactions to recover
-    {:error, :no_source_logs_available}
-  end
+  def pull_transactions_from_sources(t, [], _replay_after, _last_inclusive), do: {:error, :no_source_logs_available, t}
 
   # Single source log - use original behavior
-  def pull_transactions_from_sources(t, [source_log], first_version, last_version) do
-    pull_transactions(t, source_log, first_version, last_version)
+  def pull_transactions_from_sources(t, [source_log], replay_after, last_inclusive) do
+    pull_transactions(t, source_log, replay_after, last_inclusive)
   end
 
   # Multiple source logs - try each in order until one succeeds
   # All logs have the same version sequence, so any survivor works
-  def pull_transactions_from_sources(t, source_logs, first_version, last_version) do
-    try_pull_from_sources(t, source_logs, first_version, last_version, [])
+  def pull_transactions_from_sources(t, source_logs, replay_after, last_inclusive) do
+    try_pull_from_sources(t, source_logs, replay_after, last_inclusive, [])
   end
 
-  defp try_pull_from_sources(_t, [], _first_version, _last_version, errors) do
+  defp try_pull_from_sources(t, [], _replay_after, _last_inclusive, errors) do
     # All sources failed, return the last error
     case errors do
-      [{:error, reason} | _] -> {:error, reason}
-      _ -> {:error, :no_source_logs_available}
+      [reason | _] -> {:error, reason, t}
+      _ -> {:error, :no_source_logs_available, t}
     end
   end
 
-  defp try_pull_from_sources(t, [source_log | rest], first_version, last_version, errors) do
-    case pull_transactions(t, source_log, first_version, last_version) do
+  defp try_pull_from_sources(t, [source_log | rest], replay_after, last_inclusive, errors) do
+    case pull_transactions(t, source_log, replay_after, last_inclusive) do
       {:ok, t} ->
         {:ok, t}
 
-      {:error, {:source_log_unavailable, _}} = error ->
-        # This source is unavailable, try next
-        try_pull_from_sources(t, rest, first_version, last_version, [error | errors])
+      {:error, {:source_log_unavailable, _} = reason, t} ->
+        # A source may disappear between pages. Reset the partial destination
+        # before trying another survivor so bytes from attempts cannot mix.
+        t = prepare_replay(t, replay_after)
+        try_pull_from_sources(t, rest, replay_after, last_inclusive, [reason | errors])
 
-      {:error, _} = error ->
-        # Other error, still try next source
-        try_pull_from_sources(t, rest, first_version, last_version, [error | errors])
+      {:error, _reason, _t} = error ->
+        error
     end
   end
 
   @spec pull_transactions(
           t :: State.t(),
           log_ref :: Log.ref(),
-          first_version :: Bedrock.version(),
-          last_version :: Bedrock.version()
+          replay_after :: Bedrock.version(),
+          last_inclusive :: Bedrock.version()
         ) ::
           {:ok, State.t()}
           | Log.pull_errors()
           | {:error, {:source_log_unavailable, log_ref :: Log.ref()}}
-  def pull_transactions(t, _, first_version, last_version) when first_version == last_version do
-    {:ok, %{t | oldest_version: first_version, last_version: first_version}}
-  end
+          | {:error, term(), State.t()}
+  def pull_transactions(t, _, replay_after, last_inclusive) when replay_after == last_inclusive, do: {:ok, t}
 
-  def pull_transactions(t, log_ref, first_version, last_version) do
-    case Log.pull(log_ref, first_version, recovery: true, last_version: last_version) do
+  def pull_transactions(t, log_ref, replay_after, last_inclusive) do
+    case Log.pull(log_ref, replay_after, recovery: true, last_version: last_inclusive) do
       {:ok, []} ->
-        {:ok, t}
+        {:error, {:incomplete_replay, replay_after, last_inclusive}, t}
 
       {:ok, transactions} ->
         transactions
-        |> Enum.reduce_while({first_version, t}, fn bytes, acc ->
-          process_transaction_bytes(bytes, acc)
+        |> Enum.reduce_while({replay_after, t}, fn bytes, acc ->
+          process_transaction_bytes(bytes, acc, last_inclusive)
         end)
         |> case do
-          {:error, _reason} = error -> error
-          {next_first, t} -> pull_transactions(t, log_ref, next_first, last_version)
+          {:error, _reason, _t} = error -> error
+          {^last_inclusive, t} -> {:ok, t}
+          {next_replay_after, t} -> pull_transactions(t, log_ref, next_replay_after, last_inclusive)
         end
 
       {:error, :unavailable} ->
-        {:error, {:source_log_unavailable, log_ref}}
+        {:error, {:source_log_unavailable, log_ref}, t}
 
       {:error, reason} ->
-        {:error, {:log_pull_failed, reason, log_ref}}
+        {:error, {:log_pull_failed, reason, log_ref}, t}
     end
   end
 
-  @spec process_transaction_bytes(Transaction.encoded(), {Bedrock.version(), State.t()}) ::
-          {:cont, {Bedrock.version(), State.t()}} | {:halt, {:error, term()}}
-  defp process_transaction_bytes(bytes, {last_version, t}) do
+  @spec process_transaction_bytes(Transaction.encoded(), {Bedrock.version(), State.t()}, Bedrock.version()) ::
+          {:cont, {Bedrock.version(), State.t()}} | {:halt, {:error, term(), State.t()}}
+  defp process_transaction_bytes(bytes, {cursor, t}, last_inclusive) do
     case Transaction.commit_version(bytes) do
       {:ok, version} when is_binary(version) ->
-        handle_valid_transaction_bytes(bytes, version, last_version, t)
+        process_versioned_transaction(bytes, version, cursor, last_inclusive, t)
 
       {:ok, nil} ->
-        {:halt, {:error, :missing_transaction_id}}
+        {:halt, {:error, :missing_transaction_id, t}}
 
       {:error, :invalid_format} ->
-        {:halt, {:error, :invalid_transaction}}
+        {:halt, {:error, :invalid_transaction, t}}
 
       {:error, reason} ->
-        {:halt, {:error, reason}}
+        {:halt, {:error, reason, t}}
     end
   end
 
-  defp process_transaction_bytes(_, _) do
-    {:halt, {:error, :invalid_transaction}}
-  end
+  defp process_versioned_transaction(bytes, version, cursor, last_inclusive, t)
+       when version > cursor and version <= last_inclusive,
+       do: handle_valid_transaction_bytes(bytes, version, cursor, t)
+
+  defp process_versioned_transaction(_bytes, version, _cursor, last_inclusive, t) when version > last_inclusive,
+    do: {:halt, {:error, {:transaction_beyond_replay_endpoint, version, last_inclusive}, t}}
+
+  defp process_versioned_transaction(_bytes, version, cursor, _last_inclusive, t),
+    do: {:halt, {:error, {:transaction_not_after_cursor, version, cursor}, t}}
 
   @spec handle_valid_transaction_bytes(
           Transaction.encoded(),
@@ -208,19 +258,19 @@ defmodule Bedrock.DataPlane.Log.Shale.Recovery do
           Bedrock.version(),
           State.t()
         ) ::
-          {:cont, {Bedrock.version(), State.t()}} | {:halt, {:error, term()}}
-  defp handle_valid_transaction_bytes(bytes, version, last_version, t) do
+          {:cont, {Bedrock.version(), State.t()}} | {:halt, {:error, term(), State.t()}}
+  defp handle_valid_transaction_bytes(bytes, version, cursor, t) do
     with {:ok, _transaction} <- Transaction.decode(bytes),
-         {:ok, t, [^bytes]} <- push(t, last_version, bytes, fn _ -> :ok end) do
+         {:ok, t, [^bytes]} <- push(t, cursor, bytes, fn _ -> :ok end) do
       # Replay routes through the fresh Demux so the replayed range re-enters
       # the chunk pipeline and re-confirms deterministically.
       push_to_demux(t, version, bytes)
       {:cont, {version, t}}
     else
-      {:wait, _t} -> {:halt, {:error, :tx_out_of_order}}
-      {:error, :invalid_format} -> {:halt, {:error, :invalid_transaction}}
-      {:error, reason, _t, _appended_transactions} -> {:halt, {:error, reason}}
-      {:error, _reason} = error -> {:halt, error}
+      {:wait, t} -> {:halt, {:error, :tx_out_of_order, t}}
+      {:error, :invalid_format} -> {:halt, {:error, :invalid_transaction, t}}
+      {:error, reason, t, _appended_transactions} -> {:halt, {:error, reason, t}}
+      {:error, reason} -> {:halt, {:error, reason, t}}
     end
   end
 
@@ -240,6 +290,15 @@ defmodule Bedrock.DataPlane.Log.Shale.Recovery do
 
       t
     end)
+  end
+
+  @spec abort_all_pending_pushes(State.t()) :: State.t()
+  def abort_all_pending_pushes(%{pending_pushes: pending_pushes} = t) do
+    Enum.each(pending_pushes, fn {_version, {_transaction, ack_fn}} ->
+      :ok = ack_fn.({:error, :not_ready})
+    end)
+
+    %{t | pending_pushes: %{}}
   end
 
   @spec close_writer(State.t()) :: State.t()
@@ -271,50 +330,5 @@ defmodule Bedrock.DataPlane.Log.Shale.Recovery do
   def discard_segments(segment_recycler, [segment | remaining_segments]) do
     :ok = SegmentRecycler.check_in(segment_recycler, segment.path)
     discard_segments(segment_recycler, remaining_segments)
-  end
-
-  @spec ensure_active_segment(State.t(), Bedrock.version()) :: State.t()
-  def ensure_active_segment(%{active_segment: nil} = t, version) do
-    case Segment.allocate_from_recycler(t.segment_recycler, t.path, version) do
-      {:ok, new_segment} -> %{t | active_segment: new_segment, last_version: version}
-      {:error, :allocation_failed} -> raise "Failed to allocate new segment"
-    end
-  end
-
-  @spec ensure_active_segment(State.t()) :: State.t()
-  def ensure_active_segment(t), do: t
-
-  @spec open_writer(State.t()) :: State.t()
-  def open_writer(t) do
-    case Writer.open(t.active_segment.path) do
-      {:ok, new_writer} ->
-        %{t | writer: new_writer}
-
-      {:error, _} ->
-        raise "Failed to open writer"
-    end
-  end
-
-  @spec push_sentinel(State.t(), Bedrock.version()) :: State.t()
-  def push_sentinel(t, version) do
-    sentinel_transaction = %{
-      mutations: []
-    }
-
-    encoded_sentinel = Transaction.encode(sentinel_transaction)
-    version_binary = if is_binary(version), do: version, else: Version.from_integer(version)
-    {:ok, sentinel} = Transaction.add_commit_version(encoded_sentinel, version_binary)
-
-    case push(t, version, sentinel, fn _ -> :ok end) do
-      {:ok, t, [^sentinel]} ->
-        push_to_demux(t, version_binary, sentinel)
-        t
-
-      {:error, _reason, _t, _appended_transactions} ->
-        raise "Failed to push sentinel"
-
-      {:error, _reason} ->
-        raise "Failed to push sentinel"
-    end
   end
 end

--- a/lib/bedrock/data_plane/log/shale/segment.ex
+++ b/lib/bedrock/data_plane/log/shale/segment.ex
@@ -12,10 +12,12 @@ defmodule Bedrock.DataPlane.Log.Shale.Segment do
   @type t :: %__MODULE__{
           path: String.t(),
           min_version: Bedrock.version(),
+          previous_version: Bedrock.version(),
           transactions: nil | [Transaction.encoded()]
         }
   defstruct path: nil,
             min_version: nil,
+            previous_version: nil,
             transactions: nil
 
   @wal_prefix "wal_"
@@ -31,9 +33,14 @@ defmodule Bedrock.DataPlane.Log.Shale.Segment do
   @spec decode_file_name(String.t()) :: pos_integer()
   def decode_file_name(@wal_prefix <> log_number), do: String.to_integer(log_number, 32)
 
-  @spec allocate_from_recycler(SegmentRecycler.server(), String.t(), Bedrock.version()) ::
+  @spec allocate_from_recycler(
+          SegmentRecycler.server(),
+          String.t(),
+          Bedrock.version(),
+          Bedrock.version()
+        ) ::
           {:ok, t()} | {:error, :allocation_failed}
-  def allocate_from_recycler(segment_recycler, path, version) do
+  def allocate_from_recycler(segment_recycler, path, version, previous_version) do
     path_to_file = Path.join(path, encode_file_name(Version.to_integer(version)))
 
     case SegmentRecycler.check_out(segment_recycler, path_to_file) do
@@ -41,6 +48,7 @@ defmodule Bedrock.DataPlane.Log.Shale.Segment do
         {:ok,
          %__MODULE__{
            min_version: version,
+           previous_version: previous_version,
            path: path_to_file
          }}
 
@@ -49,9 +57,9 @@ defmodule Bedrock.DataPlane.Log.Shale.Segment do
     end
   end
 
-  @spec allocate_from_recycler!(SegmentRecycler.server(), String.t(), Bedrock.version()) :: t()
-  def allocate_from_recycler!(segment_recycler, path, version) do
-    case allocate_from_recycler(segment_recycler, path, version) do
+  @spec allocate_from_recycler!(SegmentRecycler.server(), String.t(), Bedrock.version(), Bedrock.version()) :: t()
+  def allocate_from_recycler!(segment_recycler, path, version, previous_version) do
+    case allocate_from_recycler(segment_recycler, path, version, previous_version) do
       {:ok, segment} ->
         segment
 
@@ -67,16 +75,22 @@ defmodule Bedrock.DataPlane.Log.Shale.Segment do
   Create a new segment from the given file path. We stat the file to get the
   size, ensuring that it exists.
   """
-  @spec from_path(path_to_file :: String.t()) :: {:ok, t()} | {:error, :does_not_exist}
+  @spec from_path(path_to_file :: String.t()) ::
+          {:ok, t()}
+          | {:error, :does_not_exist | {:unsupported_wal_format, String.t()} | {:invalid_wal_format, String.t()}}
   def from_path(path_to_file) do
-    if File.exists?(path_to_file) do
+    with true <- File.exists?(path_to_file),
+         {:ok, previous_version} <- TransactionStreams.read_previous_version(path_to_file) do
       {:ok,
        %__MODULE__{
          path: path_to_file,
-         min_version: path_to_file |> Path.basename() |> decode_file_name() |> Version.from_integer()
+         min_version: path_to_file |> Path.basename() |> decode_file_name() |> Version.from_integer(),
+         previous_version: previous_version
        }}
     else
-      {:error, :does_not_exist}
+      false -> {:error, :does_not_exist}
+      {:error, :unsupported_wal_format} -> {:error, {:unsupported_wal_format, path_to_file}}
+      {:error, _reason} -> {:error, {:invalid_wal_format, path_to_file}}
     end
   end
 

--- a/lib/bedrock/data_plane/log/shale/server.ex
+++ b/lib/bedrock/data_plane/log/shale/server.ex
@@ -103,6 +103,7 @@ defmodule Bedrock.DataPlane.Log.Shale.Server do
        foreman: foreman,
        object_storage: object_storage,
        reject_pushes_above_lag_us: reject_pushes_above_lag_us,
+       available_after: Version.zero(),
        oldest_version: Version.zero(),
        last_version: Version.zero()
      }, {:continue, :initialization}}
@@ -224,11 +225,12 @@ defmodule Bedrock.DataPlane.Log.Shale.Server do
   end
 
   @impl true
-  def handle_call({:recover_from, source_logs, first_version, last_version}, {_director, _}, t) do
-    trace_recover_from(source_logs, first_version, last_version)
+  def handle_call({:recover_from, source_logs, replay_after, last_inclusive}, {_director, _}, t) do
+    trace_recover_from(source_logs, replay_after, last_inclusive)
 
-    case recover_from(t, source_logs, first_version, last_version) do
+    case recover_from(t, source_logs, replay_after, last_inclusive) do
       {:ok, t} -> reply(t, {:ok, self()})
+      {:error, reason, t} -> reply(t, {:error, {:failed_to_recover, reason}})
       {:error, reason} -> reply(t, {:error, {:failed_to_recover, reason}})
     end
   end
@@ -372,11 +374,12 @@ defmodule Bedrock.DataPlane.Log.Shale.Server do
   # Initialization with resource exhaustion detection
   defp do_initialization(t) do
     with {:ok, recycler_pid} <- start_segment_recycler(t.path),
-         {:ok, {oldest_version, last_version, active_segment, segments}} <-
+         {:ok, {available_after, oldest_version, last_version, active_segment, segments}} <-
            load_or_create_segments(t.path, recycler_pid),
          {:ok, demux} <- start_demux(t) do
       {:ok,
        t
+       |> Map.put(:available_after, available_after)
        |> Map.put(:oldest_version, oldest_version)
        |> Map.put(:last_version, last_version)
        |> Map.put(:active_segment, active_segment)
@@ -404,30 +407,26 @@ defmodule Bedrock.DataPlane.Log.Shale.Server do
     end
   end
 
-  defp load_or_create_segments(path, recycler_pid) do
+  defp load_or_create_segments(path, _recycler_pid) do
     case reload_segments_at_path(path) do
       {:ok, []} ->
-        case Segment.allocate_from_recycler(recycler_pid, path, Version.zero()) do
-          {:ok, new_segment} ->
-            {:ok, {Version.zero(), Version.zero(), new_segment, []}}
-
-          {:error, :allocation_failed} ->
-            # Segment allocation can fail due to resource exhaustion (emfile/enfile)
-            # or because the recycler is unavailable. Treat as recoverable.
-            {:error, {:resource_exhausted, :allocation_failed}}
-        end
+        {:ok, {Version.zero(), Version.zero(), Version.zero(), nil, []}}
 
       {:ok, [active_segment | segments]} ->
         active_segment = Segment.ensure_transactions_are_loaded(active_segment)
-        last_version = Segment.last_version(active_segment)
-        oldest_version = Enum.min([active_segment.min_version | Enum.map(segments, & &1.min_version)])
-        {:ok, {oldest_version, last_version, active_segment, segments}}
+        last_version = Segment.last_version(active_segment) || active_segment.previous_version
+        available_after = List.last([active_segment | segments]).previous_version
+        oldest_version = determine_oldest_transaction_version([active_segment | segments], available_after)
+        {:ok, {available_after, oldest_version, last_version, active_segment, segments}}
 
       {:error, {:unable_to_list_segments, reason}} when reason in [:emfile, :enfile, :enomem] ->
         {:error, {:resource_exhausted, reason}}
 
       {:error, {:unable_to_list_segments, reason}} ->
         raise "Unable to read WAL segment files from path: #{path}. Error: #{inspect(reason)}. Check directory permissions and filesystem health."
+
+      {:error, {format_error, segment_path}} when format_error in [:unsupported_wal_format, :invalid_wal_format] ->
+        raise "Unable to establish WAL replay cursor for #{segment_path}: #{format_error}"
     end
   end
 
@@ -483,9 +482,15 @@ defmodule Bedrock.DataPlane.Log.Shale.Server do
       length(remaining_segments) + 1
     )
 
+    available_after = determine_available_after(t.active_segment, remaining_segments)
+
     t
     |> Map.put(:segments, remaining_segments)
-    |> Map.put(:oldest_version, determine_oldest_version(t.active_segment, remaining_segments))
+    |> Map.put(:available_after, available_after)
+    |> Map.put(
+      :oldest_version,
+      determine_oldest_transaction_version([t.active_segment | remaining_segments], available_after)
+    )
     |> check_floor_lag_alarm(trim_floor, lag_us)
   end
 
@@ -528,13 +533,28 @@ defmodule Bedrock.DataPlane.Log.Shale.Server do
     end
   end
 
-  defp determine_oldest_version(nil, []), do: Version.zero()
+  defp determine_available_after(nil, []), do: Version.zero()
 
-  defp determine_oldest_version(active_segment, segments) do
+  defp determine_available_after(active_segment, segments) do
     [active_segment | segments]
     |> Enum.reject(&is_nil/1)
-    |> Enum.map(&Segment.oldest_version/1)
-    |> Enum.min()
+    |> List.last()
+    |> Map.fetch!(:previous_version)
+  end
+
+  defp determine_oldest_transaction_version(segments, available_after) do
+    segments
+    |> Enum.reverse()
+    |> Enum.find_value(fn segment ->
+      segment
+      |> Segment.transactions()
+      |> List.last()
+      |> case do
+        nil -> nil
+        transaction -> Transaction.commit_version!(transaction)
+      end
+    end)
+    |> Kernel.||(available_after)
   end
 
   defp handle_resource_exhaustion(t, reason) do

--- a/lib/bedrock/data_plane/log/shale/state.ex
+++ b/lib/bedrock/data_plane/log/shale/state.ex
@@ -42,6 +42,7 @@ defmodule Bedrock.DataPlane.Log.Shale.State do
           reject_pushes_above_lag_us: non_neg_integer() | nil,
           #
           mode: mode(),
+          available_after: Bedrock.version(),
           oldest_version: Bedrock.version(),
           otp_name: Worker.otp_name(),
           params: %{
@@ -77,6 +78,7 @@ defmodule Bedrock.DataPlane.Log.Shale.State do
             reject_pushes_above_lag_us: nil,
             #
             mode: :locked,
+            available_after: <<0::unsigned-big-64>>,
             oldest_version: nil,
             otp_name: nil,
             pending_transactions: %{},

--- a/lib/bedrock/data_plane/log/shale/transaction_streams.ex
+++ b/lib/bedrock/data_plane/log/shale/transaction_streams.ex
@@ -7,8 +7,36 @@ defmodule Bedrock.DataPlane.Log.Shale.TransactionStreams do
   alias Bedrock.DataPlane.Log.Shale.Segment
   alias Bedrock.DataPlane.Transaction
 
-  @wal_magic_number <<"BED0">>
+  @wal_magic_number <<"BED1">>
   @wal_eof_version <<0xFFFFFFFFFFFFFFFF::unsigned-big-64>>
+
+  @spec read_previous_version(String.t()) ::
+          {:ok, Bedrock.version()}
+          | {:error, :unsupported_wal_format | :invalid_wal_format | File.posix()}
+  def read_previous_version(path_to_file) do
+    with {:ok, fd} <- File.open(path_to_file, [:read, :raw, :binary]) do
+      result =
+        case :file.pread(fd, 0, 12) do
+          {:ok, <<@wal_magic_number, previous_version::binary-size(8)>>} ->
+            {:ok, previous_version}
+
+          {:ok, <<"BED0", _::binary>>} ->
+            {:error, :unsupported_wal_format}
+
+          {:ok, _} ->
+            {:error, :invalid_wal_format}
+
+          :eof ->
+            {:error, :invalid_wal_format}
+
+          {:error, reason} ->
+            {:error, reason}
+        end
+
+      :ok = File.close(fd)
+      result
+    end
+  end
 
   @spec from_segments([Segment.t()], Bedrock.version()) ::
           {:ok, Enumerable.t(Transaction.encoded())} | {:error, :not_found}
@@ -76,8 +104,8 @@ defmodule Bedrock.DataPlane.Log.Shale.TransactionStreams do
     Stream.resource(
       fn ->
         case File.read!(path_to_file) do
-          <<@wal_magic_number, bytes::binary>> ->
-            {4, bytes}
+          <<@wal_magic_number, _previous_version::binary-size(8), bytes::binary>> ->
+            {12, bytes}
 
           other ->
             {:error, {:invalid_wal_format, byte_size(other)}}

--- a/lib/bedrock/data_plane/log/shale/writer.ex
+++ b/lib/bedrock/data_plane/log/shale/writer.ex
@@ -9,7 +9,8 @@ defmodule Bedrock.DataPlane.Log.Shale.Writer do
 
   @wal_eof_version <<0xFFFFFFFFFFFFFFFF::unsigned-big-64>>
   @eof_marker <<@wal_eof_version::binary, 0::unsigned-big-32, 0::unsigned-big-32>>
-  @empty_segment_header <<"BED0">> <> @eof_marker
+  @wal_magic_number <<"BED1">>
+  @header_size 12
 
   @typedoc """
   A `Writer` is a handle to a segment that can be used to write transcations
@@ -23,20 +24,22 @@ defmodule Bedrock.DataPlane.Log.Shale.Writer do
           sync_fun: (File.file_descriptor() -> :ok | {:error, File.posix()})
         }
 
-  @spec open(path_to_file :: String.t(), opts :: keyword()) :: {:ok, t()} | {:error, File.posix()}
-  def open(path_to_file, opts \\ []) do
+  @spec open(path_to_file :: String.t(), previous_version :: Bedrock.version(), opts :: keyword()) ::
+          {:ok, t()} | {:error, File.posix()}
+  def open(path_to_file, previous_version, opts \\ []) do
     sync_fun = Keyword.get(opts, :sync_fun, &:file.sync/1)
+    empty_segment_header = <<@wal_magic_number, previous_version::binary-size(8), @eof_marker>>
 
     with {:ok, stat} <- File.stat(path_to_file),
          {:ok, fd} <- File.open(path_to_file, [:write, :read, :raw, :binary]) do
       # Write header - close fd on failure to avoid leak
-      case :file.pwrite(fd, 0, @empty_segment_header) do
+      case :file.pwrite(fd, 0, empty_segment_header) do
         :ok ->
           {:ok,
            %__MODULE__{
              fd: fd,
-             write_offset: 4,
-             bytes_remaining: stat.size - 4 - 16,
+             write_offset: @header_size,
+             bytes_remaining: stat.size - @header_size - 16,
              sync_fun: sync_fun
            }}
 
@@ -50,6 +53,10 @@ defmodule Bedrock.DataPlane.Log.Shale.Writer do
   @spec close(writer :: t() | nil) :: :ok | {:error, File.posix()}
   def close(nil), do: :ok
   def close(%__MODULE__{} = writer), do: :file.close(writer.fd)
+
+  @doc "Persists an empty segment header and its replay cursor."
+  @spec sync(t()) :: :ok | {:error, File.posix()}
+  def sync(%__MODULE__{} = writer), do: writer.sync_fun.(writer.fd)
 
   @spec append(t(), Transaction.encoded(), Bedrock.version()) ::
           {:ok, t()} | {:error, :segment_full} | {:error, File.posix()}

--- a/lib/bedrock/data_plane/log/telemetry.ex
+++ b/lib/bedrock/data_plane/log/telemetry.ex
@@ -24,17 +24,17 @@ defmodule Bedrock.DataPlane.Log.Telemetry do
 
   @spec trace_recover_from(
           source_logs :: [Log.ref()],
-          first_version :: Bedrock.version(),
-          last_version :: Bedrock.version()
+          replay_after :: Bedrock.version(),
+          last_inclusive :: Bedrock.version()
         ) :: :ok
-  def trace_recover_from(source_logs, first_version, last_version) do
+  def trace_recover_from(source_logs, replay_after, last_inclusive) do
     Telemetry.execute(
       [:bedrock, :log, :recover_from],
       %{},
       Map.merge(trace_metadata(), %{
         source_logs: source_logs,
-        first_version: first_version,
-        last_version: last_version
+        replay_after: replay_after,
+        last_inclusive: last_inclusive
       })
     )
   end

--- a/lib/bedrock/data_plane/log/tracing.ex
+++ b/lib/bedrock/data_plane/log/tracing.ex
@@ -44,11 +44,15 @@ defmodule Bedrock.DataPlane.Log.Tracing do
 
   def log_event(:lock_for_recovery, _, %{epoch: epoch}), do: info("Lock for recovery in epoch #{epoch}")
 
-  def log_event(:recover_from, _, %{source_log: :none}), do: info("Reset to initial version")
+  def log_event(:recover_from, _, %{source_logs: []}), do: info("Persist empty replay baseline")
 
-  def log_event(:recover_from, _, %{source_log: source_log, first_version: first_version, last_version: last_version}) do
+  def log_event(:recover_from, _, %{
+        source_logs: source_logs,
+        replay_after: replay_after,
+        last_inclusive: last_inclusive
+      }) do
     info(
-      "Recover from #{inspect(source_log)} with versions #{Version.to_string(first_version)} to #{Version.to_string(last_version)}"
+      "Recover from #{inspect(source_logs)} over (#{Version.to_string(replay_after)}, #{Version.to_string(last_inclusive)}]"
     )
   end
 

--- a/test/bedrock/control_plane/director/recovery/log_recovery_planning_phase_test.exs
+++ b/test/bedrock/control_plane/director/recovery/log_recovery_planning_phase_test.exs
@@ -24,6 +24,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery.LogRecoveryPlanningPhaseTest do
 
   defp log_info(oldest, last),
     do: %{
+      available_after: Version.from_integer(oldest),
       oldest_version: Version.from_integer(oldest),
       last_version: Version.from_integer(last),
       minimum_durable_version: Version.from_integer(oldest)
@@ -41,7 +42,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery.LogRecoveryPlanningPhaseTest do
 
       assert is_list(old_log_ids) and length(old_log_ids) == 2
       assert is_tuple(version_vector)
-      # version_vector is {max(oldest), min(newest)} = {10, 45}
+      # version_vector is {max(available_after), min(last_inclusive)} = {10, 45}
       assert version_vector == {Version.from_integer(10), Version.from_integer(45)}
       # durable_version is min of minimum_durable_versions (5 and 10)
       assert durable_version == Version.from_integer(5)
@@ -57,7 +58,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery.LogRecoveryPlanningPhaseTest do
                LogRecoveryPlanningPhase.execute(recovery_attempt, context)
 
       assert length(old_log_ids) == 2
-      # version_vector is {max(oldest), min(newest)} = {10, 45}
+      # version_vector is {max(available_after), min(last_inclusive)} = {10, 45}
       assert version_vector == {Version.from_integer(10), Version.from_integer(45)}
     end
 
@@ -122,19 +123,40 @@ defmodule Bedrock.ControlPlane.Director.Recovery.LogRecoveryPlanningPhaseTest do
   end
 
   describe "compute_version_vector/1" do
-    test "computes version vector as {max(oldest), min(newest)}" do
+    test "computes version vector as {max(available_after), min(last_inclusive)}" do
       log_recovery_info = %{
         {:log, 1} => log_info(10, 50),
         {:log, 2} => log_info(5, 45),
         {:log, 3} => log_info(15, 55)
       }
 
-      # max(oldest) = max(10, 5, 15) = 15
-      # min(newest) = min(50, 45, 55) = 45
+      # max(available_after) = max(10, 5, 15) = 15
+      # min(last_inclusive) = min(50, 45, 55) = 45
       expected_version_vector = {Version.from_integer(15), Version.from_integer(45)}
 
       assert {:ok, ^expected_version_vector} =
                LogRecoveryPlanningPhase.compute_version_vector(log_recovery_info)
+    end
+
+    test "does not use the first retained transaction as the exclusive cursor" do
+      log_recovery_info = %{
+        {:log, 1} => %{
+          available_after: Version.from_integer(9),
+          oldest_version: Version.from_integer(10),
+          last_version: Version.from_integer(50)
+        },
+        {:log, 2} => %{
+          available_after: Version.from_integer(4),
+          oldest_version: Version.from_integer(5),
+          last_version: Version.from_integer(45)
+        }
+      }
+
+      assert {:ok, {available_after, last_inclusive}} =
+               LogRecoveryPlanningPhase.compute_version_vector(log_recovery_info)
+
+      assert available_after == Version.from_integer(9)
+      assert last_inclusive == Version.from_integer(45)
     end
 
     test "returns error for empty log recovery info" do
@@ -157,7 +179,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery.LogRecoveryPlanningPhaseTest do
         {:log, 2} => log_info(45, 15)
       }
 
-      # max(oldest) = 50, min(newest) = 10 -> invalid because 10 < 50
+      # max(available_after) = 50, min(last_inclusive) = 10 -> invalid
       assert {:error, :invalid_version_range} =
                LogRecoveryPlanningPhase.compute_version_vector(log_recovery_info)
     end
@@ -165,6 +187,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery.LogRecoveryPlanningPhaseTest do
     test "handles logs starting at version zero" do
       log_recovery_info = %{
         {:log, 1} => %{
+          available_after: Version.zero(),
           oldest_version: Version.zero(),
           last_version: Version.from_integer(50),
           minimum_durable_version: Version.zero()
@@ -172,8 +195,8 @@ defmodule Bedrock.ControlPlane.Director.Recovery.LogRecoveryPlanningPhaseTest do
         {:log, 2} => log_info(5, 45)
       }
 
-      # max(oldest) = max(0, 5) = 5
-      # min(newest) = min(50, 45) = 45
+      # max(available_after) = max(0, 5) = 5
+      # min(last_inclusive) = min(50, 45) = 45
       expected_version_vector = {Version.from_integer(5), Version.from_integer(45)}
 
       assert {:ok, ^expected_version_vector} =

--- a/test/bedrock/control_plane/director/recovery/log_replay_phase_test.exs
+++ b/test/bedrock/control_plane/director/recovery/log_replay_phase_test.exs
@@ -45,30 +45,28 @@ defmodule Bedrock.ControlPlane.Director.Recovery.LogReplayPhaseTest do
       }
     end
 
-    test "never starts below what the source WAL can supply (its trimmed oldest)" do
+    test "never starts below the source WAL's persisted availability cursor" do
       # The durable floor regresses to zero on restart (it is not
-      # persisted), but a trimmed WAL begins at its oldest retained
-      # version. Everything below that is durable in object-storage chunks
-      # — that is the only way it got trimmed — so the copy starts at the
-      # vector's first element.
-      oldest = Version.from_integer(5_000_000)
+      # persisted), while a trimmed WAL persists its exclusive predecessor
+      # cursor. The copy starts at that cursor without skipping retained data.
+      available_after = Version.from_integer(5_000_000)
       tip = Version.from_integer(9_000_000)
 
-      attempt = attempt_with(Version.zero(), {oldest, tip})
+      attempt = attempt_with(Version.zero(), {available_after, tip})
       {_attempt, _next} = LogReplayPhase.execute(attempt, context_capturing_copy_range(self()))
 
-      assert_receive {:copy_range, ^oldest, ^tip}
+      assert_receive {:copy_range, ^available_after, ^tip}
     end
 
-    test "skips the already-durable prefix when the floor is ahead of the WAL's oldest" do
-      oldest = Version.from_integer(5_000_000)
-      floor = Version.from_integer(7_000_000)
+    test "skips the already-durable prefix when durable_through is ahead" do
+      available_after = Version.from_integer(5_000_000)
+      durable_through = Version.from_integer(7_000_000)
       tip = Version.from_integer(9_000_000)
 
-      attempt = attempt_with(floor, {oldest, tip})
+      attempt = attempt_with(durable_through, {available_after, tip})
       {_attempt, _next} = LogReplayPhase.execute(attempt, context_capturing_copy_range(self()))
 
-      assert_receive {:copy_range, ^floor, ^tip}
+      assert_receive {:copy_range, ^durable_through, ^tip}
     end
   end
 

--- a/test/bedrock/control_plane/director/recovery_test.exs
+++ b/test/bedrock/control_plane/director/recovery_test.exs
@@ -464,11 +464,13 @@ defmodule Bedrock.ControlPlane.Director.RecoveryTest do
     |> with_log_recovery_info(%{
       "existing_log_1" => %{
         kind: :log,
+        available_after: Version.zero(),
         oldest_version: Version.zero(),
         last_version: Version.from_integer(100)
       },
       "existing_log_2" => %{
         kind: :log,
+        available_after: Version.zero(),
         oldest_version: Version.zero(),
         last_version: Version.from_integer(100)
       }
@@ -593,6 +595,7 @@ defmodule Bedrock.ControlPlane.Director.RecoveryTest do
     base = %{
       kind: kind,
       durable_version: Version.from_integer(95),
+      available_after: Version.zero(),
       oldest_version: Version.zero(),
       last_version: Version.from_integer(100)
     }

--- a/test/bedrock/data_plane/log/shale/cold_starting_test.exs
+++ b/test/bedrock/data_plane/log/shale/cold_starting_test.exs
@@ -3,6 +3,7 @@ defmodule Bedrock.DataPlane.Log.Shale.ColdStartingTest do
 
   alias Bedrock.DataPlane.Log.Shale.ColdStarting
   alias Bedrock.DataPlane.Log.Shale.Segment
+  alias Bedrock.DataPlane.Log.Shale.Writer
   alias Bedrock.DataPlane.Version
 
   @segment_dir "test/fixtures/segments"
@@ -15,9 +16,9 @@ defmodule Bedrock.DataPlane.Log.Shale.ColdStartingTest do
 
   describe "reload_segments_at_path/2" do
     test "returns segments sorted by version in descending order" do
-      create_segment_file(1)
-      create_segment_file(2)
-      create_segment_file(10)
+      create_segment_file(1, 0)
+      create_segment_file(2, 1)
+      create_segment_file(10, 2)
 
       version_10 = Version.from_integer(10)
       version_2 = Version.from_integer(2)
@@ -25,14 +26,16 @@ defmodule Bedrock.DataPlane.Log.Shale.ColdStartingTest do
 
       assert {:ok,
               [
-                %Segment{min_version: ^version_10},
-                %Segment{min_version: ^version_2},
-                %Segment{min_version: ^version_1}
+                %Segment{min_version: ^version_10, previous_version: ^version_2},
+                %Segment{min_version: ^version_2, previous_version: ^version_1},
+                %Segment{min_version: ^version_1, previous_version: previous_version}
               ]} = ColdStarting.reload_segments_at_path(@segment_dir)
+
+      assert previous_version == Version.zero()
     end
 
     test "ignores non-matching files in directory" do
-      create_segment_file(1)
+      create_segment_file(1, 0)
       File.write!(Path.join(@segment_dir, "other_file.log"), "")
 
       version_1 = Version.from_integer(1)
@@ -54,9 +57,20 @@ defmodule Bedrock.DataPlane.Log.Shale.ColdStartingTest do
       # Directory exists but has no segment files
       assert {:ok, []} = ColdStarting.reload_segments_at_path(@segment_dir)
     end
+
+    test "fails closed for a legacy segment without a persisted predecessor" do
+      path = Path.join(@segment_dir, Segment.encode_file_name(1))
+      File.write!(path, <<"BED0", 0::128>>)
+
+      assert {:error, {:unsupported_wal_format, ^path}} =
+               ColdStarting.reload_segments_at_path(@segment_dir)
+    end
   end
 
-  defp create_segment_file(version) do
-    File.write!(Path.join(@segment_dir, Segment.encode_file_name(version)), "")
+  defp create_segment_file(version, previous_version) do
+    path = Path.join(@segment_dir, Segment.encode_file_name(version))
+    File.write!(path, :binary.copy(<<0>>, 1024))
+    {:ok, writer} = Writer.open(path, Version.from_integer(previous_version))
+    :ok = Writer.close(writer)
   end
 end

--- a/test/bedrock/data_plane/log/shale/durability_contract_test.exs
+++ b/test/bedrock/data_plane/log/shale/durability_contract_test.exs
@@ -27,7 +27,7 @@ defmodule Bedrock.DataPlane.Log.Shale.DurabilityContractTest do
       :ok
     end
 
-    assert {:ok, writer} = Writer.open(path, sync_fun: sync_fun)
+    assert {:ok, writer} = Writer.open(path, Version.zero(), sync_fun: sync_fun)
     transaction = TransactionTestSupport.new_log_transaction(0, %{"k" => "v"})
 
     assert {:ok, updated_writer} = Writer.append(writer, transaction, Version.from_integer(0))
@@ -37,19 +37,19 @@ defmodule Bedrock.DataPlane.Log.Shale.DurabilityContractTest do
   end
 
   test "append returns error and keeps offsets when wal sync fails", %{path: path} do
-    assert {:ok, writer} = Writer.open(path, sync_fun: fn _fd -> {:error, :eio} end)
+    assert {:ok, writer} = Writer.open(path, Version.zero(), sync_fun: fn _fd -> {:error, :eio} end)
 
     transaction = TransactionTestSupport.new_log_transaction(0, %{"k" => "v"})
 
     assert {:error, :eio} = Writer.append(writer, transaction, Version.from_integer(0))
-    assert writer.write_offset == 4
-    assert writer.bytes_remaining == 1004
+    assert writer.write_offset == 12
+    assert writer.bytes_remaining == 996
 
     assert :ok = Writer.close(writer)
   end
 
   test "push does not emit false success ack when wal sync fails", %{path: path} do
-    assert {:ok, writer} = Writer.open(path, sync_fun: fn _fd -> {:error, :eio} end)
+    assert {:ok, writer} = Writer.open(path, Version.zero(), sync_fun: fn _fd -> {:error, :eio} end)
 
     state = %State{
       mode: :ready,

--- a/test/bedrock/data_plane/log/shale/facts_test.exs
+++ b/test/bedrock/data_plane/log/shale/facts_test.exs
@@ -7,6 +7,7 @@ defmodule Bedrock.DataPlane.Log.Shale.FactsTest do
   @test_state %State{
     id: "test_id",
     otp_name: :test_otp,
+    available_after: 0,
     oldest_version: 1,
     last_version: 10
   }
@@ -17,6 +18,7 @@ defmodule Bedrock.DataPlane.Log.Shale.FactsTest do
       assert {:ok, :log} = Facts.info(@test_state, :kind)
       assert {:ok, :test_otp} = Facts.info(@test_state, :otp_name)
       assert {:ok, :unavailable} = Facts.info(@test_state, :minimum_durable_version)
+      assert {:ok, 0} = Facts.info(@test_state, :available_after)
       assert {:ok, 1} = Facts.info(@test_state, :oldest_version)
       assert {:ok, 10} = Facts.info(@test_state, :last_version)
     end
@@ -52,6 +54,7 @@ defmodule Bedrock.DataPlane.Log.Shale.FactsTest do
         :id,
         :kind,
         :minimum_durable_version,
+        :available_after,
         :oldest_version,
         :last_version,
         :otp_name,

--- a/test/bedrock/data_plane/log/shale/pulling_test.exs
+++ b/test/bedrock/data_plane/log/shale/pulling_test.exs
@@ -32,6 +32,7 @@ defmodule Bedrock.DataPlane.Log.Shale.PullingTest do
         active_segment: segment,
         segments: [],
         oldest_version: Version.from_integer(0),
+        available_after: Version.from_integer(0),
         last_version: Version.from_integer(3),
         mode: :ready,
         params: @default_params
@@ -49,11 +50,13 @@ defmodule Bedrock.DataPlane.Log.Shale.PullingTest do
       assert {:waiting_for, ^version_4} = Pulling.pull(state, version_4)
     end
 
-    test "returns error when from_version is too old", %{state: state} do
-      # Test with a version that's older than oldest_version in the state
-      # The state has oldest_version = 0, so we'll create a state with older version = 1 to test this properly
-      older_state = %{state | oldest_version: Version.from_integer(1)}
-      assert {:error, {:version_too_old, _floor}} = Pulling.pull(older_state, Version.from_integer(0))
+    test "uses available_after, not the first actual transaction, as the exclusive floor", %{state: state} do
+      available_after = Version.from_integer(1)
+      older_state = %{state | oldest_version: Version.from_integer(2), available_after: available_after}
+
+      assert {:error, {:version_too_old, ^available_after}} = Pulling.pull(older_state, Version.from_integer(0))
+      assert {:ok, _, [first | _]} = Pulling.pull(older_state, available_after)
+      assert TransactionTestSupport.extract_log_version(first) == Version.from_integer(2)
     end
 
     test "returns transactions within version range", %{state: state} do
@@ -78,6 +81,14 @@ defmodule Bedrock.DataPlane.Log.Shale.PullingTest do
 
       assert {:error, :not_ready} = Pulling.pull(locked_state, version_1)
       assert {:ok, _, _} = Pulling.pull(locked_state, version_1, recovery: true)
+    end
+
+    test "returns an empty completed range when recovery is already at the endpoint", %{state: state} do
+      endpoint = state.last_version
+      locked_state = %{state | mode: :locked}
+
+      assert {:ok, ^locked_state, []} =
+               Pulling.pull(locked_state, endpoint, recovery: true, last_version: endpoint)
     end
 
     test "respects pull limits", %{state: state} do
@@ -196,6 +207,7 @@ defmodule Bedrock.DataPlane.Log.Shale.PullingTest do
         active_segment: segment,
         segments: [],
         oldest_version: Version.from_integer(0),
+        available_after: Version.from_integer(0),
         last_version: Version.from_integer(5),
         mode: :locked,
         params: @default_params

--- a/test/bedrock/data_plane/log/shale/pushing_test.exs
+++ b/test/bedrock/data_plane/log/shale/pushing_test.exs
@@ -66,7 +66,7 @@ defmodule Bedrock.DataPlane.Log.Shale.PushingTest do
         File.rm(path)
       end)
 
-      assert {:ok, writer} = Writer.open(path, sync_fun: fn _fd -> {:error, :eio} end)
+      assert {:ok, writer} = Writer.open(path, Version.zero(), sync_fun: fn _fd -> {:error, :eio} end)
 
       state = %State{
         mode: :ready,
@@ -161,7 +161,7 @@ defmodule Bedrock.DataPlane.Log.Shale.PushingTest do
         end)
       end
 
-      assert {:ok, writer} = Writer.open(path, sync_fun: sync_fun)
+      assert {:ok, writer} = Writer.open(path, Version.zero(), sync_fun: sync_fun)
 
       state = %State{
         mode: :ready,

--- a/test/bedrock/data_plane/log/shale/recovery_test.exs
+++ b/test/bedrock/data_plane/log/shale/recovery_test.exs
@@ -5,10 +5,10 @@ defmodule Bedrock.DataPlane.Log.Shale.RecoveryTest do
   alias Bedrock.DataPlane.Log.Shale.Recovery
   alias Bedrock.DataPlane.Log.Shale.SegmentRecycler
   alias Bedrock.DataPlane.Log.Shale.State
+  alias Bedrock.DataPlane.Log.Shale.TransactionStreams
   alias Bedrock.DataPlane.Transaction
   alias Bedrock.DataPlane.Version
   alias Bedrock.ObjectStorage
-  alias Bedrock.ObjectStorage.Keys
   alias Bedrock.ObjectStorage.LocalFilesystem
 
   @moduletag :tmp_dir
@@ -27,6 +27,7 @@ defmodule Bedrock.DataPlane.Log.Shale.RecoveryTest do
       active_segment: nil,
       segments: [],
       writer: nil,
+      available_after: version(0),
       oldest_version: version(0),
       last_version: version(0)
     }
@@ -50,7 +51,13 @@ defmodule Bedrock.DataPlane.Log.Shale.RecoveryTest do
     test "successfully recovers with no transactions (empty source list)", %{state: state} do
       expected_version = version(1)
 
-      assert {:ok, %{mode: :running, oldest_version: ^expected_version, last_version: ^expected_version}} =
+      assert {:ok,
+              %{
+                mode: :running,
+                available_after: ^expected_version,
+                oldest_version: ^expected_version,
+                last_version: ^expected_version
+              }} =
                Recovery.recover_from(
                  state,
                  [],
@@ -63,7 +70,7 @@ defmodule Bedrock.DataPlane.Log.Shale.RecoveryTest do
       source_log = setup_mock_log([])
       expected_version = version(1)
 
-      assert {:ok, %{mode: :running, oldest_version: ^expected_version, last_version: ^expected_version}} =
+      assert {:ok, %{mode: :running, available_after: ^expected_version, last_version: ^expected_version}} =
                Recovery.recover_from(
                  state,
                  [source_log],
@@ -77,7 +84,15 @@ defmodule Bedrock.DataPlane.Log.Shale.RecoveryTest do
       # version ranges but had no segments loaded, causing :not_found errors
       v = version(5)
 
-      assert {:ok, %{mode: :running, oldest_version: ^v, last_version: ^v, active_segment: segment, writer: writer}} =
+      assert {:ok,
+              %{
+                mode: :running,
+                available_after: ^v,
+                oldest_version: ^v,
+                last_version: ^v,
+                active_segment: segment,
+                writer: nil
+              }} =
                Recovery.recover_from(
                  state,
                  [],
@@ -86,12 +101,14 @@ defmodule Bedrock.DataPlane.Log.Shale.RecoveryTest do
                )
 
       assert segment
-      assert writer
+      assert segment.previous_version == v
+      assert {:ok, ^v} = TransactionStreams.read_previous_version(segment.path)
     end
 
-    test "successfully recovers with valid transactions", %{state: state} do
-      first_version = version(1)
-      last_version = version(2)
+    test "copies real transactions byte-for-byte across version gaps", %{state: state} do
+      replay_after = version(1)
+      first_version = version(2)
+      last_version = version(10_000)
 
       transactions = [
         create_encoded_tx(first_version, %{"data" => "test1"}),
@@ -100,19 +117,63 @@ defmodule Bedrock.DataPlane.Log.Shale.RecoveryTest do
 
       source_log = setup_mock_log(transactions)
 
-      assert {:ok, %{mode: :running, oldest_version: ^first_version, last_version: ^last_version}} =
+      assert {:ok,
+              %{
+                mode: :running,
+                available_after: ^replay_after,
+                last_version: ^last_version,
+                active_segment: active_segment
+              } = recovered} =
                Recovery.recover_from(
                  state,
                  [source_log],
-                 first_version,
+                 replay_after,
                  last_version
                )
+
+      assert recovered.oldest_version == first_version
+      assert Enum.reverse(active_segment.transactions) == transactions
+      assert active_segment.previous_version == replay_after
+    end
+
+    test "copies a single retained transaction after the exclusive cursor", %{state: state} do
+      replay_after = version(41)
+      last_inclusive = version(1_000)
+      transaction = create_encoded_tx(last_inclusive, %{"only" => "transaction"})
+      source_log = setup_mock_log([transaction])
+
+      assert {:ok, recovered} =
+               Recovery.recover_from(state, [source_log], replay_after, last_inclusive)
+
+      assert recovered.available_after == replay_after
+      assert recovered.last_version == last_inclusive
+      assert recovered.active_segment.transactions == [transaction]
+    end
+
+    test "does not report success when a source stops before the endpoint", %{state: state} do
+      replay_after = version(1)
+      last_inclusive = version(10)
+      partial_version = version(5)
+      partial = create_encoded_tx(partial_version, %{"partial" => "data"})
+      last = create_encoded_tx(last_inclusive, %{"last" => "data"})
+      source_log = setup_paged_mock_log([[partial], []])
+
+      assert {:error, {:incomplete_replay, ^partial_version, ^last_inclusive}, failed_state} =
+               Recovery.recover_from(state, [source_log], replay_after, last_inclusive)
+
+      assert failed_state.mode == :locked
+      assert failed_state.writer == nil
+      assert failed_state.last_version == partial_version
+
+      complete_source = setup_mock_log([partial, last])
+      assert {:ok, recovered} = Recovery.recover_from(failed_state, [complete_source], replay_after, last_inclusive)
+      assert Enum.reverse(recovered.active_segment.transactions) == [partial, last]
     end
 
     test "handles unavailable source log", %{state: state} do
       source_log = setup_failing_mock_log(:unavailable)
 
-      assert {:error, {:source_log_unavailable, ^source_log}} =
+      assert {:error, {:source_log_unavailable, ^source_log}, %{mode: :locked}} =
                Recovery.recover_from(
                  state,
                  [source_log],
@@ -140,7 +201,7 @@ defmodule Bedrock.DataPlane.Log.Shale.RecoveryTest do
       source1 = setup_failing_mock_log(:unavailable)
       source2 = setup_failing_mock_log(:unavailable)
 
-      assert {:error, {:source_log_unavailable, _}} =
+      assert {:error, {:source_log_unavailable, _}, %{mode: :locked}} =
                Recovery.recover_from(
                  state,
                  [source1, source2],
@@ -173,8 +234,9 @@ defmodule Bedrock.DataPlane.Log.Shale.RecoveryTest do
     end
 
     test "replays transactions through the fresh demux", %{state: state} do
-      first_version = version(1)
-      last_version = version(2)
+      replay_after = version(1)
+      first_version = version(2)
+      last_version = version(3)
 
       transactions = [
         create_encoded_tx(first_version, %{"data" => "test1"}),
@@ -183,7 +245,7 @@ defmodule Bedrock.DataPlane.Log.Shale.RecoveryTest do
 
       source_log = setup_mock_log(transactions)
 
-      assert {:ok, t} = Recovery.recover_from(state, [source_log], first_version, last_version)
+      assert {:ok, t} = Recovery.recover_from(state, [source_log], replay_after, last_version)
 
       # The replayed versions passed through the demux's push path: its
       # bucket tracking has seen them (versions 1..2 land in bucket 0).
@@ -197,19 +259,16 @@ defmodule Bedrock.DataPlane.Log.Shale.RecoveryTest do
       v = version(10)
       source_log = setup_mock_log([])
 
-      assert {:ok, %{oldest_version: ^v, last_version: ^v}} =
-               Recovery.pull_transactions(
-                 state,
-                 source_log,
-                 v,
-                 v
-               )
+      positioned_state = %{state | available_after: v, oldest_version: v, last_version: v}
+
+      assert {:ok, ^positioned_state} =
+               Recovery.pull_transactions(positioned_state, source_log, v, v)
     end
 
     test "handles invalid transaction data", %{state: state} do
       source_log = setup_mock_log(["invalid"])
 
-      assert {:error, :invalid_transaction} =
+      assert {:error, :invalid_transaction, ^state} =
                Recovery.pull_transactions(
                  state,
                  source_log,
@@ -244,6 +303,22 @@ defmodule Bedrock.DataPlane.Log.Shale.RecoveryTest do
       end
     end)
   end
+
+  defp setup_paged_mock_log(pages) do
+    spawn_link(fn -> serve_pages(pages) end)
+  end
+
+  defp serve_pages([page | remaining]) do
+    receive do
+      {:"$gen_call", {from, ref}, {:pull, _version, _opts}} ->
+        send(from, {ref, {:ok, page}})
+        serve_pages(remaining)
+    after
+      500 -> :timeout
+    end
+  end
+
+  defp serve_pages([]), do: :ok
 
   defp setup_failing_mock_log(error) do
     spawn_link(fn ->

--- a/test/bedrock/data_plane/log/shale/replay_cursor_integration_test.exs
+++ b/test/bedrock/data_plane/log/shale/replay_cursor_integration_test.exs
@@ -1,0 +1,176 @@
+defmodule Bedrock.DataPlane.Log.Shale.ReplayCursorIntegrationTest do
+  use ExUnit.Case, async: false
+
+  alias Bedrock.Cluster
+  alias Bedrock.DataPlane.Demux.Server, as: Demux
+  alias Bedrock.DataPlane.Log
+  alias Bedrock.DataPlane.Log.Shale.Server, as: Shale
+  alias Bedrock.DataPlane.Version
+  alias Bedrock.ObjectStorage
+  alias Bedrock.ObjectStorage.LocalFilesystem
+  alias Bedrock.Test.DataPlane.TransactionTestSupport
+
+  @moduletag :tmp_dir
+
+  test "untrimmed recovery copies widely gapped transactions exactly once", %{tmp_dir: tmp_dir} do
+    backend = object_storage(tmp_dir)
+    source = start_log("gapped-source", Path.join(tmp_dir, "gapped-source"), backend, true)
+    destination = start_log("gapped-destination", Path.join(tmp_dir, "gapped-destination"), backend, false)
+
+    first_version = Version.from_integer(100)
+    last_inclusive = Version.from_integer(10_000)
+    first = transaction(first_version, "first")
+    last = transaction(last_inclusive, "last")
+
+    assert :ok = Log.push(source, first, Version.zero())
+    assert :ok = Log.push(source, last, first_version)
+    lock(source)
+
+    assert {:ok, %{available_after: replay_after}} = Log.info(source, [:available_after])
+    assert replay_after == Version.zero()
+    assert {:ok, ^destination} = Log.recover_from(destination, [source], replay_after, last_inclusive)
+    assert {:ok, [^first, ^last]} = Log.pull(destination, replay_after, last_version: last_inclusive)
+  end
+
+  test "a single retained transaction is data, not the lower cursor", %{tmp_dir: tmp_dir} do
+    backend = object_storage(tmp_dir)
+    source = start_log("single-source", Path.join(tmp_dir, "single-source"), backend, true)
+    destination = start_log("single-destination", Path.join(tmp_dir, "single-destination"), backend, false)
+
+    last_inclusive = Version.from_integer(700)
+    only_transaction = transaction(last_inclusive, "only")
+
+    assert :ok = Log.push(source, only_transaction, Version.zero())
+    lock(source)
+
+    assert {:ok, ^destination} =
+             Log.recover_from(destination, [source], Version.zero(), last_inclusive)
+
+    assert {:ok, [^only_transaction]} =
+             Log.pull(destination, Version.zero(), last_version: last_inclusive)
+  end
+
+  test "physical trim and cold restart preserve the predecessor of retained data", %{tmp_dir: tmp_dir} do
+    backend = object_storage(tmp_dir)
+    source_path = Path.join(tmp_dir, "trimmed-source")
+    destination_path = Path.join(tmp_dir, "trimmed-destination")
+    {source, source_id} = start_restartable_log("trimmed-source", source_path, backend, true)
+    destination = start_log("trimmed-destination", destination_path, backend, false)
+
+    first_version = Version.from_integer(1_000)
+    last_inclusive = Version.from_integer(Demux.default_cut_interval_us())
+    cut_version = Version.from_integer(Demux.default_cut_interval_us() - 1)
+    first = transaction(first_version, "trimmed-away")
+    retained = transaction(last_inclusive, "retained")
+
+    assert :ok = Log.push(source, first, Version.zero(), known_committed_version: first_version)
+    assert :ok = Log.push(source, retained, first_version, known_committed_version: last_inclusive)
+
+    eventually(fn ->
+      assert %{min_durable_version: ^cut_version, segments: [], available_after: ^first_version} =
+               :sys.get_state(source)
+    end)
+
+    assert :ok = stop_supervised({Shale, source_id})
+
+    {restarted_source, ^source_id} =
+      start_restartable_log("trimmed-source-restart", source_path, backend, false, source_id)
+
+    assert {:ok,
+            %{
+              available_after: ^first_version,
+              oldest_version: ^last_inclusive,
+              last_version: ^last_inclusive
+            }} = Log.info(restarted_source, [:available_after, :oldest_version, :last_version])
+
+    assert {:ok, ^destination} =
+             Log.recover_from(destination, [restarted_source], first_version, last_inclusive)
+
+    assert {:ok, [^retained]} =
+             Log.pull(destination, first_version, last_version: last_inclusive)
+  end
+
+  test "an empty replay baseline survives restart and anchors the next push", %{tmp_dir: tmp_dir} do
+    backend = object_storage(tmp_dir)
+    wal_path = Path.join(tmp_dir, "empty-baseline")
+    {log, log_id} = start_restartable_log("empty-baseline", wal_path, backend, false)
+    replay_after = Version.from_integer(500)
+
+    assert {:ok, ^log} = Log.recover_from(log, [], replay_after, replay_after)
+    assert :ok = stop_supervised({Shale, log_id})
+
+    {restarted, ^log_id} = start_restartable_log("empty-baseline-restart", wal_path, backend, true, log_id)
+
+    assert {:ok, %{available_after: ^replay_after, last_version: ^replay_after}} =
+             Log.info(restarted, [:available_after, :last_version])
+
+    next_version = Version.from_integer(900)
+    next_transaction = transaction(next_version, "next")
+    assert :ok = Log.push(restarted, next_transaction, replay_after)
+    assert {:ok, [^next_transaction]} = Log.pull(restarted, replay_after, last_version: next_version)
+    assert %{active_segment: %{previous_version: ^replay_after}} = :sys.get_state(restarted)
+  end
+
+  defp transaction(version, value) do
+    TransactionTestSupport.new_log_transaction(version, %{"key" => value}, shard_id: 7)
+  end
+
+  defp object_storage(tmp_dir) do
+    root = Path.join(tmp_dir, "objects")
+    File.mkdir_p!(root)
+    ObjectStorage.backend(LocalFilesystem, root: root)
+  end
+
+  defp start_log(label, wal_path, object_storage, start_unlocked) do
+    {pid, _id} = start_restartable_log(label, wal_path, object_storage, start_unlocked)
+    pid
+  end
+
+  defp start_restartable_log(label, wal_path, object_storage, start_unlocked, id \\ nil) do
+    File.mkdir_p!(wal_path)
+    suffix = :erlang.unique_integer([:positive])
+    id = id || "replay-cursor-#{label}-#{suffix}"
+
+    spec =
+      [
+        cluster: Cluster,
+        otp_name: String.to_atom("replay_cursor_#{label}_#{suffix}"),
+        id: id,
+        foreman: self(),
+        path: wal_path,
+        object_storage: object_storage,
+        start_unlocked: start_unlocked
+      ]
+      |> Shale.child_spec()
+      |> Supervisor.child_spec(restart: :temporary)
+
+    pid = start_supervised!(spec)
+
+    eventually(fn ->
+      assert %{init_state: :initialized, demux: demux, segment_recycler: recycler} = :sys.get_state(pid)
+      assert is_pid(demux)
+      assert is_pid(recycler)
+    end)
+
+    {pid, id}
+  end
+
+  defp lock(log), do: :sys.replace_state(log, &%{&1 | mode: :locked})
+
+  defp eventually(assertion, timeout \\ 2_000) do
+    deadline = System.monotonic_time(:millisecond) + timeout
+    eventually(assertion, deadline, nil)
+  end
+
+  defp eventually(assertion, deadline, last_error) do
+    assertion.()
+  rescue
+    error in [ExUnit.AssertionError] ->
+      if System.monotonic_time(:millisecond) < deadline do
+        Process.sleep(10)
+        eventually(assertion, deadline, error)
+      else
+        reraise(last_error || error, __STACKTRACE__)
+      end
+  end
+end

--- a/test/bedrock/data_plane/log/shale/server_test.exs
+++ b/test/bedrock/data_plane/log/shale/server_test.exs
@@ -347,10 +347,11 @@ defmodule Bedrock.DataPlane.Log.Shale.ServerTest do
 
     test "handles recover_from with invalid version range", %{server: pid} do
       source_logs = [self()]
-      first_version = Version.from_integer(10)
-      last_version = Version.from_integer(1)
+      replay_after = Version.from_integer(10)
+      last_inclusive = Version.from_integer(1)
 
-      catch_exit(GenServer.call(pid, {:recover_from, source_logs, first_version, last_version}, 500))
+      assert {:error, {:failed_to_recover, :invalid_version_range}} =
+               GenServer.call(pid, {:recover_from, source_logs, replay_after, last_inclusive}, 500)
     end
   end
 
@@ -480,11 +481,17 @@ defmodule Bedrock.DataPlane.Log.Shale.ServerTest do
           state
           | mode: :running,
             last_version: v30,
-            active_segment: %Segment{path: seg30_path, min_version: v30, transactions: [tx30]},
+            active_segment: %Segment{
+              path: seg30_path,
+              min_version: v30,
+              previous_version: v20,
+              transactions: [tx30]
+            },
             segments: [
-              %Segment{path: seg20_path, min_version: v20, transactions: [tx20]},
-              %Segment{path: seg10_path, min_version: v10, transactions: [tx10]}
+              %Segment{path: seg20_path, min_version: v20, previous_version: v10, transactions: [tx20]},
+              %Segment{path: seg10_path, min_version: v10, previous_version: Version.zero(), transactions: [tx10]}
             ],
+            available_after: Version.zero(),
             oldest_version: v10,
             min_durable_version: nil
         }
@@ -496,6 +503,7 @@ defmodule Bedrock.DataPlane.Log.Shale.ServerTest do
 
       assert state.min_durable_version == v15
       assert Enum.map(state.segments, & &1.min_version) == [v20]
+      assert state.available_after == v10
       assert state.oldest_version == v20
       refute File.exists?(seg10_path)
       assert File.exists?(seg20_path)
@@ -513,7 +521,12 @@ defmodule Bedrock.DataPlane.Log.Shale.ServerTest do
           state
           | mode: :running,
             last_version: v10,
-            active_segment: %Segment{path: seg10_path, min_version: v10, transactions: [tx10]},
+            active_segment: %Segment{
+              path: seg10_path,
+              min_version: v10,
+              previous_version: Version.zero(),
+              transactions: [tx10]
+            },
             segments: [],
             oldest_version: v10,
             min_durable_version: nil
@@ -552,11 +565,17 @@ defmodule Bedrock.DataPlane.Log.Shale.ServerTest do
         state
         | mode: :running,
           last_version: v30,
-          active_segment: %Segment{path: seg30_path, min_version: v30, transactions: [tx30]},
+          active_segment: %Segment{
+            path: seg30_path,
+            min_version: v30,
+            previous_version: v20,
+            transactions: [tx30]
+          },
           segments: [
-            %Segment{path: seg20_path, min_version: v20, transactions: [tx20]},
-            %Segment{path: seg10_path, min_version: v10, transactions: [tx10]}
+            %Segment{path: seg20_path, min_version: v20, previous_version: v10, transactions: [tx20]},
+            %Segment{path: seg10_path, min_version: v10, previous_version: Version.zero(), transactions: [tx10]}
           ],
+          available_after: Version.zero(),
           oldest_version: v10,
           min_durable_version: nil
       }

--- a/test/bedrock/data_plane/log/shale/server_test.exs
+++ b/test/bedrock/data_plane/log/shale/server_test.exs
@@ -642,10 +642,17 @@ defmodule Bedrock.DataPlane.Log.Shale.ServerTest do
     end
 
     test "pushes are rejected past the configured lag limit", %{server_opts: opts} do
+      # A second server needs its own segment directory: two recyclers
+      # sharing one directory rename the same preallocated files out from
+      # under each other, occasionally killing this server mid-setup.
+      own_path = Path.join(opts[:path], "backpressure_#{System.unique_integer([:positive])}")
+      File.mkdir_p!(own_path)
+
       pid =
         opts
         |> Keyword.merge(
           reject_pushes_above_lag_us: 1_000,
+          path: own_path,
           otp_name: :"backpressure_log_#{:rand.uniform(10_000)}",
           id: "backpressure_log_#{:rand.uniform(10_000)}"
         )

--- a/test/bedrock/data_plane/log/shale/transaction_streams_edge_case_test.exs
+++ b/test/bedrock/data_plane/log/shale/transaction_streams_edge_case_test.exs
@@ -73,8 +73,8 @@ defmodule Bedrock.DataPlane.Log.Shale.TransactionStreamsEdgeCaseTest do
 
   defp create_wal_file_with_entry(tmp_dir, filename, entry_data) do
     wal_file = Path.join(tmp_dir, filename)
-    magic = <<"BED0">>
-    File.write!(wal_file, magic <> entry_data)
+    header = <<"BED1", 0::unsigned-big-64>>
+    File.write!(wal_file, header <> entry_data)
     wal_file
   end
 

--- a/test/bedrock/data_plane/log/shale/writer_test.exs
+++ b/test/bedrock/data_plane/log/shale/writer_test.exs
@@ -2,31 +2,35 @@ defmodule Bedrock.DataPlane.Log.Shale.WriterTest do
   use ExUnit.Case, async: true
 
   alias Bedrock.DataPlane.Log.Shale.Writer
+  alias Bedrock.DataPlane.Version
 
   @test_file "test_segment.log"
 
   setup do
     File.write!(@test_file, :binary.copy(<<0>>, 1024))
     on_exit(fn -> File.rm(@test_file) end)
-    {:ok, writer} = Writer.open(@test_file)
+    {:ok, writer} = Writer.open(@test_file, Version.zero())
     %{writer: writer}
   end
 
-  describe "open/1" do
+  describe "open/3" do
     test "successfully opens a file and initializes the writer struct" do
       # Use pattern matching to assert all fields and that fd is present
-      assert {:ok, %Writer{fd: fd, write_offset: 4, bytes_remaining: 1004, sync_fun: sync_fun}} =
-               Writer.open(@test_file)
+      previous_version = Version.from_integer(41)
+
+      assert {:ok, %Writer{fd: fd, write_offset: 12, bytes_remaining: 996, sync_fun: sync_fun}} =
+               Writer.open(@test_file, previous_version)
 
       assert fd
       assert is_function(sync_fun, 1)
+      assert {:ok, <<"BED1", ^previous_version::binary>>} = :file.pread(fd, 0, 12)
     end
 
     test "uses custom sync function from options" do
       sync_fun = fn _fd -> :ok end
 
       assert {:ok, %Writer{sync_fun: writer_sync_fun}} =
-               Writer.open(@test_file, sync_fun: sync_fun)
+               Writer.open(@test_file, Version.zero(), sync_fun: sync_fun)
 
       assert writer_sync_fun == sync_fun
     end
@@ -54,7 +58,7 @@ defmodule Bedrock.DataPlane.Log.Shale.WriterTest do
       commit_version = <<1::unsigned-big-64>>
 
       # Use pattern matching to assert the exact structure and values
-      assert {:ok, %Writer{write_offset: 24, bytes_remaining: 984}} =
+      assert {:ok, %Writer{write_offset: 32, bytes_remaining: 976}} =
                Writer.append(writer, transaction, commit_version)
     end
 
@@ -71,14 +75,14 @@ defmodule Bedrock.DataPlane.Log.Shale.WriterTest do
 
     test "returns sync error and does not advance offsets" do
       sync_fun = fn _fd -> {:error, :eio} end
-      assert {:ok, writer} = Writer.open(@test_file, sync_fun: sync_fun)
+      assert {:ok, writer} = Writer.open(@test_file, Version.zero(), sync_fun: sync_fun)
 
       transaction = <<1, 2, 3, 4>>
       commit_version = <<1::unsigned-big-64>>
 
       assert {:error, :eio} = Writer.append(writer, transaction, commit_version)
-      assert writer.write_offset == 4
-      assert writer.bytes_remaining == 1004
+      assert writer.write_offset == 12
+      assert writer.bytes_remaining == 996
       assert :ok = Writer.close(writer)
     end
   end

--- a/test/bedrock/data_plane/log/telemetry_test.exs
+++ b/test/bedrock/data_plane/log/telemetry_test.exs
@@ -114,32 +114,32 @@ defmodule Bedrock.DataPlane.Log.TelemetryTest do
   describe "trace_recover_from/3" do
     test "emits telemetry event with recovery details" do
       source_logs = [:some_log_ref, :another_log_ref]
-      first_version = Version.from_integer(0)
-      last_version = Version.from_integer(100)
+      replay_after = Version.from_integer(0)
+      last_inclusive = Version.from_integer(100)
 
-      assert :ok = Telemetry.trace_recover_from(source_logs, first_version, last_version)
+      assert :ok = Telemetry.trace_recover_from(source_logs, replay_after, last_inclusive)
 
       assert_received {:telemetry_event, [:bedrock, :log, :recover_from], %{},
                        %{
                          source_logs: [:some_log_ref, :another_log_ref],
-                         first_version: ^first_version,
-                         last_version: ^last_version
+                         replay_after: ^replay_after,
+                         last_inclusive: ^last_inclusive
                        }}
     end
 
     test "includes trace metadata" do
       Telemetry.trace_metadata(%{recovery_id: "rec1"})
       source_logs = [:log1, :log2]
-      first_version = Version.zero()
-      last_version = Version.from_integer(50)
+      replay_after = Version.zero()
+      last_inclusive = Version.from_integer(50)
 
-      assert :ok = Telemetry.trace_recover_from(source_logs, first_version, last_version)
+      assert :ok = Telemetry.trace_recover_from(source_logs, replay_after, last_inclusive)
 
       assert_received {:telemetry_event, [:bedrock, :log, :recover_from], %{}, metadata}
       assert metadata.recovery_id == "rec1"
       assert metadata.source_logs == [:log1, :log2]
-      assert metadata.first_version == first_version
-      assert metadata.last_version == last_version
+      assert metadata.replay_after == replay_after
+      assert metadata.last_inclusive == last_inclusive
     end
   end
 

--- a/test/bedrock/data_plane/log/tracing_test.exs
+++ b/test/bedrock/data_plane/log/tracing_test.exs
@@ -77,21 +77,21 @@ defmodule Bedrock.DataPlane.Log.TracingTest do
     end
 
     test "handles :recover_from event with no source" do
-      assert_log_contains(:recover_from, %{}, %{source_log: :none}, "Reset to initial version")
+      assert_log_contains(:recover_from, %{}, %{source_logs: []}, "Persist empty replay baseline")
     end
 
     test "handles :recover_from event with source log" do
       metadata = %{
-        source_log: :log_server_2,
-        first_version: Version.from_integer(100),
-        last_version: Version.from_integer(150)
+        source_logs: [:log_server_2],
+        replay_after: Version.from_integer(100),
+        last_inclusive: Version.from_integer(150)
       }
 
       assert_log_contains(
         :recover_from,
         %{},
         metadata,
-        "Recover from :log_server_2 with versions <0,0,0,0,0,0,0,100> to <0,0,0,0,0,0,0,150>"
+        "Recover from [:log_server_2] over (<0,0,0,0,0,0,0,100>, <0,0,0,0,0,0,0,150>]"
       )
     end
 

--- a/test/bedrock/data_plane/log/transaction_log_integration_test.exs
+++ b/test/bedrock/data_plane/log/transaction_log_integration_test.exs
@@ -54,7 +54,7 @@ defmodule Bedrock.DataPlane.Log.TransactionLogIntegrationTest do
     {:ok, transaction_with_version} =
       Transaction.add_commit_version(encoded_transaction, commit_version)
 
-    {:ok, writer} = Writer.open(@test_file)
+    {:ok, writer} = Writer.open(@test_file, Version.zero())
     {:ok, _updated_writer} = Writer.append(writer, transaction_with_version, commit_version)
     Writer.close(writer)
 
@@ -92,7 +92,7 @@ defmodule Bedrock.DataPlane.Log.TransactionLogIntegrationTest do
       %{mutations: [{:clear, "key3"}]}
     ]
 
-    {:ok, writer} = Writer.open(@test_file)
+    {:ok, writer} = Writer.open(@test_file, Version.zero())
 
     {final_writer, _} =
       Enum.reduce(transactions, {writer, 1}, fn tx, {w, version_num} ->
@@ -129,7 +129,7 @@ defmodule Bedrock.DataPlane.Log.TransactionLogIntegrationTest do
     version = Version.from_integer(123)
     {:ok, tx_with_version} = Transaction.add_commit_version(encoded, version)
 
-    {:ok, writer} = Writer.open(@test_file)
+    {:ok, writer} = Writer.open(@test_file, Version.zero())
     {:ok, _} = Writer.append(writer, tx_with_version, version)
     Writer.close(writer)
 
@@ -152,7 +152,7 @@ defmodule Bedrock.DataPlane.Log.TransactionLogIntegrationTest do
     version = Version.from_integer(1)
     {:ok, tx_with_version} = Transaction.add_commit_version(encoded, version)
 
-    {:ok, writer} = Writer.open(@test_file)
+    {:ok, writer} = Writer.open(@test_file, Version.zero())
     {:ok, _} = Writer.append(writer, tx_with_version, version)
     Writer.close(writer)
 

--- a/test/bedrock/data_plane/log_test.exs
+++ b/test/bedrock/data_plane/log_test.exs
@@ -11,7 +11,7 @@ defmodule Bedrock.DataPlane.LogTest do
     test "returns list of fact names for recovery" do
       result = Log.recovery_info()
 
-      expected = [:kind, :last_version, :oldest_version, :minimum_durable_version]
+      expected = [:kind, :last_version, :available_after, :oldest_version, :minimum_durable_version]
       assert result == expected
     end
   end
@@ -36,13 +36,13 @@ defmodule Bedrock.DataPlane.LogTest do
 
     test "delegates to GenServerApi call with proper arguments" do
       source_log = :source_log_ref
-      first_version = 100
-      last_version = 200
+      replay_after = 100
+      last_inclusive = 200
       test_pid = self()
 
       # Spawn a process that will make the call and we'll capture the message
       spawn(fn ->
-        Log.recover_from(test_pid, source_log, first_version, last_version)
+        Log.recover_from(test_pid, source_log, replay_after, last_inclusive)
       end)
 
       # Log.recover_from normalizes single refs to lists
@@ -63,12 +63,12 @@ defmodule Bedrock.DataPlane.LogTest do
 
     test "accepts list of source logs directly" do
       source_logs = [:log1, :log2]
-      first_version = 100
-      last_version = 200
+      replay_after = 100
+      last_inclusive = 200
       test_pid = self()
 
       spawn(fn ->
-        Log.recover_from(test_pid, source_logs, first_version, last_version)
+        Log.recover_from(test_pid, source_logs, replay_after, last_inclusive)
       end)
 
       # Lists are passed through unchanged

--- a/test/bedrock/directory/property_test.exs
+++ b/test/bedrock/directory/property_test.exs
@@ -125,22 +125,7 @@ defmodule Bedrock.Directory.PropertyTest do
         <<n::32>>
       end
 
-      # Use keyspace-aware stubs
-      stub(MockRepo, :get, fn _keyspace, key ->
-        cond do
-          # Version not initialized
-          key == ["version"] -> nil
-          # Directory doesn't exist yet
-          key in sorted_paths -> nil
-          # Root directory always exists
-          key == [] -> {<<>>, ""}
-          # Parent exists
-          MapSet.member?(created_dirs, key) -> {<<0, 1>>, ""}
-          true -> nil
-        end
-      end)
-
-      stub(MockRepo, :put, fn %Keyspace{}, _key, _value -> :ok end)
+      stub_repo_with_time_accurate_directory_state()
 
       layer = Directory.root(MockRepo, next_prefix_fn: next_prefix_fn)
 
@@ -176,6 +161,53 @@ defmodule Bedrock.Directory.PropertyTest do
       expected_creations = created_dirs |> MapSet.delete([]) |> MapSet.size()
       assert length(successful_nodes) == expected_creations
     end
+  end
+
+  test "a parent created in the same batch is visible to its child" do
+    # The deterministic pin for what the property above only sometimes
+    # generates: a parent-prefix pair like [["f"], ["f", "G"]]. With a
+    # stub that is not time-accurate, the just-created parent still reads
+    # as nonexistent during the child's parent check and creation fails
+    # with :parent_directory_does_not_exist.
+    stub_repo_with_time_accurate_directory_state()
+
+    prefix_counter = :counters.new(1, [])
+
+    next_prefix_fn = fn ->
+      n = :counters.get(prefix_counter, 1)
+      :counters.add(prefix_counter, 1, 1)
+      <<n::32>>
+    end
+
+    layer = Directory.root(MockRepo, next_prefix_fn: next_prefix_fn)
+
+    assert {:ok, _parent} = Directory.create(layer, ["f"])
+    assert {:ok, _child} = Directory.create(layer, ["f", "G"])
+  end
+
+  # A time-accurate repo stub: a directory exists exactly when it has been
+  # written. The get answers come from the set of paths actually put so
+  # far — never from a precomputed list, which would hide a parent created
+  # earlier in the same run behind "doesn't exist yet".
+  defp stub_repo_with_time_accurate_directory_state do
+    Process.put(:created_directory_paths, MapSet.new([[]]))
+
+    stub(MockRepo, :get, fn _keyspace, key ->
+      cond do
+        # Version not initialized
+        key == ["version"] -> nil
+        # Root directory always exists
+        key == [] -> {<<>>, ""}
+        # Anything written exists from that moment on
+        MapSet.member?(Process.get(:created_directory_paths), key) -> {<<0, 1>>, ""}
+        true -> nil
+      end
+    end)
+
+    stub(MockRepo, :put, fn %Keyspace{}, key, _value ->
+      Process.put(:created_directory_paths, MapSet.put(Process.get(:created_directory_paths), key))
+      :ok
+    end)
   end
 
   property "directory operations preserve metadata" do

--- a/test/support/control_plane/recovery_test_support.ex
+++ b/test/support/control_plane/recovery_test_support.ex
@@ -126,11 +126,13 @@ defmodule Bedrock.Test.ControlPlane.RecoveryTestSupport do
       log_recovery_info_by_id: %{
         {:log, 1} => %{
           kind: :log,
+          available_after: Version.zero(),
           oldest_version: Version.zero(),
           last_version: Version.from_integer(100)
         },
         {:log, 2} => %{
           kind: :log,
+          available_after: Version.zero(),
           oldest_version: Version.zero(),
           last_version: Version.from_integer(100)
         }
@@ -453,6 +455,7 @@ defmodule Bedrock.Test.ControlPlane.RecoveryTestSupport do
        %{
          kind: :test,
          durable_version: Version.from_integer(95),
+         available_after: Version.zero(),
          oldest_version: Version.zero(),
          last_version: Version.from_integer(100)
        }}
@@ -595,6 +598,7 @@ defmodule Bedrock.Test.ControlPlane.RecoveryTestSupport do
      %{
        kind: :test,
        durable_version: Version.from_integer(95),
+       available_after: Version.zero(),
        oldest_version: Version.zero(),
        last_version: Version.from_integer(100)
      }}

--- a/test/support/data_plane/wal_test_support.ex
+++ b/test/support/data_plane/wal_test_support.ex
@@ -52,7 +52,13 @@ defmodule Bedrock.Test.DataPlane.WALTestSupport do
     :ok = :file.write(fd, :binary.copy(<<0>>, 100_000))
     :ok = File.close(fd)
 
-    {:ok, writer} = Writer.open(file_path)
+    previous_version =
+      case version_data_pairs do
+        [{first_version, _} | _] -> Version.from_integer(max(first_version - 1, 0))
+        [] -> Version.zero()
+      end
+
+    {:ok, writer} = Writer.open(file_path, previous_version)
 
     {final_writer, version_map} =
       Enum.reduce(version_data_pairs, {writer, %{}}, fn {version_int, data}, {acc_writer, acc_map} ->

--- a/test/support/data_plane/wal_test_support.ex
+++ b/test/support/data_plane/wal_test_support.ex
@@ -84,9 +84,12 @@ defmodule Bedrock.Test.DataPlane.WALTestSupport do
   @spec read_transaction_by_version(String.t(), Version.t()) ::
           {:ok, Transaction.encoded()} | {:error, :not_found} | {:error, term()}
   def read_transaction_by_version(file_path, target_version) do
+    # A segment carries its replay cursor: previous_version is part of the
+    # contract, not an optional detail.
     segment = %Segment{
       path: file_path,
       min_version: Version.from_integer(0),
+      previous_version: Version.zero(),
       transactions: nil
     }
 


### PR DESCRIPTION
## Summary

- Persist each Shale WAL segment exclusive predecessor cursor in the versioned `BED1` header.
- Plan and execute replay uniformly as `(replay_after, last_inclusive]`, preserving the first retained transaction exactly once.
- Remove synthetic lower-bound transactions and prove completion only after observing the requested endpoint.
- Preserve empty recovery baselines across restart and fail closed on legacy WALs without predecessor metadata.
- Document `available_after`, `durable_through`, segment-header invariants, and the recovery range contract.

## Verification

- `mix format --check-formatted`
- `mix test` — 13 doctests, 158 properties, 2,499 tests, 0 failures
- `mix credo --strict`
- `mix dialyzer --format short`

Closes `bedrock-qzr.18`.

Stack parent: #120.