### PR TITLE
Commit proxy builds and owns its routing table (bedrock-q67.20.1)

### DIFF
--- a/lib/bedrock/control_plane/director/recovery/topology_phase.ex
+++ b/lib/bedrock/control_plane/director/recovery/topology_phase.ex
@@ -230,11 +230,11 @@ defmodule Bedrock.ControlPlane.Director.Recovery.TopologyPhase do
     # Extract what proxies need from TSL
     sequencer = transaction_system_layout.sequencer
     resolver_layout = CommitProxy.ResolverLayout.from_layout(transaction_system_layout)
-    routing_data = build_routing_data(transaction_system_layout)
+    routing_snapshot = build_routing_snapshot(transaction_system_layout)
 
     proxies
     |> Task.async_stream(
-      &unlock_fn.(&1, lock_token, sequencer, resolver_layout, routing_data),
+      &unlock_fn.(&1, lock_token, sequencer, resolver_layout, routing_snapshot),
       ordered: false
     )
     |> Enum.reduce_while(:ok, fn
@@ -244,16 +244,11 @@ defmodule Bedrock.ControlPlane.Director.Recovery.TopologyPhase do
     end)
   end
 
-  # Build full routing data from TSL for commit proxy unlock
-  @spec build_routing_data(TransactionSystemLayout.t()) :: CommitProxy.RoutingData.t()
-  defp build_routing_data(%{logs: logs, services: services, shard_layout: shard_layout}) do
-    # Build shard_table ETS from shard_layout
-    shard_table = :ets.new(:commit_proxy_shards, [:ordered_set, :public])
-
-    Enum.each(shard_layout || %{}, fn {end_key, {tag, _start_key}} ->
-      :ets.insert(shard_table, {end_key, tag})
-    end)
-
+  # Build the plain-data routing snapshot proxies need at unlock. Each proxy
+  # turns it into its own RoutingData (`RoutingData.from_snapshot/1`); proxies
+  # may live on other nodes, so nothing process- or node-local goes in here.
+  @spec build_routing_snapshot(TransactionSystemLayout.t()) :: CommitProxy.RoutingData.snapshot()
+  defp build_routing_snapshot(%{logs: logs, services: services, shard_layout: shard_layout}) do
     # Build log_map: index -> log_id
     log_map =
       logs
@@ -279,13 +274,11 @@ defmodule Bedrock.ControlPlane.Director.Recovery.TopologyPhase do
         end
       end)
 
-    replication_factor = max(1, map_size(logs))
-
-    %CommitProxy.RoutingData{
-      shard_table: shard_table,
+    %{
+      shard_layout: shard_layout || %{},
       log_map: log_map,
       log_services: log_services,
-      replication_factor: replication_factor
+      replication_factor: max(1, map_size(logs))
     }
   end
 

--- a/lib/bedrock/control_plane/director/recovery/topology_phase.ex
+++ b/lib/bedrock/control_plane/director/recovery/topology_phase.ex
@@ -35,7 +35,8 @@ defmodule Bedrock.ControlPlane.Director.Recovery.TopologyPhase do
 
   ## Selective Service Unlocking
 
-  Commit proxies are unlocked via `CommitProxy.recover_from/5` with lock token and TSL.
+  Commit proxies are unlocked via `CommitProxy.recover_from/5` with the lock token,
+  sequencer, resolver layout, and a plain routing snapshot.
   Other components (sequencer, resolvers, logs) transition automatically when
   system transaction completes.
 

--- a/lib/bedrock/data_plane/commit_proxy.ex
+++ b/lib/bedrock/data_plane/commit_proxy.ex
@@ -16,7 +16,7 @@ defmodule Bedrock.DataPlane.CommitProxy do
 
   The component uses a fail-fast recovery model where unrecoverable errors trigger
   process exit and Director-coordinated recovery. Commit Proxies start in locked mode
-  and require explicit unlocking through `recover_from/3` before accepting transaction
+  and require explicit unlocking through `recover_from/5` before accepting transaction
   commits, ensuring proper coordination during cluster recovery scenarios.
 
   """

--- a/lib/bedrock/data_plane/commit_proxy.ex
+++ b/lib/bedrock/data_plane/commit_proxy.ex
@@ -41,10 +41,10 @@ defmodule Bedrock.DataPlane.CommitProxy do
           lock_token :: binary(),
           sequencer :: pid(),
           resolver_layout :: ResolverLayout.t(),
-          routing_data :: RoutingData.t()
+          routing_snapshot :: RoutingData.snapshot()
         ) :: :ok | {:error, :timeout} | {:error, :unavailable}
-  def recover_from(commit_proxy, lock_token, sequencer, resolver_layout, routing_data),
-    do: call(commit_proxy, {:recover_from, lock_token, sequencer, resolver_layout, routing_data}, :infinity)
+  def recover_from(commit_proxy, lock_token, sequencer, resolver_layout, routing_snapshot),
+    do: call(commit_proxy, {:recover_from, lock_token, sequencer, resolver_layout, routing_snapshot}, :infinity)
 
   @spec commit(commit_proxy_ref :: ref(), epoch :: Bedrock.epoch(), transaction :: Transaction.encoded()) ::
           {:ok, version :: Bedrock.version(), index :: non_neg_integer()}

--- a/lib/bedrock/data_plane/commit_proxy/routing_data.ex
+++ b/lib/bedrock/data_plane/commit_proxy/routing_data.ex
@@ -37,7 +37,44 @@ defmodule Bedrock.DataPlane.CommitProxy.RoutingData do
           replication_factor: pos_integer()
         }
 
+  @typedoc """
+  A plain-data description of routing state, safe to send between processes
+  and nodes. `from_snapshot/1` turns it into runnable routing data whose ETS
+  table is created by — and therefore owned by and local to — the receiver.
+  """
+  @type snapshot :: %{
+          shard_layout: %{Bedrock.key() => {tag :: term(), start_key :: Bedrock.key()}},
+          log_map: %{non_neg_integer() => Log.id()},
+          log_services: %{Log.id() => {atom(), node()} | pid()},
+          replication_factor: pos_integer()
+        }
+
   defstruct [:shard_table, :log_map, :log_services, :replication_factor]
+
+  @doc """
+  Builds routing data from a plain snapshot, creating the ETS shard table in
+  the calling process.
+  """
+  @spec from_snapshot(snapshot()) :: t()
+  def from_snapshot(%{
+        shard_layout: shard_layout,
+        log_map: log_map,
+        log_services: log_services,
+        replication_factor: replication_factor
+      }) do
+    shard_table = :ets.new(:shard_keys, [:ordered_set, :public])
+
+    Enum.each(shard_layout, fn {end_key, {tag, _start_key}} ->
+      :ets.insert(shard_table, {end_key, tag})
+    end)
+
+    %__MODULE__{
+      shard_table: shard_table,
+      log_map: log_map,
+      log_services: log_services,
+      replication_factor: replication_factor
+    }
+  end
 
   @doc """
   Creates empty routing data for dynamic population via metadata.

--- a/lib/bedrock/data_plane/commit_proxy/routing_data.ex
+++ b/lib/bedrock/data_plane/commit_proxy/routing_data.ex
@@ -5,12 +5,13 @@ defmodule Bedrock.DataPlane.CommitProxy.RoutingData do
   Encapsulates all information needed to route mutations to logs:
   - `shard_table` - ETS ordered_set for key → tag ceiling search
   - `log_map` - Map of index → log_id for golden ratio routing
-  - `log_services` - Map of log_id → {otp_name, node} for contacting logs
+  - `log_services` - Map of log_id → pid or {otp_name, node} for contacting logs
   - `replication_factor` - Number of logs per mutation
 
   ## Lifecycle
 
   - `new_empty/0` - Creates empty routing data for dynamic population
+  - `from_snapshot/1` - Builds routing data from a plain snapshot at unlock
   - `cleanup/1` - Deletes the ETS table when the commit proxy terminates
 
   ## Shard Updates
@@ -33,7 +34,7 @@ defmodule Bedrock.DataPlane.CommitProxy.RoutingData do
   @type t :: %__MODULE__{
           shard_table: :ets.table(),
           log_map: %{non_neg_integer() => Log.id()},
-          log_services: %{Log.id() => {atom(), node()}},
+          log_services: %{Log.id() => {atom(), node()} | pid()},
           replication_factor: pos_integer()
         }
 

--- a/lib/bedrock/data_plane/commit_proxy/server.ex
+++ b/lib/bedrock/data_plane/commit_proxy/server.ex
@@ -11,7 +11,7 @@ defmodule Bedrock.DataPlane.CommitProxy.Server do
   ## Lifecycle
 
   1. **Initialization**: Starts in `:locked` mode, waiting for recovery completion
-  2. **Recovery**: Director calls `recover_from/3` to provide transaction system layout and unlock
+  2. **Recovery**: Director calls `recover_from/5` to provide the routing snapshot and unlock
   3. **Transaction Processing**: Accepts `:commit` calls, batches transactions, and finalizes
   4. **Empty Transaction Timeout**: Creates empty transactions during quiet periods to advance read versions
 
@@ -78,7 +78,7 @@ defmodule Bedrock.DataPlane.CommitProxy.Server do
     epoch = opts[:epoch] || raise "Missing :epoch option"
     lock_token = opts[:lock_token] || raise "Missing :lock_token option"
     instance = opts[:instance] || raise "Missing :instance option"
-    # sequencer and resolver_layout can be nil at startup - set via recover_from/3
+    # sequencer and resolver_layout can be nil at startup - set via recover_from/5
     sequencer = opts[:sequencer]
     resolver_layout = opts[:resolver_layout]
     max_latency_in_ms = opts[:max_latency_in_ms] || 4

--- a/lib/bedrock/data_plane/commit_proxy/server.ex
+++ b/lib/bedrock/data_plane/commit_proxy/server.ex
@@ -84,7 +84,6 @@ defmodule Bedrock.DataPlane.CommitProxy.Server do
     max_latency_in_ms = opts[:max_latency_in_ms] || 4
     max_per_batch = opts[:max_per_batch] || 32
     empty_transaction_timeout_ms = opts[:empty_transaction_timeout_ms] || 1_000
-    routing_data = opts[:routing_data]
 
     %{
       id: {__MODULE__, cluster, epoch, instance},
@@ -93,7 +92,7 @@ defmodule Bedrock.DataPlane.CommitProxy.Server do
          [
            __MODULE__,
            {cluster, director, epoch, max_latency_in_ms, max_per_batch, empty_transaction_timeout_ms, lock_token,
-            sequencer, resolver_layout, routing_data}
+            sequencer, resolver_layout}
          ]},
       restart: :temporary
     }
@@ -102,20 +101,19 @@ defmodule Bedrock.DataPlane.CommitProxy.Server do
   @impl true
   @spec init(
           {module(), pid(), Bedrock.epoch(), non_neg_integer(), pos_integer(), non_neg_integer(), binary(), pid(),
-           ResolverLayout.t(), RoutingData.t() | nil}
+           ResolverLayout.t()}
         ) ::
           {:ok, State.t(), timeout()}
   def init(
         {cluster, director, epoch, max_latency_in_ms, max_per_batch, empty_transaction_timeout_ms, lock_token,
-         sequencer, resolver_layout, provided_routing_data}
+         sequencer, resolver_layout}
       ) do
     # Monitor the Director - if it dies, this commit proxy should terminate
     Process.monitor(director)
 
     trace_metadata(%{cluster: cluster, pid: self()})
 
-    # Use provided routing data or start with empty (populated via metadata from first transaction)
-    routing_data = provided_routing_data || RoutingData.new_empty()
+    routing_data = RoutingData.new_empty()
 
     then(
       %State{
@@ -144,18 +142,20 @@ defmodule Bedrock.DataPlane.CommitProxy.Server do
 
   @impl true
   @spec handle_call(
-          {:recover_from, binary(), pid(), ResolverLayout.t(), RoutingData.t()}
+          {:recover_from, binary(), pid(), ResolverLayout.t(), RoutingData.snapshot()}
           | {:commit, Bedrock.transaction()},
           GenServer.from(),
           State.t()
         ) ::
           {:reply, term(), State.t()} | {:noreply, State.t(), timeout() | {:continue, term()}}
-  def handle_call({:recover_from, lock_token, sequencer, resolver_layout, routing_data}, _from, %{mode: :locked} = t) do
+  def handle_call(
+        {:recover_from, lock_token, sequencer, resolver_layout, routing_snapshot},
+        _from,
+        %{mode: :locked} = t
+      ) do
     if lock_token == t.lock_token do
-      # Clean up old routing_data only if it's a different ETS table
-      if t.routing_data.shard_table != routing_data.shard_table do
-        RoutingData.cleanup(t.routing_data)
-      end
+      RoutingData.cleanup(t.routing_data)
+      routing_data = RoutingData.from_snapshot(routing_snapshot)
 
       reply(
         %{t | mode: :running, sequencer: sequencer, resolver_layout: resolver_layout, routing_data: routing_data},

--- a/test/bedrock/control_plane/director/recovery/commit_proxy_startup_phase_test.exs
+++ b/test/bedrock/control_plane/director/recovery/commit_proxy_startup_phase_test.exs
@@ -171,7 +171,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery.CommitProxyStartupPhaseTest do
                       [
                         Server,
                         {TestCluster, _director, 42, _max_latency, _max_per_batch, 5000, "test_lock_token", _sequencer,
-                         _resolver_layout, _routing_data}
+                         _resolver_layout}
                       ]}
                  } = child_spec
 
@@ -213,7 +213,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery.CommitProxyStartupPhaseTest do
                     [
                       _,
                       {_cluster, _director, _epoch, _max_latency, _max_per_batch, 2500, _lock_token, _sequencer,
-                       _resolver_layout, _routing_data}
+                       _resolver_layout}
                     ]}
                }
              ] = Agent.get(agent, & &1)

--- a/test/bedrock/control_plane/director/recovery/topology_phase_test.exs
+++ b/test/bedrock/control_plane/director/recovery/topology_phase_test.exs
@@ -50,6 +50,43 @@ defmodule Bedrock.ControlPlane.Director.Recovery.TopologyPhaseTest do
              } = result
     end
 
+    test "unlocks proxies with a plain routing snapshot that carries no process-local handles" do
+      test_pid = self()
+
+      recovery_attempt =
+        base_recovery_attempt()
+        |> with_logs(%{"log_1" => [1, 2]})
+        |> with_transaction_services(%{
+          "log_1" => %{status: {:up, self()}, kind: :log, last_seen: {:log_1, :node1}}
+        })
+
+      context =
+        recovery_context()
+        |> with_lock_token("test_token")
+        |> Map.put(:unlock_commit_proxy_fn, fn _proxy, _token, _sequencer, _resolver_layout, snapshot ->
+          send(test_pid, {:routing_snapshot, snapshot})
+          :ok
+        end)
+
+      {_result, _next_phase} = TopologyPhase.execute(recovery_attempt, context)
+
+      assert_received {:routing_snapshot, snapshot}
+
+      # An ETS table reference is only usable by the process/node that made
+      # it; the proxy must receive plain data and build its own table.
+      refute is_struct(snapshot)
+
+      assert %{
+               shard_layout: shard_layout,
+               log_map: %{0 => "log_1"},
+               log_services: %{"log_1" => _},
+               replication_factor: 1
+             } = snapshot
+
+      assert is_map(shard_layout)
+      refute snapshot |> Map.values() |> Enum.any?(&is_reference/1)
+    end
+
     test "fails when commit proxy unlocking fails" do
       recovery_attempt =
         base_recovery_attempt()

--- a/test/bedrock/data_plane/commit_proxy/routing_data_test.exs
+++ b/test/bedrock/data_plane/commit_proxy/routing_data_test.exs
@@ -4,6 +4,38 @@ defmodule Bedrock.DataPlane.CommitProxy.RoutingDataTest do
   alias Bedrock.DataPlane.CommitProxy.RoutingData
   alias Bedrock.SystemKeys
 
+  describe "from_snapshot/1" do
+    test "builds fully-populated routing data owned by the calling process" do
+      snapshot = %{
+        shard_layout: %{"m" => {1, ""}, <<0xFF, 0xFF>> => {0, "m"}},
+        log_map: %{0 => "log-a", 1 => "log-b"},
+        log_services: %{"log-a" => {:log_a, :node1}, "log-b" => {:log_b, :node2}},
+        replication_factor: 2
+      }
+
+      routing_data = RoutingData.from_snapshot(snapshot)
+
+      assert :ets.info(routing_data.shard_table, :owner) == self()
+      assert :ets.tab2list(routing_data.shard_table) == [{"m", 1}, {<<0xFF, 0xFF>>, 0}]
+      assert routing_data.log_map == %{0 => "log-a", 1 => "log-b"}
+      assert routing_data.log_services == %{"log-a" => {:log_a, :node1}, "log-b" => {:log_b, :node2}}
+      assert routing_data.replication_factor == 2
+
+      RoutingData.cleanup(routing_data)
+    end
+
+    test "builds empty routing data from an empty snapshot" do
+      snapshot = %{shard_layout: %{}, log_map: %{}, log_services: %{}, replication_factor: 1}
+
+      routing_data = RoutingData.from_snapshot(snapshot)
+
+      assert :ets.tab2list(routing_data.shard_table) == []
+      assert routing_data.replication_factor == 1
+
+      RoutingData.cleanup(routing_data)
+    end
+  end
+
   describe "new_empty/0" do
     test "creates empty routing data with all fields initialized" do
       routing_data = RoutingData.new_empty()

--- a/test/bedrock/data_plane/commit_proxy/server_test.exs
+++ b/test/bedrock/data_plane/commit_proxy/server_test.exs
@@ -6,7 +6,6 @@ defmodule Bedrock.DataPlane.CommitProxy.ServerTest do
 
   alias Bedrock.DataPlane.CommitProxy.Batch
   alias Bedrock.DataPlane.CommitProxy.ResolverLayout
-  alias Bedrock.DataPlane.CommitProxy.RoutingData
   alias Bedrock.DataPlane.CommitProxy.Server
   alias Bedrock.DataPlane.CommitProxy.State
   alias Bedrock.DataPlane.Transaction
@@ -71,20 +70,13 @@ defmodule Bedrock.DataPlane.CommitProxy.ServerTest do
     Map.merge(base, overrides)
   end
 
-  # Build routing data from a transaction system layout for testing
-  # This replaces the deleted RoutingData.new/1 for test purposes
-  defp build_routing_data(transaction_system_layout) do
+  # Build the plain routing snapshot recover_from carries, as the director's
+  # topology phase would assemble it from a transaction system layout.
+  defp build_routing_snapshot(transaction_system_layout) do
     logs = Map.get(transaction_system_layout, :logs, %{})
     services = Map.get(transaction_system_layout, :services, %{})
     # Default shard layout covering entire keyspace with a single shard (tag 0)
     shard_layout = Map.get(transaction_system_layout, :shard_layout, %{<<0xFF, 0xFF>> => {0, <<>>}})
-
-    table = :ets.new(:test_shard_keys, [:ordered_set, :public])
-
-    # Populate shard_keys from shard_layout: %{end_key => {tag, start_key}}
-    Enum.each(shard_layout, fn {end_key, {tag, _start_key}} ->
-      :ets.insert(table, {end_key, tag})
-    end)
 
     log_map =
       logs
@@ -110,24 +102,17 @@ defmodule Bedrock.DataPlane.CommitProxy.ServerTest do
         end
       end)
 
-    replication_factor = max(1, map_size(logs))
-
-    %RoutingData{
-      shard_table: table,
+    %{
+      shard_layout: shard_layout,
       log_map: log_map,
       log_services: log_services,
-      replication_factor: replication_factor
+      replication_factor: max(1, map_size(logs))
     }
   end
 
-  # Build minimal routing data for tests that don't need full routing
-  defp build_empty_routing_data do
-    %RoutingData{
-      shard_table: :ets.new(:test_shard_keys_empty, [:ordered_set, :public]),
-      log_map: %{},
-      log_services: %{},
-      replication_factor: 1
-    }
+  # Minimal routing snapshot for tests that don't need full routing
+  defp empty_routing_snapshot do
+    %{shard_layout: %{}, log_map: %{}, log_services: %{}, replication_factor: 1}
   end
 
   describe "error handling integration" do
@@ -223,7 +208,7 @@ defmodule Bedrock.DataPlane.CommitProxy.ServerTest do
   describe "init/1" do
     test "sets empty_transaction_timeout_ms in state and initial timeout" do
       resolver_layout = %ResolverLayout.Single{resolver_ref: :test_resolver}
-      init_args = {TestCluster, self(), 1, 10, 5, 1000, "test_token", :fake_sequencer, resolver_layout, nil}
+      init_args = {TestCluster, self(), 1, 10, 5, 1000, "test_token", :fake_sequencer, resolver_layout}
 
       assert {:ok, %State{empty_transaction_timeout_ms: 1000}, 1000} =
                Server.init(init_args)
@@ -266,7 +251,7 @@ defmodule Bedrock.DataPlane.CommitProxy.ServerTest do
 
       # Create commit proxy with larger batches to test indexing
       resolver_layout = ResolverLayout.from_layout(transaction_system_layout)
-      routing_data = build_routing_data(transaction_system_layout)
+      routing_snapshot = build_routing_snapshot(transaction_system_layout)
 
       opts = [
         cluster: TestCluster,
@@ -280,12 +265,13 @@ defmodule Bedrock.DataPlane.CommitProxy.ServerTest do
         empty_transaction_timeout_ms: 1000,
         lock_token: "index_test_token",
         sequencer: sequencer,
-        resolver_layout: resolver_layout,
-        routing_data: routing_data
+        resolver_layout: resolver_layout
       ]
 
       commit_proxy = start_supervised!(Server.child_spec(opts))
-      :ok = GenServer.call(commit_proxy, {:recover_from, "index_test_token", sequencer, resolver_layout, routing_data})
+
+      :ok =
+        GenServer.call(commit_proxy, {:recover_from, "index_test_token", sequencer, resolver_layout, routing_snapshot})
 
       {:ok, commit_proxy: commit_proxy}
     end
@@ -378,7 +364,7 @@ defmodule Bedrock.DataPlane.CommitProxy.ServerTest do
       }
 
       resolver_layout = ResolverLayout.from_layout(transaction_system_layout)
-      routing_data = build_routing_data(transaction_system_layout)
+      routing_snapshot = build_routing_snapshot(transaction_system_layout)
 
       opts = [
         cluster: TestCluster,
@@ -392,14 +378,16 @@ defmodule Bedrock.DataPlane.CommitProxy.ServerTest do
         empty_transaction_timeout_ms: 1000,
         lock_token: "failure_test_token",
         sequencer: sequencer,
-        resolver_layout: resolver_layout,
-        routing_data: routing_data
+        resolver_layout: resolver_layout
       ]
 
       commit_proxy = start_supervised!(Server.child_spec(opts))
 
       :ok =
-        GenServer.call(commit_proxy, {:recover_from, "failure_test_token", sequencer, resolver_layout, routing_data})
+        GenServer.call(
+          commit_proxy,
+          {:recover_from, "failure_test_token", sequencer, resolver_layout, routing_snapshot}
+        )
 
       {:ok, commit_proxy: commit_proxy, failing_log: failing_log}
     end
@@ -541,7 +529,7 @@ defmodule Bedrock.DataPlane.CommitProxy.ServerTest do
       instance = 0
       lock_token = "test_token_onslaught"
       resolver_layout = ResolverLayout.from_layout(transaction_system_layout)
-      routing_data = build_routing_data(transaction_system_layout)
+      routing_snapshot = build_routing_snapshot(transaction_system_layout)
 
       opts = [
         cluster: TestCluster,
@@ -553,14 +541,13 @@ defmodule Bedrock.DataPlane.CommitProxy.ServerTest do
         empty_transaction_timeout_ms: 1000,
         lock_token: lock_token,
         sequencer: sequencer,
-        resolver_layout: resolver_layout,
-        routing_data: routing_data
+        resolver_layout: resolver_layout
       ]
 
       commit_proxy = start_supervised!(Server.child_spec(opts))
 
       # Unlock the commit proxy
-      :ok = GenServer.call(commit_proxy, {:recover_from, lock_token, sequencer, resolver_layout, routing_data})
+      :ok = GenServer.call(commit_proxy, {:recover_from, lock_token, sequencer, resolver_layout, routing_snapshot})
 
       {:ok, commit_proxy: commit_proxy, sequencer: sequencer, resolver: resolver, log: log}
     end
@@ -711,7 +698,7 @@ defmodule Bedrock.DataPlane.CommitProxy.ServerTest do
       instance = 0
       lock_token = "test_token_ordering"
       resolver_layout = ResolverLayout.from_layout(transaction_system_layout)
-      routing_data = build_routing_data(transaction_system_layout)
+      routing_snapshot = build_routing_snapshot(transaction_system_layout)
 
       opts = [
         cluster: TestCluster,
@@ -723,14 +710,13 @@ defmodule Bedrock.DataPlane.CommitProxy.ServerTest do
         empty_transaction_timeout_ms: 1000,
         lock_token: lock_token,
         sequencer: sequencer,
-        resolver_layout: resolver_layout,
-        routing_data: routing_data
+        resolver_layout: resolver_layout
       ]
 
       commit_proxy = start_supervised!(Server.child_spec(opts))
 
       # Unlock the commit proxy
-      :ok = GenServer.call(commit_proxy, {:recover_from, lock_token, sequencer, resolver_layout, routing_data})
+      :ok = GenServer.call(commit_proxy, {:recover_from, lock_token, sequencer, resolver_layout, routing_snapshot})
 
       {:ok, commit_proxy: commit_proxy, sequencer: sequencer, resolver: resolver, log: log}
     end
@@ -767,7 +753,7 @@ defmodule Bedrock.DataPlane.CommitProxy.ServerTest do
       assert :ok =
                GenServer.call(
                  commit_proxy,
-                 {:recover_from, lock_token, :fake_sequencer, resolver_layout, build_empty_routing_data()}
+                 {:recover_from, lock_token, :fake_sequencer, resolver_layout, empty_routing_snapshot()}
                )
 
       # Now commit returns different error (sequencer unavailable)
@@ -802,7 +788,7 @@ defmodule Bedrock.DataPlane.CommitProxy.ServerTest do
       assert {:error, :unauthorized} =
                GenServer.call(
                  commit_proxy,
-                 {:recover_from, wrong_token, :fake_sequencer, resolver_layout, build_empty_routing_data()}
+                 {:recover_from, wrong_token, :fake_sequencer, resolver_layout, empty_routing_snapshot()}
                )
 
       # Should still be locked
@@ -836,14 +822,14 @@ defmodule Bedrock.DataPlane.CommitProxy.ServerTest do
       assert {:error, :unauthorized} =
                GenServer.call(
                  commit_proxy,
-                 {:recover_from, wrong_token, :fake_sequencer, resolver_layout, build_empty_routing_data()}
+                 {:recover_from, wrong_token, :fake_sequencer, resolver_layout, empty_routing_snapshot()}
                )
 
       # Second attempt with correct token should succeed
       assert :ok =
                GenServer.call(
                  commit_proxy,
-                 {:recover_from, correct_token, :fake_sequencer, resolver_layout, build_empty_routing_data()}
+                 {:recover_from, correct_token, :fake_sequencer, resolver_layout, empty_routing_snapshot()}
                )
 
       # Verify no longer locked
@@ -864,7 +850,7 @@ defmodule Bedrock.DataPlane.CommitProxy.ServerTest do
       {:ok, commit_proxy} =
         GenServer.start_link(
           Server,
-          {TestCluster, director, 1, 50, 5, 1000, lock_token, :fake_sequencer, resolver_layout, nil}
+          {TestCluster, director, 1, 50, 5, 1000, lock_token, :fake_sequencer, resolver_layout}
         )
 
       # Monitor the commit proxy
@@ -937,7 +923,7 @@ defmodule Bedrock.DataPlane.CommitProxy.ServerTest do
       assert :ok =
                GenServer.call(
                  commit_proxy,
-                 {:recover_from, lock_token, :fake_sequencer, resolver_layout, build_empty_routing_data()}
+                 {:recover_from, lock_token, :fake_sequencer, resolver_layout, empty_routing_snapshot()}
                )
 
       # Send metadata update
@@ -1054,7 +1040,7 @@ defmodule Bedrock.DataPlane.CommitProxy.ServerTest do
       :ok =
         GenServer.call(
           commit_proxy,
-          {:recover_from, "token", :fake_sequencer, resolver_layout, build_empty_routing_data()}
+          {:recover_from, "token", :fake_sequencer, resolver_layout, empty_routing_snapshot()}
         )
 
       transaction = TransactionTestSupport.new_log_transaction(0, %{"k" => "v"})
@@ -1064,6 +1050,48 @@ defmodule Bedrock.DataPlane.CommitProxy.ServerTest do
   end
 
   describe "recover_from with routing_data" do
+    test "builds routing data owned by the proxy from a plain snapshot" do
+      director = self()
+      lock_token = "snapshot_ownership_token"
+
+      resolver_layout = %ResolverLayout.Single{resolver_ref: :test_resolver}
+
+      opts = [
+        cluster: TestCluster,
+        director: director,
+        epoch: 1,
+        instance: 0,
+        max_latency_in_ms: 50,
+        max_per_batch: 5,
+        empty_transaction_timeout_ms: 1000,
+        lock_token: lock_token,
+        sequencer: :fake_sequencer,
+        resolver_layout: resolver_layout
+      ]
+
+      commit_proxy = start_supervised!(Server.child_spec(opts))
+
+      snapshot = %{
+        shard_layout: %{<<0xFF, 0xFF>> => {0, ""}},
+        log_map: %{0 => "log-1"},
+        log_services: %{"log-1" => {:log_1, :node1}},
+        replication_factor: 1
+      }
+
+      assert :ok =
+               GenServer.call(commit_proxy, {:recover_from, lock_token, :fake_sequencer, resolver_layout, snapshot})
+
+      %{routing_data: routing_data} = :sys.get_state(commit_proxy)
+
+      # The table must be created by (and die with) the proxy itself: a table
+      # reference built in another process is invalid after that process dies,
+      # and is never valid on another node.
+      assert :ets.info(routing_data.shard_table, :owner) == commit_proxy
+      assert :ets.tab2list(routing_data.shard_table) == [{<<0xFF, 0xFF>>, 0}]
+      assert routing_data.log_map == %{0 => "log-1"}
+      assert routing_data.log_services == %{"log-1" => {:log_1, :node1}}
+    end
+
     test "sets full routing_data when recovering" do
       director = self()
       epoch = 1
@@ -1099,7 +1127,7 @@ defmodule Bedrock.DataPlane.CommitProxy.ServerTest do
       }
 
       resolver_layout = ResolverLayout.from_layout(transaction_system_layout)
-      routing_data = build_routing_data(transaction_system_layout)
+      routing_snapshot = build_routing_snapshot(transaction_system_layout)
 
       # Start commit proxy with empty routing_data (simulating startup before unlock)
       opts = [
@@ -1120,7 +1148,7 @@ defmodule Bedrock.DataPlane.CommitProxy.ServerTest do
 
       # Recover with full routing_data
       assert :ok =
-               GenServer.call(commit_proxy, {:recover_from, lock_token, sequencer, resolver_layout, routing_data})
+               GenServer.call(commit_proxy, {:recover_from, lock_token, sequencer, resolver_layout, routing_snapshot})
 
       # Verify proxy can commit - the log_services should now be set
       transaction = TransactionTestSupport.new_log_transaction(0, %{"key" => "value"})
@@ -1153,13 +1181,13 @@ defmodule Bedrock.DataPlane.CommitProxy.ServerTest do
 
       commit_proxy = start_supervised!(Server.child_spec(opts))
 
-      routing_data = build_empty_routing_data()
+      routing_snapshot = empty_routing_snapshot()
 
       # Recovery with wrong token should fail
       assert {:error, :unauthorized} =
                GenServer.call(
                  commit_proxy,
-                 {:recover_from, wrong_token, :fake_sequencer, resolver_layout, routing_data}
+                 {:recover_from, wrong_token, :fake_sequencer, resolver_layout, routing_snapshot}
                )
 
       # Should still be locked

--- a/test/bedrock/data_plane/commit_proxy_test.exs
+++ b/test/bedrock/data_plane/commit_proxy_test.exs
@@ -3,7 +3,6 @@ defmodule Bedrock.DataPlane.CommitProxyTest do
 
   alias Bedrock.DataPlane.CommitProxy
   alias Bedrock.DataPlane.CommitProxy.ResolverLayout
-  alias Bedrock.DataPlane.CommitProxy.RoutingData
 
   # Mock GenServer for testing API functions
   defmodule MockCommitProxy do
@@ -30,14 +29,14 @@ defmodule Bedrock.DataPlane.CommitProxyTest do
       sequencer = self()
       resolver_layout = %ResolverLayout.Single{resolver_ref: self()}
 
-      routing_data = %RoutingData{
-        shard_table: :ets.new(:test_shards, [:ordered_set, :public]),
+      routing_snapshot = %{
+        shard_layout: %{},
         log_map: %{},
         log_services: %{"test_log" => self()},
         replication_factor: 1
       }
 
-      assert :ok = CommitProxy.recover_from(pid, "test_lock_token", sequencer, resolver_layout, routing_data)
+      assert :ok = CommitProxy.recover_from(pid, "test_lock_token", sequencer, resolver_layout, routing_snapshot)
     end
   end
 end


### PR DESCRIPTION
## Why

A commit proxy routes each mutation to the right shard using a small ETS lookup table. Today the director builds that table during recovery and sends the proxy a handle to it. An ETS handle only works for the node that created the table, and the table itself vanishes the moment its creating process dies. So the moment a proxy lives on a different node than the director — which happens whenever recovery recruits across nodes — the proxy's very first shard lookup explodes (`:ets.insert ... not a valid table identifier`), taking the director and the whole recovery attempt down with it. This exact crash loop was observed on a two-node livebook cluster on 2026-08-19.

## What

The director stops sending an ETS handle. `recover_from` now carries a plain map — shard layout, log map, log services, replication factor — that is safe to send anywhere. The proxy turns that map into its own ETS table the moment it unlocks.

- `RoutingData.from_snapshot/1` (new): builds routing data from the plain map, creating the table in the calling process.
- `TopologyPhase.build_routing_snapshot/1`: same assembly as before, minus any `:ets` calls.
- `Server.handle_call({:recover_from, ...})`: always discards its previous table and builds the new one itself; the "is this a different table?" check is gone because the answer is now always yes.
- The unused `opts[:routing_data]` init seam is removed — the proxy starts empty and there is exactly one place routing data gets built.

## How

The routing table's whole lifecycle now lives inside the proxy process: created at init (`new_empty`) or unlock (`from_snapshot`), replaced only by the proxy itself, deleted in `terminate`. Nothing that crosses a process or node boundary refers to a live table, so the two failure modes (wrong node, dead owner) can no longer occur by construction. Tests assert the table's owner is the proxy pid and that the unlock message contains no process-local handles.

Ticket: bedrock-q67.20.1 · TDD: ownership/plainness tests written first, failed against the old code (4 red), pass after (full suite 2553 tests green, credo --strict + dialyzer clean).