### PR TITLE
Do not materialize preallocated WAL segments on the push path (bedrock-qzr.26)

### DIFF
--- a/lib/bedrock/data_plane/log/shale/pushing.ex
+++ b/lib/bedrock/data_plane/log/shale/pushing.ex
@@ -148,7 +148,7 @@ defmodule Bedrock.DataPlane.Log.Shale.Pushing do
          t
          | writer: new_writer,
            last_version: version,
-           oldest_version: if(wal_has_transactions?(t), do: t.oldest_version, else: version),
+           oldest_version: oldest_after_append(t, version),
            active_segment: update_segment_transaction_cache(new_segment, encoded_transaction),
            segments: if(t.active_segment, do: [t.active_segment | t.segments], else: t.segments)
        }}
@@ -183,20 +183,17 @@ defmodule Bedrock.DataPlane.Log.Shale.Pushing do
   end
 
   defp append_encoded_transaction(t, encoded_transaction, version) do
-    had_transactions? = wal_has_transactions?(t)
-
     case Writer.append(t.writer, encoded_transaction, version) do
       {:ok, writer} ->
         # Update the active segment's transaction cache to keep it coherent with disk
         updated_active_segment = update_segment_transaction_cache(t.active_segment, encoded_transaction)
-        oldest_version = if had_transactions?, do: t.oldest_version, else: version
 
         {:ok,
          %{
            t
            | writer: writer,
              last_version: version,
-             oldest_version: oldest_version,
+             oldest_version: oldest_after_append(t, version),
              active_segment: updated_active_segment
          }}
 
@@ -211,10 +208,14 @@ defmodule Bedrock.DataPlane.Log.Shale.Pushing do
     end
   end
 
-  defp wal_has_transactions?(t) do
-    [t.active_segment | t.segments]
-    |> Enum.reject(&is_nil/1)
-    |> Enum.any?(fn segment -> Segment.transactions(segment) != [] end)
+  # Whether the retained WAL holds any transaction is a fact the cursors
+  # already state: `available_after` is the persisted exclusive floor, and
+  # the tip sits exactly on it (`last_version == available_after`) exactly
+  # when nothing is retained. Reading segment contents to answer this —
+  # the old way — cost a synchronous 64 MiB file read on the first append
+  # to every fresh or rolled segment.
+  defp oldest_after_append(t, appended_version) do
+    if t.last_version == t.available_after, do: appended_version, else: t.oldest_version
   end
 
   @spec update_segment_transaction_cache(Segment.t(), Transaction.encoded()) :: Segment.t()

--- a/lib/bedrock/data_plane/log/shale/segment.ex
+++ b/lib/bedrock/data_plane/log/shale/segment.ex
@@ -45,11 +45,16 @@ defmodule Bedrock.DataPlane.Log.Shale.Segment do
 
     case SegmentRecycler.check_out(segment_recycler, path_to_file) do
       :ok ->
+        # A freshly checked-out segment is KNOWN empty — `transactions: []`
+        # says so without ever reading the (preallocated, 64 MiB) file.
+        # `nil` is reserved for cold-start segments whose contents exist on
+        # disk but have not been decoded.
         {:ok,
          %__MODULE__{
            min_version: version,
            previous_version: previous_version,
-           path: path_to_file
+           path: path_to_file,
+           transactions: []
          }}
 
       _ ->

--- a/test/bedrock/data_plane/log/shale/pushing_test.exs
+++ b/test/bedrock/data_plane/log/shale/pushing_test.exs
@@ -393,6 +393,77 @@ defmodule Bedrock.DataPlane.Log.Shale.PushingTest do
     end
   end
 
+  describe "appends decide emptiness from state, never by reading segments" do
+    setup :recycler_in_tmp_dir
+
+    test "a recycler-allocated segment is known empty without touching the file", %{dir: dir, recycler: recycler} do
+      assert {:ok, segment} =
+               Segment.allocate_from_recycler(recycler, dir, Version.from_integer(1_000), Version.zero())
+
+      assert segment.transactions == []
+    end
+
+    test "an append never loads segment contents to decide emptiness", %{dir: dir} do
+      # The active segment's transaction cache is unloaded and its path
+      # does not exist: any attempt to read the file to answer "is the
+      # WAL empty?" raises instead of costing a silent 64 MiB read.
+      path = Path.join(dir, "wal_real_segment")
+      File.write!(path, :binary.copy(<<0>>, 1024))
+      assert {:ok, writer} = Writer.open(path, Version.zero())
+
+      state = %State{
+        mode: :ready,
+        last_version: Version.from_integer(1_000),
+        available_after: Version.zero(),
+        oldest_version: Version.from_integer(1_000),
+        writer: writer,
+        active_segment: %Segment{
+          path: Path.join(dir, "does_not_exist"),
+          min_version: Version.from_integer(1_000),
+          transactions: nil
+        }
+      }
+
+      tx = TransactionTestSupport.new_log_transaction(2_000, %{"k" => "v"})
+      assert {:ok, state} = Pushing.write_encoded_transaction(state, tx)
+
+      # Nonempty WAL (tip past the floor): oldest_version is retained.
+      assert state.oldest_version == Version.from_integer(1_000)
+      assert state.last_version == Version.from_integer(2_000)
+      assert :ok = Writer.close(state.writer)
+    end
+
+    test "the first append to an empty WAL initializes oldest_version from the cursor invariant",
+         %{dir: dir, recycler: recycler} do
+      # Empty retained WAL: the tip sits exactly on the persisted
+      # exclusive floor (last_version == available_after).
+      floor = Version.from_integer(5_000)
+
+      state = %State{
+        mode: :ready,
+        path: dir,
+        segment_recycler: recycler,
+        writer: nil,
+        active_segment: nil,
+        segments: [],
+        last_version: floor,
+        available_after: floor,
+        oldest_version: floor
+      }
+
+      tx = TransactionTestSupport.new_log_transaction(6_000, %{"k" => "v"})
+      assert {:ok, state} = Pushing.write_encoded_transaction(state, tx)
+
+      assert state.oldest_version == Version.from_integer(6_000)
+      assert state.last_version == Version.from_integer(6_000)
+
+      # And the next append keeps it: the WAL is no longer empty.
+      tx2 = TransactionTestSupport.new_log_transaction(7_000, %{"k" => "v"})
+      assert {:ok, state} = Pushing.write_encoded_transaction(state, tx2)
+      assert state.oldest_version == Version.from_integer(6_000)
+    end
+  end
+
   describe "write_encoded_transaction/2 error handling" do
     test "raises when transaction version cannot be extracted" do
       state = %State{


### PR DESCRIPTION
Fixes the P1 review finding from #121 (ticket bedrock-qzr.26).

## Why

Before every append, Shale asked "does the retained WAL hold any transaction yet?" — solely to decide whether `oldest_version` should initialize. It answered by loading the active segment's transaction cache, and on the first append to a fresh or rolled segment that cache is empty, so the loader read the **entire preallocated 64 MiB file** into memory, synchronously, inside the Log GenServer. That price was paid on the initial append and again after every cut-driven segment roll — a storage scan to learn a fact the recycler already knew: the file it just handed out contains nothing.

## What

Two changes, no new state and no second scan:

- **A recycler-allocated segment is constructed as known empty** (`transactions: []`). `nil` now means exactly one thing: a cold-start segment whose on-disk contents exist but have not been decoded — and those stay lazily loaded for callers that genuinely need the bytes.
- **The append path derives emptiness from the cursor invariant** instead of reading anything: `available_after` is the persisted exclusive floor, and the tip sits exactly on it (`last_version == available_after`) precisely when the retained WAL is empty. The first append past that baseline initializes `oldest_version`; every later append retains it. `wal_has_transactions?/1` is deleted.

WAL encoding, append ordering, sync behavior, and the meanings of `oldest_version` / `available_after` / `last_version` are unchanged.

## How it's tested

- A regression test hands the append path an unloaded segment whose file path does not exist: any attempt to read segment contents to decide emptiness raises, so the test fails loudly if the scan ever returns. It passes only because the append consults state alone.
- A recycler-allocated segment is asserted known-empty without touching its file.
- The empty-baseline case (tip == floor, covering both a fresh WAL and a persisted empty replay baseline after trimming) initializes `oldest_version` from the first append and holds it thereafter.
- Existing suites keep covering the nonempty WAL, cut-driven rolls, staged rollover, and cold restart.

Full suite: 2508 tests, 158 properties, 0 failures; credo --strict and dialyzer clean.