### PR TITLE
Uniform Shale push transitions; Server owns replies; recovery uses the append primitive (bedrock-qzr.28)

### DIFF
--- a/lib/bedrock/data_plane/log.ex
+++ b/lib/bedrock/data_plane/log.ex
@@ -239,7 +239,7 @@ defmodule Bedrock.DataPlane.Log do
           replay_after :: Bedrock.version(),
           last_inclusive :: Bedrock.version()
         ) ::
-          {:ok, pid()} | {:error, :unavailable}
+          {:ok, pid()} | {:error, {:failed_to_recover, term()}} | {:error, :unavailable}
   def recover_from(log, source_logs, replay_after, last_inclusive),
     do: call(log, {:recover_from, normalize_source_logs(source_logs), replay_after, last_inclusive}, :infinity)
 

--- a/lib/bedrock/data_plane/log/shale/pushing.ex
+++ b/lib/bedrock/data_plane/log/shale/pushing.ex
@@ -1,5 +1,27 @@
 defmodule Bedrock.DataPlane.Log.Shale.Pushing do
-  @moduledoc false
+  @moduledoc """
+  Predecessor scheduling and WAL appends, expressed as one uniform
+  transition.
+
+  This module owns WAL and resource state only. It never replies to a
+  caller, never forwards to the Demux, and never notifies a puller — every
+  `push/4` returns the same transition shape, and `Shale.Server` interprets
+  it exactly once:
+
+    * `state` — the resulting WAL state.
+    * `appended` — the append events, in predecessor-chain order. Each is
+      `{version, encoded_transaction}` (the exact bytes written), which is
+      everything Demux delivery and puller notification need.
+    * `replies` — ordered `{token, result}` instructions. Tokens are the
+      opaque values callers were parked or presented with; this module never
+      looks inside them and never invokes anything.
+    * `parked?` — whether the current request was stored to wait for its
+      predecessor (no reply owed yet).
+
+  The tuple-arity protocol this replaces encoded *whether replies had
+  already been sent* in the shape of the return value; the server had to
+  know which shapes had which side effects. Now the effects are data.
+  """
   import Bedrock.DataPlane.Log.Telemetry
 
   alias Bedrock.DataPlane.Demux
@@ -9,8 +31,15 @@ defmodule Bedrock.DataPlane.Log.Shale.Pushing do
   alias Bedrock.DataPlane.Transaction
   alias Bedrock.DataPlane.Version
 
-  @type appended_transactions :: [Transaction.encoded()]
-  @type append_error :: {:error, term(), State.t(), appended_transactions()}
+  @type append_event :: {Bedrock.version(), Transaction.encoded()}
+  @type reply_token :: term()
+  @type reply_instruction :: {reply_token(), :ok | {:error, term()}}
+  @type transition :: %{
+          state: State.t(),
+          appended: [append_event()],
+          replies: [reply_instruction()],
+          parked?: boolean()
+        }
   @type wal_limit_error ::
           {:recovery_required,
            {:wal_limit_exceeded,
@@ -22,123 +51,148 @@ defmodule Bedrock.DataPlane.Log.Shale.Pushing do
               limit_us: non_neg_integer()
             }}}
 
-  @spec push(
-          t :: State.t(),
-          expected_version :: Bedrock.version(),
-          encoded_transaction :: Transaction.encoded(),
-          ack_fn :: (:ok | {:error, term()} -> :ok)
-        ) ::
-          {:ok, State.t(), appended_transactions()}
-          | {:wait, State.t()}
-          | append_error()
-          | {:error, :not_ready | :tx_out_of_order | :tx_too_large}
-  def push(%{mode: :locked}, _, _, _) do
-    {:error, :not_ready}
-  end
+  @doc """
+  Schedules one live push and returns the resulting transition.
 
-  def push(_, _, encoded_transaction, _ack_fn) when byte_size(encoded_transaction) > 10_000_000 do
-    {:error, :tx_too_large}
-  end
+  Covers immediate success, parking behind a missing predecessor, rejection
+  (locked, oversized, stale, backpressured), ordered multi-entry drains of
+  the pending queue, and partial-drain failure — all in the same shape.
+  """
+  @spec push(State.t(), expected_version :: Bedrock.version(), Transaction.encoded(), reply_token()) ::
+          transition()
+  def push(%{mode: :locked} = t, _, _, token), do: rejection(t, token, :not_ready)
 
-  def push(t, expected_version, encoded_transaction, ack_fn) when expected_version == t.last_version do
-    case write_encoded_transaction(t, encoded_transaction) do
-      {:ok, t} ->
+  def push(t, _, encoded_transaction, token) when byte_size(encoded_transaction) > 10_000_000,
+    do: rejection(t, token, :tx_too_large)
+
+  def push(t, expected_version, encoded_transaction, token) when expected_version == t.last_version do
+    case append_transaction(t, encoded_transaction) do
+      {:ok, t, event} ->
         trace_push_transaction(encoded_transaction)
-        :ok = ack_fn.(:ok)
-        do_pending_pushes(t, [encoded_transaction])
+        drain(t, [event], [{token, :ok}])
 
       {:error, {:recovery_required, {:wal_limit_exceeded, _}} = reason, t} ->
         # Version assignment and resolution have already scheduled this
         # link for commit. Refusing its WAL append invalidates the epoch;
         # release every successor so the commit proxies can fail fast and
         # the Director can recover instead of leaving callers stranded.
-        :ok = ack_fn.({:error, reason})
-        {:error, reason, reject_pending_pushes(t, reason), []}
+        {t, flushed} = reject_all_pending(t, reason)
+        %{state: t, appended: [], replies: [{token, {:error, reason}} | flushed], parked?: false}
 
       {:error, reason, t} ->
-        :ok = ack_fn.({:error, reason})
-        {:error, reason, t, []}
+        rejection(t, token, reason)
     end
   end
 
-  def push(t, expected_version, encoded_transaction, ack_fn) when expected_version > t.last_version do
+  def push(t, expected_version, encoded_transaction, token) when expected_version > t.last_version do
     case admit(t, commit_version_or_nil(encoded_transaction)) do
       :ok ->
-        {:wait, Map.update!(t, :pending_pushes, &Map.put(&1, expected_version, {encoded_transaction, ack_fn}))}
+        parked =
+          Map.update!(t, :pending_pushes, &Map.put(&1, expected_version, {encoded_transaction, token}))
 
-      {:error, _reason} = error ->
-        error
+        %{state: parked, appended: [], replies: [], parked?: true}
+
+      {:error, reason} ->
+        rejection(t, token, reason)
     end
   end
 
-  def push(t, expected_version, _, _) do
+  def push(t, expected_version, _, token) do
     trace_push_out_of_order(expected_version, t.last_version)
-    {:error, :tx_out_of_order}
+    rejection(t, token, :tx_out_of_order)
   end
 
-  @spec do_pending_pushes(State.t()) ::
-          {:ok, State.t(), appended_transactions()} | append_error()
-  def do_pending_pushes(t), do: do_pending_pushes(t, [])
+  defp rejection(t, token, reason), do: %{state: t, appended: [], replies: [{token, {:error, reason}}], parked?: false}
 
-  defp do_pending_pushes(t, appended) do
-    next_expected_version = t.last_version
-
-    case Map.pop(t.pending_pushes, next_expected_version) do
+  # Drains the pending queue along the predecessor chain. A drained entry
+  # that fails to append gets its error reply; on backpressure the rest of
+  # the queue (all later versions, equally inadmissible, gap now
+  # unfillable) is rejected too, while other errors leave the remaining
+  # entries parked — the admitted prefix is the tip either way.
+  defp drain(t, appended, replies) do
+    case Map.pop(t.pending_pushes, t.last_version) do
       {nil, _} ->
-        {:ok, t, Enum.reverse(appended)}
+        %{state: t, appended: Enum.reverse(appended), replies: Enum.reverse(replies), parked?: false}
 
-      {{encoded_transaction, ack_fn}, pending_pushes} ->
-        t_with_updated_pending = %{t | pending_pushes: pending_pushes}
+      {{encoded_transaction, token}, pending_pushes} ->
+        t = %{t | pending_pushes: pending_pushes}
 
-        case write_encoded_transaction(t_with_updated_pending, encoded_transaction) do
-          {:ok, new_t} ->
+        case append_transaction(t, encoded_transaction) do
+          {:ok, t, event} ->
             trace_push_transaction(encoded_transaction)
-            :ok = ack_fn.(:ok)
-            do_pending_pushes(new_t, [encoded_transaction | appended])
+            drain(t, [event | appended], [{token, :ok} | replies])
 
-          {:error, {:recovery_required, {:wal_limit_exceeded, _}} = reason, error_t} ->
+          {:error, {:recovery_required, {:wal_limit_exceeded, _}} = reason, t} ->
             # The admitted prefix remains the durable tip. The failed link
             # makes every queued successor unusable in this epoch, so wake
             # all of their callers and let coordinated recovery decide the
             # committed prefix.
-            :ok = ack_fn.({:error, reason})
-            {:error, reason, reject_pending_pushes(error_t, reason), Enum.reverse(appended)}
+            {t, flushed} = reject_all_pending(t, reason)
 
-          {:error, reason, error_t} ->
-            :ok = ack_fn.({:error, reason})
-            {:error, reason, error_t, Enum.reverse(appended)}
+            %{
+              state: t,
+              appended: Enum.reverse(appended),
+              replies: Enum.reverse([{token, {:error, reason}} | replies], flushed),
+              parked?: false
+            }
+
+          {:error, reason, t} ->
+            %{
+              state: t,
+              appended: Enum.reverse(appended),
+              replies: Enum.reverse([{token, {:error, reason}} | replies]),
+              parked?: false
+            }
         end
     end
   end
 
-  @spec write_encoded_transaction(State.t(), Transaction.encoded()) ::
-          {:ok, State.t()} | {:error, term(), State.t()}
-  def write_encoded_transaction(t, encoded_transaction) when is_nil(t.writer) do
-    version =
-      case Transaction.commit_version(encoded_transaction) do
-        {:ok, version} ->
-          version
+  defp reject_all_pending(t, reason) do
+    flushed = Enum.map(t.pending_pushes, fn {_expected, {_transaction, token}} -> {token, {:error, reason}} end)
+    {%{t | pending_pushes: %{}}, flushed}
+  end
 
-        {:error, reason} ->
-          raise "Failed to extract version: #{inspect(reason)}"
-      end
+  @doc """
+  The single-entry, effect-free WAL append primitive.
 
-    previous_version = t.last_version
+  Appends one encoded transaction — allocating or rolling segments as
+  needed — and returns the new state with the append event, or the error
+  with the caller's state intact. The WAL acknowledgement boundary is here:
+  a returned event means the bytes and their sync completed. No caller
+  reply, no Demux cast, no puller notification.
 
+  Recovery replays through this directly: its source stream is already
+  validated and strictly ordered, so it needs the append, not the
+  scheduler.
+  """
+  @spec append_transaction(State.t(), Transaction.encoded()) ::
+          {:ok, State.t(), append_event()} | {:error, term(), State.t()}
+  def append_transaction(t, encoded_transaction) do
+    case Transaction.commit_version(encoded_transaction) do
+      {:ok, version} ->
+        case do_append(t, encoded_transaction, version) do
+          {:ok, t} -> {:ok, t, {version, encoded_transaction}}
+          {:error, reason, t} -> {:error, reason, t}
+        end
+
+      {:error, reason} ->
+        {:error, reason, t}
+    end
+  end
+
+  defp do_append(t, encoded_transaction, version) when is_nil(t.writer) do
     with :ok <- admit(t, version),
          {:ok, new_segment} <-
-           Segment.allocate_from_recycler(t.segment_recycler, t.path, version, previous_version) do
+           Segment.allocate_from_recycler(t.segment_recycler, t.path, version, t.last_version) do
       stage_successor_and_append(t, new_segment, encoded_transaction, version)
     else
       {:error, reason} -> {:error, reason, t}
     end
   end
 
-  def write_encoded_transaction(t, encoded_transaction) do
-    with {:ok, version} <- Transaction.commit_version(encoded_transaction),
-         :ok <- admit(t, version) do
-      maybe_roll_and_append(t, encoded_transaction, version)
-    else
+  defp do_append(t, encoded_transaction, version) do
+    case admit(t, version) do
+      :ok -> maybe_roll_and_append(t, encoded_transaction, version)
       {:error, reason} -> {:error, reason, t}
     end
   end
@@ -154,7 +208,7 @@ defmodule Bedrock.DataPlane.Log.Shale.Pushing do
       # `available_after` chasing the untrimmed tail. A roll is a rename
       # from the preallocated pool.
       case Writer.close(t.writer) do
-        :ok -> write_encoded_transaction(%{t | writer: nil}, encoded_transaction)
+        :ok -> do_append(%{t | writer: nil}, encoded_transaction, version)
         {:error, reason} -> {:error, reason, t}
       end
     else
@@ -234,7 +288,7 @@ defmodule Bedrock.DataPlane.Log.Shale.Pushing do
 
       {:error, :segment_full} ->
         case Writer.close(t.writer) do
-          :ok -> write_encoded_transaction(%{t | writer: nil}, encoded_transaction)
+          :ok -> do_append(%{t | writer: nil}, encoded_transaction, version)
           {:error, reason} -> {:error, reason, t}
         end
 
@@ -301,11 +355,6 @@ defmodule Bedrock.DataPlane.Log.Shale.Pushing do
       {:ok, version} -> version
       {:error, _} -> nil
     end
-  end
-
-  defp reject_pending_pushes(%{pending_pushes: pending} = t, reason) do
-    Enum.each(pending, fn {_expected, {_transaction, ack_fn}} -> :ok = ack_fn.({:error, reason}) end)
-    %{t | pending_pushes: %{}}
   end
 
   @spec update_segment_transaction_cache(Segment.t(), Transaction.encoded()) :: Segment.t()

--- a/lib/bedrock/data_plane/log/shale/recovery.ex
+++ b/lib/bedrock/data_plane/log/shale/recovery.ex
@@ -6,7 +6,7 @@ defmodule Bedrock.DataPlane.Log.Shale.Recovery do
   available survivor, appends each source binary unchanged, and lets the fresh
   destination Demux perform normal shard slicing.
   """
-  import Bedrock.DataPlane.Log.Shale.Pushing, only: [push: 4]
+  import Bedrock.DataPlane.Log.Shale.Pushing, only: [append_transaction: 2]
 
   alias Bedrock.DataPlane.Demux
   alias Bedrock.DataPlane.Log
@@ -23,13 +23,8 @@ defmodule Bedrock.DataPlane.Log.Shale.Recovery do
           replay_after :: Bedrock.version(),
           last_inclusive :: Bedrock.version()
         ) ::
-          {:ok, State.t()}
-          | {:error, :lock_required}
-          | {:error, {:source_log_unavailable, log_ref :: Log.ref()}}
-          | {:error, :no_source_logs_available}
-          | {:error, {:incomplete_replay, Bedrock.version(), Bedrock.version()}}
-          | {:error, term(), State.t()}
-  def recover_from(t, _, _, _) when t.mode != :locked, do: {:error, :lock_required}
+          {:ok, State.t()} | {:error, term(), State.t()}
+  def recover_from(t, _, _, _) when t.mode != :locked, do: {:error, :lock_required, t}
 
   def recover_from(t, _source_logs, replay_after, last_inclusive) when replay_after > last_inclusive,
     do: {:error, :invalid_version_range, t}
@@ -145,11 +140,7 @@ defmodule Bedrock.DataPlane.Log.Shale.Recovery do
           replay_after :: Bedrock.version(),
           last_inclusive :: Bedrock.version()
         ) ::
-          {:ok, State.t()}
-          | Log.pull_errors()
-          | {:error, {:source_log_unavailable, log_ref :: Log.ref()}}
-          | {:error, :no_source_logs_available}
-          | {:error, term(), State.t()}
+          {:ok, State.t()} | {:error, term(), State.t()}
 
   def pull_transactions_from_sources(t, [], _replay_after, _last_inclusive), do: {:error, :no_source_logs_available, t}
 
@@ -194,10 +185,7 @@ defmodule Bedrock.DataPlane.Log.Shale.Recovery do
           replay_after :: Bedrock.version(),
           last_inclusive :: Bedrock.version()
         ) ::
-          {:ok, State.t()}
-          | Log.pull_errors()
-          | {:error, {:source_log_unavailable, log_ref :: Log.ref()}}
-          | {:error, term(), State.t()}
+          {:ok, State.t()} | {:error, term(), State.t()}
   def pull_transactions(t, _, replay_after, last_inclusive) when replay_after == last_inclusive, do: {:ok, t}
 
   def pull_transactions(t, log_ref, replay_after, last_inclusive) do
@@ -259,17 +247,20 @@ defmodule Bedrock.DataPlane.Log.Shale.Recovery do
           State.t()
         ) ::
           {:cont, {Bedrock.version(), State.t()}} | {:halt, {:error, term(), State.t()}}
-  defp handle_valid_transaction_bytes(bytes, version, cursor, t) do
+  defp handle_valid_transaction_bytes(bytes, version, _cursor, t) do
+    # The source stream is already validated and strictly ordered
+    # (process_versioned_transaction), so replay uses the effect-free
+    # append primitive directly — no predecessor scheduling, no parking,
+    # no acknowledgement plumbing.
     with {:ok, _transaction} <- Transaction.decode(bytes),
-         {:ok, t, [^bytes]} <- push(t, cursor, bytes, fn _ -> :ok end) do
+         {:ok, t, {^version, _}} <- append_transaction(t, bytes) do
       # Replay routes through the fresh Demux so the replayed range re-enters
       # the chunk pipeline and re-confirms deterministically.
       push_to_demux(t, version, bytes)
       {:cont, {version, t}}
     else
-      {:wait, t} -> {:halt, {:error, :tx_out_of_order, t}}
       {:error, :invalid_format} -> {:halt, {:error, :invalid_transaction, t}}
-      {:error, reason, t, _appended_transactions} -> {:halt, {:error, reason, t}}
+      {:error, reason, t} -> {:halt, {:error, reason, t}}
       {:error, reason} -> {:halt, {:error, reason, t}}
     end
   end
@@ -292,10 +283,13 @@ defmodule Bedrock.DataPlane.Log.Shale.Recovery do
     end)
   end
 
+  # Parked pushes hold opaque caller tokens (GenServer froms), not
+  # closures; recovery runs inside the server process, so replying to
+  # them here is the server replying.
   @spec abort_all_pending_pushes(State.t()) :: State.t()
   def abort_all_pending_pushes(%{pending_pushes: pending_pushes} = t) do
-    Enum.each(pending_pushes, fn {_version, {_transaction, ack_fn}} ->
-      :ok = ack_fn.({:error, :not_ready})
+    Enum.each(pending_pushes, fn {_version, {_transaction, from}} ->
+      :ok = GenServer.reply(from, {:error, :not_ready})
     end)
 
     %{t | pending_pushes: %{}}

--- a/lib/bedrock/data_plane/log/shale/server.ex
+++ b/lib/bedrock/data_plane/log/shale/server.ex
@@ -113,7 +113,7 @@ defmodule Bedrock.DataPlane.Log.Shale.Server do
   @impl true
   @spec handle_continue(
           :initialization
-          | {:notify_waiting_pullers, Bedrock.version(), Transaction.encoded()}
+          | {:notify_appended, [{Bedrock.version(), Transaction.encoded()}]}
           | :check_for_expired_pullers
           | :wait_for_next_puller_deadline,
           State.t()
@@ -135,12 +135,15 @@ defmodule Bedrock.DataPlane.Log.Shale.Server do
   end
 
   @impl true
-  def handle_continue({:notify_waiting_pullers, version, transaction}, t) do
+  def handle_continue({:notify_appended, events}, t) do
+    # Wake pullers from the authoritative append events themselves — each
+    # event carries its own version and bytes, in predecessor-chain order.
     t
-    |> Map.update!(
-      :waiting_pullers,
-      &notify_waiting_pullers(&1, version, transaction)
-    )
+    |> Map.update!(:waiting_pullers, fn waiting_pullers ->
+      Enum.reduce(events, waiting_pullers, fn {version, transaction}, acc ->
+        notify_waiting_pullers(acc, version, transaction)
+      end)
+    end)
     |> noreply(continue: :check_for_expired_pullers)
   end
 
@@ -232,7 +235,6 @@ defmodule Bedrock.DataPlane.Log.Shale.Server do
     case recover_from(t, source_logs, replay_after, last_inclusive) do
       {:ok, t} -> reply(t, {:ok, self()})
       {:error, reason, t} -> reply(t, {:error, {:failed_to_recover, reason}})
-      {:error, reason} -> reply(t, {:error, {:failed_to_recover, reason}})
     end
   end
 
@@ -240,20 +242,9 @@ defmodule Bedrock.DataPlane.Log.Shale.Server do
   def handle_call({:push, transaction_bytes, expected_version, known_committed_version}, from, %State{} = t) do
     with {:ok, transaction} <- Transaction.validate(transaction_bytes),
          :ok <- validate_has_shard_index(transaction) do
-      case push(t, expected_version, transaction, ack_fn(from)) do
-        {:ok, t, appended_transactions} ->
-          finish_push(t, appended_transactions, known_committed_version, expected_version, transaction)
-
-        {:wait, t} ->
-          advance_demux_kcv(t.demux, known_committed_version)
-          noreply(t, continue: :check_for_expired_pullers)
-
-        {:error, _reason, t, appended_transactions} ->
-          finish_push(t, appended_transactions, known_committed_version, expected_version, transaction)
-
-        {:error, _reason} = error ->
-          reply(t, error, continue: :check_for_expired_pullers)
-      end
+      t
+      |> push(expected_version, transaction, from)
+      |> apply_push_transition(known_committed_version)
     else
       {:error, _reason} = error -> reply(t, error, continue: :check_for_expired_pullers)
     end
@@ -325,30 +316,36 @@ defmodule Bedrock.DataPlane.Log.Shale.Server do
     end
   end
 
-  # Pushing owns predecessor scheduling and WAL appends; the Server owns the
-  # corresponding live Demux delivery. The binaries returned here are the
-  # exact ref-counted inputs written to the WAL, already in predecessor-chain
-  # order, so forwarding neither slices nor copies them.
-  defp finish_push(t, appended_transactions, known_committed_version, expected_version, transaction) do
-    forward_appended_transactions(t.demux, appended_transactions, known_committed_version)
+  # The Server is the sole owner of live effects, applied exactly once
+  # from the transition Pushing returned: every caller reply is issued
+  # here (tokens are the callers' `from`s), every append event forwards
+  # to the Demux in predecessor-chain order, and puller notification runs
+  # from those same authoritative events. The binaries in the events are
+  # the exact ref-counted inputs written to the WAL, so forwarding
+  # neither slices nor copies them.
+  defp apply_push_transition(
+         %{state: t, appended: appended, replies: replies, parked?: parked?},
+         known_committed_version
+       ) do
+    Enum.each(replies, fn {from, result} -> GenServer.reply(from, result) end)
+    forward_appended_transactions(t.demux, appended, known_committed_version)
 
-    if appended_transactions == [] do
+    # A parked push carries commit evidence even though nothing appended:
+    # the known-committed version still advances the Demux's cut gate.
+    if parked?, do: advance_demux_kcv(t.demux, known_committed_version)
+
+    if appended == [] do
       noreply(t, continue: :check_for_expired_pullers)
     else
-      noreply(t, continue: {:notify_waiting_pullers, expected_version, transaction})
+      noreply(t, continue: {:notify_appended, appended})
     end
   end
 
-  defp forward_appended_transactions(nil, _transactions, _known_committed_version), do: :ok
+  defp forward_appended_transactions(nil, _events, _known_committed_version), do: :ok
 
-  defp forward_appended_transactions(demux, transactions, known_committed_version) do
-    Enum.each(transactions, fn transaction ->
-      Demux.Server.push(
-        demux,
-        Transaction.commit_version!(transaction),
-        transaction,
-        known_committed_version
-      )
+  defp forward_appended_transactions(demux, events, known_committed_version) do
+    Enum.each(events, fn {version, transaction} ->
+      Demux.Server.push(demux, version, transaction, known_committed_version)
     end)
   end
 
@@ -361,9 +358,6 @@ defmodule Bedrock.DataPlane.Log.Shale.Server do
 
   @spec check_running(term()) :: {:error, :unavailable}
   def check_running(_t), do: {:error, :unavailable}
-
-  @spec ack_fn(GenServer.from()) :: (:ok | {:error, term()} -> :ok)
-  def ack_fn(from), do: fn result -> GenServer.reply(from, result) end
 
   @spec reply_to_fn(GenServer.from()) :: (term() -> :ok)
   def reply_to_fn(from), do: &GenServer.reply(from, &1)

--- a/lib/bedrock/data_plane/log/shale/state.ex
+++ b/lib/bedrock/data_plane/log/shale/state.ex
@@ -36,8 +36,7 @@ defmodule Bedrock.DataPlane.Log.Shale.State do
           active_segment: Segment.t() | nil,
           segments: [Segment.t()],
           pending_pushes: %{
-            Bedrock.version() =>
-              {encoded_transaction :: Transaction.encoded(), ack_fn :: (:ok | {:error, term()} -> :ok)}
+            Bedrock.version() => {encoded_transaction :: Transaction.encoded(), reply_token :: term()}
           },
           #
           floor_lag_alarm_active: boolean(),

--- a/test/bedrock/data_plane/log/shale/durability_contract_test.exs
+++ b/test/bedrock/data_plane/log/shale/durability_contract_test.exs
@@ -60,18 +60,10 @@ defmodule Bedrock.DataPlane.Log.Shale.DurabilityContractTest do
     }
 
     transaction = TransactionTestSupport.new_log_transaction(0, %{"k" => "v"})
-    caller = self()
-
-    ack_fn = fn result ->
-      send(caller, {:ack_result, result})
-      :ok
-    end
-
-    assert {:error, :eio, ^state, []} =
-             Pushing.push(state, Version.from_integer(0), transaction, ack_fn)
-
-    assert_receive {:ack_result, {:error, :eio}}
-    refute_receive {:ack_result, :ok}, 20
+    # The transition carries no append event and exactly one reply — the
+    # error — so no false success acknowledgement can exist.
+    assert %{state: ^state, appended: [], replies: [{:tok, {:error, :eio}}], parked?: false} =
+             Pushing.push(state, Version.from_integer(0), transaction, :tok)
 
     assert :ok = Writer.close(writer)
   end

--- a/test/bedrock/data_plane/log/shale/pushing_test.exs
+++ b/test/bedrock/data_plane/log/shale/pushing_test.exs
@@ -11,6 +11,10 @@ defmodule Bedrock.DataPlane.Log.Shale.PushingTest do
   alias Bedrock.DataPlane.Version
   alias Bedrock.Test.DataPlane.TransactionTestSupport
 
+  # Every push returns the same transition shape; these tests assert the
+  # effects as data (replies, append events, parking) rather than
+  # observing callbacks — Pushing performs no effects itself.
+  #
   # ExUnit owns the directory lifecycle: each test gets a fresh tmp_dir,
   # wiped before the test runs — so no teardown can race the linked
   # recycler still creating preallocated files.
@@ -28,55 +32,57 @@ defmodule Bedrock.DataPlane.Log.Shale.PushingTest do
     %{dir: dir, recycler: recycler}
   end
 
-  describe "push/4 error conditions" do
+  describe "push/4 rejections" do
+    test "rejects while locked" do
+      state = %State{mode: :locked, last_version: Version.zero()}
+
+      assert %{state: ^state, appended: [], replies: [{:tok, {:error, :not_ready}}], parked?: false} =
+               Pushing.push(state, Version.zero(), <<1, 2, 3>>, :tok)
+    end
+
     test "rejects transaction that is too large" do
       state = %State{
-        mode: :ready,
+        mode: :running,
         last_version: Version.from_integer(0)
       }
 
       # Create a transaction larger than 10MB limit
       large_transaction = :binary.copy(<<0>>, 10_000_001)
-      ack_fn = fn _result -> :ok end
 
-      assert {:error, :tx_too_large} =
-               Pushing.push(state, Version.from_integer(1), large_transaction, ack_fn)
+      assert %{state: ^state, appended: [], replies: [{:tok, {:error, :tx_too_large}}], parked?: false} =
+               Pushing.push(state, Version.from_integer(1), large_transaction, :tok)
     end
 
     test "rejects out of order transaction with version less than last_version" do
       state = %State{
-        mode: :ready,
+        mode: :running,
         last_version: Version.from_integer(5),
         pending_pushes: %{}
       }
 
       transaction = TransactionTestSupport.new_log_transaction(3, %{"a" => "1"})
-      ack_fn = fn _result -> :ok end
 
       # Trying to push version 3 when last_version is 5
-      assert {:error, :tx_out_of_order} =
-               Pushing.push(state, Version.from_integer(3), transaction, ack_fn)
+      assert %{state: ^state, appended: [], replies: [{:tok, {:error, :tx_out_of_order}}], parked?: false} =
+               Pushing.push(state, Version.from_integer(3), transaction, :tok)
     end
 
-    test "waits for future transaction version" do
+    test "parks a future transaction version with its token, unreplied" do
       state = %State{
-        mode: :ready,
+        mode: :running,
         last_version: Version.from_integer(5),
         pending_pushes: %{}
       }
 
       transaction = TransactionTestSupport.new_log_transaction(10, %{"a" => "1"})
-      ack_fn = fn _result -> :ok end
 
-      # Trying to push version 10 when last_version is 5 should wait
-      assert {:wait, new_state} =
-               Pushing.push(state, Version.from_integer(10), transaction, ack_fn)
+      assert %{state: parked_state, appended: [], replies: [], parked?: true} =
+               Pushing.push(state, Version.from_integer(10), transaction, :tok)
 
-      # Transaction should be in pending pushes
-      assert Map.has_key?(new_state.pending_pushes, Version.from_integer(10))
+      assert {^transaction, :tok} = Map.fetch!(parked_state.pending_pushes, Version.from_integer(10))
     end
 
-    test "acknowledges sync failure as push error" do
+    test "a sync failure is an error reply with the caller's state intact" do
       path = Path.join(System.tmp_dir!(), "shale_push_sync_fail_#{System.unique_integer([:positive])}.log")
       File.write!(path, :binary.copy(<<0>>, 1024))
 
@@ -87,7 +93,7 @@ defmodule Bedrock.DataPlane.Log.Shale.PushingTest do
       assert {:ok, writer} = Writer.open(path, Version.zero(), sync_fun: fn _fd -> {:error, :eio} end)
 
       state = %State{
-        mode: :ready,
+        mode: :running,
         last_version: Version.from_integer(0),
         pending_pushes: %{},
         writer: writer,
@@ -95,17 +101,9 @@ defmodule Bedrock.DataPlane.Log.Shale.PushingTest do
       }
 
       transaction = TransactionTestSupport.new_log_transaction(0, %{"a" => "1"})
-      caller = self()
 
-      ack_fn = fn result ->
-        send(caller, {:ack_result, result})
-        :ok
-      end
-
-      assert {:error, :eio, ^state, []} =
-               Pushing.push(state, Version.from_integer(0), transaction, ack_fn)
-
-      assert_receive {:ack_result, {:error, :eio}}
+      assert %{state: ^state, appended: [], replies: [{:tok, {:error, :eio}}], parked?: false} =
+               Pushing.push(state, Version.from_integer(0), transaction, :tok)
 
       assert :ok = Writer.close(writer)
     end
@@ -114,9 +112,9 @@ defmodule Bedrock.DataPlane.Log.Shale.PushingTest do
   describe "draining queued pushes" do
     setup :recycler_in_tmp_dir
 
-    test "returns every appended transaction in predecessor-chain order", %{dir: dir, recycler: recycler} do
+    test "a drain returns every append event and reply in predecessor-chain order", %{dir: dir, recycler: recycler} do
       state = %State{
-        mode: :ready,
+        mode: :running,
         path: dir,
         segment_recycler: recycler,
         writer: nil,
@@ -126,34 +124,31 @@ defmodule Bedrock.DataPlane.Log.Shale.PushingTest do
         pending_pushes: %{}
       }
 
+      v1 = Version.from_integer(1)
+      v2 = Version.from_integer(2)
       first = TransactionTestSupport.new_log_transaction(1, %{"first" => "1"})
       second = TransactionTestSupport.new_log_transaction(2, %{"second" => "2"})
-      caller = self()
 
-      assert {:wait, state} =
-               Pushing.push(state, Version.from_integer(1), second, fn result ->
-                 send(caller, {:ack, :second, result})
-                 :ok
-               end)
+      assert %{state: state, parked?: true, replies: []} =
+               Pushing.push(state, v1, second, :second_token)
 
-      refute_receive {:ack, :second, _}
+      assert %{
+               state: state,
+               appended: [{^v1, ^first}, {^v2, ^second}],
+               replies: [{:first_token, :ok}, {:second_token, :ok}],
+               parked?: false
+             } = Pushing.push(state, Version.zero(), first, :first_token)
 
-      assert {:ok, state, [^first, ^second]} =
-               Pushing.push(state, Version.zero(), first, fn result ->
-                 send(caller, {:ack, :first, result})
-                 :ok
-               end)
-
-      assert_receive {:ack, :first, :ok}
-      assert_receive {:ack, :second, :ok}
-      assert state.last_version == Version.from_integer(2)
+      assert state.last_version == v2
       assert state.pending_pushes == %{}
     end
 
-    test "retains the valid state and appended prefix when a queued append fails" do
+    test "a partial drain keeps the admitted prefix and reports the failure", ctx do
       path = Path.join(System.tmp_dir!(), "pushing_partial_#{System.unique_integer([:positive])}.log")
       File.write!(path, :binary.copy(<<0>>, 1_000_000))
       on_exit(fn -> File.rm(path) end)
+
+      _ = ctx
 
       {:ok, sync_count} = Agent.start_link(fn -> 0 end)
 
@@ -167,34 +162,181 @@ defmodule Bedrock.DataPlane.Log.Shale.PushingTest do
       assert {:ok, writer} = Writer.open(path, Version.zero(), sync_fun: sync_fun)
 
       state = %State{
-        mode: :ready,
+        mode: :running,
         last_version: Version.zero(),
         pending_pushes: %{},
         writer: writer,
         active_segment: %Segment{path: path, min_version: Version.zero(), transactions: []}
       }
 
+      v1 = Version.from_integer(1)
       first = TransactionTestSupport.new_log_transaction(1, %{"first" => "1"})
       second = TransactionTestSupport.new_log_transaction(2, %{"second" => "2"})
-      caller = self()
 
-      assert {:wait, state} =
-               Pushing.push(state, Version.from_integer(1), second, fn result ->
-                 send(caller, {:ack, :second, result})
-                 :ok
-               end)
+      assert %{state: state, parked?: true} = Pushing.push(state, v1, second, :second_token)
 
-      assert {:error, :eio, state, [^first]} =
-               Pushing.push(state, Version.zero(), first, fn result ->
-                 send(caller, {:ack, :first, result})
-                 :ok
-               end)
+      assert %{
+               state: state,
+               appended: [{^v1, ^first}],
+               replies: [{:first_token, :ok}, {:second_token, {:error, :eio}}],
+               parked?: false
+             } = Pushing.push(state, Version.zero(), first, :first_token)
 
-      assert_receive {:ack, :first, :ok}
-      assert_receive {:ack, :second, {:error, :eio}}
-      assert state.last_version == Version.from_integer(1)
+      assert state.last_version == v1
       assert state.pending_pushes == %{}
       assert :ok = Writer.close(state.writer)
+    end
+  end
+
+  describe "WAL safety limit bounds every prospective commit version" do
+    setup :recycler_in_tmp_dir
+
+    defp bounded_state(dir, recycler, limit, floor_int) do
+      %State{
+        mode: :running,
+        path: dir,
+        segment_recycler: recycler,
+        writer: nil,
+        active_segment: nil,
+        segments: [],
+        last_version: Version.from_integer(1_000),
+        available_after: Version.from_integer(1_000),
+        oldest_version: Version.from_integer(1_000),
+        reject_pushes_above_lag_us: limit,
+        min_durable_version: floor_int && Version.from_integer(floor_int),
+        pending_pushes: %{}
+      }
+    end
+
+    defp bp_tx(version_int), do: TransactionTestSupport.new_log_transaction(version_int, %{"k" => "v"})
+
+    defp assert_wal_limit_error(reason, expected) do
+      assert {:recovery_required, {:wal_limit_exceeded, details}} = reason
+
+      Enum.each(expected, fn {key, value} ->
+        assert Map.fetch!(details, key) == value
+      end)
+
+      reason
+    end
+
+    test "a direct push beyond the bound trips the recovery-required fuse before append",
+         %{dir: dir, recycler: recycler} do
+      state = bounded_state(dir, recycler, 1_000, 1_000)
+
+      assert %{state: after_state, appended: [], replies: [{:tok, {:error, reason}}], parked?: false} =
+               Pushing.push(state, Version.from_integer(1_000), bp_tx(2_001), :tok)
+
+      assert_wal_limit_error(reason,
+        commit_version: Version.from_integer(2_001),
+        min_durable_version: Version.from_integer(1_000),
+        last_version: Version.from_integer(1_000),
+        lag_us: 1_001,
+        limit_us: 1_000
+      )
+
+      assert after_state.last_version == Version.from_integer(1_000)
+    end
+
+    test "a future push beyond the bound signals recovery instead of entering the queue",
+         %{dir: dir, recycler: recycler} do
+      state = bounded_state(dir, recycler, 1_000, 1_000)
+
+      assert %{appended: [], replies: [{:tok, {:error, reason}}], parked?: false} =
+               Pushing.push(state, Version.from_integer(3_000), bp_tx(4_000), :tok)
+
+      assert_wal_limit_error(reason,
+        commit_version: Version.from_integer(4_000),
+        min_durable_version: Version.from_integer(1_000),
+        last_version: Version.from_integer(1_000),
+        lag_us: 3_000,
+        limit_us: 1_000
+      )
+    end
+
+    test "entries queued before the floor existed cannot cross the bound when the gap fills",
+         %{dir: dir, recycler: recycler} do
+      # No durable floor yet: the future push is admitted unchecked (the
+      # bound cannot be evaluated without a floor).
+      state = bounded_state(dir, recycler, 2_500, nil)
+
+      assert %{state: state, parked?: true} =
+               Pushing.push(state, Version.from_integer(3_000), bp_tx(5_000), :queued_token)
+
+      # The first confirmation establishes the floor. Filling the gap now
+      # admits the filler (2_000 <= 2_500 behind the floor) but must NOT
+      # blindly drain the queue past the bound: the queued transaction sits
+      # 4_000 behind the floor.
+      state = %{state | min_durable_version: Version.from_integer(1_000)}
+      filler = bp_tx(3_000)
+      v3000 = Version.from_integer(3_000)
+
+      assert %{
+               state: after_state,
+               appended: [{^v3000, ^filler}],
+               replies: [{:filler_token, :ok}, {:queued_token, {:error, reason}}],
+               parked?: false
+             } = Pushing.push(state, Version.from_integer(1_000), filler, :filler_token)
+
+      assert_wal_limit_error(reason,
+        commit_version: Version.from_integer(5_000),
+        min_durable_version: Version.from_integer(1_000),
+        last_version: Version.from_integer(3_000),
+        lag_us: 4_000,
+        limit_us: 2_500
+      )
+
+      # Ordering state stays consistent: the admitted prefix is the tip,
+      # the rejected suffix is gone, nobody is stranded.
+      assert after_state.last_version == v3000
+      assert after_state.pending_pushes == %{}
+    end
+
+    test "tripping the fuse releases every queued successor so recovery cannot strand callers",
+         %{dir: dir, recycler: recycler} do
+      state = bounded_state(dir, recycler, 2_500, nil)
+
+      assert %{state: state, parked?: true} =
+               Pushing.push(state, Version.from_integer(9_000), bp_tx(9_500), :queued_token_1)
+
+      assert %{state: state, parked?: true} =
+               Pushing.push(state, Version.from_integer(9_500), bp_tx(10_000), :queued_token_2)
+
+      state = %{state | min_durable_version: Version.from_integer(1_000)}
+
+      assert %{
+               state: after_state,
+               appended: [],
+               replies: [
+                 {:direct_token, {:error, reason}},
+                 {:queued_token_1, {:error, reason_1}},
+                 {:queued_token_2, {:error, reason_2}}
+               ],
+               parked?: false
+             } = Pushing.push(state, Version.from_integer(1_000), bp_tx(9_000), :direct_token)
+
+      assert_wal_limit_error(reason,
+        commit_version: Version.from_integer(9_000),
+        min_durable_version: Version.from_integer(1_000),
+        last_version: Version.from_integer(1_000),
+        lag_us: 8_000,
+        limit_us: 2_500
+      )
+
+      assert reason_1 == reason
+      assert reason_2 == reason
+      assert after_state.pending_pushes == %{}
+    end
+
+    test "with no hard limit, arbitrarily lagged pushes stay admitted", %{dir: dir, recycler: recycler} do
+      state = bounded_state(dir, recycler, nil, 1_000)
+      tx = bp_tx(10_000_000)
+      v = Version.from_integer(10_000_000)
+
+      assert %{state: state, appended: [{^v, ^tx}], replies: [{:tok, :ok}], parked?: false} =
+               Pushing.push(state, Version.from_integer(1_000), tx, :tok)
+
+      assert state.last_version == v
     end
   end
 
@@ -203,7 +345,7 @@ defmodule Bedrock.DataPlane.Log.Shale.PushingTest do
 
     defp write!(state, version_int) do
       tx = TransactionTestSupport.new_log_transaction(version_int, %{"k" => "v"})
-      {:ok, state} = Pushing.write_encoded_transaction(state, tx)
+      {:ok, state, _event} = Pushing.append_transaction(state, tx)
       state
     end
 
@@ -211,7 +353,7 @@ defmodule Bedrock.DataPlane.Log.Shale.PushingTest do
       interval = Demux.Server.default_cut_interval_us()
 
       state = %State{
-        mode: :ready,
+        mode: :running,
         path: dir,
         segment_recycler: recycler,
         writer: nil,
@@ -265,7 +407,7 @@ defmodule Bedrock.DataPlane.Log.Shale.PushingTest do
 
     defp state_with(dir, recycler, writer_opts) do
       %State{
-        mode: :ready,
+        mode: :running,
         path: dir,
         segment_recycler: recycler,
         writer: nil,
@@ -287,8 +429,8 @@ defmodule Bedrock.DataPlane.Log.Shale.PushingTest do
       {control, sync_fun} = controlled_sync()
 
       state = state_with(dir, recycler, sync_fun: sync_fun)
-      {:ok, state} = Pushing.write_encoded_transaction(state, tx(1_000))
-      {:ok, state} = Pushing.write_encoded_transaction(state, tx(2_000))
+      {:ok, state, _} = Pushing.append_transaction(state, tx(1_000))
+      {:ok, state, _} = Pushing.append_transaction(state, tx(2_000))
       predecessor = state.active_segment
       wal_files_before = wal_files(dir)
 
@@ -297,7 +439,7 @@ defmodule Bedrock.DataPlane.Log.Shale.PushingTest do
       Agent.update(control, &%{&1 | fail: true})
 
       assert {:error, :eio, failed_state} =
-               Pushing.write_encoded_transaction(state, tx(interval + 1))
+               Pushing.append_transaction(state, tx(interval + 1))
 
       # The predecessor is still the active segment — not in the
       # trim-eligible list — and no successor is represented as owned WAL
@@ -317,8 +459,8 @@ defmodule Bedrock.DataPlane.Log.Shale.PushingTest do
       Agent.update(control, &%{&1 | fail: false})
       Agent.update(control, &%{&1 | calls: 0})
 
-      assert {:ok, rolled_state} =
-               Pushing.write_encoded_transaction(failed_state, tx(interval + 1))
+      assert {:ok, rolled_state, _} =
+               Pushing.append_transaction(failed_state, tx(interval + 1))
 
       assert rolled_state.active_segment.min_version == Version.from_integer(interval + 1)
       assert [%{path: rolled_predecessor_path}] = rolled_state.segments
@@ -346,14 +488,14 @@ defmodule Bedrock.DataPlane.Log.Shale.PushingTest do
       end
 
       state = state_with(dir, recycler, pwrite_fun: pwrite_fun)
-      {:ok, state} = Pushing.write_encoded_transaction(state, tx(1_000))
+      {:ok, state, _} = Pushing.append_transaction(state, tx(1_000))
       predecessor = state.active_segment
       wal_files_before = wal_files(dir)
 
       Agent.update(control, fn _ -> true end)
 
       assert {:error, :enospc, failed_state} =
-               Pushing.write_encoded_transaction(state, tx(interval + 1))
+               Pushing.append_transaction(state, tx(interval + 1))
 
       assert failed_state.active_segment.path == predecessor.path
       assert failed_state.segments == []
@@ -363,8 +505,8 @@ defmodule Bedrock.DataPlane.Log.Shale.PushingTest do
 
       Agent.update(control, fn _ -> false end)
 
-      assert {:ok, rolled_state} =
-               Pushing.write_encoded_transaction(failed_state, tx(interval + 1))
+      assert {:ok, rolled_state, _} =
+               Pushing.append_transaction(failed_state, tx(interval + 1))
 
       assert rolled_state.active_segment.min_version == Version.from_integer(interval + 1)
       assert [%{path: kept}] = rolled_state.segments
@@ -379,171 +521,17 @@ defmodule Bedrock.DataPlane.Log.Shale.PushingTest do
       state = state_with(dir, recycler, sync_fun: sync_fun)
       first = tx(1_000)
       second = tx(2_000)
-      {:ok, state} = Pushing.write_encoded_transaction(state, first)
-      {:ok, state} = Pushing.write_encoded_transaction(state, second)
+      {:ok, state, _} = Pushing.append_transaction(state, first)
+      {:ok, state, _} = Pushing.append_transaction(state, second)
 
       Agent.update(control, &%{&1 | fail: true})
-      assert {:error, :eio, _failed_state} = Pushing.write_encoded_transaction(state, tx(interval + 1))
+      assert {:error, :eio, _failed_state} = Pushing.append_transaction(state, tx(interval + 1))
 
       # What a cold start reads from disk is the predecessor alone, with
       # both transactions and its original replay cursor.
       assert {:ok, [segment]} = ColdStarting.reload_segments_at_path(dir)
       assert segment.previous_version == Version.from_integer(0)
       assert [^second, ^first] = Segment.transactions(segment)
-    end
-  end
-
-  describe "WAL safety limit bounds every prospective commit version" do
-    setup :recycler_in_tmp_dir
-
-    defp bounded_state(dir, recycler, limit, floor_int) do
-      %State{
-        mode: :running,
-        path: dir,
-        segment_recycler: recycler,
-        writer: nil,
-        active_segment: nil,
-        segments: [],
-        last_version: Version.from_integer(1_000),
-        available_after: Version.from_integer(1_000),
-        oldest_version: Version.from_integer(1_000),
-        reject_pushes_above_lag_us: limit,
-        min_durable_version: floor_int && Version.from_integer(floor_int),
-        pending_pushes: %{}
-      }
-    end
-
-    defp bp_tx(version_int), do: TransactionTestSupport.new_log_transaction(version_int, %{"k" => "v"})
-
-    defp ack_to(caller, tag) do
-      fn result ->
-        send(caller, {:ack, tag, result})
-        :ok
-      end
-    end
-
-    defp assert_wal_limit_error(reason, expected) do
-      assert {:recovery_required, {:wal_limit_exceeded, details}} = reason
-
-      Enum.each(expected, fn {key, value} ->
-        assert Map.fetch!(details, key) == value
-      end)
-
-      reason
-    end
-
-    test "a direct push beyond the bound trips the recovery-required fuse before append",
-         %{dir: dir, recycler: recycler} do
-      state = bounded_state(dir, recycler, 1_000, 1_000)
-      caller = self()
-
-      assert {:error, reason, after_state, []} =
-               Pushing.push(state, Version.from_integer(1_000), bp_tx(2_001), ack_to(caller, :direct))
-
-      assert_wal_limit_error(reason,
-        commit_version: Version.from_integer(2_001),
-        min_durable_version: Version.from_integer(1_000),
-        last_version: Version.from_integer(1_000),
-        lag_us: 1_001,
-        limit_us: 1_000
-      )
-
-      assert_receive {:ack, :direct, {:error, ^reason}}
-      assert after_state.last_version == Version.from_integer(1_000)
-    end
-
-    test "a future push beyond the bound signals recovery instead of entering the queue",
-         %{dir: dir, recycler: recycler} do
-      state = bounded_state(dir, recycler, 1_000, 1_000)
-
-      assert {:error, reason} =
-               Pushing.push(state, Version.from_integer(3_000), bp_tx(4_000), fn _ -> :ok end)
-
-      assert_wal_limit_error(reason,
-        commit_version: Version.from_integer(4_000),
-        min_durable_version: Version.from_integer(1_000),
-        last_version: Version.from_integer(1_000),
-        lag_us: 3_000,
-        limit_us: 1_000
-      )
-    end
-
-    test "entries queued before the floor existed cannot cross the bound when the gap fills",
-         %{dir: dir, recycler: recycler} do
-      # No durable floor yet: the future push is admitted unchecked (the
-      # bound cannot be evaluated without a floor).
-      state = bounded_state(dir, recycler, 2_500, nil)
-      caller = self()
-
-      assert {:wait, state} =
-               Pushing.push(state, Version.from_integer(3_000), bp_tx(5_000), ack_to(caller, :queued))
-
-      # The first confirmation establishes the floor. Filling the gap now
-      # admits the filler (2_000 <= 2_500 behind the floor) but must NOT
-      # blindly drain the queue past the bound: the queued transaction sits
-      # 4_000 behind the floor.
-      state = %{state | min_durable_version: Version.from_integer(1_000)}
-      filler = bp_tx(3_000)
-
-      assert {:error, reason, after_state, [^filler]} =
-               Pushing.push(state, Version.from_integer(1_000), filler, ack_to(caller, :filler))
-
-      assert_wal_limit_error(reason,
-        commit_version: Version.from_integer(5_000),
-        min_durable_version: Version.from_integer(1_000),
-        last_version: Version.from_integer(3_000),
-        lag_us: 4_000,
-        limit_us: 2_500
-      )
-
-      assert_receive {:ack, :filler, :ok}
-      assert_receive {:ack, :queued, {:error, ^reason}}
-
-      # Ordering state stays consistent: the admitted prefix is the tip,
-      # the rejected suffix is gone, nobody is stranded.
-      assert after_state.last_version == Version.from_integer(3_000)
-      assert after_state.pending_pushes == %{}
-    end
-
-    test "tripping the fuse releases every queued successor so recovery cannot strand callers",
-         %{dir: dir, recycler: recycler} do
-      state = bounded_state(dir, recycler, 2_500, nil)
-      caller = self()
-
-      assert {:wait, state} =
-               Pushing.push(state, Version.from_integer(9_000), bp_tx(9_500), ack_to(caller, :queued_1))
-
-      assert {:wait, state} =
-               Pushing.push(state, Version.from_integer(9_500), bp_tx(10_000), ack_to(caller, :queued_2))
-
-      state = %{state | min_durable_version: Version.from_integer(1_000)}
-
-      assert {:error, reason, after_state, []} =
-               Pushing.push(state, Version.from_integer(1_000), bp_tx(9_000), ack_to(caller, :direct))
-
-      assert_wal_limit_error(reason,
-        commit_version: Version.from_integer(9_000),
-        min_durable_version: Version.from_integer(1_000),
-        last_version: Version.from_integer(1_000),
-        lag_us: 8_000,
-        limit_us: 2_500
-      )
-
-      assert_receive {:ack, :direct, {:error, ^reason}}
-      assert_receive {:ack, :queued_1, {:error, ^reason}}
-      assert_receive {:ack, :queued_2, {:error, ^reason}}
-      assert after_state.pending_pushes == %{}
-    end
-
-    test "with no hard limit, arbitrarily lagged pushes stay admitted", %{dir: dir, recycler: recycler} do
-      state = bounded_state(dir, recycler, nil, 1_000)
-      caller = self()
-
-      assert {:ok, state, [_tx]} =
-               Pushing.push(state, Version.from_integer(1_000), bp_tx(10_000_000), ack_to(caller, :unbounded))
-
-      assert_receive {:ack, :unbounded, :ok}
-      assert state.last_version == Version.from_integer(10_000_000)
     end
   end
 
@@ -566,7 +554,7 @@ defmodule Bedrock.DataPlane.Log.Shale.PushingTest do
       assert {:ok, writer} = Writer.open(path, Version.zero())
 
       state = %State{
-        mode: :ready,
+        mode: :running,
         last_version: Version.from_integer(1_000),
         available_after: Version.zero(),
         oldest_version: Version.from_integer(1_000),
@@ -579,7 +567,7 @@ defmodule Bedrock.DataPlane.Log.Shale.PushingTest do
       }
 
       tx = TransactionTestSupport.new_log_transaction(2_000, %{"k" => "v"})
-      assert {:ok, state} = Pushing.write_encoded_transaction(state, tx)
+      assert {:ok, state, _event} = Pushing.append_transaction(state, tx)
 
       # Nonempty WAL (tip past the floor): oldest_version is retained.
       assert state.oldest_version == Version.from_integer(1_000)
@@ -594,7 +582,7 @@ defmodule Bedrock.DataPlane.Log.Shale.PushingTest do
       floor = Version.from_integer(5_000)
 
       state = %State{
-        mode: :ready,
+        mode: :running,
         path: dir,
         segment_recycler: recycler,
         writer: nil,
@@ -606,22 +594,22 @@ defmodule Bedrock.DataPlane.Log.Shale.PushingTest do
       }
 
       tx = TransactionTestSupport.new_log_transaction(6_000, %{"k" => "v"})
-      assert {:ok, state} = Pushing.write_encoded_transaction(state, tx)
+      assert {:ok, state, _event} = Pushing.append_transaction(state, tx)
 
       assert state.oldest_version == Version.from_integer(6_000)
       assert state.last_version == Version.from_integer(6_000)
 
       # And the next append keeps it: the WAL is no longer empty.
       tx2 = TransactionTestSupport.new_log_transaction(7_000, %{"k" => "v"})
-      assert {:ok, state} = Pushing.write_encoded_transaction(state, tx2)
+      assert {:ok, state, _event} = Pushing.append_transaction(state, tx2)
       assert state.oldest_version == Version.from_integer(6_000)
     end
   end
 
-  describe "write_encoded_transaction/2 error handling" do
-    test "raises when transaction version cannot be extracted" do
+  describe "append_transaction/2 error handling" do
+    test "an unversionable transaction is an error with the caller's state" do
       state = %State{
-        mode: :ready,
+        mode: :running,
         last_version: Version.from_integer(0),
         writer: nil,
         segment_recycler: nil
@@ -630,9 +618,7 @@ defmodule Bedrock.DataPlane.Log.Shale.PushingTest do
       # Malformed transaction that will fail version extraction
       malformed_transaction = <<0, 1, 2>>
 
-      assert_raise RuntimeError, ~r/Failed to extract version/, fn ->
-        Pushing.write_encoded_transaction(state, malformed_transaction)
-      end
+      assert {:error, _reason, ^state} = Pushing.append_transaction(state, malformed_transaction)
     end
   end
 end

--- a/test/bedrock/data_plane/log/shale/recovery_test.exs
+++ b/test/bedrock/data_plane/log/shale/recovery_test.exs
@@ -39,7 +39,9 @@ defmodule Bedrock.DataPlane.Log.Shale.RecoveryTest do
     test "returns error when not in locked mode", %{state: state} do
       unlocked_state = %{state | mode: :running}
 
-      assert {:error, :lock_required} =
+      # Precondition failure returns the unchanged state: recovery exits
+      # are uniformly {:ok, state} | {:error, reason, state}.
+      assert {:error, :lock_required, ^unlocked_state} =
                Recovery.recover_from(
                  unlocked_state,
                  [:source],

--- a/test/bedrock/data_plane/log/shale/wal_segment_issues_test.exs
+++ b/test/bedrock/data_plane/log/shale/wal_segment_issues_test.exs
@@ -166,8 +166,8 @@ defmodule Bedrock.DataPlane.Log.Shale.WalSegmentIssuesTest do
 
   # Helper for push operations with better error handling
   defp assert_push_success(state, expected_version, transaction) do
-    assert {:ok, new_state, [^transaction]} =
-             Pushing.push(state, expected_version, transaction, fn _ -> :ok end)
+    assert %{state: new_state, appended: [{_version, ^transaction}], replies: [{_token, :ok}], parked?: false} =
+             Pushing.push(state, expected_version, transaction, :test_token)
 
     new_state
   end


### PR DESCRIPTION
Implements the transition-boundary refactor from the qzr.17/.18/.25 review thread (ticket bedrock-qzr.28).

## Why

`Pushing.push/4` returned four different tuple shapes, and the *shape* encoded whether client replies had already been sent: acknowledgement closures were stored in state and invoked mid-append, so `Shale.Server` had to infer effect ownership from tuple arity. That implicit protocol is exactly what previously let queued transactions be acknowledged and WAL-appended without Demux delivery (repaired point-wise in qzr.17), and it forced downstream effects to be reconstructed from the outer request because drained entries carried no events of their own. Recovery imported the same client-facing scheduler with a dummy acknowledgement and had to match `:wait` and multiple error shapes for a stream it had already validated as strictly ordered.

## What

**One effect-free append primitive.** `Pushing.append_transaction/2` is the single entry for putting bytes in the WAL: `{:ok, state, {version, bytes}} | {:error, reason, state}`. It owns WAL/resource state only (allocation, cut-cadence rolls, staged rollover, backpressure admission) and never replies, casts to the Demux, or notifies a puller. The WAL acknowledgement boundary is unchanged: a returned event means append plus sync completed.

**One uniform live transition.** `Pushing.push/4` now takes an opaque reply token (no closures in state) and always returns the same shape: `%{state, appended, replies, parked?}`. Immediate success, parking, every rejection (locked, oversized, stale, backpressured), ordered multi-entry drains, and partial-drain failure are all the same value. Each append event carries its own version and bytes — everything downstream needs, with the original binary passed unchanged.

**Server is the sole owner of live effects, applied exactly once.** It issues every caller reply from the transition's reply list, forwards every append event to the Demux in predecessor-chain order (no version recomputation), and wakes pullers from those same authoritative events — per event, not from the outer request's version as before.

**Recovery uses the primitive directly.** Replay appends validated, ordered source bytes with no dummy callback and cannot produce or match `:wait`. All recovery exits are normalized to `{:ok, state} | {:error, reason, state}` — precondition failures (`:lock_required`, invalid range) return the unchanged state — which collapses the Server's duplicate error clauses, and `Log.recover_from/4`'s spec now states the `{:error, {:failed_to_recover, reason}}` result it actually returns.

Explicitly *not* done, per the ticket: no mutation slicing moved into Shale, and no generic effects framework — this is one small Shale-specific boundary.

## How it's tested

The Pushing suite asserts effects as data across all the required paths: locked, oversized, stale, parked (token stored, nothing replied), immediate success, ordered multi-entry drain (events and replies in predecessor-chain order), partial-drain failure (admitted prefix is the tip, failed entry reported, remainder handled), backpressure flush, staged rollover (sync and pwrite faults), and recovery success/failure including the normalized precondition exit. Server-level push/pull/recovery integration tests pass unchanged — external behavior is identical.

Full suite: 2524 tests, 158 properties, 0 failures; credo --strict and dialyzer clean.