### PR TITLE
Read legacy BED0 WALs with a synthetic replay cursor

### DIFF
--- a/guides/deep-dives/architecture/implementations/shale.md
+++ b/guides/deep-dives/architecture/implementations/shale.md
@@ -29,8 +29,11 @@ the header before acknowledging. Thus an older segment cannot become
 trim-eligible before its successor durably records the exact predecessor
 cursor. An empty recovery range explicitly fsyncs the header by itself.
 
-Headers that predate `BED1` do not contain enough information to reconstruct a
-trimmed exclusive range. Startup rejects them instead of guessing a cursor.
+Cold start also reads non-empty legacy `BED0` segments. Because versions are
+unsigned integers, one less than the first retained version is an unambiguous
+synthetic exclusive cursor; version zero remains zero. Empty `BED0` segments
+have no first retained version from which to derive that cursor and fail closed.
+All newly written segments use `BED1`.
 
 ## Ordered Appends
 

--- a/lib/bedrock/data_plane/log/shale/segment.ex
+++ b/lib/bedrock/data_plane/log/shale/segment.ex
@@ -4,6 +4,7 @@ defmodule Bedrock.DataPlane.Log.Shale.Segment do
   """
   alias Bedrock.DataPlane.Log.Shale.SegmentRecycler
   alias Bedrock.DataPlane.Log.Shale.TransactionStreams
+  alias Bedrock.DataPlane.Log.Shale.WalFormat
   alias Bedrock.DataPlane.Transaction
   alias Bedrock.DataPlane.Version
 
@@ -90,14 +91,17 @@ defmodule Bedrock.DataPlane.Log.Shale.Segment do
           | {:error, {:wal_format, String.t(), :unsupported_wal_format | :invalid_wal_format}}
           | {:error, {:wal_io, String.t(), File.posix()}}
   def from_path(path_to_file) do
-    case TransactionStreams.read_previous_version(path_to_file) do
-      {:ok, previous_version} ->
-        {:ok,
-         %__MODULE__{
-           path: path_to_file,
-           min_version: path_to_file |> Path.basename() |> decode_file_name() |> Version.from_integer(),
-           previous_version: previous_version
-         }}
+    min_version = path_to_file |> Path.basename() |> decode_file_name() |> Version.from_integer()
+
+    case WalFormat.read(path_to_file) do
+      {:ok, %WalFormat{version: :bed0, first_version: ^min_version, previous_version: previous_version}} ->
+        {:ok, new(path_to_file, min_version, previous_version)}
+
+      {:ok, %WalFormat{version: :bed0}} ->
+        {:error, {:wal_format, path_to_file, :invalid_wal_format}}
+
+      {:ok, %WalFormat{version: :bed1, previous_version: previous_version}} ->
+        {:ok, new(path_to_file, min_version, previous_version)}
 
       {:error, format} when format in [:unsupported_wal_format, :invalid_wal_format] ->
         {:error, {:wal_format, path_to_file, format}}
@@ -105,6 +109,14 @@ defmodule Bedrock.DataPlane.Log.Shale.Segment do
       {:error, posix} ->
         {:error, {:wal_io, path_to_file, posix}}
     end
+  end
+
+  defp new(path, min_version, previous_version) do
+    %__MODULE__{
+      path: path,
+      min_version: min_version,
+      previous_version: previous_version
+    }
   end
 
   @spec ensure_transactions_are_loaded(t()) :: t()

--- a/lib/bedrock/data_plane/log/shale/transaction_streams.ex
+++ b/lib/bedrock/data_plane/log/shale/transaction_streams.ex
@@ -5,38 +5,13 @@ defmodule Bedrock.DataPlane.Log.Shale.TransactionStreams do
   """
 
   alias Bedrock.DataPlane.Log.Shale.Segment
+  alias Bedrock.DataPlane.Log.Shale.WalFormat
   alias Bedrock.DataPlane.Transaction
-
-  @wal_magic_number <<"BED1">>
-  @wal_eof_version <<0xFFFFFFFFFFFFFFFF::unsigned-big-64>>
 
   @spec read_previous_version(String.t()) ::
           {:ok, Bedrock.version()}
           | {:error, :unsupported_wal_format | :invalid_wal_format | File.posix()}
-  def read_previous_version(path_to_file) do
-    with {:ok, fd} <- File.open(path_to_file, [:read, :raw, :binary]) do
-      result =
-        case :file.pread(fd, 0, 12) do
-          {:ok, <<@wal_magic_number, previous_version::binary-size(8)>>} ->
-            {:ok, previous_version}
-
-          {:ok, <<"BED0", _::binary>>} ->
-            {:error, :unsupported_wal_format}
-
-          {:ok, _} ->
-            {:error, :invalid_wal_format}
-
-          :eof ->
-            {:error, :invalid_wal_format}
-
-          {:error, reason} ->
-            {:error, reason}
-        end
-
-      :ok = File.close(fd)
-      result
-    end
-  end
+  defdelegate read_previous_version(path), to: WalFormat, as: :previous_version
 
   @spec from_segments([Segment.t()], Bedrock.version()) ::
           {:ok, Enumerable.t(Transaction.encoded())} | {:error, :not_found}
@@ -66,13 +41,22 @@ defmodule Bedrock.DataPlane.Log.Shale.TransactionStreams do
     end
   end
 
-  # Find segments starting from the first one that could contain transactions > target_version
-  defp find_segments_from_target(segments, target_version), do: find_valid_segments(segments, target_version, [])
+  # State keeps segments newest-first. Prepending only the relevant prefix
+  # produces the chronological view required by pull without reversing or
+  # loading the older tail.
+  defp find_segments_from_target(segments, target_version), do: find_segments_from_target(segments, target_version, [])
 
-  defp find_valid_segments([segment | rest], target_version, acc),
-    do: find_valid_segments(rest, target_version, [segment | acc])
+  defp find_segments_from_target(
+         [%Segment{previous_version: <<_::unsigned-big-64>> = previous_version} = segment | _],
+         target_version,
+         selected
+       )
+       when target_version >= previous_version, do: [segment | selected]
 
-  defp find_valid_segments([], _target_version, acc), do: Enum.reverse(acc)
+  defp find_segments_from_target([segment | rest], target_version, selected),
+    do: find_segments_from_target(rest, target_version, [segment | selected])
+
+  defp find_segments_from_target([], _target_version, selected), do: selected
 
   @spec from_list_of_transactions((-> [Transaction.encoded()] | nil)) :: Enumerable.t(Transaction.encoded())
   def from_list_of_transactions(transactions_fn) do
@@ -103,12 +87,11 @@ defmodule Bedrock.DataPlane.Log.Shale.TransactionStreams do
   def from_file!(path_to_file) do
     Stream.resource(
       fn ->
-        case File.read!(path_to_file) do
-          <<@wal_magic_number, _previous_version::binary-size(8), bytes::binary>> ->
-            {12, bytes}
+        wal = File.read!(path_to_file)
 
-          other ->
-            {:error, {:invalid_wal_format, byte_size(other)}}
+        case WalFormat.split(wal) do
+          {:ok, format, entries} -> {format.header_size, entries}
+          {:error, reason} -> {:error, {reason, byte_size(wal)}}
         end
       end,
       fn
@@ -119,7 +102,7 @@ defmodule Bedrock.DataPlane.Log.Shale.TransactionStreams do
          <<version_binary::binary-size(8), size_in_bytes::unsigned-big-32, payload::binary-size(size_in_bytes),
            crc32::unsigned-big-32, remaining_bytes::binary>>} ->
           cond do
-            @wal_eof_version == version_binary ->
+            WalFormat.eof_version?(version_binary) ->
               {:halt, nil}
 
             :erlang.crc32(payload) == crc32 ->

--- a/lib/bedrock/data_plane/log/shale/wal_format.ex
+++ b/lib/bedrock/data_plane/log/shale/wal_format.ex
@@ -1,0 +1,98 @@
+defmodule Bedrock.DataPlane.Log.Shale.WalFormat do
+  @moduledoc false
+
+  alias Bedrock.DataPlane.Version
+
+  @bed0_magic "BED0"
+  @bed1_magic "BED1"
+  @eof_version <<0xFFFFFFFFFFFFFFFF::unsigned-big-64>>
+  @eof_marker <<@eof_version::binary, 0::unsigned-big-32, 0::unsigned-big-32>>
+  @bed0_header_size 4
+  @bed1_header_size 12
+  @prefix_size @bed1_header_size + byte_size(@eof_marker)
+
+  @enforce_keys [:version, :header_size, :previous_version]
+  defstruct [:version, :header_size, :previous_version, :first_version]
+
+  @type t :: %__MODULE__{
+          version: :bed0 | :bed1,
+          header_size: 4 | 12,
+          previous_version: Bedrock.version(),
+          first_version: Bedrock.version() | nil
+        }
+
+  @type format_error :: :unsupported_wal_format | :invalid_wal_format
+
+  @spec decode(binary()) :: {:ok, t()} | {:error, format_error()}
+  def decode(<<@bed1_magic, previous_version::binary-size(8), _::binary>>) do
+    {:ok,
+     %__MODULE__{
+       version: :bed1,
+       header_size: @bed1_header_size,
+       previous_version: previous_version
+     }}
+  end
+
+  def decode(<<@bed0_magic, @eof_marker, _::binary>>), do: {:error, :unsupported_wal_format}
+  def decode(<<@bed0_magic, @eof_version, _::binary>>), do: {:error, :invalid_wal_format}
+
+  def decode(<<@bed0_magic, first_version::binary-size(8), _size::unsigned-big-32, _::binary-size(4), _::binary>>) do
+    {:ok,
+     %__MODULE__{
+       version: :bed0,
+       header_size: @bed0_header_size,
+       previous_version: legacy_cursor(first_version),
+       first_version: first_version
+     }}
+  end
+
+  def decode(_), do: {:error, :invalid_wal_format}
+
+  @spec read(Path.t()) :: {:ok, t()} | {:error, format_error() | File.posix()}
+  def read(path) do
+    with {:ok, fd} <- File.open(path, [:read, :raw, :binary]) do
+      result =
+        case :file.pread(fd, 0, @prefix_size) do
+          {:ok, prefix} -> decode(prefix)
+          :eof -> {:error, :invalid_wal_format}
+          {:error, reason} -> {:error, reason}
+        end
+
+      :ok = File.close(fd)
+      result
+    end
+  end
+
+  @spec previous_version(Path.t()) :: {:ok, Bedrock.version()} | {:error, format_error() | File.posix()}
+  def previous_version(path) do
+    with {:ok, format} <- read(path), do: {:ok, format.previous_version}
+  end
+
+  @spec split(binary()) :: {:ok, t(), binary()} | {:error, format_error()}
+  def split(<<@bed1_magic, _previous_version::binary-size(8), entries::binary>> = wal) do
+    with {:ok, format} <- decode(wal), do: {:ok, format, entries}
+  end
+
+  def split(<<@bed0_magic, entries::binary>> = wal) do
+    with {:ok, format} <- decode(wal), do: {:ok, format, entries}
+  end
+
+  def split(_), do: {:error, :invalid_wal_format}
+
+  @spec empty_segment(Bedrock.version()) :: binary()
+  def empty_segment(<<_::unsigned-big-64>> = previous_version),
+    do: <<@bed1_magic, previous_version::binary, @eof_marker>>
+
+  @spec current_header_size() :: 12
+  def current_header_size, do: @bed1_header_size
+
+  @spec eof_marker() :: binary()
+  def eof_marker, do: @eof_marker
+
+  @spec eof_version?(Bedrock.version()) :: boolean()
+  def eof_version?(@eof_version), do: true
+  def eof_version?(<<_::unsigned-big-64>>), do: false
+
+  defp legacy_cursor(<<0::unsigned-big-64>>), do: Version.zero()
+  defp legacy_cursor(<<version::unsigned-big-64>>), do: Version.from_integer(version - 1)
+end

--- a/lib/bedrock/data_plane/log/shale/writer.ex
+++ b/lib/bedrock/data_plane/log/shale/writer.ex
@@ -3,14 +3,10 @@ defmodule Bedrock.DataPlane.Log.Shale.Writer do
   A struct that represents a writer for a segment.
   """
 
+  alias Bedrock.DataPlane.Log.Shale.WalFormat
   alias Bedrock.DataPlane.Transaction
 
   defstruct [:fd, :write_offset, :bytes_remaining, :sync_fun, :pwrite_fun]
-
-  @wal_eof_version <<0xFFFFFFFFFFFFFFFF::unsigned-big-64>>
-  @eof_marker <<@wal_eof_version::binary, 0::unsigned-big-32, 0::unsigned-big-32>>
-  @wal_magic_number <<"BED1">>
-  @header_size 12
 
   @typedoc """
   A `Writer` is a handle to a segment that can be used to write transcations
@@ -30,18 +26,19 @@ defmodule Bedrock.DataPlane.Log.Shale.Writer do
   def open(path_to_file, previous_version, opts \\ []) do
     sync_fun = Keyword.get(opts, :sync_fun, &:file.sync/1)
     pwrite_fun = Keyword.get(opts, :pwrite_fun, &:file.pwrite/3)
-    empty_segment_header = <<@wal_magic_number, previous_version::binary-size(8), @eof_marker>>
+    empty_segment = WalFormat.empty_segment(previous_version)
+    header_size = WalFormat.current_header_size()
 
     with {:ok, stat} <- File.stat(path_to_file),
          {:ok, fd} <- File.open(path_to_file, [:write, :read, :raw, :binary]) do
       # Write header - close fd on failure to avoid leak
-      case pwrite_fun.(fd, 0, empty_segment_header) do
+      case pwrite_fun.(fd, 0, empty_segment) do
         :ok ->
           {:ok,
            %__MODULE__{
              fd: fd,
-             write_offset: @header_size,
-             bytes_remaining: stat.size - @header_size - 16,
+             write_offset: header_size,
+             bytes_remaining: stat.size - header_size - byte_size(WalFormat.eof_marker()),
              sync_fun: sync_fun,
              pwrite_fun: pwrite_fun
            }}
@@ -79,7 +76,7 @@ defmodule Bedrock.DataPlane.Log.Shale.Writer do
     >>
 
     writer.fd
-    |> writer.pwrite_fun.(writer.write_offset, [log_entry, @eof_marker])
+    |> writer.pwrite_fun.(writer.write_offset, [log_entry, WalFormat.eof_marker()])
     |> case do
       :ok ->
         case writer.sync_fun.(writer.fd) do

--- a/test/bedrock/data_plane/log/shale/cold_starting_test.exs
+++ b/test/bedrock/data_plane/log/shale/cold_starting_test.exs
@@ -5,6 +5,7 @@ defmodule Bedrock.DataPlane.Log.Shale.ColdStartingTest do
   alias Bedrock.DataPlane.Log.Shale.Segment
   alias Bedrock.DataPlane.Log.Shale.Writer
   alias Bedrock.DataPlane.Version
+  alias Bedrock.Test.DataPlane.TransactionTestSupport
 
   @segment_dir "test/fixtures/segments"
 
@@ -55,11 +56,42 @@ defmodule Bedrock.DataPlane.Log.Shale.ColdStartingTest do
       assert {:ok, []} = ColdStarting.reload_segments_at_path(@segment_dir)
     end
 
-    test "fails closed for a legacy segment without a persisted predecessor" do
+    test "loads a non-empty BED0 segment with a synthetic exclusive cursor" do
+      path = create_legacy_segment_file(41)
+      first_version = Version.from_integer(41)
+      expected_cursor = Version.from_integer(40)
+
+      assert {:ok,
+              [
+                %Segment{
+                  path: ^path,
+                  min_version: ^first_version,
+                  previous_version: ^expected_cursor
+                }
+              ]} = ColdStarting.reload_segments_at_path(@segment_dir)
+    end
+
+    test "fails closed for an empty legacy segment" do
       path = Path.join(@segment_dir, Segment.encode_file_name(1))
-      File.write!(path, <<"BED0", 0::128>>)
+      eof_marker = <<0xFFFFFFFFFFFFFFFF::unsigned-big-64, 0::unsigned-big-32, 0::unsigned-big-32>>
+      File.write!(path, <<"BED0", eof_marker::binary>>)
 
       assert {:error, {:wal_format, ^path, :unsupported_wal_format}} =
+               ColdStarting.reload_segments_at_path(@segment_dir)
+    end
+
+    test "fails closed when a BED0 filename disagrees with its first transaction" do
+      first_version = Version.from_integer(41)
+      transaction = TransactionTestSupport.new_log_transaction(41, %{"key" => "value"})
+
+      entry =
+        <<first_version::binary, byte_size(transaction)::unsigned-big-32, transaction::binary,
+          :erlang.crc32(transaction)::unsigned-big-32>>
+
+      path = Path.join(@segment_dir, Segment.encode_file_name(42))
+      File.write!(path, <<"BED0", entry::binary>>)
+
+      assert {:error, {:wal_format, ^path, :invalid_wal_format}} =
                ColdStarting.reload_segments_at_path(@segment_dir)
     end
 
@@ -85,5 +117,19 @@ defmodule Bedrock.DataPlane.Log.Shale.ColdStartingTest do
     File.write!(path, :binary.copy(<<0>>, 1024))
     {:ok, writer} = Writer.open(path, Version.from_integer(previous_version))
     :ok = Writer.close(writer)
+  end
+
+  defp create_legacy_segment_file(version) do
+    path = Path.join(@segment_dir, Segment.encode_file_name(version))
+    commit_version = Version.from_integer(version)
+    transaction = TransactionTestSupport.new_log_transaction(version, %{"key" => "value"})
+    crc32 = :erlang.crc32(transaction)
+
+    entry =
+      <<commit_version::binary, byte_size(transaction)::unsigned-big-32, transaction::binary, crc32::unsigned-big-32>>
+
+    eof_marker = <<0xFFFFFFFFFFFFFFFF::unsigned-big-64, 0::unsigned-big-32, 0::unsigned-big-32>>
+    File.write!(path, <<"BED0", entry::binary, eof_marker::binary>>)
+    path
   end
 end

--- a/test/bedrock/data_plane/log/shale/replay_cursor_integration_test.exs
+++ b/test/bedrock/data_plane/log/shale/replay_cursor_integration_test.exs
@@ -4,6 +4,7 @@ defmodule Bedrock.DataPlane.Log.Shale.ReplayCursorIntegrationTest do
   alias Bedrock.Cluster
   alias Bedrock.DataPlane.Demux.Server, as: Demux
   alias Bedrock.DataPlane.Log
+  alias Bedrock.DataPlane.Log.Shale.Segment
   alias Bedrock.DataPlane.Log.Shale.Server, as: Shale
   alias Bedrock.DataPlane.Version
   alias Bedrock.ObjectStorage
@@ -11,6 +12,42 @@ defmodule Bedrock.DataPlane.Log.Shale.ReplayCursorIntegrationTest do
   alias Bedrock.Test.DataPlane.TransactionTestSupport
 
   @moduletag :tmp_dir
+
+  test "a legacy BED0 source rolls forward to BED1 and replays its first retained transaction", %{tmp_dir: tmp_dir} do
+    backend = object_storage(tmp_dir)
+    source_path = Path.join(tmp_dir, "legacy-source")
+    destination_path = Path.join(tmp_dir, "legacy-destination")
+    first_version = Version.from_integer(41)
+    legacy_last_version = Version.from_integer(500)
+    last_inclusive = Version.from_integer(900)
+    first = transaction(first_version, "legacy-first")
+    legacy_last = transaction(legacy_last_version, "legacy-last")
+    current = transaction(last_inclusive, "current")
+
+    write_legacy_wal(source_path, [{first_version, first}, {legacy_last_version, legacy_last}])
+    {source, source_id} = start_restartable_log("legacy-source", source_path, backend, true)
+    assert :ok = Log.push(source, current, legacy_last_version)
+    assert :ok = stop_supervised({Shale, source_id})
+
+    {source, ^source_id} =
+      start_restartable_log("legacy-source-restart", source_path, backend, false, source_id)
+
+    destination = start_log("legacy-destination", destination_path, backend, false)
+    expected_cursor = Version.from_integer(40)
+
+    assert {:ok,
+            %{
+              available_after: ^expected_cursor,
+              oldest_version: ^first_version,
+              last_version: ^last_inclusive
+            }} = Log.info(source, [:available_after, :oldest_version, :last_version])
+
+    assert {:ok, ^destination} =
+             Log.recover_from(destination, [source], expected_cursor, last_inclusive)
+
+    assert {:ok, [^first, ^legacy_last, ^current]} =
+             Log.pull(destination, expected_cursor, last_version: last_inclusive)
+  end
 
   test "untrimmed recovery copies widely gapped transactions exactly once", %{tmp_dir: tmp_dir} do
     backend = object_storage(tmp_dir)
@@ -119,6 +156,20 @@ defmodule Bedrock.DataPlane.Log.Shale.ReplayCursorIntegrationTest do
     root = Path.join(tmp_dir, "objects")
     File.mkdir_p!(root)
     ObjectStorage.backend(LocalFilesystem, root: root)
+  end
+
+  defp write_legacy_wal(path, [{first_version, _} | _] = transactions) do
+    File.mkdir_p!(path)
+    wal_path = Path.join(path, Segment.encode_file_name(Version.to_integer(first_version)))
+
+    entries =
+      Enum.map(transactions, fn {version, transaction} ->
+        <<version::binary, byte_size(transaction)::unsigned-big-32, transaction::binary,
+          :erlang.crc32(transaction)::unsigned-big-32>>
+      end)
+
+    eof_marker = <<0xFFFFFFFFFFFFFFFF::unsigned-big-64, 0::unsigned-big-32, 0::unsigned-big-32>>
+    File.write!(wal_path, ["BED0", entries, eof_marker])
   end
 
   defp start_log(label, wal_path, object_storage, start_unlocked) do

--- a/test/bedrock/data_plane/log/shale/transaction_streams_edge_case_test.exs
+++ b/test/bedrock/data_plane/log/shale/transaction_streams_edge_case_test.exs
@@ -8,6 +8,16 @@ defmodule Bedrock.DataPlane.Log.Shale.TransactionStreamsEdgeCaseTest do
   @moduletag :tmp_dir
 
   describe "TransactionStreams.from_file!/1" do
+    test "streams transactions from a BED0 segment", %{tmp_dir: tmp_dir} do
+      transaction = TransactionTestSupport.new_log_transaction(41, %{"key" => "value"})
+      entry = create_entry(transaction, Version.from_integer(41))
+      wal_file = Path.join(tmp_dir, "legacy.wal")
+      eof_marker = <<0xFFFFFFFFFFFFFFFF::unsigned-big-64, 0::unsigned-big-32, 0::unsigned-big-32>>
+      File.write!(wal_file, <<"BED0", entry::binary, eof_marker::binary>>)
+
+      assert [^transaction] = wal_file |> TransactionStreams.from_file!() |> Enum.to_list()
+    end
+
     test "gracefully handles files with corrupted CRC32 checksums", %{tmp_dir: tmp_dir} do
       # Create a WAL file with invalid CRC32 to trigger corruption handling
       transaction = TransactionTestSupport.new_log_transaction(1, %{"key" => "value"})
@@ -86,6 +96,13 @@ defmodule Bedrock.DataPlane.Log.Shale.TransactionStreamsEdgeCaseTest do
 
     <<version_binary::binary-size(8), size_in_bytes::unsigned-big-32, transaction::binary,
       wrong_crc32::unsigned-big-32>>
+  end
+
+  defp create_entry(transaction, version) do
+    size_in_bytes = byte_size(transaction)
+    crc32 = :erlang.crc32(transaction)
+
+    <<version::binary, size_in_bytes::unsigned-big-32, transaction::binary, crc32::unsigned-big-32>>
   end
 
   defp create_truncated_entry do

--- a/test/bedrock/data_plane/log/shale/transaction_streams_invariants_test.exs
+++ b/test/bedrock/data_plane/log/shale/transaction_streams_invariants_test.exs
@@ -34,18 +34,20 @@ defmodule Bedrock.DataPlane.Log.Shale.TransactionStreamsInvariantsTest do
         Enum.reduce(segment_sizes, {[], 0}, fn size, {acc_segments, offset} ->
           segment_versions = Enum.slice(all_versions, offset, size)
           min_version = List.first(segment_versions)
-          transactions = Enum.map(segment_versions, &transaction_generator/1)
+          previous_version = if offset == 0, do: Version.zero(), else: Enum.at(all_versions, offset - 1)
+          transactions = segment_versions |> Enum.map(&transaction_generator/1) |> Enum.reverse()
 
           segment = %Segment{
             path: "/tmp/property_test_segment",
             min_version: min_version,
+            previous_version: previous_version,
             transactions: transactions
           }
 
           {[segment | acc_segments], offset + size}
         end)
 
-      Enum.reverse(segments)
+      segments
     end
   end
 
@@ -218,17 +220,17 @@ defmodule Bedrock.DataPlane.Log.Shale.TransactionStreamsInvariantsTest do
   defp assert_segments_have_non_overlapping_ranges(segments) do
     segments
     |> Enum.chunk_every(2, 1, :discard)
-    |> Enum.each(fn [prev_segment, next_segment] ->
-      prev_max_version =
-        prev_segment.transactions
+    |> Enum.each(fn [newer_segment, older_segment] ->
+      older_max_version =
+        older_segment.transactions
         |> Enum.map(&TransactionTestSupport.extract_log_version/1)
         |> Enum.max(fn -> Version.from_integer(0) end)
 
-      assert next_segment.min_version > prev_max_version,
+      assert newer_segment.min_version > older_max_version,
              """
              Segments have overlapping version ranges!
-             Previous segment max version: #{Version.to_integer(prev_max_version)}
-             Next segment min version: #{Version.to_integer(next_segment.min_version)}
+             Older segment max version: #{Version.to_integer(older_max_version)}
+             Newer segment min version: #{Version.to_integer(newer_segment.min_version)}
              """
     end)
   end
@@ -260,6 +262,9 @@ defmodule Bedrock.DataPlane.Log.Shale.TransactionStreamsInvariantsTest do
 
     assert Enum.all?(versions, &(&1 > zero_version)),
            "Found invalid transaction versions: #{inspect(Enum.map(versions, &Version.to_integer/1))}"
+
+    assert versions == Enum.sort(versions),
+           "Transactions are not oldest-first: #{inspect(Enum.map(versions, &Version.to_integer/1))}"
   end
 
   defp assert_contains_all_expected(actual_transactions, expected_transactions) do
@@ -308,6 +313,7 @@ defmodule Bedrock.DataPlane.Log.Shale.TransactionStreamsInvariantsTest do
 
   defp simulate_stream_behavior(segments, target_version, last_version, limit) do
     segments
+    |> Enum.reverse()
     |> Enum.flat_map(&Enum.reverse(&1.transactions))
     |> Enum.filter(fn tx ->
       version = Transaction.commit_version!(tx)

--- a/test/bedrock/data_plane/log/shale/transaction_streams_test.exs
+++ b/test/bedrock/data_plane/log/shale/transaction_streams_test.exs
@@ -54,6 +54,32 @@ defmodule Bedrock.DataPlane.Log.Shale.TransactionStreamsTest do
       assert TransactionTestSupport.extract_log_version(transaction) == Version.from_integer(2)
     end
 
+    test "does not load older segments at or below the requested cursor" do
+      transaction_300 = create_test_transaction(300, %{"key" => "value"})
+
+      newest = %Segment{
+        path: "newest",
+        min_version: Version.from_integer(300),
+        previous_version: Version.from_integer(200),
+        transactions: [transaction_300]
+      }
+
+      irrelevant_older = %Segment{
+        path: "must_not_be_loaded",
+        min_version: Version.from_integer(100),
+        previous_version: Version.from_integer(0),
+        transactions: nil
+      }
+
+      assert {:ok, stream} =
+               TransactionStreams.from_segments(
+                 [newest, irrelevant_older],
+                 Version.from_integer(200)
+               )
+
+      assert [^transaction_300] = Enum.to_list(stream)
+    end
+
     test "returns error when given empty segment list" do
       assert {:error, :not_found} = TransactionStreams.from_segments([], Version.from_integer(1))
     end

--- a/test/bedrock/data_plane/log/shale/wal_format_test.exs
+++ b/test/bedrock/data_plane/log/shale/wal_format_test.exs
@@ -1,0 +1,50 @@
+defmodule Bedrock.DataPlane.Log.Shale.WalFormatTest do
+  use ExUnit.Case, async: true
+
+  alias Bedrock.DataPlane.Log.Shale.WalFormat
+  alias Bedrock.DataPlane.Version
+
+  describe "decode/1" do
+    test "reads the persisted replay cursor from BED1" do
+      previous_version = Version.from_integer(41)
+
+      assert {:ok,
+              %WalFormat{
+                version: :bed1,
+                header_size: 12,
+                previous_version: ^previous_version
+              }} = WalFormat.decode(<<"BED1", previous_version::binary, 0::128>>)
+    end
+
+    test "derives a synthetic exclusive cursor from the first BED0 transaction" do
+      first_version = Version.from_integer(41)
+      expected_cursor = Version.from_integer(40)
+
+      assert {:ok,
+              %WalFormat{
+                version: :bed0,
+                header_size: 4,
+                previous_version: ^expected_cursor,
+                first_version: ^first_version
+              }} = WalFormat.decode(<<"BED0", first_version::binary, 0::64>>)
+    end
+
+    test "keeps the synthetic BED0 cursor at zero without underflow" do
+      zero = Version.zero()
+
+      assert {:ok, %WalFormat{version: :bed0, previous_version: ^zero}} =
+               WalFormat.decode(<<"BED0", zero::binary, 0::64>>)
+    end
+
+    test "rejects an empty BED0 segment because it has no derivable cursor" do
+      eof_marker = <<0xFFFFFFFFFFFFFFFF::unsigned-big-64, 0::unsigned-big-32, 0::unsigned-big-32>>
+
+      assert {:error, :unsupported_wal_format} = WalFormat.decode(<<"BED0", eof_marker::binary>>)
+    end
+
+    test "rejects malformed and unknown headers" do
+      assert {:error, :invalid_wal_format} = WalFormat.decode("BED0")
+      assert {:error, :invalid_wal_format} = WalFormat.decode(<<"NOPE", 0::128>>)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- centralize BED0/BED1 recognition, header offsets, EOF markers, and current-format encoding in WalFormat
- derive a zero-safe synthetic exclusive cursor from the first retained BED0 transaction while continuing to write only BED1
- preserve newest-first segment storage while selecting only the relevant prefix for chronological pull/replay
- fail closed for empty legacy segments and filename/first-version disagreement
- document the compatibility behavior

## TDD

- format contract tests first failed because WalFormat did not exist
- mixed BED0-to-BED1 restart/replay then exposed newest-segment-first output with transaction_not_after_cursor
- a focused performance test proved the first fix loaded an irrelevant older segment
- cursor-aware selection made both regression cases green without reversing stored segment order

## Verification

- mix test: 13 doctests, 158 properties, 2,536 tests, 0 failures (2 excluded)
- focused Shale/log suite: 5 properties, 195 tests, 0 failures
- mix format --check-formatted
- mix credo --strict
- mix dialyzer --format short
- original failing WAL files load with cursor 257330069667 and stream all six retained versions in ascending order

Closes bedrock-egw.