### PR TITLE
Bound post-recovery reads and transaction retries

### DIFF
--- a/lib/bedrock/data_plane/materializer/olivine/reading.ex
+++ b/lib/bedrock/data_plane/materializer/olivine/reading.ex
@@ -11,6 +11,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Reading do
   alias Bedrock.DataPlane.Materializer.Olivine.IndexManager
   alias Bedrock.DataPlane.Materializer.Olivine.Telemetry, as: OlivineTelemetry
   alias Bedrock.DataPlane.Materializer.Telemetry
+  alias Bedrock.DataPlane.Version
   alias Bedrock.Internal.WaitingList
   alias Bedrock.KeySelector
 
@@ -166,9 +167,9 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Reading do
   @spec notify_waiting_fetches(t(), ReadingContext.t(), Bedrock.version()) :: t()
   def notify_waiting_fetches(%__MODULE__{} = manager, context, applied_version) do
     {updated_waiting_fetches, waiting_entries} =
-      WaitingList.remove_all(
+      WaitingList.remove_all_less_than(
         manager.waiting_fetches,
-        applied_version
+        Version.increment(applied_version)
       )
 
     # Process waiting entries and collect spawned PIDs
@@ -183,6 +184,16 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Reading do
     # Add spawned PIDs to active tasks
     manager_with_updated_waiting = %{manager | waiting_fetches: updated_waiting_fetches}
     Enum.reduce(spawned_pids, manager_with_updated_waiting, &add_active_task(&2, &1))
+  end
+
+  @doc """
+  Expires waiting fetches whose deadlines have elapsed and replies to them.
+  """
+  @spec expire_waiting_fetches(t(), term()) :: t()
+  def expire_waiting_fetches(%__MODULE__{} = manager, error_response \\ {:error, :waiting_timeout}) do
+    {waiting_fetches, expired_entries} = WaitingList.expire(manager.waiting_fetches)
+    WaitingList.reply_to_expired(expired_entries, error_response)
+    %{manager | waiting_fetches: waiting_fetches}
   end
 
   @doc """

--- a/lib/bedrock/data_plane/materializer/olivine/server.ex
+++ b/lib/bedrock/data_plane/materializer/olivine/server.ex
@@ -68,7 +68,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Server do
     # Set operation context metadata for this request
     Telemetry.trace_metadata(%{operation: :get, key: key})
 
-    fetch_opts = Keyword.put(opts, :reply_fn, reply_fn_for(from))
+    fetch_opts = opts |> Keyword.put(:reply_fn, reply_fn_for(from)) |> Keyword.put_new(:wait_ms, 1_000)
     context = Reading.ReadingContext.new(t.index_manager, t.database)
 
     {updated_manager, result} =
@@ -77,10 +77,11 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Server do
         context,
         key,
         version,
-        Keyword.put_new(fetch_opts, :wait_ms, 1_000)
+        fetch_opts
       )
 
     updated_state = %{t | read_request_manager: updated_manager}
+    schedule_waiter_expiration(t.read_request_manager, updated_manager, fetch_opts[:wait_ms])
 
     case result do
       :ok -> noreply(updated_state, continue: :maybe_process_transactions)
@@ -92,7 +93,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Server do
     # Set operation context metadata for this request
     Telemetry.trace_metadata(%{operation: :get_range, key: {start_key, end_key}})
 
-    fetch_opts = Keyword.put(opts, :reply_fn, reply_fn_for(from))
+    fetch_opts = opts |> Keyword.put(:reply_fn, reply_fn_for(from)) |> Keyword.put_new(:wait_ms, 1_000)
     context = Reading.ReadingContext.new(t.index_manager, t.database)
 
     {updated_manager, result} =
@@ -102,10 +103,11 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Server do
         start_key,
         end_key,
         version,
-        Keyword.put_new(fetch_opts, :wait_ms, 1_000)
+        fetch_opts
       )
 
     updated_state = %{t | read_request_manager: updated_manager}
+    schedule_waiter_expiration(t.read_request_manager, updated_manager, fetch_opts[:wait_ms])
 
     case result do
       :ok -> noreply(updated_state, continue: :maybe_process_transactions)
@@ -310,6 +312,12 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Server do
   end
 
   @impl true
+  def handle_info(:expire_waiting_fetches, %State{} = t) do
+    updated_manager = Reading.expire_waiting_fetches(t.read_request_manager)
+    noreply(%{t | read_request_manager: updated_manager})
+  end
+
+  @impl true
   def handle_info({:DOWN, _ref, :process, pid, _reason}, %State{} = t) do
     updated_manager = Reading.remove_active_task(t.read_request_manager, pid)
     updated_state = %{t | read_request_manager: updated_manager}
@@ -476,6 +484,17 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Server do
   def terminate(_reason, _state), do: :ok
 
   defp reply_fn_for(from), do: fn result -> GenServer.reply(from, result) end
+
+  defp schedule_waiter_expiration(previous_manager, updated_manager, wait_ms)
+       when is_integer(wait_ms) and wait_ms > 0 do
+    if previous_manager.waiting_fetches != updated_manager.waiting_fetches do
+      Process.send_after(self(), :expire_waiting_fetches, wait_ms)
+    end
+
+    :ok
+  end
+
+  defp schedule_waiter_expiration(_previous_manager, _updated_manager, _wait_ms), do: :ok
 
   # Calculate min/max key bounds from page_map
   defp calculate_key_bounds_from_pages(page_map) when map_size(page_map) == 0, do: {<<0xFF, 0xFF>>, <<>>}

--- a/lib/bedrock/internal/repo.ex
+++ b/lib/bedrock/internal/repo.ex
@@ -3,14 +3,17 @@ defmodule Bedrock.Internal.Repo do
   import Bitwise
 
   alias Bedrock.Cluster.Link
+  alias Bedrock.Internal.Repo.TransactionContext
   alias Bedrock.Internal.TransactionBuilder
   alias Bedrock.KeySelector
+
+  @default_timeout_in_ms 5_000
 
   @type transaction :: pid()
   @type key :: term()
   @type value :: term()
 
-  defp txn(repo_module), do: Process.get({:transaction, repo_module})
+  defp txn(repo_module), do: TransactionContext.builder(repo_module)
   defp txn!(repo_module), do: txn(repo_module) || raise("No active transaction")
 
   @spec add_read_conflict_key(module(), key()) :: :ok
@@ -27,7 +30,7 @@ defmodule Bedrock.Internal.Repo do
   def get(repo_module, key, opts) do
     t = txn!(repo_module)
 
-    case GenServer.call(t, {:get, key, opts}, :infinity) do
+    case call_transaction(repo_module, t, {:get, key, opts}) do
       {:ok, value} ->
         value
 
@@ -49,7 +52,7 @@ defmodule Bedrock.Internal.Repo do
   def select(repo_module, %KeySelector{} = key_selector, opts) do
     t = txn!(repo_module)
 
-    case GenServer.call(t, {:get_key_selector, key_selector, opts}, :infinity) do
+    case call_transaction(repo_module, t, {:get_key_selector, key_selector, opts}) do
       {:ok, {_key, _value} = result} ->
         result
 
@@ -100,6 +103,7 @@ defmodule Bedrock.Internal.Repo do
 
     # Initial state tracks the current position in the range
     initial_state = %{
+      repo: repo_module,
       txn: txn,
       current_key: start_key,
       end_key: end_key,
@@ -153,7 +157,8 @@ defmodule Bedrock.Internal.Repo do
         limit -> min(batch_size, limit - state.items_returned)
       end
 
-    case GenServer.call(
+    case call_transaction(
+           state.repo,
            state.txn,
            {:get_range, state.current_key, state.end_key, effective_batch_size, state.txn_opts},
            timeout
@@ -210,6 +215,8 @@ defmodule Bedrock.Internal.Repo do
   ## Options
 
   - `:retry_limit` - Maximum number of retry attempts (default: unlimited)
+  - `:timeout_in_ms` - End-to-end transaction timeout, including retries
+    (default: 5000; use `:infinity` to disable)
   - `:transaction_system_layout` - Use a specific TSL instead of fetching from coordinator
   """
   @spec transact(cluster :: module(), repo :: module(), (-> result) | (module() -> result), opts :: keyword()) :: result
@@ -217,46 +224,55 @@ defmodule Bedrock.Internal.Repo do
   def transact(cluster, repo, fun, opts \\ []) do
     case txn(repo) do
       nil ->
-        run_new_transaction(cluster, repo, fun, {:transaction, repo}, opts)
+        run_new_transaction(cluster, repo, fun, opts)
 
       existing_txn ->
-        run_nested_transaction(repo, existing_txn, fun)
+        run_nested_transaction(repo, existing_txn, fun, opts)
     end
   end
 
-  defp run_new_transaction(cluster, repo, fun, tx_key, opts) do
+  defp run_new_transaction(cluster, repo, fun, opts) do
     retry_limit = Keyword.get(opts, :retry_limit)
     provided_tsl = Keyword.get(opts, :transaction_system_layout)
     link = if provided_tsl, do: nil, else: cluster.link!()
+    timeout_in_ms = Keyword.get(opts, :timeout_in_ms, @default_timeout_in_ms)
 
-    run_retryable_transaction(repo, fun, 0, retry_limit, fn ->
-      tsl = fetch_tsl_for_transaction(provided_tsl, link)
-      start_transaction_builder(tsl, tx_key)
+    TransactionContext.with_deadline(repo, timeout_in_ms, fn ->
+      run_retryable_transaction(repo, fun, 0, retry_limit, fn ->
+        tsl = fetch_tsl_for_transaction(repo, provided_tsl, link)
+        start_transaction_builder(tsl, repo)
+      end)
     end)
   after
-    Process.delete(tx_key)
+    TransactionContext.clear_builder(repo)
   end
 
-  defp run_nested_transaction(repo, txn, fun) do
-    run_retryable_transaction(repo, fun, 0, nil, fn ->
-      GenServer.call(txn, :nested_transaction, :infinity)
-      txn
+  defp run_nested_transaction(repo, txn, fun, opts) do
+    timeout_in_ms = Keyword.get(opts, :timeout_in_ms, @default_timeout_in_ms)
+
+    TransactionContext.with_deadline(repo, timeout_in_ms, fn ->
+      run_retryable_transaction(repo, fun, 0, nil, fn ->
+        call_transaction(repo, txn, :nested_transaction)
+        txn
+      end)
     end)
   end
 
-  defp fetch_tsl_for_transaction(nil, link) do
-    case Link.fetch_transaction_system_layout(link) do
+  defp fetch_tsl_for_transaction(repo, nil, link) do
+    case Link.fetch_transaction_system_layout(link,
+           timeout_in_ms: TransactionContext.remaining_timeout!(repo, :timeout)
+         ) do
       {:ok, tsl} -> tsl
       {:error, reason} -> throw({__MODULE__, nil, :retryable_failure, reason})
     end
   end
 
-  defp fetch_tsl_for_transaction(tsl, _link), do: tsl
+  defp fetch_tsl_for_transaction(_repo, tsl, _link), do: tsl
 
-  defp start_transaction_builder(tsl, tx_key) do
+  defp start_transaction_builder(tsl, repo) do
     case TransactionBuilder.start_link(transaction_system_layout: tsl) do
       {:ok, txn} ->
-        Process.put(tx_key, txn)
+        TransactionContext.put_builder(repo, txn)
         txn
 
       {:error, reason} ->
@@ -265,12 +281,13 @@ defmodule Bedrock.Internal.Repo do
   end
 
   defp run_retryable_transaction(repo, fun, retry_count, retry_limit, restart_fn) do
+    TransactionContext.remaining_timeout!(repo, :timeout)
     run_transaction(repo, restart_fn.(), fun)
   catch
     {__MODULE__, failed_txn, :retryable_failure, reason} ->
       try_to_rollback(failed_txn)
       enforce_retry_limit(retry_count, retry_limit, reason)
-      wait_befor_retry(retry_count)
+      wait_before_retry(repo, retry_count, reason)
       run_retryable_transaction(repo, fun, retry_count + 1, retry_limit, restart_fn)
 
     {__MODULE__, :rollback, reason} ->
@@ -289,18 +306,21 @@ defmodule Bedrock.Internal.Repo do
       {:arity, 1} -> fun.(repo)
       {:arity, 0} -> fun.()
     end
-    |> then(&try_to_commit(txn, &1))
+    |> then(&try_to_commit(repo, txn, &1))
   rescue
     exception ->
       try_to_rollback(txn)
       reraise exception, __STACKTRACE__
   end
 
-  defp wait_befor_retry(retry_count) do
+  defp wait_before_retry(repo, retry_count, last_reason) do
     base_delay = 1 <<< retry_count
     jitter = :rand.uniform(3)
     wait_time_in_ms = min(base_delay + jitter, 1000)
-    Process.sleep(wait_time_in_ms)
+    remaining = TransactionContext.remaining_timeout!(repo, last_reason)
+
+    Process.sleep(min_timeout(wait_time_in_ms, remaining))
+    TransactionContext.remaining_timeout!(repo, last_reason)
   end
 
   defp enforce_retry_limit(_retry_count, nil, _reason), do: :ok
@@ -311,8 +331,8 @@ defmodule Bedrock.Internal.Repo do
           "Transaction retry limit exceeded after #{retry_limit} attempts. Last error: #{inspect(reason)}"
   end
 
-  defp try_to_commit(txn, result) do
-    case GenServer.call(txn, :commit) do
+  defp try_to_commit(repo, txn, result) do
+    case call_transaction(repo, txn, :commit) do
       :ok -> result
       {:ok, _commit_version} -> result
       {:error, reason} -> throw({__MODULE__, txn, :retryable_failure, reason})
@@ -321,4 +341,21 @@ defmodule Bedrock.Internal.Repo do
 
   defp try_to_rollback(nil), do: :ok
   defp try_to_rollback(txn), do: GenServer.cast(txn, :rollback)
+
+  defp call_transaction(repo, txn, message, timeout \\ :transaction_deadline) do
+    timeout = bounded_timeout(repo, timeout)
+    GenServer.call(txn, message, timeout)
+  catch
+    :exit, {:timeout, _} -> throw({__MODULE__, txn, :retryable_failure, :timeout})
+  end
+
+  defp bounded_timeout(repo, :transaction_deadline), do: TransactionContext.remaining_timeout!(repo, :timeout)
+
+  defp bounded_timeout(repo, timeout) do
+    min_timeout(timeout, TransactionContext.remaining_timeout!(repo, :timeout))
+  end
+
+  defp min_timeout(:infinity, timeout), do: timeout
+  defp min_timeout(timeout, :infinity), do: timeout
+  defp min_timeout(a, b), do: min(a, b)
 end

--- a/lib/bedrock/internal/repo/transaction_context.ex
+++ b/lib/bedrock/internal/repo/transaction_context.ex
@@ -1,0 +1,118 @@
+defmodule Bedrock.Internal.Repo.TransactionContext do
+  @moduledoc false
+
+  alias Bedrock.Internal.Time
+
+  @process_key __MODULE__
+
+  @type t :: %__MODULE__{
+          builder: pid() | nil,
+          deadline: integer() | :infinity | nil,
+          timeout_in_ms: timeout() | nil
+        }
+
+  defstruct builder: nil,
+            deadline: nil,
+            timeout_in_ms: nil
+
+  @spec builder(module()) :: pid() | nil
+  def builder(repo), do: context(repo).builder
+
+  @spec put_builder(module(), pid()) :: :ok
+  def put_builder(repo, builder) when is_pid(builder) do
+    update_context(repo, &%{&1 | builder: builder})
+  end
+
+  @spec clear_builder(module()) :: :ok
+  def clear_builder(repo) do
+    case context(repo) do
+      %__MODULE__{deadline: nil} -> clear(repo)
+      %__MODULE__{} = context -> put_context(repo, %{context | builder: nil})
+    end
+  end
+
+  @spec clear(module()) :: :ok
+  def clear(repo) do
+    case Map.delete(contexts(), repo) do
+      contexts when map_size(contexts) == 0 ->
+        Process.delete(@process_key)
+        :ok
+
+      contexts ->
+        Process.put(@process_key, contexts)
+        :ok
+    end
+  end
+
+  @spec with_deadline(module(), timeout(), (-> result)) :: result when result: term()
+  def with_deadline(repo, timeout_in_ms, fun) when is_function(fun, 0) do
+    previous_context = Map.get(contexts(), repo)
+
+    case previous_context || %__MODULE__{} do
+      %__MODULE__{deadline: nil} = context ->
+        context = %{
+          context
+          | deadline: deadline_after(timeout_in_ms),
+            timeout_in_ms: timeout_in_ms
+        }
+
+        put_context(repo, context)
+
+        try do
+          fun.()
+        after
+          restore_context(repo, previous_context)
+        end
+
+      %__MODULE__{} ->
+        fun.()
+    end
+  end
+
+  @spec remaining_timeout!(module(), term()) :: timeout()
+  def remaining_timeout!(repo, last_reason) do
+    case context(repo) do
+      %__MODULE__{deadline: nil} ->
+        :infinity
+
+      %__MODULE__{deadline: :infinity} ->
+        :infinity
+
+      %__MODULE__{deadline: deadline} = context ->
+        case deadline - Time.monotonic_now_in_ms() do
+          remaining when remaining > 0 -> remaining
+          _expired -> raise_timeout!(context, last_reason)
+        end
+    end
+  end
+
+  defp deadline_after(:infinity), do: :infinity
+
+  defp deadline_after(timeout_in_ms) when is_integer(timeout_in_ms) and timeout_in_ms >= 0,
+    do: Time.monotonic_now_in_ms() + timeout_in_ms
+
+  defp deadline_after(invalid), do: raise(ArgumentError, "invalid transaction timeout: #{inspect(invalid)}")
+
+  defp raise_timeout!(context, last_reason) do
+    raise RuntimeError,
+          "Transaction timed out after #{context.timeout_in_ms}ms. Last error: #{inspect(last_reason)}"
+  end
+
+  defp context(repo), do: Map.get(contexts(), repo, %__MODULE__{})
+  defp contexts, do: Process.get(@process_key, %{})
+
+  defp update_context(repo, update_fn) do
+    repo
+    |> context()
+    |> update_fn.()
+    |> then(&put_context(repo, &1))
+  end
+
+  defp put_context(repo, context) do
+    Process.put(@process_key, Map.put(contexts(), repo, context))
+    :ok
+  end
+
+  defp restore_context(repo, nil), do: clear(repo)
+  defp restore_context(repo, context), do: put_context(repo, context)
+end

--- a/lib/bedrock/repo.ex
+++ b/lib/bedrock/repo.ex
@@ -17,7 +17,8 @@ defmodule Bedrock.Repo do
   ## Options
 
   - `:retry_limit` - Maximum number of retries on transaction conflicts (default: nil for unlimited)
-  - `:timeout_in_ms` - Transaction timeout in milliseconds
+  - `:timeout_in_ms` - End-to-end transaction timeout, including retries
+    (default: 5000; use `:infinity` to disable)
 
   ## Examples
 

--- a/test/bedrock/data_plane/materializer/olivine/genserver_integration_test.exs
+++ b/test/bedrock/data_plane/materializer/olivine/genserver_integration_test.exs
@@ -180,6 +180,18 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.GenServerIntegrationTest do
 
       GenServer.stop(successful_pid, :normal, @timeout)
     end
+
+    @tag :tmp_dir
+    test "waitlisted reads expire and leave no orphaned waiter", %{tmp_dir: tmp_dir} do
+      {_worker_id, _otp_name, pid} = setup_supervised_worker(tmp_dir, "wait_timeout")
+      future_version = Version.from_integer(1)
+
+      assert {:error, :waiting_timeout} =
+               GenServer.call(pid, {:get, "key1", future_version, [wait_ms: 25]}, 1_000)
+
+      state = :sys.get_state(pid)
+      assert state.read_request_manager.waiting_fetches == %{}
+    end
   end
 
   describe "Foreman Integration" do

--- a/test/bedrock/data_plane/materializer/olivine/reading_test.exs
+++ b/test/bedrock/data_plane/materializer/olivine/reading_test.exs
@@ -23,6 +23,8 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.ReadingTest do
 
   defp v1, do: Version.from_integer(1)
   defp v2, do: Version.from_integer(2)
+  defp v3, do: Version.from_integer(3)
+  defp v4, do: Version.from_integer(4)
 
   defp apply_mutations(index_manager, database, version, mutations) do
     transaction = Transaction.encode(%{commit_version: version, mutations: mutations})
@@ -299,6 +301,39 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.ReadingTest do
   end
 
   describe "notify_waiting_fetches/3" do
+    test "delivers waiters for every version made readable by a batch", %{
+      manager: manager,
+      context: context,
+      index_manager: index_manager,
+      database: database
+    } do
+      test_pid = self()
+
+      {manager, :ok} =
+        Reading.handle_get(manager, context, "key1", v2(),
+          wait_ms: 5_000,
+          reply_fn: fn result -> send(test_pid, {:readable, result}) end
+        )
+
+      {manager, :ok} =
+        Reading.handle_get(manager, context, "key1", v4(),
+          wait_ms: 5_000,
+          reply_fn: fn result -> send(test_pid, {:future, result}) end
+        )
+
+      {index_manager, database} =
+        apply_mutations(index_manager, database, v2(), [{:set, "key4", "value4"}])
+
+      {index_manager, database} = apply_mutations(index_manager, database, v3(), [])
+      context_at_v3 = ReadingContext.new(index_manager, database)
+      notified_manager = Reading.notify_waiting_fetches(manager, context_at_v3, v3())
+
+      assert_receive {:readable, {:ok, "value1"}}
+      refute_receive {:future, _}
+      refute Map.has_key?(notified_manager.waiting_fetches, v2())
+      assert Map.has_key?(notified_manager.waiting_fetches, v4())
+    end
+
     test "delivers results for all four waitlisted request shapes once the version is applied", %{
       manager: manager,
       context: context,

--- a/test/bedrock/internal/repo/snapshot_test.exs
+++ b/test/bedrock/internal/repo/snapshot_test.exs
@@ -10,6 +10,7 @@ defmodule Bedrock.Internal.Repo.SnapshotTest do
   use ExUnit.Case, async: true
 
   alias Bedrock.Internal.Repo
+  alias Bedrock.Internal.Repo.TransactionContext
 
   defmodule TestRepo do
     use Bedrock.Repo, cluster: MockCluster
@@ -61,7 +62,7 @@ defmodule Bedrock.Internal.Repo.SnapshotTest do
   describe "get/3 with snapshot: true" do
     test "returns same value as get/2 with snapshot option" do
       {:ok, tx} = MockTransaction.start_link(%{"test_key" => "test_value"})
-      Process.put({:transaction, TestRepo}, tx)
+      TransactionContext.put_builder(TestRepo, tx)
 
       regular_result = Repo.get(TestRepo, "test_key")
       snapshot_result = Repo.get(TestRepo, "test_key", snapshot: true)
@@ -72,13 +73,13 @@ defmodule Bedrock.Internal.Repo.SnapshotTest do
 
     test "returns nil for non-existent keys" do
       {:ok, tx} = MockTransaction.start_link(%{})
-      Process.put({:transaction, TestRepo}, tx)
+      TransactionContext.put_builder(TestRepo, tx)
       assert Repo.get(TestRepo, "non_existent", snapshot: true) == nil
     end
 
     test "works with multiple keys" do
       {:ok, tx} = MockTransaction.start_link(%{"key1" => "value1", "key2" => "value2"})
-      Process.put({:transaction, TestRepo}, tx)
+      TransactionContext.put_builder(TestRepo, tx)
 
       assert Repo.get(TestRepo, "key1", snapshot: true) == "value1"
       assert Repo.get(TestRepo, "key2", snapshot: true) == "value2"
@@ -100,7 +101,7 @@ defmodule Bedrock.Internal.Repo.SnapshotTest do
     end
 
     test "returns consistent results across multiple calls", %{tx: tx, expected_results: expected} do
-      Process.put({:transaction, TestRepo}, tx)
+      TransactionContext.put_builder(TestRepo, tx)
       result1 = TestRepo |> Repo.get_range("key", "key4", snapshot: true) |> Enum.to_list()
       result2 = TestRepo |> Repo.get_range("key", "key4", snapshot: true) |> Enum.to_list()
 
@@ -109,13 +110,13 @@ defmodule Bedrock.Internal.Repo.SnapshotTest do
     end
 
     test "works with batch_size parameter", %{tx: tx, expected_results: expected} do
-      Process.put({:transaction, TestRepo}, tx)
+      TransactionContext.put_builder(TestRepo, tx)
       results = TestRepo |> Repo.get_range("key", "key4", batch_size: 2, snapshot: true) |> Enum.to_list()
       assert results == expected
     end
 
     test "supports stream operations and early halting", %{tx: tx} do
-      Process.put({:transaction, TestRepo}, tx)
+      TransactionContext.put_builder(TestRepo, tx)
       # Test early halting
       [first_result] = TestRepo |> Repo.get_range("key", "key4", snapshot: true) |> Enum.take(1)
       assert first_result == {"key1", "value1"}
@@ -131,7 +132,7 @@ defmodule Bedrock.Internal.Repo.SnapshotTest do
     end
 
     test "handles empty ranges", %{tx: tx} do
-      Process.put({:transaction, TestRepo}, tx)
+      TransactionContext.put_builder(TestRepo, tx)
       empty_result = TestRepo |> Repo.get_range("nonexistent", "nonexistent1", snapshot: true) |> Enum.to_list()
       assert empty_result == []
 
@@ -143,7 +144,7 @@ defmodule Bedrock.Internal.Repo.SnapshotTest do
   describe "integration and error handling" do
     test "snapshot reads work alongside regular operations and handle errors gracefully" do
       {:ok, tx} = MockTransaction.start_link(%{"test" => "data"})
-      Process.put({:transaction, TestRepo}, tx)
+      TransactionContext.put_builder(TestRepo, tx)
 
       # Mix regular operations with snapshot operations
       Repo.put(TestRepo, "new_key", "new_value")
@@ -151,7 +152,7 @@ defmodule Bedrock.Internal.Repo.SnapshotTest do
 
       # Test error handling with empty transaction
       {:ok, empty_tx} = MockTransaction.start_link(%{})
-      Process.put({:transaction, TestRepo}, empty_tx)
+      TransactionContext.put_builder(TestRepo, empty_tx)
       assert Repo.get(TestRepo, "any_key", snapshot: true) == nil
 
       empty_range_results = TestRepo |> Repo.get_range("start", "end", snapshot: true) |> Enum.to_list()

--- a/test/bedrock/internal/repo/transaction_context_test.exs
+++ b/test/bedrock/internal/repo/transaction_context_test.exs
@@ -1,0 +1,58 @@
+defmodule Bedrock.Internal.Repo.TransactionContextTest do
+  use ExUnit.Case, async: true
+
+  alias Bedrock.Internal.Repo.TransactionContext
+
+  defmodule RepoA do
+    @moduledoc false
+  end
+
+  defmodule RepoB do
+    @moduledoc false
+  end
+
+  test "stores every Repo context under one process key" do
+    TransactionContext.put_builder(RepoA, self())
+    TransactionContext.put_builder(RepoB, self())
+
+    assert %{
+             RepoA => %TransactionContext{builder: repo_a_builder},
+             RepoB => %TransactionContext{builder: repo_b_builder}
+           } = Process.get(TransactionContext)
+
+    assert repo_a_builder == self()
+    assert repo_b_builder == self()
+
+    TransactionContext.clear(RepoA)
+
+    assert %{RepoB => %TransactionContext{}} = Process.get(TransactionContext)
+    refute Map.has_key?(Process.get(TransactionContext), RepoA)
+  end
+
+  test "adds a deadline to the existing builder context and restores it afterward" do
+    TransactionContext.put_builder(RepoA, self())
+
+    assert :infinity = TransactionContext.remaining_timeout!(RepoA, :timeout)
+
+    TransactionContext.with_deadline(RepoA, 1_000, fn ->
+      assert TransactionContext.builder(RepoA) == self()
+      assert TransactionContext.remaining_timeout!(RepoA, :timeout) in 1..1_000
+    end)
+
+    assert TransactionContext.builder(RepoA) == self()
+    assert :infinity = TransactionContext.remaining_timeout!(RepoA, :timeout)
+  end
+
+  test "nested work inherits rather than replaces the outer deadline" do
+    TransactionContext.with_deadline(RepoA, 1_000, fn ->
+      outer_remaining = TransactionContext.remaining_timeout!(RepoA, :timeout)
+
+      TransactionContext.with_deadline(RepoA, 10_000, fn ->
+        assert TransactionContext.remaining_timeout!(RepoA, :timeout) <= outer_remaining
+      end)
+    end)
+
+    assert :infinity = TransactionContext.remaining_timeout!(RepoA, :timeout)
+    assert Process.get(TransactionContext) == nil
+  end
+end

--- a/test/bedrock/internal/repo_error_handling_test.exs
+++ b/test/bedrock/internal/repo_error_handling_test.exs
@@ -2,6 +2,7 @@ defmodule Bedrock.Internal.RepoErrorHandlingTest do
   use ExUnit.Case, async: true
 
   alias Bedrock.Internal.Repo
+  alias Bedrock.Internal.Repo.TransactionContext
 
   defmodule TestRepo do
     use Bedrock.Repo, cluster: MockCluster
@@ -17,7 +18,7 @@ defmodule Bedrock.Internal.RepoErrorHandlingTest do
           end
         end)
 
-      Process.put({:transaction, TestRepo}, txn)
+      TransactionContext.put_builder(TestRepo, txn)
 
       assert Repo.get(TestRepo, "test_key") == nil
     end
@@ -31,7 +32,7 @@ defmodule Bedrock.Internal.RepoErrorHandlingTest do
           end
         end)
 
-      Process.put({:transaction, TestRepo}, txn)
+      TransactionContext.put_builder(TestRepo, txn)
 
       assert Repo.get(TestRepo, "test_key") == "test_value"
     end
@@ -45,7 +46,7 @@ defmodule Bedrock.Internal.RepoErrorHandlingTest do
           end
         end)
 
-      Process.put({:transaction, TestRepo}, txn)
+      TransactionContext.put_builder(TestRepo, txn)
 
       {Repo, failed_txn, :retryable_failure, :unavailable} = catch_throw(Repo.get(TestRepo, "test_key"))
       assert failed_txn == txn
@@ -60,7 +61,7 @@ defmodule Bedrock.Internal.RepoErrorHandlingTest do
           end
         end)
 
-      Process.put({:transaction, TestRepo}, txn)
+      TransactionContext.put_builder(TestRepo, txn)
 
       {Repo, failed_txn, :retryable_failure, :timeout} = catch_throw(Repo.get(TestRepo, "test_key"))
       assert failed_txn == txn
@@ -75,7 +76,7 @@ defmodule Bedrock.Internal.RepoErrorHandlingTest do
           end
         end)
 
-      Process.put({:transaction, TestRepo}, txn)
+      TransactionContext.put_builder(TestRepo, txn)
 
       {module, failed_txn, type, reason, operation, key} = catch_throw(Repo.get(TestRepo, "test_key"))
       assert module == Repo
@@ -96,7 +97,7 @@ defmodule Bedrock.Internal.RepoErrorHandlingTest do
           end
         end)
 
-      Process.put({:transaction, TestRepo}, txn)
+      TransactionContext.put_builder(TestRepo, txn)
 
       {module, failed_txn, error_type, reason} = catch_throw(Repo.get(TestRepo, "specific_test_key"))
 
@@ -117,7 +118,7 @@ defmodule Bedrock.Internal.RepoErrorHandlingTest do
           end
         end)
 
-      Process.put({:transaction, TestRepo}, txn)
+      TransactionContext.put_builder(TestRepo, txn)
 
       selector = Bedrock.KeySelector.first_greater_than("test_key")
       assert Repo.select(TestRepo, selector) == nil
@@ -132,7 +133,7 @@ defmodule Bedrock.Internal.RepoErrorHandlingTest do
           end
         end)
 
-      Process.put({:transaction, TestRepo}, txn)
+      TransactionContext.put_builder(TestRepo, txn)
 
       selector = Bedrock.KeySelector.first_greater_than("test_key")
       assert Repo.select(TestRepo, selector) == nil
@@ -147,7 +148,7 @@ defmodule Bedrock.Internal.RepoErrorHandlingTest do
           end
         end)
 
-      Process.put({:transaction, TestRepo}, txn)
+      TransactionContext.put_builder(TestRepo, txn)
 
       selector = Bedrock.KeySelector.first_greater_than("test_key")
       assert Repo.select(TestRepo, selector) == {"resolved_key", "value"}
@@ -162,7 +163,7 @@ defmodule Bedrock.Internal.RepoErrorHandlingTest do
           end
         end)
 
-      Process.put({:transaction, TestRepo}, txn)
+      TransactionContext.put_builder(TestRepo, txn)
 
       selector = Bedrock.KeySelector.first_greater_than("test_key")
 
@@ -179,7 +180,7 @@ defmodule Bedrock.Internal.RepoErrorHandlingTest do
           end
         end)
 
-      Process.put({:transaction, TestRepo}, txn)
+      TransactionContext.put_builder(TestRepo, txn)
 
       selector = Bedrock.KeySelector.first_greater_than("test_key")
 
@@ -196,7 +197,7 @@ defmodule Bedrock.Internal.RepoErrorHandlingTest do
           end
         end)
 
-      Process.put({:transaction, TestRepo}, txn)
+      TransactionContext.put_builder(TestRepo, txn)
 
       selector = Bedrock.KeySelector.first_greater_than("selector_test_key")
 
@@ -222,7 +223,7 @@ defmodule Bedrock.Internal.RepoErrorHandlingTest do
             end
           end)
 
-        Process.put({:transaction, TestRepo}, txn)
+        TransactionContext.put_builder(TestRepo, txn)
 
         {module, failed_txn, error_type, reason} = catch_throw(Repo.get(TestRepo, "test_key"))
 
@@ -245,7 +246,7 @@ defmodule Bedrock.Internal.RepoErrorHandlingTest do
             end
           end)
 
-        Process.put({:transaction, TestRepo}, txn)
+        TransactionContext.put_builder(TestRepo, txn)
 
         {module, failed_txn, type, reason, operation, key} = catch_throw(Repo.get(TestRepo, "test_key"))
         assert module == Repo

--- a/test/bedrock/internal/repo_test.exs
+++ b/test/bedrock/internal/repo_test.exs
@@ -2,6 +2,7 @@ defmodule Bedrock.Internal.RepoSimpleTest do
   use ExUnit.Case, async: true
 
   alias Bedrock.Internal.Repo
+  alias Bedrock.Internal.Repo.TransactionContext
   alias Bedrock.KeySelector
 
   defmodule TestRepo do
@@ -116,14 +117,14 @@ defmodule Bedrock.Internal.RepoSimpleTest do
   describe "get/2 (no options)" do
     test "returns value when fetch succeeds" do
       txn_pid = spawn_get_mock("get_key", {:ok, "get_value"})
-      Process.put({:transaction, TestRepo}, txn_pid)
+      TransactionContext.put_builder(TestRepo, txn_pid)
 
       assert Repo.get(TestRepo, "get_key") == "get_value"
     end
 
     test "returns nil when fetch returns error" do
       txn_pid = spawn_get_mock("missing_get_key", {:error, :not_found})
-      Process.put({:transaction, TestRepo}, txn_pid)
+      TransactionContext.put_builder(TestRepo, txn_pid)
 
       assert Repo.get(TestRepo, "missing_get_key") == nil
     end
@@ -132,7 +133,7 @@ defmodule Bedrock.Internal.RepoSimpleTest do
   describe "get/3 with options" do
     test "returns value when key exists" do
       {:ok, tx} = MockTransaction.start_link(%{"test_key" => "test_value"})
-      Process.put({:transaction, TestRepo}, tx)
+      TransactionContext.put_builder(TestRepo, tx)
 
       assert Repo.get(TestRepo, "test_key", []) == "test_value"
       assert Repo.get(TestRepo, "test_key", snapshot: true) == "test_value"
@@ -140,7 +141,7 @@ defmodule Bedrock.Internal.RepoSimpleTest do
 
     test "returns nil for non-existent keys" do
       {:ok, tx} = MockTransaction.start_link(%{})
-      Process.put({:transaction, TestRepo}, tx)
+      TransactionContext.put_builder(TestRepo, tx)
 
       assert Repo.get(TestRepo, "non_existent", []) == nil
       assert Repo.get(TestRepo, "non_existent", snapshot: true) == nil
@@ -152,7 +153,7 @@ defmodule Bedrock.Internal.RepoSimpleTest do
       txn_pid = self()
       key = "put_key"
       value = "put_value"
-      Process.put({:transaction, TestRepo}, txn_pid)
+      TransactionContext.put_builder(TestRepo, txn_pid)
 
       result = Repo.put(TestRepo, key, value)
 
@@ -181,7 +182,7 @@ defmodule Bedrock.Internal.RepoSimpleTest do
           [{"key_c", "value_c"}]
         )
 
-      Process.put({:transaction, TestRepo}, txn_pid)
+      TransactionContext.put_builder(TestRepo, txn_pid)
       stream = Repo.get_range(TestRepo, "key_a", "key_z", batch_size: 2)
       results = stream |> Enum.to_list() |> List.flatten()
 
@@ -190,7 +191,7 @@ defmodule Bedrock.Internal.RepoSimpleTest do
 
     test "handles empty results gracefully" do
       txn_pid = spawn_range_mock("key_a", "key_z", 10, {:ok, {[], false}})
-      Process.put({:transaction, TestRepo}, txn_pid)
+      TransactionContext.put_builder(TestRepo, txn_pid)
 
       stream = Repo.get_range(TestRepo, "key_a", "key_z", batch_size: 10)
       results = Enum.to_list(stream)
@@ -201,7 +202,7 @@ defmodule Bedrock.Internal.RepoSimpleTest do
     test "respects limit option" do
       expected_results = [{"key_b", "value_b"}, {"key_c", "value_c"}]
       txn_pid = spawn_range_mock_with_limit("key_a", "key_z", 2, 2, expected_results)
-      Process.put({:transaction, TestRepo}, txn_pid)
+      TransactionContext.put_builder(TestRepo, txn_pid)
 
       stream = Repo.get_range(TestRepo, "key_a", "key_z", batch_size: 10, limit: 2)
       results = stream |> Enum.to_list() |> List.flatten()
@@ -216,7 +217,7 @@ defmodule Bedrock.Internal.RepoSimpleTest do
       key_selector = KeySelector.first_greater_or_equal("test_key")
 
       spawn(fn ->
-        Process.put({:transaction, TestRepo}, txn_pid)
+        TransactionContext.put_builder(TestRepo, txn_pid)
         Repo.select(TestRepo, key_selector)
       end)
 
@@ -226,7 +227,7 @@ defmodule Bedrock.Internal.RepoSimpleTest do
     test "returns success result with resolved key-value pair" do
       key_selector = KeySelector.first_greater_or_equal("mykey")
       txn_pid = spawn_select_mock(key_selector, {:ok, {"resolved_key", "resolved_value"}})
-      Process.put({:transaction, TestRepo}, txn_pid)
+      TransactionContext.put_builder(TestRepo, txn_pid)
 
       assert {"resolved_key", "resolved_value"} = Repo.select(TestRepo, key_selector)
     end
@@ -234,7 +235,7 @@ defmodule Bedrock.Internal.RepoSimpleTest do
     test "returns nil when KeySelector resolution fails with not_found" do
       key_selector = KeySelector.first_greater_than("nonexistent")
       txn_pid = spawn_select_mock(key_selector, {:error, :not_found})
-      Process.put({:transaction, TestRepo}, txn_pid)
+      TransactionContext.put_builder(TestRepo, txn_pid)
 
       assert nil == Repo.select(TestRepo, key_selector)
     end
@@ -242,7 +243,7 @@ defmodule Bedrock.Internal.RepoSimpleTest do
     test "throws TransactionError tuple on version errors" do
       key_selector = KeySelector.first_greater_or_equal("versioned_key")
       txn_pid = spawn_select_mock(key_selector, {:error, :version_too_old})
-      Process.put({:transaction, TestRepo}, txn_pid)
+      TransactionContext.put_builder(TestRepo, txn_pid)
 
       {Repo, failed_txn, :transaction_error, :version_too_old, :select, ^key_selector} =
         catch_throw(Repo.select(TestRepo, key_selector))
@@ -253,7 +254,7 @@ defmodule Bedrock.Internal.RepoSimpleTest do
     test "handles clamped errors from cross-shard operations" do
       key_selector = "cross_shard" |> KeySelector.first_greater_or_equal() |> KeySelector.add(1000)
       txn_pid = spawn_select_mock(key_selector, {:error, :not_found})
-      Process.put({:transaction, TestRepo}, txn_pid)
+      TransactionContext.put_builder(TestRepo, txn_pid)
 
       assert Repo.select(TestRepo, key_selector) == nil
     end

--- a/test/bedrock/internal/repo_transact_test.exs
+++ b/test/bedrock/internal/repo_transact_test.exs
@@ -14,12 +14,13 @@ defmodule Bedrock.Internal.RepoTransactTest do
     deterministically without any cluster infrastructure.
 
   - For the nested-transaction and cast APIs, a scripted stub GenServer (or
-    `self()`) is seeded into the process dictionary under the
-    `{:transaction, repo}` key, so exact call/cast messages can be asserted.
+    `self()`) is seeded through the transaction-context API, so exact
+    call/cast messages can be asserted.
   """
   use ExUnit.Case, async: true
 
   alias Bedrock.Internal.Repo
+  alias Bedrock.Internal.Repo.TransactionContext
 
   defmodule TestRepo do
     use Bedrock.Repo, cluster: MockCluster
@@ -76,6 +77,11 @@ defmodule Bedrock.Internal.RepoTransactTest do
       {:reply, reply, {rest, test_pid}}
     end
 
+    def handle_call({:get, key, opts}, _from, {[], test_pid} = state) do
+      send(test_pid, {:txn_call, {:get, key, opts}})
+      {:noreply, state}
+    end
+
     @impl true
     def handle_cast(msg, {_, test_pid} = state) do
       send(test_pid, {:txn_cast, msg})
@@ -85,12 +91,7 @@ defmodule Bedrock.Internal.RepoTransactTest do
 
   @minimal_tsl %{epoch: 1, proxies: []}
 
-  defp seed_txn(pid), do: Process.put({:transaction, TestRepo}, pid)
-
-  setup do
-    on_exit(fn -> Process.delete({:transaction, TestRepo}) end)
-    :ok
-  end
+  defp seed_txn(pid), do: TransactionContext.put_builder(TestRepo, pid)
 
   describe "cast-based transaction API" do
     test "add_read_conflict_key sends the exact cast to the transaction" do
@@ -201,7 +202,7 @@ defmodule Bedrock.Internal.RepoTransactTest do
       result = Repo.transact(NoCluster, TestRepo, fn -> :computed_result end, transaction_system_layout: @minimal_tsl)
 
       assert result == :computed_result
-      assert Process.get({:transaction, TestRepo}) == nil
+      assert TransactionContext.builder(TestRepo) == nil
     end
 
     test "passes the repo module to an arity-1 function" do
@@ -211,14 +212,14 @@ defmodule Bedrock.Internal.RepoTransactTest do
       assert result == {:got_repo, TestRepo}
     end
 
-    test "makes the transaction pid visible in the process dictionary while running" do
+    test "makes the builder visible through the transaction context while running" do
       txn_during =
-        Repo.transact(NoCluster, TestRepo, fn -> Process.get({:transaction, TestRepo}) end,
+        Repo.transact(NoCluster, TestRepo, fn -> TransactionContext.builder(TestRepo) end,
           transaction_system_layout: @minimal_tsl
         )
 
       assert is_pid(txn_during)
-      assert Process.get({:transaction, TestRepo}) == nil
+      assert TransactionContext.builder(TestRepo) == nil
     end
 
     test "rolls back and reraises when the function raises" do
@@ -230,7 +231,7 @@ defmodule Bedrock.Internal.RepoTransactTest do
         )
       end
 
-      assert Process.get({:transaction, TestRepo}) == nil
+      assert TransactionContext.builder(TestRepo) == nil
     end
 
     test "Repo.rollback inside the function returns {:error, reason}" do
@@ -242,7 +243,7 @@ defmodule Bedrock.Internal.RepoTransactTest do
         )
 
       assert result == {:error, :user_requested}
-      assert Process.get({:transaction, TestRepo}) == nil
+      assert TransactionContext.builder(TestRepo) == nil
     end
 
     test "raises after exhausting the retry limit when commit keeps failing" do
@@ -269,7 +270,41 @@ defmodule Bedrock.Internal.RepoTransactTest do
 
       # Initial attempt + 2 retries, each in a fresh TransactionBuilder.
       assert :counters.get(attempts, 1) == 3
-      assert Process.get({:transaction, TestRepo}) == nil
+      assert TransactionContext.builder(TestRepo) == nil
+    end
+
+    test "a transaction deadline bounds retries without resetting" do
+      started_at = System.monotonic_time(:millisecond)
+
+      assert_raise RuntimeError,
+                   "Transaction timed out after 30ms. Last error: :unavailable",
+                   fn ->
+                     Repo.transact(DeadLinkCluster, TestRepo, fn -> :never_runs end, timeout_in_ms: 30)
+                   end
+
+      assert System.monotonic_time(:millisecond) - started_at < 500
+      assert TransactionContext.builder(TestRepo) == nil
+    end
+
+    test "the deadline is inherited by nested transaction work" do
+      assert_raise RuntimeError,
+                   "Transaction timed out after 20ms. Last error: :timeout",
+                   fn ->
+                     Repo.transact(
+                       NoCluster,
+                       TestRepo,
+                       fn ->
+                         Repo.transact(NoCluster, TestRepo, fn ->
+                           Process.sleep(30)
+                           :too_late
+                         end)
+                       end,
+                       transaction_system_layout: @minimal_tsl,
+                       timeout_in_ms: 20
+                     )
+                   end
+
+      assert TransactionContext.builder(TestRepo) == nil
     end
   end
 
@@ -283,7 +318,7 @@ defmodule Bedrock.Internal.RepoTransactTest do
                      Repo.transact(DeadLinkCluster, TestRepo, fn -> :never_runs end, retry_limit: 1)
                    end
 
-      assert Process.get({:transaction, TestRepo}) == nil
+      assert TransactionContext.builder(TestRepo) == nil
     end
 
     test "retries a failed layout fetch and succeeds on the second attempt" do
@@ -309,11 +344,32 @@ defmodule Bedrock.Internal.RepoTransactTest do
 
       assert result == :eventually_committed
       assert_received :second_fetch
-      assert Process.get({:transaction, TestRepo}) == nil
+      assert TransactionContext.builder(TestRepo) == nil
     end
   end
 
   describe "transact/4 nested transactions" do
+    test "a client read call cannot wait forever for an unresponsive transaction builder" do
+      {:ok, txn} = ScriptedTxn.start_link([])
+      seed_txn(txn)
+
+      assert_raise RuntimeError,
+                   "Transaction timed out after 20ms. Last error: :timeout",
+                   fn ->
+                     Repo.transact(
+                       NoCluster,
+                       TestRepo,
+                       fn -> Repo.get(TestRepo, "stuck") end,
+                       timeout_in_ms: 20
+                     )
+                   end
+
+      assert_received {:txn_call, :nested_transaction}
+      assert_received {:txn_call, {:get, "stuck", []}}
+      assert_receive {:txn_cast, :rollback}
+      assert TransactionContext.builder(TestRepo) == txn
+    end
+
     test "reuses the existing transaction and commits locally" do
       {:ok, txn} = ScriptedTxn.start_link([:ok])
       seed_txn(txn)
@@ -324,7 +380,7 @@ defmodule Bedrock.Internal.RepoTransactTest do
       assert_received {:txn_call, :nested_transaction}
       assert_received {:txn_call, :commit}
       # The outer transaction is still active.
-      assert Process.get({:transaction, TestRepo}) == txn
+      assert TransactionContext.builder(TestRepo) == txn
     end
 
     test "returns the result when nested commit reports a version" do
@@ -385,7 +441,7 @@ defmodule Bedrock.Internal.RepoTransactTest do
       assert_receive {:txn_cast, :rollback}
       refute_received {:txn_call, :commit}
       # The outer transaction remains active for the caller.
-      assert Process.get({:transaction, TestRepo}) == txn
+      assert TransactionContext.builder(TestRepo) == txn
     end
 
     test "a non-retryable operation error rolls back and raises with operation context" do


### PR DESCRIPTION
## Problem

After recovery, Olivine may make several versions readable in one applied batch. It woke only waiters keyed to the batch-ending version, so a read waiting on an intermediate version could remain parked forever. Develop also no longer expired Olivine waiters, and Repo point reads waited indefinitely on the TransactionBuilder while retryable failures had no end-to-end deadline.

## Changes

- wake every Olivine waiter at or below the applied version while preserving later waiters
- expire parked reads inside Olivine with a dedicated message, leaving the ingestion timeout and Demux newest-first/backpressure paths unchanged
- enforce the existing transaction timeout option as one monotonic deadline across layout fetches, point and range reads, commits, retries, and nested work
- store builder and deadline state beneath one `TransactionContext` process key, with per-Repo structs and accessors
- default the transaction deadline to 5 seconds; allow `:infinity` explicitly
- surface a terminal timeout with the last retry reason and request rollback of the active builder

## TDD

The regressions failed first for skipped-version waiters, idle waitlist expiry, unbounded retries, nested deadline reset, an unresponsive TransactionBuilder read, and the missing transaction-context abstraction.

Green verification:

- transaction-context and Repo-focused tests
- 461 internal tests and 42 properties
- full suite: 2,544 tests, 158 properties, 13 doctests
- `mix format --check-formatted`
- `mix credo --strict`
- `mix dialyzer --format short`

Tracker: `bedrock-qj1`