### PR TITLE
Remove the Shale-owned floor-lag alarm; trim telemetry stays raw facts (bedrock-qzr.29)

### DIFF
--- a/guides/durability-foundation.md
+++ b/guides/durability-foundation.md
@@ -209,15 +209,15 @@ Trim floor and WAL growth:
 
 - `[:bedrock, :demux, :durability, :floor_advanced]` — carries the shard
   currently pinning the floor and the active shard count
-- `[:bedrock, :log, :trim]` — floor, lag, and segment counts on each trim
-- `[:bedrock, :log, :floor_lag_alarm]` — fires once per crossing when the
-  floor lags the WAL tip by more than eight cut intervals; pair with the
-  opt-in `reject_pushes_above_lag_us` safety fuse for bounded version-time
-  growth
+- `[:bedrock, :log, :trim]` — raw observability on each trim: floor, WAL
+  tip, lag, and retained/recycled segment counts. Shale reports these facts
+  and does not judge them — alerting thresholds and admission policy belong
+  to the operator (or a future ratekeeper), not to a single log.
 - `[:bedrock, :log, :wal_limit_exceeded]` — an error-severity, recovery-required
-  signal carrying the floor, WAL tip, refused prospective version, lag, limit,
-  and queued count. Crossing the limit invalidates the current epoch; it is not
-  an instruction to retry the assigned version chain in place.
+  signal from the opt-in `reject_pushes_above_lag_us` safety fuse, carrying the
+  floor, WAL tip, refused prospective version, lag, limit, and queued count.
+  Crossing the limit invalidates the current epoch; it is not an instruction to
+  retry the assigned version chain in place.
 
 ## Validation Gates
 

--- a/lib/bedrock/data_plane/log/shale/server.ex
+++ b/lib/bedrock/data_plane/log/shale/server.ex
@@ -37,12 +37,6 @@ defmodule Bedrock.DataPlane.Log.Shale.Server do
   @max_retry_delay_ms 30_000
   @max_retry_attempts 10
 
-  # Alarm when the trim floor lags the WAL tip by more than this much
-  # version-time (8 cut intervals). Growth is unbounded-with-alerting by
-  # default; reject_pushes_above_lag_us opts into an epoch-fatal safety
-  # fuse despite its legacy option name.
-  @floor_lag_alarm_us 40_000_000
-
   @doc false
   @spec child_spec(
           opts :: [
@@ -514,22 +508,6 @@ defmodule Bedrock.DataPlane.Log.Shale.Server do
       :oldest_version,
       determine_oldest_transaction_version([t.active_segment | remaining_segments], available_after)
     )
-    |> check_floor_lag_alarm(trim_floor, lag_us)
-  end
-
-  # Alarm once per crossing; clears when the floor catches back up.
-  defp check_floor_lag_alarm(t, trim_floor, lag_us) do
-    cond do
-      lag_us > @floor_lag_alarm_us and not t.floor_lag_alarm_active ->
-        trace_floor_lag_alarm(trim_floor, t.last_version, lag_us, @floor_lag_alarm_us)
-        %{t | floor_lag_alarm_active: true}
-
-      lag_us <= @floor_lag_alarm_us and t.floor_lag_alarm_active ->
-        %{t | floor_lag_alarm_active: false}
-
-      true ->
-        t
-    end
   end
 
   # The optional WAL backpressure hard limit is enforced in Pushing,

--- a/lib/bedrock/data_plane/log/shale/state.ex
+++ b/lib/bedrock/data_plane/log/shale/state.ex
@@ -39,7 +39,6 @@ defmodule Bedrock.DataPlane.Log.Shale.State do
             Bedrock.version() => {encoded_transaction :: Transaction.encoded(), reply_token :: term()}
           },
           #
-          floor_lag_alarm_active: boolean(),
           reject_pushes_above_lag_us: non_neg_integer() | nil,
           #
           mode: mode(),
@@ -77,7 +76,6 @@ defmodule Bedrock.DataPlane.Log.Shale.State do
             active_segment: nil,
             pending_pushes: %{},
             #
-            floor_lag_alarm_active: false,
             reject_pushes_above_lag_us: nil,
             #
             mode: :locked,

--- a/lib/bedrock/data_plane/log/telemetry.ex
+++ b/lib/bedrock/data_plane/log/telemetry.ex
@@ -117,21 +117,4 @@ defmodule Bedrock.DataPlane.Log.Telemetry do
       })
     )
   end
-
-  @spec trace_floor_lag_alarm(
-          floor :: Bedrock.version(),
-          last_version :: Bedrock.version(),
-          lag_us :: non_neg_integer(),
-          limit_us :: non_neg_integer()
-        ) :: :ok
-  def trace_floor_lag_alarm(floor, last_version, lag_us, limit_us) do
-    Telemetry.execute(
-      [:bedrock, :log, :floor_lag_alarm],
-      %{lag_us: lag_us, limit_us: limit_us},
-      Map.merge(trace_metadata(), %{
-        floor: floor,
-        last_version: last_version
-      })
-    )
-  end
 end

--- a/test/bedrock/data_plane/log/shale/server_test.exs
+++ b/test/bedrock/data_plane/log/shale/server_test.exs
@@ -600,7 +600,6 @@ defmodule Bedrock.DataPlane.Log.Shale.ServerTest do
           handler_id,
           [
             [:bedrock, :log, :trim],
-            [:bedrock, :log, :floor_lag_alarm],
             [:bedrock, :log, :wal_limit_exceeded]
           ],
           fn event, measurements, metadata, pid -> send(pid, {:telemetry, event, measurements, metadata}) end,
@@ -622,27 +621,6 @@ defmodule Bedrock.DataPlane.Log.Shale.ServerTest do
       assert measurements.segments_retained == 2
       assert measurements.lag_us == 15
       assert metadata.floor == Version.from_integer(15)
-    end
-
-    test "floor lag past the limit raises the alarm once per crossing", %{server: pid, path: path} do
-      attach_trim_telemetry("alarm")
-      seed_trimmable_segments(pid, path)
-
-      # Version-time tip far beyond the floor (> 40s of lag)
-      far_tip = Version.from_integer(50_000_000)
-      :sys.replace_state(pid, fn state -> %{state | last_version: far_tip} end)
-
-      send(pid, {:min_durable_version, demux_of(pid), Version.from_integer(15)})
-      :pong = GenServer.call(pid, :ping)
-
-      assert_receive {:telemetry, [:bedrock, :log, :floor_lag_alarm], measurements, _metadata}
-      assert measurements.lag_us > measurements.limit_us
-
-      # A second advance while still lagging does not re-alarm
-      send(pid, {:min_durable_version, demux_of(pid), Version.from_integer(16)})
-      :pong = GenServer.call(pid, :ping)
-
-      refute_received {:telemetry, [:bedrock, :log, :floor_lag_alarm], _, _}
     end
 
     test "crossing the configured WAL limit loudly requires recovery", %{server_opts: opts} do


### PR DESCRIPTION
Closes the final open ticket in the bedrock-qzr epic.

## Why

Shale owned a fixed 40-second floor-lag threshold, an edge-triggered `floor_lag_alarm_active` state bit, and the `[:bedrock, :log, :floor_lag_alarm]` event. That was policy masquerading as observability, and unsound policy at that: version-time lag is not a capacity measure, the check only ran when the durability floor *advanced* — so a truly stalled floor never alarmed — and a single log cannot make a cluster-wide admission decision. The log's job is to persist and forward transactions, trim durable segments, and report raw facts; backpressure policy belongs to a future ratekeeper that can see the whole active log set.

## What

Pure removal, no replacement: the threshold constant, the alarm state bit, the transition check, the telemetry emitter, the alarm test, and the guide bullet are gone. `[:bedrock, :log, :trim]` is unchanged — floor, WAL tip, lag, and retained/recycled segment counts on every trim — and the guide now says plainly that Shale reports these facts without judging them. The opt-in `reject_pushes_above_lag_us` hard limit (a mechanism, not an alarm) is untouched, as are push, pull, recovery, and durability semantics.

Full suite: 2523 tests, 158 properties, 0 failures; credo --strict and dialyzer clean.