### PR TITLE
Reconcile async persistence guide with the integrated protocol (bedrock-qzr.24)

### DIFF
--- a/guides/async-persistence-queue.md
+++ b/guides/async-persistence-queue.md
@@ -1,26 +1,67 @@
-# Async Persistence Queue (Demux Foundation)
+# Async Persistence Queue
 
-`Bedrock.DataPlane.Demux.PersistenceQueue` and
-`Bedrock.DataPlane.Demux.PersistenceWorker` provide bounded queue primitives for
-future non-blocking shard persistence.
+Every shard's chunk writes go through a small, bounded pipeline:
+`Bedrock.DataPlane.Demux.PersistenceQueue` holds the work,
+`Bedrock.DataPlane.Demux.PersistenceWorker` performs it. Together they keep
+the push path non-blocking — a `ShardServer` never waits on object storage —
+while durability is only ever reported after a write has actually been
+confirmed.
 
-This foundational slice is intentionally additive:
+## How a chunk becomes durable
 
-- It introduces queue/worker infrastructure without changing current Demux or
-  external APIs.
-- It emits queue lag and backpressure telemetry for capacity planning.
-- It includes deterministic unit tests for queue ordering and retry scheduling.
+1. Every ShardServer is an anonymous child of one log replica's Demux; the
+   Demux's shard map is its only registry, so persistence confirmation is
+   replica-local even though deterministic chunk objects are shared.
+2. `ShardServer.push/4` only updates the in-memory buffer — ShardServers
+   never decide when to flush. The Demux commands `{:flush, cut_version}` on
+   deterministic version-time boundaries, and a cut candidate fires only once
+   the known-committed version has reached it, so a chunk can never contain a
+   version a recovery would discard.
+3. The ShardServer hands the flush payload to its PersistenceWorker and keeps
+   going. At most one flush is in flight per shard; the flushed entries stay
+   in the buffer — still pullable — until the write confirms.
+4. The worker writes the chunk with `put_if_not_exists`. Because every
+   replica produces byte-identical chunks, `{:error, :already_exists}` is a
+   truthful confirmation, not a conflict.
+5. On `{:flush_persisted, cut_version}`, the ShardServer evicts the flushed
+   entries and reports the cut as its floor contribution to the Demux, which
+   aggregates the per-shard floors into the log's durability watermark.
 
-## Queue Semantics
+A flush that exhausts its retries crashes the ShardServer. That is
+deliberate: the linked ShardServer → Demux → log chain turns a permanently
+failed write into a recovery instead of a silently frozen trim floor.
+
+## Queue semantics
 
 - Bounded capacity across pending, in-flight, and scheduled-retry entries.
 - FIFO dequeue order for ready entries.
 - Explicit `ack` and `nack` handling using dequeue tokens.
 - Retry scheduling with bounded attempts and exponential backoff.
 
-## Telemetry Events
+## WAL trim safety boundary
 
-The queue emits these additive events:
+`Log.Shale.Server` treats `min_durable_version` as a monotonic watermark and
+only trims WAL segments that are fully behind that boundary.
+
+- Older watermark updates are ignored (no regression).
+- Segment trimming is gated on confirmed durable watermark progression.
+- Segments that straddle the boundary are retained.
+
+## Recovery and corruption handling
+
+Chunk replay fails fast on decode/header corruption instead of silently
+skipping damaged objects.
+
+- `ChunkReader` raises `ChunkReader.ReadError` by default when chunk metadata
+  or content cannot be decoded.
+- `ShardServer.pull/3` surfaces this as
+  `{:error, {:storage_read_failed, reason}}`.
+- `ChunkReader.list_chunk_metadata/2` supports `on_error: :skip` only for
+  explicit best-effort tooling paths.
+
+## Observability signals
+
+Queue pressure:
 
 - `[:bedrock, :demux, :persistence_queue, :enqueue]`
 - `[:bedrock, :demux, :persistence_queue, :dequeue]`
@@ -31,65 +72,19 @@ The queue emits these additive events:
 Measurements include lag/backlog counts (`pending`, `scheduled`, `in_flight`,
 `lag`) plus capacity context.
 
-## Follow-On Integration
+Persistence outcomes:
 
-`ShardServer` routes chunk flush work through `PersistenceWorker`:
-
-1. Every ShardServer is an anonymous child of one log replica's Demux; the
-   Demux's shard map is its only registry, so persistence confirmation is
-   replica-local even though deterministic chunk objects are shared.
-2. `push/4` only updates the in-memory buffer — ShardServers never decide
-   when to flush. The Demux commands `{:flush, cut_version}` on deterministic
-   version-time boundaries, gated on the known committed version.
-3. Worker persists chunk payloads out-of-band (at most one flush in flight
-   per shard; a flush that exhausts its retries crashes the ShardServer so
-   the linked Demux → log chain converts it into a recovery instead of a
-   silent wedge).
-4. `ShardServer` confirms the cut only after receiving
-   `{:flush_persisted, cut_version}` confirmation; buffered entries stay
-   pullable until then.
-
-This keeps pushes non-blocking while preserving explicit durability
-watermark progression semantics.
-
-## WAL Trim Safety Boundary
-
-`Log.Shale.Server` treats `min_durable_version` as a monotonic watermark and
-only trims WAL segments that are fully behind that boundary.
-
-- Older watermark updates are ignored (no regression).
-- Segment trimming is gated on confirmed durable watermark progression.
-- Segments that straddle the boundary are retained.
-
-## Recovery and Corruption Handling
-
-Chunk replay now fails fast on decode/header corruption instead of silently
-skipping damaged objects.
-
-- `ChunkReader` raises `ChunkReader.ReadError` by default when chunk metadata or
-  content cannot be decoded.
-- `ShardServer.pull/3` surfaces this as
-  `{:error, {:storage_read_failed, reason}}`.
-- `ChunkReader.list_chunk_metadata/2` supports `on_error: :skip` only for
-  explicit best-effort tooling paths.
-
-## Observability Signals
-
-Queue and persistence telemetry now provide direct instrumentation points:
-
-- Queue pressure:
-  - `[:bedrock, :demux, :persistence_queue, :enqueue]`
-  - `[:bedrock, :demux, :persistence_queue, :dequeue]`
-  - `[:bedrock, :demux, :persistence_queue, :backpressure]`
-  - `[:bedrock, :demux, :persistence_queue, :retry_scheduled]`
-  - `[:bedrock, :demux, :persistence_queue, :retry_dropped]`
-- Persistence outcomes:
-  - `[:bedrock, :demux, :persistence, :write, :ok]`
-  - `[:bedrock, :demux, :persistence, :write, :error]`
-  - `[:bedrock, :demux, :persistence, :watermark, :advanced]`
+- `[:bedrock, :demux, :persistence, :write, :ok]`
+- `[:bedrock, :demux, :persistence, :write, :error]`
+- `[:bedrock, :demux, :persistence, :watermark, :advanced]`
+- `[:bedrock, :demux, :durability, :floor_advanced]`
 
 Suggested alerts:
 
 - sustained non-zero queue backpressure events;
 - increasing retry scheduling without matching write success;
 - stalled watermark advancement for active shards.
+
+See `durability-foundation.md` for the full life of a write — from commit
+through cuts, chunks, and WAL trimming — and the Shale and Olivine guides for
+the log and materializer ends of the same pipeline.


### PR DESCRIPTION
Closes the last open ticket in the bedrock-qzr epic (docs chore).

## Why

`guides/async-persistence-queue.md` opened by describing PersistenceQueue and PersistenceWorker as *future*, intentionally additive infrastructure that "does not change current Demux or external APIs" — and then went on to document the already-integrated `push/4`, deterministic cuts, KCV gating, crash-on-exhausted-retries, and WAL trimming. The opening contradicted the body.

## What

The guide is now current-state documentation. The future/additive/API-preserving framing is gone, replaced with a "how a chunk becomes durable" walk-through that matches production code exactly: buffer-only `push/4`, Demux-commanded cuts fired only once the KCV reaches them, one flush in flight per shard with flushed entries pullable until confirmation, byte-identical chunks making `:already_exists` a truthful confirmation, floor contributions aggregating into the log's watermark, and the deliberate crash of a shard whose flush permanently fails. The telemetry list gains the existing (previously undocumented) `[:bedrock, :demux, :durability, :floor_advanced]` event, and the guide now cross-links durability-foundation.md and the Shale/Olivine guides.

Accuracy check across the qzr guide set: no Basalt references remain, and every `Log.pull` mention is in its correct recovery-only context.

Docs build clean (`mix docs`); full suite 2523 tests, 0 failures.