### PR TITLE
Replay the current TSL to late Link subscribers at registration (bedrock-qzr.22)

### DIFF
--- a/lib/bedrock/control_plane/coordinator/server.ex
+++ b/lib/bedrock/control_plane/coordinator/server.ex
@@ -24,6 +24,7 @@ defmodule Bedrock.ControlPlane.Coordinator.Server do
       put_transaction_system_layout: 2,
       update_raft: 2,
       add_tsl_subscriber: 2,
+      replay_tsl_to: 2,
       remove_tsl_subscriber: 2,
       check_for_recovery_capability_changes: 1,
       update_recovery_capability_hash: 1
@@ -162,9 +163,15 @@ defmodule Bedrock.ControlPlane.Coordinator.Server do
   end
 
   def handle_call({:register_node_resources, client_pid, compact_services, capabilities}, from, t) do
-    # Always subscribe client for TSL updates (monitor to clean up on death)
+    # Always subscribe client for TSL updates (monitor to clean up on death),
+    # and replay the current layout so a late joiner learns it immediately
+    # instead of waiting for the next broadcast (i.e., the next recovery).
     Process.monitor(client_pid)
-    updated_state = add_tsl_subscriber(t, client_pid)
+
+    updated_state =
+      t
+      |> add_tsl_subscriber(client_pid)
+      |> replay_tsl_to(client_pid)
 
     # Expand compact services to full format
     caller_node = node(client_pid)

--- a/lib/bedrock/control_plane/coordinator/state.ex
+++ b/lib/bedrock/control_plane/coordinator/state.ex
@@ -113,6 +113,25 @@ defmodule Bedrock.ControlPlane.Coordinator.State do
     @spec remove_tsl_subscriber(t :: State.t(), subscriber :: pid()) :: State.t()
     def remove_tsl_subscriber(t, subscriber), do: %{t | tsl_subscribers: MapSet.delete(t.tsl_subscribers, subscriber)}
 
+    @doc """
+    Replays the current layout to one subscriber, if a layout exists.
+
+    Broadcasts only reach subscribers that existed when the layout was
+    published. A Link that registers after the layout stabilized would
+    otherwise keep a nil cache until the next recovery — its clients
+    unavailable and its foreman never handed the reconciliation trigger.
+    The message is identical to a live broadcast, so the subscriber's
+    handling is too. With no layout yet (bootstrap, mid-recovery) nothing
+    is sent: an incomplete layout is not a runtime layout.
+    """
+    @spec replay_tsl_to(t :: State.t(), subscriber :: pid()) :: State.t()
+    def replay_tsl_to(%{transaction_system_layout: nil} = t, _subscriber), do: t
+
+    def replay_tsl_to(t, subscriber) do
+      send(subscriber, {:tsl_updated, t.transaction_system_layout})
+      t
+    end
+
     @spec broadcast_tsl_update(t :: State.t(), tsl :: TransactionSystemLayout.t() | nil) :: State.t()
     def broadcast_tsl_update(t, tsl) do
       for subscriber <- t.tsl_subscribers do

--- a/test/bedrock/control_plane/coordinator/tsl_replay_test.exs
+++ b/test/bedrock/control_plane/coordinator/tsl_replay_test.exs
@@ -1,0 +1,66 @@
+defmodule Bedrock.ControlPlane.Coordinator.TslReplayTest do
+  @moduledoc """
+  A Link that registers after the layout is already stable must still learn
+  it (bedrock-qzr.22). Broadcasts only reach subscribers that existed when
+  the layout was published; registration itself must replay the current
+  snapshot, or a late-joining node keeps a nil TSL — clients stall and its
+  foreman never receives the reconciliation trigger.
+  """
+  use ExUnit.Case, async: true
+
+  alias Bedrock.ControlPlane.Coordinator.Server
+  alias Bedrock.ControlPlane.Coordinator.State
+
+  defp follower_state(overrides) do
+    # A follower coordinator: registration subscribes locally and forwards
+    # the durable write to the leader, so the handler can run without Raft.
+    struct!(
+      State,
+      Map.merge(
+        %{
+          my_node: :me@nowhere,
+          leader_node: :leader@nowhere,
+          otp_name: :tsl_replay_test_coordinator,
+          tsl_subscribers: MapSet.new()
+        },
+        overrides
+      )
+    )
+  end
+
+  defp register(state) do
+    Server.handle_call({:register_node_resources, self(), [], []}, {self(), make_ref()}, state)
+  end
+
+  test "registration replays the current layout to the new subscriber" do
+    tsl = %{id: "layout-1", epoch: 7, logs: %{}, services: %{}}
+    state = follower_state(%{transaction_system_layout: tsl})
+
+    assert {:noreply, updated} = register(state)
+
+    # The same message shape as a live broadcast: Link's existing handler
+    # caches it and forwards it to the local foreman unchanged.
+    assert_receive {:tsl_updated, ^tsl}
+    assert MapSet.member?(updated.tsl_subscribers, self())
+  end
+
+  test "with no current layout, nothing is replayed" do
+    state = follower_state(%{transaction_system_layout: nil})
+
+    assert {:noreply, _updated} = register(state)
+
+    refute_receive {:tsl_updated, _}, 50
+  end
+
+  test "duplicate registration is idempotent: one subscription, same snapshot each time" do
+    tsl = %{id: "layout-1", epoch: 7, logs: %{}, services: %{}}
+    state = follower_state(%{transaction_system_layout: tsl})
+
+    assert {:noreply, state} = register(state)
+    assert {:noreply, state} = register(state)
+
+    assert_receive {:tsl_updated, ^tsl}
+    assert_receive {:tsl_updated, ^tsl}
+    assert MapSet.size(state.tsl_subscribers) == 1
+  end
+end


### PR DESCRIPTION
Fixes the P2 review finding (ticket bedrock-qzr.22).

## Why

TSL broadcasts only reach subscribers that existed at the moment the layout was published. A Link (and therefore a node) that registered *after* the stable layout went out kept a nil cached TSL until the next recovery happened to broadcast a new one: its clients stayed unavailable, and its Foreman never received the trigger that layout-driven worker reconciliation depends on — so a restarted node could retain obsolete workers indefinitely, against the durable-layout-is-what-exists rule.

## What

`register_node_resources` now replays the coordinator's current layout to the newly subscribed Link, in the same step that adds the subscription. The replay is the identical `{:tsl_updated, tsl}` message a live broadcast sends, so the Link's existing handler does exactly what it does for broadcasts: cache the layout and forward it to the local Foreman, which reconciles stale workers — no new code path on the receiving side. When no layout exists yet (bootstrap, mid-recovery), nothing is sent: an incomplete layout is never exposed as a runtime layout.

Duplicate registration, reconnect, and leader-change re-registration are naturally idempotent: the subscriber set is a set, the replayed snapshot is the same layout each time, and Foreman reconciliation against an unchanged layout retires nothing.

## How it's tested

Handler-level tests drive the real `register_node_resources` callback on a follower coordinator (no Raft required):

- a registration after the layout is stable delivers the exact layout to the new subscriber (failed before the fix);
- with no current layout, nothing is replayed;
- duplicate registration keeps one subscription and replays the same snapshot each time.

The Link→Foreman half of the chain is the existing, already-tested broadcast path — the replay message is indistinguishable from a broadcast.

Full suite: 2518 tests, 158 properties, 0 failures; credo --strict and dialyzer clean.