### PR TITLE
Fix mix docs warning: hidden WalFormat reference in defdelegate doc

### DIFF
--- a/lib/bedrock/data_plane/log/shale/transaction_streams.ex
+++ b/lib/bedrock/data_plane/log/shale/transaction_streams.ex
@@ -8,6 +8,9 @@ defmodule Bedrock.DataPlane.Log.Shale.TransactionStreams do
   alias Bedrock.DataPlane.Log.Shale.WalFormat
   alias Bedrock.DataPlane.Transaction
 
+  @doc """
+  Reads the previous-version marker from the WAL file header at `path`.
+  """
   @spec read_previous_version(String.t()) ::
           {:ok, Bedrock.version()}
           | {:error, :unsupported_wal_format | :invalid_wal_format | File.posix()}


### PR DESCRIPTION
## Summary
- `mix docs` warned (once per formatter) that `TransactionStreams.read_previous_version/1` references the hidden `WalFormat.previous_version/1` — the auto-generated `defdelegate` doc linked into a `@moduledoc false` module.
- Give the delegate an explicit `@doc` so ExDoc no longer emits the hidden-module link.

Closes bedrock-mnf.

## Test plan
- `mix docs` runs with no warnings.