### PR TITLE
Publish WAL rollover state only after the successor cursor is durable (bedrock-qzr.25)

### DIFF
--- a/lib/bedrock/data_plane/log/shale/pushing.ex
+++ b/lib/bedrock/data_plane/log/shale/pushing.ex
@@ -95,22 +95,7 @@ defmodule Bedrock.DataPlane.Log.Shale.Pushing do
 
     case Segment.allocate_from_recycler(t.segment_recycler, t.path, version, previous_version) do
       {:ok, new_segment} ->
-        case Writer.open(new_segment.path, previous_version) do
-          {:ok, new_writer} ->
-            write_encoded_transaction(
-              %{
-                t
-                | writer: new_writer,
-                  active_segment: new_segment,
-                  segments: if(t.active_segment, do: [t.active_segment | t.segments], else: t.segments)
-              },
-              encoded_transaction
-            )
-
-          {:error, reason} ->
-            :ok = Segment.return_to_recycler(new_segment, t.segment_recycler)
-            {:error, reason, t}
-        end
+        stage_successor_and_append(t, new_segment, encoded_transaction, version)
 
       {:error, reason} ->
         {:error, reason, t}
@@ -139,6 +124,51 @@ defmodule Bedrock.DataPlane.Log.Shale.Pushing do
 
       {:error, reason} ->
         {:error, reason, t}
+    end
+  end
+
+  # The successor exists only in local variables until its header and
+  # first entry have survived one successful sync — Writer.append is that
+  # barrier for both. Only then does ownership transfer: successor becomes
+  # the active segment and the predecessor moves to the trim-eligible
+  # list, as a single state transition. On any failure the staged
+  # successor is closed and recycled, and the caller's state comes back
+  # untouched: the predecessor stays active (trim-immune, still owning
+  # the durable previous_version boundary) with writer: nil, ready for a
+  # later retry. Without the staging, a durability watermark arriving
+  # after a failed roll could recycle the predecessor against a successor
+  # cursor that was never made durable.
+  @spec stage_successor_and_append(State.t(), Segment.t(), Transaction.encoded(), Bedrock.version()) ::
+          {:ok, State.t()} | {:error, term(), State.t()}
+  defp stage_successor_and_append(t, new_segment, encoded_transaction, version) do
+    with {:ok, new_writer} <- Writer.open(new_segment.path, new_segment.previous_version, t.writer_opts),
+         {:ok, new_writer} <- first_append_or_close(new_writer, encoded_transaction, version) do
+      {:ok,
+       %{
+         t
+         | writer: new_writer,
+           last_version: version,
+           oldest_version: if(wal_has_transactions?(t), do: t.oldest_version, else: version),
+           active_segment: update_segment_transaction_cache(new_segment, encoded_transaction),
+           segments: if(t.active_segment, do: [t.active_segment | t.segments], else: t.segments)
+       }}
+    else
+      {:error, reason} ->
+        :ok = Segment.return_to_recycler(new_segment, t.segment_recycler)
+        {:error, reason, t}
+    end
+  end
+
+  # The staged writer is closed at the point of its failure, so the shared
+  # failure path above only has to recycle the staged segment.
+  defp first_append_or_close(writer, encoded_transaction, version) do
+    case Writer.append(writer, encoded_transaction, version) do
+      {:ok, writer} ->
+        {:ok, writer}
+
+      {:error, reason} ->
+        _ = Writer.close(writer)
+        {:error, reason}
     end
   end
 

--- a/lib/bedrock/data_plane/log/shale/state.ex
+++ b/lib/bedrock/data_plane/log/shale/state.ex
@@ -31,6 +31,7 @@ defmodule Bedrock.DataPlane.Log.Shale.State do
           #
           last_version: Bedrock.version(),
           writer: Writer.t() | nil,
+          writer_opts: keyword(),
           active_segment: Segment.t() | nil,
           segments: [Segment.t()],
           pending_pushes: %{
@@ -70,6 +71,7 @@ defmodule Bedrock.DataPlane.Log.Shale.State do
             #
             last_version: nil,
             writer: nil,
+            writer_opts: [],
             segments: [],
             active_segment: nil,
             pending_pushes: %{},

--- a/lib/bedrock/data_plane/log/shale/writer.ex
+++ b/lib/bedrock/data_plane/log/shale/writer.ex
@@ -5,7 +5,7 @@ defmodule Bedrock.DataPlane.Log.Shale.Writer do
 
   alias Bedrock.DataPlane.Transaction
 
-  defstruct [:fd, :write_offset, :bytes_remaining, :sync_fun]
+  defstruct [:fd, :write_offset, :bytes_remaining, :sync_fun, :pwrite_fun]
 
   @wal_eof_version <<0xFFFFFFFFFFFFFFFF::unsigned-big-64>>
   @eof_marker <<@wal_eof_version::binary, 0::unsigned-big-32, 0::unsigned-big-32>>
@@ -21,26 +21,29 @@ defmodule Bedrock.DataPlane.Log.Shale.Writer do
           fd: File.file_descriptor(),
           write_offset: pos_integer(),
           bytes_remaining: pos_integer(),
-          sync_fun: (File.file_descriptor() -> :ok | {:error, File.posix()})
+          sync_fun: (File.file_descriptor() -> :ok | {:error, File.posix()}),
+          pwrite_fun: (File.file_descriptor(), non_neg_integer(), iodata() -> :ok | {:error, File.posix()})
         }
 
   @spec open(path_to_file :: String.t(), previous_version :: Bedrock.version(), opts :: keyword()) ::
           {:ok, t()} | {:error, File.posix()}
   def open(path_to_file, previous_version, opts \\ []) do
     sync_fun = Keyword.get(opts, :sync_fun, &:file.sync/1)
+    pwrite_fun = Keyword.get(opts, :pwrite_fun, &:file.pwrite/3)
     empty_segment_header = <<@wal_magic_number, previous_version::binary-size(8), @eof_marker>>
 
     with {:ok, stat} <- File.stat(path_to_file),
          {:ok, fd} <- File.open(path_to_file, [:write, :read, :raw, :binary]) do
       # Write header - close fd on failure to avoid leak
-      case :file.pwrite(fd, 0, empty_segment_header) do
+      case pwrite_fun.(fd, 0, empty_segment_header) do
         :ok ->
           {:ok,
            %__MODULE__{
              fd: fd,
              write_offset: @header_size,
              bytes_remaining: stat.size - @header_size - 16,
-             sync_fun: sync_fun
+             sync_fun: sync_fun,
+             pwrite_fun: pwrite_fun
            }}
 
         {:error, reason} ->
@@ -76,7 +79,7 @@ defmodule Bedrock.DataPlane.Log.Shale.Writer do
     >>
 
     writer.fd
-    |> :file.pwrite(writer.write_offset, [log_entry, @eof_marker])
+    |> writer.pwrite_fun.(writer.write_offset, [log_entry, @eof_marker])
     |> case do
       :ok ->
         case writer.sync_fun.(writer.fd) do

--- a/test/bedrock/data_plane/log/shale/pushing_test.exs
+++ b/test/bedrock/data_plane/log/shale/pushing_test.exs
@@ -2,6 +2,7 @@ defmodule Bedrock.DataPlane.Log.Shale.PushingTest do
   use ExUnit.Case, async: true
 
   alias Bedrock.DataPlane.Demux
+  alias Bedrock.DataPlane.Log.Shale.ColdStarting
   alias Bedrock.DataPlane.Log.Shale.Pushing
   alias Bedrock.DataPlane.Log.Shale.Segment
   alias Bedrock.DataPlane.Log.Shale.SegmentRecycler
@@ -9,6 +10,23 @@ defmodule Bedrock.DataPlane.Log.Shale.PushingTest do
   alias Bedrock.DataPlane.Log.Shale.Writer
   alias Bedrock.DataPlane.Version
   alias Bedrock.Test.DataPlane.TransactionTestSupport
+
+  # ExUnit owns the directory lifecycle: each test gets a fresh tmp_dir,
+  # wiped before the test runs — so no teardown can race the linked
+  # recycler still creating preallocated files.
+  @moduletag :tmp_dir
+
+  defp recycler_in_tmp_dir(%{tmp_dir: dir}) do
+    {:ok, recycler} =
+      SegmentRecycler.start_link(
+        path: dir,
+        min_available: 2,
+        max_available: 4,
+        segment_size: 1_000_000
+      )
+
+    %{dir: dir, recycler: recycler}
+  end
 
   describe "push/4 error conditions" do
     test "rejects transaction that is too large" do
@@ -94,22 +112,7 @@ defmodule Bedrock.DataPlane.Log.Shale.PushingTest do
   end
 
   describe "draining queued pushes" do
-    setup do
-      dir = Path.join(System.tmp_dir!(), "pushing_drain_#{System.unique_integer([:positive])}")
-      File.mkdir_p!(dir)
-
-      {:ok, recycler} =
-        SegmentRecycler.start_link(
-          path: dir,
-          min_available: 2,
-          max_available: 4,
-          segment_size: 1_000_000
-        )
-
-      on_exit(fn -> File.rm_rf!(dir) end)
-
-      %{dir: dir, recycler: recycler}
-    end
+    setup :recycler_in_tmp_dir
 
     test "returns every appended transaction in predecessor-chain order", %{dir: dir, recycler: recycler} do
       state = %State{
@@ -196,22 +199,7 @@ defmodule Bedrock.DataPlane.Log.Shale.PushingTest do
   end
 
   describe "segment rolling on cut boundaries" do
-    setup do
-      dir = Path.join(System.tmp_dir!(), "pushing_roll_#{System.unique_integer([:positive])}")
-      File.mkdir_p!(dir)
-
-      {:ok, recycler} =
-        SegmentRecycler.start_link(
-          path: dir,
-          min_available: 2,
-          max_available: 4,
-          segment_size: 1_000_000
-        )
-
-      on_exit(fn -> File.rm_rf!(dir) end)
-
-      %{dir: dir, recycler: recycler}
-    end
+    setup :recycler_in_tmp_dir
 
     defp write!(state, version_int) do
       tx = TransactionTestSupport.new_log_transaction(version_int, %{"k" => "v"})
@@ -253,6 +241,155 @@ defmodule Bedrock.DataPlane.Log.Shale.PushingTest do
       state = write!(state, 4 * interval + 1)
       assert length(state.segments) == 2
       assert state.active_segment.min_version == Version.from_integer(4 * interval + 1)
+    end
+  end
+
+  describe "rollover publishes only after the successor cursor is durable" do
+    setup :recycler_in_tmp_dir
+
+    # A sync_fun that succeeds until armed, then fails with :eio until
+    # disarmed. Also counts every call so the single-barrier criterion can
+    # be asserted.
+    defp controlled_sync do
+      {:ok, control} = Agent.start_link(fn -> %{fail: false, calls: 0} end)
+
+      sync_fun = fn _fd ->
+        Agent.get_and_update(control, fn state ->
+          result = if state.fail, do: {:error, :eio}, else: :ok
+          {result, %{state | calls: state.calls + 1}}
+        end)
+      end
+
+      {control, sync_fun}
+    end
+
+    defp state_with(dir, recycler, writer_opts) do
+      %State{
+        mode: :ready,
+        path: dir,
+        segment_recycler: recycler,
+        writer: nil,
+        active_segment: nil,
+        segments: [],
+        last_version: Version.from_integer(0),
+        oldest_version: nil,
+        writer_opts: writer_opts
+      }
+    end
+
+    defp tx(version_int), do: TransactionTestSupport.new_log_transaction(version_int, %{"k" => "v"})
+
+    defp wal_files(dir), do: dir |> File.ls!() |> Enum.filter(&String.starts_with?(&1, "wal_"))
+
+    test "a failed first-append sync on a rolled successor leaves the predecessor active and trim-immune",
+         %{dir: dir, recycler: recycler} do
+      interval = Demux.Server.default_cut_interval_us()
+      {control, sync_fun} = controlled_sync()
+
+      state = state_with(dir, recycler, sync_fun: sync_fun)
+      {:ok, state} = Pushing.write_encoded_transaction(state, tx(1_000))
+      {:ok, state} = Pushing.write_encoded_transaction(state, tx(2_000))
+      predecessor = state.active_segment
+      wal_files_before = wal_files(dir)
+
+      # The roll happens with the predecessor's writer already closed, so
+      # the state entering the staged path carries writer: nil.
+      Agent.update(control, &%{&1 | fail: true})
+
+      assert {:error, :eio, failed_state} =
+               Pushing.write_encoded_transaction(state, tx(interval + 1))
+
+      # The predecessor is still the active segment — not in the
+      # trim-eligible list — and no successor is represented as owned WAL
+      # state. A watermark processed now has nothing to recycle and no
+      # successor to advance available_after from.
+      assert failed_state.active_segment.path == predecessor.path
+      assert failed_state.segments == []
+      assert failed_state.writer == nil
+      assert failed_state.last_version == Version.from_integer(2_000)
+      assert failed_state.oldest_version == Version.from_integer(1_000)
+
+      # The failed successor file was recycled back to the preallocated
+      # pool: the WAL namespace holds exactly the files it held before.
+      assert wal_files(dir) == wal_files_before
+
+      # A subsequent valid push retries the roll and succeeds.
+      Agent.update(control, &%{&1 | fail: false})
+      Agent.update(control, &%{&1 | calls: 0})
+
+      assert {:ok, rolled_state} =
+               Pushing.write_encoded_transaction(failed_state, tx(interval + 1))
+
+      assert rolled_state.active_segment.min_version == Version.from_integer(interval + 1)
+      assert [%{path: rolled_predecessor_path}] = rolled_state.segments
+      assert rolled_predecessor_path == predecessor.path
+      assert rolled_state.last_version == Version.from_integer(interval + 1)
+
+      # Header plus first entry share one sync barrier: the successful
+      # roll issued exactly one sync.
+      assert Agent.get(control, & &1.calls) == 1
+    end
+
+    test "a failed first-append pwrite on a rolled successor leaves the predecessor active",
+         %{dir: dir, recycler: recycler} do
+      interval = Demux.Server.default_cut_interval_us()
+      {:ok, control} = Agent.start_link(fn -> false end)
+
+      # Fail only entry pwrites (offset > 0) while armed; the header write
+      # at offset 0 succeeds, so the failure lands on the first append.
+      pwrite_fun = fn fd, offset, data ->
+        if Agent.get(control, & &1) and offset > 0 do
+          {:error, :enospc}
+        else
+          :file.pwrite(fd, offset, data)
+        end
+      end
+
+      state = state_with(dir, recycler, pwrite_fun: pwrite_fun)
+      {:ok, state} = Pushing.write_encoded_transaction(state, tx(1_000))
+      predecessor = state.active_segment
+      wal_files_before = wal_files(dir)
+
+      Agent.update(control, fn _ -> true end)
+
+      assert {:error, :enospc, failed_state} =
+               Pushing.write_encoded_transaction(state, tx(interval + 1))
+
+      assert failed_state.active_segment.path == predecessor.path
+      assert failed_state.segments == []
+      assert failed_state.writer == nil
+      assert failed_state.last_version == Version.from_integer(1_000)
+      assert wal_files(dir) == wal_files_before
+
+      Agent.update(control, fn _ -> false end)
+
+      assert {:ok, rolled_state} =
+               Pushing.write_encoded_transaction(failed_state, tx(interval + 1))
+
+      assert rolled_state.active_segment.min_version == Version.from_integer(interval + 1)
+      assert [%{path: kept}] = rolled_state.segments
+      assert kept == predecessor.path
+    end
+
+    test "cold restart after a failed roll reconstructs the retained predecessor cursor and transactions",
+         %{dir: dir, recycler: recycler} do
+      interval = Demux.Server.default_cut_interval_us()
+      {control, sync_fun} = controlled_sync()
+
+      state = state_with(dir, recycler, sync_fun: sync_fun)
+      first = tx(1_000)
+      second = tx(2_000)
+      {:ok, state} = Pushing.write_encoded_transaction(state, first)
+      {:ok, state} = Pushing.write_encoded_transaction(state, second)
+
+      Agent.update(control, &%{&1 | fail: true})
+      assert {:error, :eio, _failed_state} = Pushing.write_encoded_transaction(state, tx(interval + 1))
+
+      # What a cold start reads from disk is the predecessor alone, with
+      # both transactions and its original replay cursor.
+      assert {:ok, [segment]} = ColdStarting.reload_segments_at_path(dir)
+      assert segment.previous_version == Version.from_integer(0)
+      assert [^second, ^first] = Segment.transactions(segment)
     end
   end
 


### PR DESCRIPTION
Fixes the P0 review finding from #121 (ticket bedrock-qzr.25).

## Why

When a push crosses a cut boundary, Shale rolls to a fresh WAL segment. The old code installed the successor as the active segment — and moved the predecessor into the trim-eligible list — *before* the successor's header and first entry had survived a sync. If that first pwrite or sync failed, the returned state still claimed the successor owned the durable `previous_version` boundary. A durability watermark arriving after that failure could recycle the predecessor and advance `available_after` from a successor cursor that was never made durable; a crash at that point could lose both the predecessor WAL and any durable successor cursor.

## What

The rollover is now staged. The successor segment and its writer live only in local variables while the first append runs. `Writer.append` remains the single sync barrier for header plus first entry — no extra header sync was added.

- **On success**: the successor becomes `active_segment`, the predecessor moves into `segments`, and the cursor fields advance — one state transition, published only after the sync returned `:ok`.
- **On failure** (allocation, open, pwrite, or sync): the staged writer is closed, the staged segment file is returned to the recycler (renamed back to the `preallocated.*` pool, so it never appears as WAL state, on disk or in memory), and the caller gets its state back untouched: the closed predecessor is still active and trim-immune, with `writer: nil`, ready for the next push to retry the roll.

A fresh-segment `:segment_full` now surfaces as an error instead of re-rolling forever (a transaction that cannot fit an empty segment can never fit the next empty segment either; the 10 MB push cap makes this unreachable in practice).

## How it's tested

`Writer` gains a `pwrite_fun` injection point symmetric to the existing `sync_fun`, and Shale's `State` gains `writer_opts` so tests can reach the writer that `Pushing` opens internally during a roll. Deterministic fault-injection tests cover:

- first-append **sync** failure on a rolled successor: predecessor stays active and out of the trim-eligible list, no successor WAL file remains, and a subsequent push retries the roll and succeeds with exactly one sync barrier;
- first-append **pwrite** failure (header write allowed, entry write failed): same guarantees;
- **cold restart** after a failed roll: the on-disk scan reconstructs the retained predecessor alone, with its original replay cursor and both transactions.

All three tests were verified to fail against the old early-publication behavior.

Full suite: 2502 tests, 158 properties, 0 failures; credo --strict and dialyzer clean.