### PR TITLE
Repair the distributed MinIO durability gate for cut and KCV semantics (bedrock-qzr.20)

### DIFF
--- a/lib/bedrock/data_plane/demux/shard_server.ex
+++ b/lib/bedrock/data_plane/demux/shard_server.ex
@@ -169,8 +169,22 @@ defmodule Bedrock.DataPlane.Demux.ShardServer do
 
   # GenServer callbacks
 
+  @known_options ~w[
+    shard_id demux cluster object_storage
+    persistence_queue_capacity persistence_max_retries
+    persistence_retry_backoff_ms persistence_retry_tick_ms
+  ]a
+
   @impl true
   def init(opts) do
+    # Refuse unknown options at startup. A silently-ignored option lets
+    # configuration written against a removed protocol keep "working" and
+    # fail far away as an inscrutable timeout.
+    case Keyword.keys(opts) -- @known_options do
+      [] -> :ok
+      unknown -> raise ArgumentError, "unknown ShardServer options: #{inspect(unknown)}"
+    end
+
     shard_id = Keyword.fetch!(opts, :shard_id)
     demux = Keyword.fetch!(opts, :demux)
     cluster = Keyword.fetch!(opts, :cluster)

--- a/test/bedrock/data_plane/demux/shard_server_test.exs
+++ b/test/bedrock/data_plane/demux/shard_server_test.exs
@@ -121,6 +121,24 @@ defmodule Bedrock.DataPlane.Demux.ShardServerTest do
       assert %{demux: demux} = :sys.get_state(pid)
       assert demux == self()
     end
+
+    test "rejects unknown options loudly", %{backend: backend} do
+      # A silently-ignored option is how a test suite rots: configuration
+      # written against a removed protocol keeps "passing" its setup and
+      # fails later as an inscrutable timeout. Startup is the place to
+      # refuse.
+      Process.flag(:trap_exit, true)
+
+      assert {:error, {%ArgumentError{message: message}, _stack}} =
+               ShardServer.start_link(
+                 shard_id: 99,
+                 cluster: "test",
+                 object_storage: backend,
+                 version_gap: 100
+               )
+
+      assert message =~ "version_gap"
+    end
   end
 
   describe "push/3" do

--- a/test/bedrock/distributed/minio_durability_test.exs
+++ b/test/bedrock/distributed/minio_durability_test.exs
@@ -1,4 +1,21 @@
 defmodule Bedrock.Distributed.MinioDurabilityTest do
+  @moduledoc """
+  The distributed durability gate, against a real MinIO backend
+  (bedrock-qzr.20).
+
+  Exercises the Demux cut protocol end to end: cuts are deterministic
+  version-bucket boundaries, a cut candidate fires only once the
+  known-committed version reaches it, every shard's confirmed cut is its
+  floor contribution, and the global watermark is the minimum over shards.
+  Chunks written through a demux's lifetime replay from object storage
+  after a restart, and a transient write failure heals through the
+  persistence worker's retry without losing the cut.
+
+  Run with:
+
+      BEDROCK_INCLUDE_DISTRIBUTED=1 mix test --include distributed \\
+        test/bedrock/distributed/minio_durability_test.exs
+  """
   use ExUnit.Case, async: false
 
   alias Bedrock.DataPlane.Demux.Server
@@ -11,6 +28,11 @@ defmodule Bedrock.Distributed.MinioDurabilityTest do
   alias Bedrock.Test.Minio
 
   @moduletag :distributed
+
+  # Small version-time buckets so test versions (microsecond integers in
+  # the low thousands) cross cut boundaries; the default five-second
+  # interval would never be crossed and no cut would ever fire.
+  @cut_interval_us 100
 
   if System.get_env("BEDROCK_MINIO_AVAILABLE") != "1" do
     @moduletag skip: "MinIO not available"
@@ -84,56 +106,84 @@ defmodule Bedrock.Distributed.MinioDurabilityTest do
     {:ok, backend: backend, shard_base: shard_base}
   end
 
-  test "3-shard durability watermark advances and survives demux restart", %{
+  test "3-shard durability watermark advances behind KCV and survives demux restart", %{
     backend: backend,
     shard_base: shard_base
   } do
     {:ok, demux} = start_demux(backend)
-    shards = [shard_base + 11, shard_base + 22, shard_base + 33]
+    [shard_a, shard_b, shard_c] = shards = [shard_base + 11, shard_base + 22, shard_base + 33]
 
-    for shard <- shards do
-      push_txn(demux, shard, 1_000)
-      push_txn(demux, shard, 1_200)
-    end
+    # Bucket 10 (interval 100): one transaction per shard, in global commit
+    # order, KCV trailing one commit behind — the shape the commit proxies
+    # produce.
+    push_txn(demux, shard_a, 1_010, nil)
+    push_txn(demux, shard_b, 1_020, 1_010)
+    push_txn(demux, shard_c, 1_030, 1_020)
 
-    assert_eventually(fn ->
-      Server.min_durable_version(demux) == Version.from_integer(1_000)
-    end)
+    # Crossing into bucket 12 proposes the cut at 1_199 — a CANDIDATE only.
+    # The KCV (1_030) has not reached it: nothing may become durable.
+    push_txn(demux, shard_a, 1_210, 1_030)
+    Process.sleep(100)
 
-    # Advance one shard first: global min should remain bounded by slower shards.
-    push_txn(demux, hd(shards), 1_400)
-    Process.sleep(25)
-    assert Server.min_durable_version(demux) == Version.from_integer(1_000)
+    # Shards exist but nothing is confirmed: the floor is honestly zero.
+    premature = Server.min_durable_version(demux)
 
-    # Advance remaining shards and verify global watermark moves forward.
-    push_txn(demux, Enum.at(shards, 1), 1_400)
-    push_txn(demux, Enum.at(shards, 2), 1_400)
+    assert premature == Version.zero(),
+           "cut advanced before the known-committed version reached it: #{inspect(premature)}"
 
-    assert_eventually(fn ->
-      Server.min_durable_version(demux) == Version.from_integer(1_200)
-    end)
+    # The KCV passes the cut: it fires, every shard flushes its bucket-10
+    # data and confirms, and the global minimum is the confirmed cut.
+    push_txn(demux, shard_b, 1_220, 1_210)
 
-    # Simulate demux restart and verify persisted replay from object storage.
+    assert_eventually(
+      fn -> Server.min_durable_version(demux) == Version.from_integer(1_199) end,
+      3_000,
+      fn -> "watermark did not reach 1_199; at #{inspect(Server.min_durable_version(demux))}" end
+    )
+
+    # Next bucket, same discipline: the candidate at 1_299 waits for the KCV…
+    push_txn(demux, shard_c, 1_230, 1_220)
+    push_txn(demux, shard_a, 1_310, 1_230)
+    Process.sleep(100)
+
+    assert Server.min_durable_version(demux) == Version.from_integer(1_199),
+           "cut advanced before the known-committed version reached it"
+
+    # …and moves the watermark forward once the KCV passes it.
+    push_txn(demux, shard_b, 1_320, 1_310)
+
+    assert_eventually(
+      fn -> Server.min_durable_version(demux) == Version.from_integer(1_299) end,
+      3_000,
+      fn -> "watermark did not reach 1_299; at #{inspect(Server.min_durable_version(demux))}" end
+    )
+
+    # Restart: a fresh demux over the same object storage replays every
+    # flushed transaction from MinIO chunks.
     Process.exit(demux, :kill)
     Process.sleep(50)
 
     {:ok, demux_after_restart} = start_demux(backend)
 
+    expected_by_shard = %{shard_a => [1_010, 1_210], shard_b => [1_020, 1_220], shard_c => [1_030, 1_230]}
+
     for shard <- shards do
       {:ok, shard_server} = Server.get_shard_server(demux_after_restart, shard)
+      expected = Map.fetch!(expected_by_shard, shard)
 
       assert_eventually(
         fn ->
           case ShardServer.pull(shard_server, Version.from_integer(900), timeout: 200, limit: 10) do
             {:ok, txns, _currency} ->
               versions = Enum.map(txns, fn {version, _slice} -> Version.to_integer(version) end)
-              1_000 in versions and 1_200 in versions
+              Enum.all?(expected, &(&1 in versions))
 
             _ ->
               false
           end
         end,
-        8_000
+        8_000,
+        fn -> "shard #{shard} did not replay #{inspect(expected)} from MinIO chunks" end
       )
     end
   end
@@ -144,28 +194,35 @@ defmodule Bedrock.Distributed.MinioDurabilityTest do
   } do
     {:ok, failures} = Agent.start_link(fn -> 0 end)
     on_exit(fn -> if Process.alive?(failures), do: Agent.stop(failures) end)
-    shard_ids = [shard_base + 11, shard_base + 22, shard_base + 33]
-    shard_with_partition = Enum.at(shard_ids, 1)
+    [shard_a, shard_b, shard_c] = [shard_base + 11, shard_base + 22, shard_base + 33]
 
     flaky_backend =
       ObjectStorage.backend(FlakyS3Proxy,
         delegate_backend: backend,
-        fail_shard_tag: Keys.shard_tag(shard_with_partition),
+        fail_shard_tag: Keys.shard_tag(shard_b),
         failures: failures
       )
 
     {:ok, demux} = start_demux(flaky_backend)
 
-    for shard <- shard_ids do
-      push_txn(demux, shard, 1_000)
-      push_txn(demux, shard, 1_200)
-    end
+    push_txn(demux, shard_a, 1_010, nil)
+    push_txn(demux, shard_b, 1_020, 1_010)
+    push_txn(demux, shard_c, 1_030, 1_020)
 
-    assert_eventually(fn ->
-      Server.min_durable_version(demux) == Version.from_integer(1_000)
-    end)
+    # Fire the cut at 1_199: shard B's first chunk write fails once, the
+    # persistence worker retries, and the confirmed cut still reaches the
+    # global minimum — the partition cost latency, never durability.
+    push_txn(demux, shard_a, 1_210, 1_030)
+    push_txn(demux, shard_b, 1_220, 1_210)
 
-    assert_eventually(fn -> Agent.get(failures, & &1) >= 1 end)
+    assert_eventually(
+      fn -> Server.min_durable_version(demux) == Version.from_integer(1_199) end,
+      5_000,
+      fn -> "watermark did not heal to 1_199; at #{inspect(Server.min_durable_version(demux))}" end
+    )
+
+    assert Agent.get(failures, & &1) >= 1,
+           "the flaky backend never failed a write: the retry path was not exercised"
   end
 
   defp start_demux(backend) do
@@ -175,8 +232,8 @@ defmodule Bedrock.Distributed.MinioDurabilityTest do
          cluster: "distributed-test-cluster",
          object_storage: backend,
          log: self(),
+         cut_interval_us: @cut_interval_us,
          shard_server_opts: [
-           version_gap: 100,
            persistence_retry_backoff_ms: 1,
            persistence_retry_tick_ms: 1
          ]},
@@ -186,8 +243,9 @@ defmodule Bedrock.Distributed.MinioDurabilityTest do
     {:ok, start_supervised!(child_spec)}
   end
 
-  defp push_txn(demux, shard_id, version_int) do
+  defp push_txn(demux, shard_id, version_int, kcv_int) do
     version = Version.from_integer(version_int)
+    kcv = if kcv_int, do: Version.from_integer(kcv_int)
 
     txn =
       Transaction.encode(%{
@@ -196,23 +254,23 @@ defmodule Bedrock.Distributed.MinioDurabilityTest do
         commit_version: version
       })
 
-    :ok = Server.push(demux, version, txn)
+    :ok = Server.push(demux, version, txn, kcv)
   end
 
-  defp assert_eventually(fun, timeout_ms \\ 3_000) do
+  defp assert_eventually(fun, timeout_ms, describe_fn) do
     deadline = System.monotonic_time(:millisecond) + timeout_ms
-    eventually_loop(fun, deadline)
+    eventually_loop(fun, deadline, describe_fn)
   end
 
-  defp eventually_loop(fun, deadline) do
+  defp eventually_loop(fun, deadline, describe_fn) do
     if fun.() do
       :ok
     else
       if System.monotonic_time(:millisecond) < deadline do
         Process.sleep(25)
-        eventually_loop(fun, deadline)
+        eventually_loop(fun, deadline, describe_fn)
       else
-        flunk("condition not met before timeout")
+        flunk(describe_fn.())
       end
     end
   end


### PR DESCRIPTION
Fixes the P1 review finding: the documented distributed durability command failed both tests with bare timeouts (ticket bedrock-qzr.20).

## Why

The suite was written against a protocol that no longer exists. It passed the removed `version_gap` ShardServer option (silently ignored), pushed transactions with no known-committed version, and used versions (1000–1400) that never cross the default five-second cut interval. Under the current protocol — deterministic version-bucket cuts, fired only once the KCV reaches them — no cut could ever fire, so every assertion timed out.

## What

**Tests rewritten for the real protocol.** The demux is configured with `cut_interval_us: 100` so test versions cross bucket boundaries; pushes arrive in global commit order with a monotonic KCV trailing one commit behind, the shape the commit proxies produce. The suite now proves, in order:

- a cut candidate does **not** advance the watermark while the KCV is below it (asserted twice, at two consecutive cuts, with a settle window);
- once the KCV passes the cut, all three shards confirm and the global minimum is exactly the confirmed cut — then advances to the next confirmed cut;
- after killing the demux, a fresh one over the same MinIO bucket replays every flushed transaction per shard from chunks;
- a transient `put_if_not_exists` failure on one shard heals through the persistence worker's retry: the watermark still reaches the cut, and the test asserts the failure path actually fired.

Failure messages now report the observed watermark instead of a bare "condition not met".

**Guard so this cannot rot silently again.** `ShardServer.init` now rejects unknown options with an `ArgumentError` naming them. The removed `version_gap` option was accepted and ignored for months; configuration written against a dead protocol should fail at startup, loudly, not surface later as an inscrutable timeout. A unit test pins the guard.

## Verification

`BEDROCK_INCLUDE_DISTRIBUTED=1 mix test --include distributed test/bedrock/distributed/minio_durability_test.exs` — 2 tests, 0 failures (repeated runs). Full suite 2505 tests / 158 properties, 0 failures; credo --strict and dialyzer clean.