### PR TITLE
Separate recovery input from runnable transaction layouts

### DIFF
--- a/lib/bedrock/control_plane/coordinator/director_management.ex
+++ b/lib/bedrock/control_plane/coordinator/director_management.ex
@@ -6,6 +6,7 @@ defmodule Bedrock.ControlPlane.Coordinator.DirectorManagement do
       put_director: 2,
       put_config: 2,
       put_leader_startup_state: 2,
+      clear_transaction_system_layout: 1,
       convert_to_capability_map: 1
     ]
 
@@ -29,15 +30,16 @@ defmodule Bedrock.ControlPlane.Coordinator.DirectorManagement do
   def try_to_start_director(t) when t.leader_node == t.my_node and t.director == :unavailable do
     t = maybe_put_default_config(t)
 
-    trace_director_launch(t.epoch, t.transaction_system_layout)
+    trace_director_launch(t.epoch, t.old_transaction_system_layout)
 
     case start_director_with_monitoring(t) do
       {:ok, new_director} ->
         trace_director_changed(new_director)
-        # Clear cached TSL in all Links so user transactions get :unavailable during recovery
-        # instead of using the stale OLD TSL with dead PIDs
-        State.Changes.broadcast_tsl_update(t, nil)
-        put_director(t, new_director)
+        # The recovery source stays with the Coordinator, but Links must wait
+        # for the Director to publish the next runnable layout.
+        t
+        |> clear_transaction_system_layout()
+        |> put_director(new_director)
 
       {:error, reason} ->
         Logger.warning("Failed to start director: #{inspect(reason)}")
@@ -62,7 +64,7 @@ defmodule Bedrock.ControlPlane.Coordinator.DirectorManagement do
             [
               cluster: t.cluster,
               config: t.config,
-              old_transaction_system_layout: t.transaction_system_layout,
+              old_transaction_system_layout: t.old_transaction_system_layout,
               epoch: t.epoch,
               coordinator: self(),
               services: t.service_directory,

--- a/lib/bedrock/control_plane/coordinator/server.ex
+++ b/lib/bedrock/control_plane/coordinator/server.ex
@@ -100,7 +100,8 @@ defmodule Bedrock.ControlPlane.Coordinator.Server do
          supervisor_otp_name: cluster.otp_name(:sup),
          epoch: loaded_epoch,
          config: loaded_config,
-         transaction_system_layout: loaded_tsl,
+         old_transaction_system_layout: loaded_tsl,
+         transaction_system_layout: nil,
          raft:
            Raft.new(
              my_node,
@@ -133,6 +134,9 @@ defmodule Bedrock.ControlPlane.Coordinator.Server do
 
   @impl true
   def handle_call(:fetch_config, _from, t), do: reply(t, {:ok, t.config})
+
+  def handle_call(:fetch_transaction_system_layout, _from, %{transaction_system_layout: nil} = t),
+    do: reply(t, {:error, :unavailable})
 
   def handle_call(:fetch_transaction_system_layout, _from, t), do: reply(t, {:ok, t.transaction_system_layout})
 

--- a/lib/bedrock/control_plane/coordinator/state.ex
+++ b/lib/bedrock/control_plane/coordinator/state.ex
@@ -23,6 +23,8 @@ defmodule Bedrock.ControlPlane.Coordinator.State do
           supervisor_otp_name: atom(),
           last_durable_txn_id: Raft.transaction_id(),
           config: Config.t() | nil,
+          old_transaction_system_layout:
+            TransactionSystemLayout.t() | %{required(:logs) => TransactionSystemLayout.log_map()} | nil,
           transaction_system_layout: TransactionSystemLayout.t() | nil,
           waiting_list: %{Raft.transaction_id() => pid()},
           service_directory: %{String.t() => {atom(), {atom(), node()}}},
@@ -41,6 +43,7 @@ defmodule Bedrock.ControlPlane.Coordinator.State do
             supervisor_otp_name: nil,
             last_durable_txn_id: nil,
             config: nil,
+            old_transaction_system_layout: nil,
             transaction_system_layout: nil,
             waiting_list: %{},
             service_directory: %{},
@@ -92,8 +95,19 @@ defmodule Bedrock.ControlPlane.Coordinator.State do
     @spec put_transaction_system_layout(t :: State.t(), TransactionSystemLayout.t()) ::
             State.t()
     def put_transaction_system_layout(t, transaction_system_layout) do
-      updated_state = %{t | transaction_system_layout: transaction_system_layout}
+      updated_state = %{
+        t
+        | old_transaction_system_layout: transaction_system_layout,
+          transaction_system_layout: transaction_system_layout
+      }
+
       broadcast_tsl_update(updated_state, transaction_system_layout)
+    end
+
+    @spec clear_transaction_system_layout(t :: State.t()) :: State.t()
+    def clear_transaction_system_layout(t) do
+      updated_state = %{t | transaction_system_layout: nil}
+      broadcast_tsl_update(updated_state, nil)
     end
 
     @spec put_service_directory(t :: State.t(), %{String.t() => {atom(), {atom(), node()}}}) ::

--- a/test/bedrock/control_plane/coordinator/initialization_test.exs
+++ b/test/bedrock/control_plane/coordinator/initialization_test.exs
@@ -1,0 +1,42 @@
+defmodule Bedrock.ControlPlane.Coordinator.InitializationTest do
+  use ExUnit.Case, async: false
+
+  alias Bedrock.ControlPlane.Coordinator.Server
+  alias Bedrock.ObjectStorage
+  alias Bedrock.ObjectStorage.LocalFilesystem
+  alias Bedrock.SystemKeys.ClusterBootstrap
+
+  @moduletag :tmp_dir
+
+  defmodule TestCluster do
+    @moduledoc false
+
+    def fetch_coordinator_nodes, do: {:ok, [Node.self()]}
+    def node_config, do: Application.fetch_env!(:bedrock, __MODULE__)
+    def otp_name(component), do: :"coordinator_initialization_test_#{component}"
+  end
+
+  setup %{tmp_dir: tmp_dir} do
+    backend = ObjectStorage.backend(LocalFilesystem, root: tmp_dir)
+    Application.put_env(:bedrock, TestCluster, object_storage: backend)
+    on_exit(fn -> Application.delete_env(:bedrock, TestCluster) end)
+    %{backend: backend}
+  end
+
+  test "bootstrap logs are recovery input, not a runnable layout", %{backend: backend} do
+    bootstrap = %{
+      cluster_id: "cluster-1",
+      epoch: 7,
+      logs: [%{id: "old-log", otp_ref: nil, shard_tags: []}],
+      coordinators: [%{node: Atom.to_string(Node.self())}]
+    }
+
+    :ok = ObjectStorage.put(backend, "bootstrap", ClusterBootstrap.to_binary(bootstrap))
+
+    assert {:ok, state, {:continue, :check_recovery_consensus}} =
+             Server.init({TestCluster, TestCluster.otp_name(:coordinator)})
+
+    assert state.old_transaction_system_layout == %{logs: %{"old-log" => []}}
+    assert state.transaction_system_layout == nil
+  end
+end

--- a/test/bedrock/control_plane/coordinator/state_test.exs
+++ b/test/bedrock/control_plane/coordinator/state_test.exs
@@ -4,6 +4,43 @@ defmodule Bedrock.ControlPlane.Coordinator.StateTest do
   alias Bedrock.ControlPlane.Coordinator.State
   alias Bedrock.ControlPlane.Coordinator.State.Changes
 
+  describe "transaction system layout lifecycle" do
+    test "clearing the runnable layout preserves the recovery source" do
+      recovery_source = %{logs: %{"old-log" => []}}
+      runnable_layout = %{id: "layout-1", epoch: 7, logs: %{}, services: %{}}
+
+      state =
+        struct!(State,
+          old_transaction_system_layout: recovery_source,
+          transaction_system_layout: runnable_layout,
+          tsl_subscribers: MapSet.new([self()])
+        )
+
+      result = Changes.clear_transaction_system_layout(state)
+
+      assert result.transaction_system_layout == nil
+      assert result.old_transaction_system_layout == recovery_source
+      assert_receive {:tsl_updated, nil}
+    end
+
+    test "publishing a runnable layout also refreshes the recovery source" do
+      runnable_layout = %{id: "layout-2", epoch: 8, logs: %{}, services: %{}}
+
+      state =
+        struct!(State,
+          old_transaction_system_layout: %{logs: %{"old-log" => []}},
+          transaction_system_layout: nil,
+          tsl_subscribers: MapSet.new([self()])
+        )
+
+      result = Changes.put_transaction_system_layout(state, runnable_layout)
+
+      assert result.transaction_system_layout == runnable_layout
+      assert result.old_transaction_system_layout == runnable_layout
+      assert_receive {:tsl_updated, ^runnable_layout}
+    end
+  end
+
   describe "service directory state changes" do
     test "put_service_directory replaces entire service directory" do
       initial_state = %State{

--- a/test/bedrock/control_plane/coordinator/tsl_replay_test.exs
+++ b/test/bedrock/control_plane/coordinator/tsl_replay_test.exs
@@ -5,6 +5,9 @@ defmodule Bedrock.ControlPlane.Coordinator.TslReplayTest do
   the layout was published; registration itself must replay the current
   snapshot, or a late-joining node keeps a nil TSL — clients stall and its
   foreman never receives the reconciliation trigger.
+
+  Recovery input is deliberately separate (bedrock-bkj). Bootstrap can only
+  reconstruct `%{logs: ...}`, which is enough for recovery but not for reads.
   """
   use ExUnit.Case, async: true
 
@@ -50,6 +53,29 @@ defmodule Bedrock.ControlPlane.Coordinator.TslReplayTest do
     assert {:noreply, _updated} = register(state)
 
     refute_receive {:tsl_updated, _}, 50
+  end
+
+  test "a recovery-only layout is not replayed as runnable" do
+    state =
+      follower_state(%{
+        old_transaction_system_layout: %{logs: %{"old-log" => []}},
+        transaction_system_layout: nil
+      })
+
+    assert {:noreply, _updated} = register(state)
+
+    refute_receive {:tsl_updated, _}, 50
+  end
+
+  test "fetch returns unavailable when no runnable layout exists" do
+    state =
+      follower_state(%{
+        old_transaction_system_layout: %{logs: %{"old-log" => []}},
+        transaction_system_layout: nil
+      })
+
+    assert {:reply, {:error, :unavailable}, ^state} =
+             Server.handle_call(:fetch_transaction_system_layout, {self(), make_ref()}, state)
   end
 
   test "duplicate registration is idempotent: one subscription, same snapshot each time" do


### PR DESCRIPTION
## Summary

- keep bootstrap log hints in a recovery-only Coordinator field
- expose a transaction system layout only after the Director publishes a complete runnable layout
- preserve recovery input while clearing existing and late Link clients during recovery
- atomically refresh both runtime and future recovery state when recovery completes

This fixes the post-recovery `KeyError` where `%{logs: ...}` reached `ReadVersions` without an `:epoch`. It does not change newest-first WAL replay or WAL ordering.

Ticket: `bedrock-bkj`

## TDD

The regression tests were added first and failed against `develop` because bootstrap populated the live TSL slot, runtime fetch returned `{:ok, partial_layout}`, and Coordinator state had no separate recovery source.

Coverage includes:

- bootstrap initialization
- late registration during recovery
- unavailable runtime fetch during recovery
- clearing live state while preserving recovery input
- atomic publication of completed layouts

## Verification

- `mix test` — 13 doctests, 158 properties, 2549 tests, 0 failures
- `mix quality` — format, Credo strict, and Dialyzer pass