### PR TITLE
Enforce prospective WAL limit as an epoch-fatal safety fuse (bedrock-qzr.23)

### DIFF
--- a/guides/deep-dives/architecture/implementations/shale.md
+++ b/guides/deep-dives/architecture/implementations/shale.md
@@ -84,8 +84,20 @@ Shale recycles only completed segments fully behind the floor and recomputes
 `available_after` from the oldest segment that remains.
 
 Trim-floor telemetry reports lag and segment counts. Growth is
-unbounded-with-alerting by default; an optional hard limit rejects pushes with
-`{:error, :wal_backpressure}`.
+unbounded-with-alerting by default. The optional hard limit is an epoch-fatal
+safety fuse, not retryable per-push backpressure. Shale checks each prospective
+commit version, including queued successors when a predecessor gap closes. If
+the version-time lag exceeds the limit, every affected caller is released with
+`{:error, {:recovery_required, {:wal_limit_exceeded, details}}}` and the commit
+proxy stops so the Director can recover the known-committed prefix. Continuing
+the epoch would be unsafe because the sequencer and resolvers have already
+incorporated the refused version, and some log replicas may already have
+fsynced it.
+
+The fuse emits `[:bedrock, :log, :wal_limit_exceeded]` at error severity with
+the floor, current tip, prospective version, lag, configured limit, and queued
+count. Recovery replay is exempt because it copies history already selected as
+committed.
 
 ## Code References
 

--- a/guides/durability-foundation.md
+++ b/guides/durability-foundation.md
@@ -212,7 +212,12 @@ Trim floor and WAL growth:
 - `[:bedrock, :log, :trim]` — floor, lag, and segment counts on each trim
 - `[:bedrock, :log, :floor_lag_alarm]` — fires once per crossing when the
   floor lags the WAL tip by more than eight cut intervals; pair with the
-  opt-in `reject_pushes_above_lag_us` hard limit for bounded growth
+  opt-in `reject_pushes_above_lag_us` safety fuse for bounded version-time
+  growth
+- `[:bedrock, :log, :wal_limit_exceeded]` — an error-severity, recovery-required
+  signal carrying the floor, WAL tip, refused prospective version, lag, limit,
+  and queued count. Crossing the limit invalidates the current epoch; it is not
+  an instruction to retry the assigned version chain in place.
 
 ## Validation Gates
 

--- a/lib/bedrock/data_plane/commit_proxy/finalization.ex
+++ b/lib/bedrock/data_plane/commit_proxy/finalization.ex
@@ -63,7 +63,7 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization do
                                   timeout: Bedrock.timeout_in_ms(),
                                   async_stream_fn: async_stream_fn()
                                 ] ->
-                                  :ok | {:error, log_push_error()})
+                                  :ok | {:error, log_push_error() | recovery_required_error()})
 
   @type log_push_single_fn() :: (ServiceDescriptor.t(), binary(), Bedrock.version() ->
                                    :ok | {:error, :unavailable})
@@ -93,10 +93,13 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization do
           | {:insufficient_acknowledgments, non_neg_integer(), non_neg_integer(), [{Log.id(), term()}]}
           | :log_push_failed
 
+  @type recovery_required_error() :: {:recovery_required, log_push_error()}
+
   @type finalization_error() ::
           resolution_error()
           | storage_coverage_error()
           | log_push_error()
+          | recovery_required_error()
 
   # ============================================================================
   # Data Structures
@@ -909,7 +912,9 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization do
   ## Returns
     - `:ok` if acknowledgements have been received from ALL log servers.
     - `{:error, log_push_error()}` if any log has not successfully acknowledged the
-       push within the timeout period or other errors occur.
+      push within the timeout period or another non-fatal error occurs.
+    - `{:error, recovery_required_error()}` if a log reports that the current
+      transaction-system epoch cannot safely continue.
   """
   @spec push_transaction_to_logs_direct(
           last_commit_version :: Bedrock.version(),
@@ -921,7 +926,7 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization do
             log_push_fn: (pid() | {atom(), node()}, binary(), Bedrock.version() -> :ok | {:error, term()}),
             timeout: non_neg_integer()
           ]
-        ) :: :ok | {:error, log_push_error()}
+        ) :: :ok | {:error, log_push_error() | recovery_required_error()}
   def push_transaction_to_logs_direct(last_commit_version, transactions_by_log, _commit_version, opts) do
     log_services = Keyword.fetch!(opts, :log_services)
     async_stream_fn = Keyword.get(opts, :async_stream_fn, &Task.async_stream/3)
@@ -979,13 +984,30 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization do
         :ok
 
       {:error, errors} ->
-        {:error, {:log_failures, errors}}
+        classify_log_failures(errors)
 
       {count, errors} when count < required_acknowledgments ->
         {:error, {:insufficient_acknowledgments, count, required_acknowledgments, errors}}
 
       _other ->
         {:error, :log_push_failed}
+    end
+  end
+
+  # A log can refuse a version only before the global commit point, but the
+  # sequencer and resolvers have already incorporated that scheduled version.
+  # Promote the log's signal to an explicit epoch-fatal reason so the commit
+  # proxy stops and its Director monitor starts coordinated recovery.
+  defp classify_log_failures(errors) do
+    log_failures = {:log_failures, errors}
+
+    if Enum.any?(errors, fn
+         {_log_id, {:recovery_required, _reason}} -> true
+         _error -> false
+       end) do
+      {:error, {:recovery_required, log_failures}}
+    else
+      {:error, log_failures}
     end
   end
 

--- a/lib/bedrock/data_plane/commit_proxy/server.ex
+++ b/lib/bedrock/data_plane/commit_proxy/server.ex
@@ -196,8 +196,16 @@ defmodule Bedrock.DataPlane.CommitProxy.Server do
   def handle_call({:commit, _epoch, _transaction}, _from, %{mode: :locked} = t), do: reply(t, {:error, :locked})
 
   @impl true
-  @spec handle_info(:timeout | {:routing_data_update, RoutingData.t()}, State.t()) ::
-          {:noreply, State.t(), timeout()}
+  @spec handle_info(
+          :timeout
+          | {:routing_data_update, RoutingData.t()}
+          | {:finalization_failed, term()}
+          | {:DOWN, reference(), :process, pid(), term()},
+          State.t()
+        ) ::
+          {:noreply, State.t()}
+          | {:noreply, State.t(), timeout()}
+          | {:stop, term(), State.t()}
   def handle_info(:timeout, %{batch: nil, mode: :running} = t) do
     empty_transaction = Transaction.empty_transaction()
 
@@ -237,6 +245,12 @@ defmodule Bedrock.DataPlane.CommitProxy.Server do
     {:stop, :normal, t}
   end
 
+  # A failed finalization cannot be treated as an isolated transaction
+  # abort. Version assignment and conflict resolution have already mutated
+  # epoch-local state, and some required logs may have fsynced the batch.
+  # Stop explicitly so the Director's component monitor initiates recovery.
+  def handle_info({:finalization_failed, reason}, t), do: stop(t, reason)
+
   def handle_info(_msg, t) do
     {:noreply, t}
   end
@@ -265,7 +279,7 @@ defmodule Bedrock.DataPlane.CommitProxy.Server do
           send(server_pid, {:routing_data_update, updated_routing_data})
 
         {:error, reason} ->
-          exit(reason)
+          send(server_pid, {:finalization_failed, reason})
       end
     end)
   end

--- a/lib/bedrock/data_plane/log.ex
+++ b/lib/bedrock/data_plane/log.ex
@@ -14,6 +14,16 @@ defmodule Bedrock.DataPlane.Log do
   @type ref :: Worker.ref()
   @type id :: Worker.id()
   @type health :: Worker.health()
+  @type wal_limit_error ::
+          {:recovery_required,
+           {:wal_limit_exceeded,
+            %{
+              commit_version: Bedrock.version(),
+              min_durable_version: Bedrock.version(),
+              last_version: Bedrock.version(),
+              lag_us: pos_integer(),
+              limit_us: non_neg_integer()
+            }}}
   @type fact_name ::
           Worker.fact_name()
           | :last_version
@@ -61,6 +71,11 @@ defmodule Bedrock.DataPlane.Log do
   This call will not return until the transaction has been made durable on the
   log, ensuring that the transactions that precede it are also durable.
 
+  If the optional WAL lag safety limit is exceeded, the call returns
+  `{:error, {:recovery_required, {:wal_limit_exceeded, details}}}`. This is
+  fatal to the current transaction-system epoch: the caller must not retry or
+  continue the assigned version chain without coordinated recovery.
+
   ## Options
 
     - `known_committed_version`: The highest version known to be committed
@@ -74,7 +89,7 @@ defmodule Bedrock.DataPlane.Log do
           last_commit_version :: Bedrock.version(),
           opts :: [known_committed_version: Bedrock.version() | nil]
         ) ::
-          :ok | {:error, :tx_out_of_order | :locked | :unavailable | :wal_backpressure}
+          :ok | {:error, :tx_out_of_order | :locked | :unavailable | wal_limit_error()}
   def push(log, transaction, last_commit_version, opts \\ []) do
     call(log, {:push, transaction, last_commit_version, opts[:known_committed_version]}, :infinity)
   end

--- a/lib/bedrock/data_plane/log/shale/pushing.ex
+++ b/lib/bedrock/data_plane/log/shale/pushing.ex
@@ -11,6 +11,16 @@ defmodule Bedrock.DataPlane.Log.Shale.Pushing do
 
   @type appended_transactions :: [Transaction.encoded()]
   @type append_error :: {:error, term(), State.t(), appended_transactions()}
+  @type wal_limit_error ::
+          {:recovery_required,
+           {:wal_limit_exceeded,
+            %{
+              commit_version: Bedrock.version(),
+              min_durable_version: Bedrock.version(),
+              last_version: Bedrock.version(),
+              lag_us: pos_integer(),
+              limit_us: non_neg_integer()
+            }}}
 
   @spec push(
           t :: State.t(),
@@ -37,11 +47,11 @@ defmodule Bedrock.DataPlane.Log.Shale.Pushing do
         :ok = ack_fn.(:ok)
         do_pending_pushes(t, [encoded_transaction])
 
-      {:error, :wal_backpressure = reason, t} ->
-        # Queued successors carry even later commit versions, so none of
-        # them can be admitted either — and with this push rejected, the
-        # gap in front of them can never fill. Reject them all rather
-        # than strand their callers.
+      {:error, {:recovery_required, {:wal_limit_exceeded, _}} = reason, t} ->
+        # Version assignment and resolution have already scheduled this
+        # link for commit. Refusing its WAL append invalidates the epoch;
+        # release every successor so the commit proxies can fail fast and
+        # the Director can recover instead of leaving callers stranded.
         :ok = ack_fn.({:error, reason})
         {:error, reason, reject_pending_pushes(t, reason), []}
 
@@ -86,10 +96,11 @@ defmodule Bedrock.DataPlane.Log.Shale.Pushing do
             :ok = ack_fn.(:ok)
             do_pending_pushes(new_t, [encoded_transaction | appended])
 
-          {:error, :wal_backpressure = reason, error_t} ->
-            # Everything still queued has a later commit version and is
-            # equally inadmissible: reject the lot, leaving the admitted
-            # prefix as the tip and no caller stranded.
+          {:error, {:recovery_required, {:wal_limit_exceeded, _}} = reason, error_t} ->
+            # The admitted prefix remains the durable tip. The failed link
+            # makes every queued successor unusable in this epoch, so wake
+            # all of their callers and let coordinated recovery decide the
+            # committed prefix.
             :ok = ack_fn.({:error, reason})
             {:error, reason, reject_pending_pushes(error_t, reason), Enum.reverse(appended)}
 
@@ -242,19 +253,42 @@ defmodule Bedrock.DataPlane.Log.Shale.Pushing do
     if t.last_version == t.available_after, do: appended_version, else: t.oldest_version
   end
 
-  # The optional hard limit, enforced against each transaction's own
-  # prospective commit version — for direct appends AND entries drained
-  # from the pending queue (which may have been admitted unchecked while
-  # no durable floor existed yet). Only running logs are subject to it:
-  # recovery replay copies already-committed history and must never be
-  # refused. Disabled (nil limit) is the documented
-  # unbounded-with-alerting posture; a log with no confirmed floor has
-  # nothing to measure against.
-  @spec admit(State.t(), Bedrock.version() | nil) :: :ok | {:error, :wal_backpressure}
-  defp admit(%{mode: :running, reject_pushes_above_lag_us: limit, min_durable_version: floor}, version)
+  # This optional limit is an epoch-fatal WAL safety fuse, not ordinary
+  # retryable backpressure. Once the sequencer has assigned a version and
+  # resolvers have processed it, refusing a required WAL append means the
+  # current epoch cannot continue: replicas may hold different speculative
+  # tails and the sequencer's successor chain includes the refused link.
+  #
+  # Enforce it against each transaction's own prospective commit version,
+  # for direct appends and entries drained from the pending queue. Recovery
+  # replay copies already-committed history and must never trip the fuse.
+  # A nil limit retains the unbounded posture; without a confirmed floor
+  # there is not yet a safe distance to measure.
+  @spec admit(State.t(), Bedrock.version() | nil) :: :ok | {:error, wal_limit_error()}
+  defp admit(%{mode: :running, reject_pushes_above_lag_us: limit, min_durable_version: floor} = t, version)
        when not is_nil(limit) and not is_nil(floor) and not is_nil(version) do
-    if Version.distance(version, floor) > limit do
-      {:error, :wal_backpressure}
+    lag_us = Version.distance(version, floor)
+
+    if lag_us > limit do
+      trace_wal_limit_exceeded(
+        floor,
+        t.last_version,
+        version,
+        lag_us,
+        limit,
+        map_size(t.pending_pushes)
+      )
+
+      {:error,
+       {:recovery_required,
+        {:wal_limit_exceeded,
+         %{
+           commit_version: version,
+           min_durable_version: floor,
+           last_version: t.last_version,
+           lag_us: lag_us,
+           limit_us: limit
+         }}}}
     else
       :ok
     end

--- a/lib/bedrock/data_plane/log/shale/pushing.ex
+++ b/lib/bedrock/data_plane/log/shale/pushing.ex
@@ -37,6 +37,14 @@ defmodule Bedrock.DataPlane.Log.Shale.Pushing do
         :ok = ack_fn.(:ok)
         do_pending_pushes(t, [encoded_transaction])
 
+      {:error, :wal_backpressure = reason, t} ->
+        # Queued successors carry even later commit versions, so none of
+        # them can be admitted either — and with this push rejected, the
+        # gap in front of them can never fill. Reject them all rather
+        # than strand their callers.
+        :ok = ack_fn.({:error, reason})
+        {:error, reason, reject_pending_pushes(t, reason), []}
+
       {:error, reason, t} ->
         :ok = ack_fn.({:error, reason})
         {:error, reason, t, []}
@@ -44,7 +52,13 @@ defmodule Bedrock.DataPlane.Log.Shale.Pushing do
   end
 
   def push(t, expected_version, encoded_transaction, ack_fn) when expected_version > t.last_version do
-    {:wait, Map.update!(t, :pending_pushes, &Map.put(&1, expected_version, {encoded_transaction, ack_fn}))}
+    case admit(t, commit_version_or_nil(encoded_transaction)) do
+      :ok ->
+        {:wait, Map.update!(t, :pending_pushes, &Map.put(&1, expected_version, {encoded_transaction, ack_fn}))}
+
+      {:error, _reason} = error ->
+        error
+    end
   end
 
   def push(t, expected_version, _, _) do
@@ -72,6 +86,13 @@ defmodule Bedrock.DataPlane.Log.Shale.Pushing do
             :ok = ack_fn.(:ok)
             do_pending_pushes(new_t, [encoded_transaction | appended])
 
+          {:error, :wal_backpressure = reason, error_t} ->
+            # Everything still queued has a later commit version and is
+            # equally inadmissible: reject the lot, leaving the admitted
+            # prefix as the tip and no caller stranded.
+            :ok = ack_fn.({:error, reason})
+            {:error, reason, reject_pending_pushes(error_t, reason), Enum.reverse(appended)}
+
           {:error, reason, error_t} ->
             :ok = ack_fn.({:error, reason})
             {:error, reason, error_t, Enum.reverse(appended)}
@@ -93,37 +114,40 @@ defmodule Bedrock.DataPlane.Log.Shale.Pushing do
 
     previous_version = t.last_version
 
-    case Segment.allocate_from_recycler(t.segment_recycler, t.path, version, previous_version) do
-      {:ok, new_segment} ->
-        stage_successor_and_append(t, new_segment, encoded_transaction, version)
-
-      {:error, reason} ->
-        {:error, reason, t}
+    with :ok <- admit(t, version),
+         {:ok, new_segment} <-
+           Segment.allocate_from_recycler(t.segment_recycler, t.path, version, previous_version) do
+      stage_successor_and_append(t, new_segment, encoded_transaction, version)
+    else
+      {:error, reason} -> {:error, reason, t}
     end
   end
 
   def write_encoded_transaction(t, encoded_transaction) do
-    case Transaction.commit_version(encoded_transaction) do
-      {:ok, version} ->
-        if crosses_cut_boundary?(t.active_segment, version) do
-          # Roll on the cut cadence, not just on byte size: the active
-          # segment is trim-immune, so a low-traffic log that never fills a
-          # segment would otherwise hold its entire history in one
-          # untrimmable file — and every recovery would copy that history
-          # from version zero. Rolling per cut bucket gives trimming a
-          # successor header whose persisted predecessor keeps
-          # `available_after` chasing the untrimmed tail. A roll is a rename
-          # from the preallocated pool.
-          case Writer.close(t.writer) do
-            :ok -> write_encoded_transaction(%{t | writer: nil}, encoded_transaction)
-            {:error, reason} -> {:error, reason, t}
-          end
-        else
-          append_encoded_transaction(t, encoded_transaction, version)
-        end
+    with {:ok, version} <- Transaction.commit_version(encoded_transaction),
+         :ok <- admit(t, version) do
+      maybe_roll_and_append(t, encoded_transaction, version)
+    else
+      {:error, reason} -> {:error, reason, t}
+    end
+  end
 
-      {:error, reason} ->
-        {:error, reason, t}
+  defp maybe_roll_and_append(t, encoded_transaction, version) do
+    if crosses_cut_boundary?(t.active_segment, version) do
+      # Roll on the cut cadence, not just on byte size: the active
+      # segment is trim-immune, so a low-traffic log that never fills a
+      # segment would otherwise hold its entire history in one
+      # untrimmable file — and every recovery would copy that history
+      # from version zero. Rolling per cut bucket gives trimming a
+      # successor header whose persisted predecessor keeps
+      # `available_after` chasing the untrimmed tail. A roll is a rename
+      # from the preallocated pool.
+      case Writer.close(t.writer) do
+        :ok -> write_encoded_transaction(%{t | writer: nil}, encoded_transaction)
+        {:error, reason} -> {:error, reason, t}
+      end
+    else
+      append_encoded_transaction(t, encoded_transaction, version)
     end
   end
 
@@ -216,6 +240,38 @@ defmodule Bedrock.DataPlane.Log.Shale.Pushing do
   # to every fresh or rolled segment.
   defp oldest_after_append(t, appended_version) do
     if t.last_version == t.available_after, do: appended_version, else: t.oldest_version
+  end
+
+  # The optional hard limit, enforced against each transaction's own
+  # prospective commit version — for direct appends AND entries drained
+  # from the pending queue (which may have been admitted unchecked while
+  # no durable floor existed yet). Only running logs are subject to it:
+  # recovery replay copies already-committed history and must never be
+  # refused. Disabled (nil limit) is the documented
+  # unbounded-with-alerting posture; a log with no confirmed floor has
+  # nothing to measure against.
+  @spec admit(State.t(), Bedrock.version() | nil) :: :ok | {:error, :wal_backpressure}
+  defp admit(%{mode: :running, reject_pushes_above_lag_us: limit, min_durable_version: floor}, version)
+       when not is_nil(limit) and not is_nil(floor) and not is_nil(version) do
+    if Version.distance(version, floor) > limit do
+      {:error, :wal_backpressure}
+    else
+      :ok
+    end
+  end
+
+  defp admit(_t, _version), do: :ok
+
+  defp commit_version_or_nil(encoded_transaction) do
+    case Transaction.commit_version(encoded_transaction) do
+      {:ok, version} -> version
+      {:error, _} -> nil
+    end
+  end
+
+  defp reject_pending_pushes(%{pending_pushes: pending} = t, reason) do
+    Enum.each(pending, fn {_expected, {_transaction, ack_fn}} -> :ok = ack_fn.({:error, reason}) end)
+    %{t | pending_pushes: %{}}
   end
 
   @spec update_segment_transaction_cache(Segment.t(), Transaction.encoded()) :: Segment.t()

--- a/lib/bedrock/data_plane/log/shale/server.ex
+++ b/lib/bedrock/data_plane/log/shale/server.ex
@@ -39,7 +39,8 @@ defmodule Bedrock.DataPlane.Log.Shale.Server do
 
   # Alarm when the trim floor lags the WAL tip by more than this much
   # version-time (8 cut intervals). Growth is unbounded-with-alerting by
-  # default; pass reject_pushes_above_lag_us to enforce a hard limit.
+  # default; reject_pushes_above_lag_us opts into an epoch-fatal safety
+  # fuse despite its legacy option name.
   @floor_lag_alarm_us 40_000_000
 
   @doc false

--- a/lib/bedrock/data_plane/log/shale/server.ex
+++ b/lib/bedrock/data_plane/log/shale/server.ex
@@ -237,8 +237,7 @@ defmodule Bedrock.DataPlane.Log.Shale.Server do
 
   @impl true
   def handle_call({:push, transaction_bytes, expected_version, known_committed_version}, from, %State{} = t) do
-    with :ok <- check_wal_backpressure(t),
-         {:ok, transaction} <- Transaction.validate(transaction_bytes),
+    with {:ok, transaction} <- Transaction.validate(transaction_bytes),
          :ok <- validate_has_shard_index(transaction) do
       case push(t, expected_version, transaction, ack_fn(from)) do
         {:ok, t, appended_transactions} ->
@@ -509,20 +508,9 @@ defmodule Bedrock.DataPlane.Log.Shale.Server do
     end
   end
 
-  # Optional hard limit: refuse new pushes while the trim floor lags the WAL
-  # tip by more than the configured version-time. Disabled (nil) by default —
-  # the documented posture is unbounded-with-alerting. A log with no floor
-  # yet (nothing confirmed) never rejects.
-  defp check_wal_backpressure(%{reject_pushes_above_lag_us: nil}), do: :ok
-  defp check_wal_backpressure(%{min_durable_version: nil}), do: :ok
-
-  defp check_wal_backpressure(t) do
-    if Version.distance(t.last_version, t.min_durable_version) > t.reject_pushes_above_lag_us do
-      {:error, :wal_backpressure}
-    else
-      :ok
-    end
-  end
+  # The optional WAL backpressure hard limit is enforced in Pushing,
+  # against each transaction's own prospective commit version — including
+  # entries drained from the pending queue.
 
   defp segment_fully_durable?(segment, min_durable_version) do
     loaded_segment = Segment.ensure_transactions_are_loaded(segment)

--- a/lib/bedrock/data_plane/log/telemetry.ex
+++ b/lib/bedrock/data_plane/log/telemetry.ex
@@ -63,6 +63,27 @@ defmodule Bedrock.DataPlane.Log.Telemetry do
     )
   end
 
+  @spec trace_wal_limit_exceeded(
+          floor :: Bedrock.version(),
+          last_version :: Bedrock.version(),
+          commit_version :: Bedrock.version(),
+          lag_us :: pos_integer(),
+          limit_us :: non_neg_integer(),
+          pending_pushes :: non_neg_integer()
+        ) :: :ok
+  def trace_wal_limit_exceeded(floor, last_version, commit_version, lag_us, limit_us, pending_pushes) do
+    Telemetry.execute(
+      [:bedrock, :log, :wal_limit_exceeded],
+      %{lag_us: lag_us, limit_us: limit_us, pending_pushes: pending_pushes},
+      Map.merge(trace_metadata(), %{
+        floor: floor,
+        last_version: last_version,
+        commit_version: commit_version,
+        recovery_required: true
+      })
+    )
+  end
+
   @spec trace_pull_transactions(from_version :: Bedrock.version(), opts :: Keyword.t()) :: :ok
   def trace_pull_transactions(from_version, opts) do
     Telemetry.execute(

--- a/lib/bedrock/data_plane/log/tracing.ex
+++ b/lib/bedrock/data_plane/log/tracing.ex
@@ -18,6 +18,7 @@ defmodule Bedrock.DataPlane.Log.Tracing do
         [:bedrock, :log, :recover_from],
         [:bedrock, :log, :push],
         [:bedrock, :log, :push_out_of_order],
+        [:bedrock, :log, :wal_limit_exceeded],
         [:bedrock, :log, :pull]
       ],
       &__MODULE__.handler/4,
@@ -70,6 +71,20 @@ defmodule Bedrock.DataPlane.Log.Tracing do
     )
   end
 
+  def log_event(:wal_limit_exceeded, %{lag_us: lag_us, limit_us: limit_us, pending_pushes: pending_pushes}, %{
+        floor: floor,
+        last_version: last_version,
+        commit_version: commit_version,
+        recovery_required: true
+      }) do
+    error(
+      "WAL safety limit exceeded; recovery required " <>
+        "(floor=#{Version.to_string(floor)}, tip=#{Version.to_string(last_version)}, " <>
+        "prospective=#{Version.to_string(commit_version)}, lag_us=#{lag_us}, " <>
+        "limit_us=#{limit_us}, pending_pushes=#{pending_pushes})"
+    )
+  end
+
   def log_event(:pull, _, %{from_version: from_version, opts: opts}),
     do: info("Pull transactions from version #{Version.to_string(from_version)} with options #{inspect(opts)}")
 
@@ -78,5 +93,12 @@ defmodule Bedrock.DataPlane.Log.Tracing do
     cluster = Keyword.fetch!(metadata, :cluster)
     id = Keyword.fetch!(metadata, :id)
     Logger.info("Bedrock Log [#{cluster.name()}/#{id}]: #{message}")
+  end
+
+  defp error(message) do
+    metadata = Logger.metadata()
+    cluster = Keyword.fetch!(metadata, :cluster)
+    id = Keyword.fetch!(metadata, :id)
+    Logger.error("Bedrock Log [#{cluster.name()}/#{id}]: #{message}")
   end
 end

--- a/test/bedrock/data_plane/commit_proxy/server_test.exs
+++ b/test/bedrock/data_plane/commit_proxy/server_test.exs
@@ -335,7 +335,7 @@ defmodule Bedrock.DataPlane.CommitProxy.ServerTest do
 
       {:ok, resolver} = FakeResolver.start_link([])
 
-      # Create a fake log that NEVER acknowledges (always fails)
+      # Simulate a log tripping its epoch-fatal WAL safety fuse.
       defmodule FailingLog do
         @moduledoc false
         use GenServer
@@ -344,10 +344,23 @@ defmodule Bedrock.DataPlane.CommitProxy.ServerTest do
 
         def init(state), do: {:ok, state}
 
-        # This log immediately fails all push attempts to simulate log failure
-        def handle_call({:push, _transaction, _last_commit_version, _kcv}, _from, state) do
-          # Immediately return an error to simulate log failure
-          {:reply, {:error, :log_unavailable}, state}
+        def handle_call({:push, transaction, _last_commit_version, _kcv}, _from, state) do
+          {:ok, commit_version} = Transaction.commit_version(transaction)
+          floor = Bedrock.DataPlane.Version.zero()
+          lag_us = Bedrock.DataPlane.Version.distance(commit_version, floor)
+
+          reason =
+            {:recovery_required,
+             {:wal_limit_exceeded,
+              %{
+                commit_version: commit_version,
+                min_durable_version: floor,
+                last_version: floor,
+                lag_us: lag_us,
+                limit_us: 0
+              }}}
+
+          {:reply, {:error, reason}, state}
         end
       end
 
@@ -391,7 +404,7 @@ defmodule Bedrock.DataPlane.CommitProxy.ServerTest do
       {:ok, commit_proxy: commit_proxy, failing_log: failing_log}
     end
 
-    test "commit proxy dies when logs fail to acknowledge and cancels all waiting batches", %{
+    test "WAL safety fuse explicitly terminates the commit proxy for Director recovery", %{
       commit_proxy: commit_proxy
     } do
       # Monitor the commit proxy to detect when it dies
@@ -430,8 +443,14 @@ defmodule Bedrock.DataPlane.CommitProxy.ServerTest do
           # Wait for the commit proxy to detect log failure and die
           receive do
             {:DOWN, ^commit_proxy_ref, :process, ^commit_proxy, reason} ->
-              # Verify the commit proxy died due to insufficient acknowledgments
-              assert reason == {:log_failures, [{"failing_log", :log_unavailable}]}
+              assert {:recovery_required,
+                      {:log_failures,
+                       [
+                         {"failing_log", {:recovery_required, {:wal_limit_exceeded, details}}}
+                       ]}} = reason
+
+              assert details.limit_us == 0
+              assert details.lag_us > 0
           after
             15_000 ->
               flunk("Commit proxy should have died due to log acknowledgment failure")

--- a/test/bedrock/data_plane/log/shale/pushing_test.exs
+++ b/test/bedrock/data_plane/log/shale/pushing_test.exs
@@ -393,6 +393,113 @@ defmodule Bedrock.DataPlane.Log.Shale.PushingTest do
     end
   end
 
+  describe "WAL backpressure bounds every prospective commit version" do
+    setup :recycler_in_tmp_dir
+
+    defp bounded_state(dir, recycler, limit, floor_int) do
+      %State{
+        mode: :running,
+        path: dir,
+        segment_recycler: recycler,
+        writer: nil,
+        active_segment: nil,
+        segments: [],
+        last_version: Version.from_integer(1_000),
+        available_after: Version.from_integer(1_000),
+        oldest_version: Version.from_integer(1_000),
+        reject_pushes_above_lag_us: limit,
+        min_durable_version: floor_int && Version.from_integer(floor_int),
+        pending_pushes: %{}
+      }
+    end
+
+    defp bp_tx(version_int), do: TransactionTestSupport.new_log_transaction(version_int, %{"k" => "v"})
+
+    defp ack_to(caller, tag) do
+      fn result ->
+        send(caller, {:ack, tag, result})
+        :ok
+      end
+    end
+
+    test "a direct push whose commit version exceeds the bound is rejected", %{dir: dir, recycler: recycler} do
+      state = bounded_state(dir, recycler, 1_000, 1_000)
+      caller = self()
+
+      assert {:error, :wal_backpressure, after_state, []} =
+               Pushing.push(state, Version.from_integer(1_000), bp_tx(2_001), ack_to(caller, :direct))
+
+      assert_receive {:ack, :direct, {:error, :wal_backpressure}}
+      assert after_state.last_version == Version.from_integer(1_000)
+    end
+
+    test "a future push whose commit version exceeds the bound is rejected at enqueue",
+         %{dir: dir, recycler: recycler} do
+      state = bounded_state(dir, recycler, 1_000, 1_000)
+
+      assert {:error, :wal_backpressure} =
+               Pushing.push(state, Version.from_integer(3_000), bp_tx(4_000), fn _ -> :ok end)
+    end
+
+    test "entries queued before the floor existed cannot cross the bound when the gap fills",
+         %{dir: dir, recycler: recycler} do
+      # No durable floor yet: the future push is admitted unchecked (the
+      # bound cannot be evaluated without a floor).
+      state = bounded_state(dir, recycler, 2_500, nil)
+      caller = self()
+
+      assert {:wait, state} =
+               Pushing.push(state, Version.from_integer(3_000), bp_tx(5_000), ack_to(caller, :queued))
+
+      # The first confirmation establishes the floor. Filling the gap now
+      # admits the filler (2_000 <= 2_500 behind the floor) but must NOT
+      # blindly drain the queue past the bound: the queued transaction sits
+      # 4_000 behind the floor.
+      state = %{state | min_durable_version: Version.from_integer(1_000)}
+      filler = bp_tx(3_000)
+
+      assert {:error, :wal_backpressure, after_state, [^filler]} =
+               Pushing.push(state, Version.from_integer(1_000), filler, ack_to(caller, :filler))
+
+      assert_receive {:ack, :filler, :ok}
+      assert_receive {:ack, :queued, {:error, :wal_backpressure}}
+
+      # Ordering state stays consistent: the admitted prefix is the tip,
+      # the rejected suffix is gone, nobody is stranded.
+      assert after_state.last_version == Version.from_integer(3_000)
+      assert after_state.pending_pushes == %{}
+    end
+
+    test "rejecting a direct push also rejects queued successors instead of stranding them",
+         %{dir: dir, recycler: recycler} do
+      state = bounded_state(dir, recycler, 2_500, nil)
+      caller = self()
+
+      assert {:wait, state} =
+               Pushing.push(state, Version.from_integer(9_000), bp_tx(9_500), ack_to(caller, :queued))
+
+      state = %{state | min_durable_version: Version.from_integer(1_000)}
+
+      assert {:error, :wal_backpressure, after_state, []} =
+               Pushing.push(state, Version.from_integer(1_000), bp_tx(9_000), ack_to(caller, :direct))
+
+      assert_receive {:ack, :direct, {:error, :wal_backpressure}}
+      assert_receive {:ack, :queued, {:error, :wal_backpressure}}
+      assert after_state.pending_pushes == %{}
+    end
+
+    test "with no hard limit, arbitrarily lagged pushes stay admitted", %{dir: dir, recycler: recycler} do
+      state = bounded_state(dir, recycler, nil, 1_000)
+      caller = self()
+
+      assert {:ok, state, [_tx]} =
+               Pushing.push(state, Version.from_integer(1_000), bp_tx(10_000_000), ack_to(caller, :unbounded))
+
+      assert_receive {:ack, :unbounded, :ok}
+      assert state.last_version == Version.from_integer(10_000_000)
+    end
+  end
+
   describe "appends decide emptiness from state, never by reading segments" do
     setup :recycler_in_tmp_dir
 

--- a/test/bedrock/data_plane/log/shale/pushing_test.exs
+++ b/test/bedrock/data_plane/log/shale/pushing_test.exs
@@ -393,7 +393,7 @@ defmodule Bedrock.DataPlane.Log.Shale.PushingTest do
     end
   end
 
-  describe "WAL backpressure bounds every prospective commit version" do
+  describe "WAL safety limit bounds every prospective commit version" do
     setup :recycler_in_tmp_dir
 
     defp bounded_state(dir, recycler, limit, floor_int) do
@@ -422,23 +422,50 @@ defmodule Bedrock.DataPlane.Log.Shale.PushingTest do
       end
     end
 
-    test "a direct push whose commit version exceeds the bound is rejected", %{dir: dir, recycler: recycler} do
+    defp assert_wal_limit_error(reason, expected) do
+      assert {:recovery_required, {:wal_limit_exceeded, details}} = reason
+
+      Enum.each(expected, fn {key, value} ->
+        assert Map.fetch!(details, key) == value
+      end)
+
+      reason
+    end
+
+    test "a direct push beyond the bound trips the recovery-required fuse before append",
+         %{dir: dir, recycler: recycler} do
       state = bounded_state(dir, recycler, 1_000, 1_000)
       caller = self()
 
-      assert {:error, :wal_backpressure, after_state, []} =
+      assert {:error, reason, after_state, []} =
                Pushing.push(state, Version.from_integer(1_000), bp_tx(2_001), ack_to(caller, :direct))
 
-      assert_receive {:ack, :direct, {:error, :wal_backpressure}}
+      assert_wal_limit_error(reason,
+        commit_version: Version.from_integer(2_001),
+        min_durable_version: Version.from_integer(1_000),
+        last_version: Version.from_integer(1_000),
+        lag_us: 1_001,
+        limit_us: 1_000
+      )
+
+      assert_receive {:ack, :direct, {:error, ^reason}}
       assert after_state.last_version == Version.from_integer(1_000)
     end
 
-    test "a future push whose commit version exceeds the bound is rejected at enqueue",
+    test "a future push beyond the bound signals recovery instead of entering the queue",
          %{dir: dir, recycler: recycler} do
       state = bounded_state(dir, recycler, 1_000, 1_000)
 
-      assert {:error, :wal_backpressure} =
+      assert {:error, reason} =
                Pushing.push(state, Version.from_integer(3_000), bp_tx(4_000), fn _ -> :ok end)
+
+      assert_wal_limit_error(reason,
+        commit_version: Version.from_integer(4_000),
+        min_durable_version: Version.from_integer(1_000),
+        last_version: Version.from_integer(1_000),
+        lag_us: 3_000,
+        limit_us: 1_000
+      )
     end
 
     test "entries queued before the floor existed cannot cross the bound when the gap fills",
@@ -458,11 +485,19 @@ defmodule Bedrock.DataPlane.Log.Shale.PushingTest do
       state = %{state | min_durable_version: Version.from_integer(1_000)}
       filler = bp_tx(3_000)
 
-      assert {:error, :wal_backpressure, after_state, [^filler]} =
+      assert {:error, reason, after_state, [^filler]} =
                Pushing.push(state, Version.from_integer(1_000), filler, ack_to(caller, :filler))
 
+      assert_wal_limit_error(reason,
+        commit_version: Version.from_integer(5_000),
+        min_durable_version: Version.from_integer(1_000),
+        last_version: Version.from_integer(3_000),
+        lag_us: 4_000,
+        limit_us: 2_500
+      )
+
       assert_receive {:ack, :filler, :ok}
-      assert_receive {:ack, :queued, {:error, :wal_backpressure}}
+      assert_receive {:ack, :queued, {:error, ^reason}}
 
       # Ordering state stays consistent: the admitted prefix is the tip,
       # the rejected suffix is gone, nobody is stranded.
@@ -470,21 +505,33 @@ defmodule Bedrock.DataPlane.Log.Shale.PushingTest do
       assert after_state.pending_pushes == %{}
     end
 
-    test "rejecting a direct push also rejects queued successors instead of stranding them",
+    test "tripping the fuse releases every queued successor so recovery cannot strand callers",
          %{dir: dir, recycler: recycler} do
       state = bounded_state(dir, recycler, 2_500, nil)
       caller = self()
 
       assert {:wait, state} =
-               Pushing.push(state, Version.from_integer(9_000), bp_tx(9_500), ack_to(caller, :queued))
+               Pushing.push(state, Version.from_integer(9_000), bp_tx(9_500), ack_to(caller, :queued_1))
+
+      assert {:wait, state} =
+               Pushing.push(state, Version.from_integer(9_500), bp_tx(10_000), ack_to(caller, :queued_2))
 
       state = %{state | min_durable_version: Version.from_integer(1_000)}
 
-      assert {:error, :wal_backpressure, after_state, []} =
+      assert {:error, reason, after_state, []} =
                Pushing.push(state, Version.from_integer(1_000), bp_tx(9_000), ack_to(caller, :direct))
 
-      assert_receive {:ack, :direct, {:error, :wal_backpressure}}
-      assert_receive {:ack, :queued, {:error, :wal_backpressure}}
+      assert_wal_limit_error(reason,
+        commit_version: Version.from_integer(9_000),
+        min_durable_version: Version.from_integer(1_000),
+        last_version: Version.from_integer(1_000),
+        lag_us: 8_000,
+        limit_us: 2_500
+      )
+
+      assert_receive {:ack, :direct, {:error, ^reason}}
+      assert_receive {:ack, :queued_1, {:error, ^reason}}
+      assert_receive {:ack, :queued_2, {:error, ^reason}}
       assert after_state.pending_pushes == %{}
     end
 

--- a/test/bedrock/data_plane/log/shale/server_test.exs
+++ b/test/bedrock/data_plane/log/shale/server_test.exs
@@ -598,7 +598,11 @@ defmodule Bedrock.DataPlane.Log.Shale.ServerTest do
       :ok =
         :telemetry.attach_many(
           handler_id,
-          [[:bedrock, :log, :trim], [:bedrock, :log, :floor_lag_alarm]],
+          [
+            [:bedrock, :log, :trim],
+            [:bedrock, :log, :floor_lag_alarm],
+            [:bedrock, :log, :wal_limit_exceeded]
+          ],
           fn event, measurements, metadata, pid -> send(pid, {:telemetry, event, measurements, metadata}) end,
           test_pid
         )
@@ -641,7 +645,9 @@ defmodule Bedrock.DataPlane.Log.Shale.ServerTest do
       refute_received {:telemetry, [:bedrock, :log, :floor_lag_alarm], _, _}
     end
 
-    test "pushes are rejected past the configured lag limit", %{server_opts: opts} do
+    test "crossing the configured WAL limit loudly requires recovery", %{server_opts: opts} do
+      attach_trim_telemetry("wal-limit")
+
       # A second server needs its own segment directory: two recyclers
       # sharing one directory rename the same preallocated files out from
       # under each other, occasionally killing this server mid-setup.
@@ -671,7 +677,19 @@ defmodule Bedrock.DataPlane.Log.Shale.ServerTest do
 
       encoded_bytes = TransactionTestSupport.new_log_transaction(5_000_001, %{"k" => "v"})
 
-      assert {:error, :wal_backpressure} = GenServer.call(pid, {:push, encoded_bytes, Version.from_integer(5_000_001)})
+      assert {:error, {:recovery_required, {:wal_limit_exceeded, details}}} =
+               GenServer.call(pid, {:push, encoded_bytes, Version.from_integer(5_000_001)})
+
+      assert details.commit_version == Version.from_integer(5_000_001)
+      assert details.min_durable_version == Version.from_integer(10)
+      assert details.last_version == Version.from_integer(5_000_000)
+      assert details.lag_us == 4_999_991
+      assert details.limit_us == 1_000
+
+      assert_receive {:telemetry, [:bedrock, :log, :wal_limit_exceeded], measurements, metadata}
+      assert measurements == %{lag_us: 4_999_991, limit_us: 1_000, pending_pushes: 0}
+      assert metadata.recovery_required
+      assert metadata.commit_version == Version.from_integer(5_000_001)
     end
   end
 

--- a/test/bedrock/data_plane/log/telemetry_test.exs
+++ b/test/bedrock/data_plane/log/telemetry_test.exs
@@ -26,6 +26,7 @@ defmodule Bedrock.DataPlane.Log.TelemetryTest do
         [:bedrock, :log, :recover_from],
         [:bedrock, :log, :push],
         [:bedrock, :log, :push_out_of_order],
+        [:bedrock, :log, :wal_limit_exceeded],
         [:bedrock, :log, :pull]
       ],
       &__MODULE__.handle_event/4,
@@ -192,6 +193,28 @@ defmodule Bedrock.DataPlane.Log.TelemetryTest do
     end
   end
 
+  describe "trace_wal_limit_exceeded/6" do
+    test "emits an epoch-fatal event with the complete safety-limit context" do
+      Telemetry.trace_metadata(%{log_id: "log-1"})
+      floor = Version.from_integer(1_000)
+      last_version = Version.from_integer(3_000)
+      commit_version = Version.from_integer(5_000)
+
+      assert :ok =
+               Telemetry.trace_wal_limit_exceeded(floor, last_version, commit_version, 4_000, 2_500, 3)
+
+      assert_received {:telemetry_event, [:bedrock, :log, :wal_limit_exceeded],
+                       %{lag_us: 4_000, limit_us: 2_500, pending_pushes: 3},
+                       %{
+                         log_id: "log-1",
+                         floor: ^floor,
+                         last_version: ^last_version,
+                         commit_version: ^commit_version,
+                         recovery_required: true
+                       }}
+    end
+  end
+
   describe "trace_pull_transactions/2" do
     test "emits telemetry event with pull details" do
       from_version = Version.from_integer(50)
@@ -237,6 +260,7 @@ defmodule Bedrock.DataPlane.Log.TelemetryTest do
       assert :ok = Telemetry.trace_recover_from(:log, version, version)
       assert :ok = Telemetry.trace_push_transaction(transaction)
       assert :ok = Telemetry.trace_push_out_of_order(version, version)
+      assert :ok = Telemetry.trace_wal_limit_exceeded(version, version, version, 1, 0, 0)
       assert :ok = Telemetry.trace_pull_transactions(version, [])
     end
 

--- a/test/bedrock/data_plane/log/tracing_test.exs
+++ b/test/bedrock/data_plane/log/tracing_test.exs
@@ -126,6 +126,33 @@ defmodule Bedrock.DataPlane.Log.TracingTest do
       )
     end
 
+    test "logs a WAL limit crossing as a recovery-required error" do
+      floor = Version.from_integer(100)
+      last_version = Version.from_integer(200)
+      commit_version = Version.from_integer(300)
+
+      log =
+        capture_log(fn ->
+          Tracing.handler(
+            [:bedrock, :log, :wal_limit_exceeded],
+            %{lag_us: 200, limit_us: 150, pending_pushes: 2},
+            %{
+              floor: floor,
+              last_version: last_version,
+              commit_version: commit_version,
+              recovery_required: true
+            },
+            nil
+          )
+        end)
+
+      assert log =~ "WAL safety limit exceeded; recovery required"
+      assert log =~ "lag_us=200"
+      assert log =~ "limit_us=150"
+      assert log =~ "pending_pushes=2"
+      assert log =~ "Bedrock Log [test_cluster/test_log_1]"
+    end
+
     test "handles :pull event" do
       metadata = %{
         from_version: Version.from_integer(100),


### PR DESCRIPTION
Fixes the P2 WAL-growth finding tracked by `bedrock-qzr.23`.

## Why

The optional `reject_pushes_above_lag_us` limit was checked once at the server boundary against the current WAL tip. Out-of-order pushes could queue below that threshold and later drain past it after their missing predecessor arrived, so the advertised bound did not actually hold.

There is a second, more important semantic constraint: a transaction reaching a log has already received a sequencer version and passed resolver processing. If one required WAL cannot accept that scheduled version, this is not ordinary per-push backpressure. Some replicas may already have fsynced the version, resolver state includes it, and the sequencer successor chain names it. The current transaction-system epoch cannot safely continue and must recover from the known-committed prefix.

## What

- Moves the WAL limit to the append choke point and evaluates every transaction against its own prospective commit version:
  `distance(commit_version, min_durable_version) <= limit`.
- Applies the same check to direct appends, future pushes at enqueue, and every entry drained from `pending_pushes`.
- Reports a limit crossing as:
  `{:error, {:recovery_required, {:wal_limit_exceeded, details}}}`.
  Details include the prospective commit version, durability floor, current WAL tip, measured lag, and configured limit.
- Releases the triggering caller and every queued successor with the same recovery-required reason. Any prefix already fsynced remains the WAL tip and its callers retain `:ok`; no caller is silently dropped or stranded.
- Promotes a recovery-required log failure through commit finalization and makes the commit proxy explicitly stop with the tagged reason. The Director component monitor then initiates coordinated recovery. Application transactions that did not commit are released as aborted and may retry against the recovered transaction system.
- Emits `[:bedrock, :log, :wal_limit_exceeded]` and logs it at error severity with floor, tip, prospective version, lag, limit, and queued count.
- Documents the option as an epoch-fatal WAL safety fuse rather than retryable flow control.

## Scope guards

- Enforcement applies only to running logs.
- Recovery replay is exempt because it copies history already selected as committed.
- A `nil` limit preserves the unbounded posture.
- A log with no confirmed durability floor remains unenforced because there is not yet a safe distance to measure.

## Tests

Coverage proves:

- direct and future versions beyond the bound signal recovery before append or enqueue;
- a suffix queued before the first floor exists cannot cross the bound when its gap closes;
- every queued successor is released when the fuse trips;
- the admitted prefix and ordering state remain consistent;
- `nil` keeps unbounded behavior;
- the Shale server emits the structured recovery-required response and telemetry;
- the commit proxy terminates with a tagged `recovery_required` reason so Director recovery is triggered.

Validation:

- full suite: 2,516 tests, 158 properties, 13 doctests, 0 failures;
- focused post-restack suite: 118 tests and 1 property, 0 failures;
- `mix credo --strict`: clean;
- `mix dialyzer`: clean.