### PR TITLE
Explicit versioned encodings for system-key values (bedrock-q67.20.2)

### DIFF
--- a/lib/bedrock/control_plane/director/recovery/materializer_bootstrap_phase.ex
+++ b/lib/bedrock/control_plane/director/recovery/materializer_bootstrap_phase.ex
@@ -37,6 +37,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhase do
   alias Bedrock.DataPlane.Materializer
   alias Bedrock.Service.Foreman
   alias Bedrock.Service.Worker
+  alias Bedrock.SystemKeys.Values
 
   require Logger
 
@@ -504,23 +505,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhase do
 
     case Materializer.get_range(materializer_pid, prefix, end_key, read_version, limit: 1000) do
       {:ok, {entries, _more}} ->
-        # Key format: \xff/system/shard_keys/<end_key>; value: the tag
-        # (persistence writes `shard_key(end_key) -> tag`). Start keys are
-        # not stored — ranges are contiguous, so each shard starts where
-        # the previous one ends (the first starts at the empty key).
-        shard_layout =
-          entries
-          |> Enum.map(fn {key, value} ->
-            {extract_end_key_from_shard_key(key), decode_shard_tag(value)}
-          end)
-          |> Enum.sort_by(fn {end_key, _tag} -> end_key end)
-          |> Enum.map_reduce(<<>>, fn {end_key, tag}, start_key ->
-            {{end_key, {tag, start_key}}, end_key}
-          end)
-          |> elem(0)
-          |> Map.new()
-
-        {:ok, shard_layout}
+        shard_layout_from_entries(entries)
 
       {:error, reason} ->
         {:error, {:shard_layout_query_failed, reason}}
@@ -530,16 +515,63 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhase do
     end
   end
 
+  @doc false
+  # Key format: \xff/system/shard_keys/<end_key>; value: {tag, start_key}
+  # (see Bedrock.SystemKeys.Values). Ranges are contiguous, so start keys
+  # are rebuilt from the sorted end keys — each shard starts where the
+  # previous one ends, the first at the empty key — which also covers
+  # legacy values that carried only the tag.
+  @spec shard_layout_from_entries([{Bedrock.key(), binary()}]) ::
+          {:ok, TransactionSystemLayout.shard_layout()} | {:error, {:invalid_shard_value, Bedrock.key()}}
+  def shard_layout_from_entries(entries) do
+    entries
+    |> Enum.reduce_while({:ok, []}, fn {key, value}, {:ok, acc} ->
+      case decode_shard_tag(value) do
+        {:ok, tag} -> {:cont, {:ok, [{extract_end_key_from_shard_key(key), tag} | acc]}}
+        {:error, _} -> {:halt, {:error, {:invalid_shard_value, key}}}
+      end
+    end)
+    |> case do
+      {:ok, tags_by_end_key} ->
+        shard_layout =
+          tags_by_end_key
+          |> Enum.sort_by(fn {end_key, _tag} -> end_key end)
+          |> Enum.map_reduce(<<>>, fn {end_key, tag}, start_key ->
+            {{end_key, {tag, start_key}}, end_key}
+          end)
+          |> elem(0)
+          |> Map.new()
+
+        {:ok, shard_layout}
+
+      error ->
+        error
+    end
+  end
+
   defp extract_end_key_from_shard_key(key) do
     prefix = Bedrock.SystemKeys.shard_keys_prefix()
     prefix_len = byte_size(prefix)
     binary_part(key, prefix_len, byte_size(key) - prefix_len)
   end
 
-  defp decode_shard_tag(value) when is_binary(value) do
-    case :erlang.binary_to_term(value) do
-      tag when is_integer(tag) -> tag
-      {tag, _start_key} when is_integer(tag) -> tag
+  defp decode_shard_tag(value) do
+    case Values.decode_shard_key_entry(value) do
+      {:ok, {tag, _start_key}} -> {:ok, tag}
+      {:error, _} -> decode_legacy_shard_tag(value)
     end
+  end
+
+  # Clusters created before Bedrock.SystemKeys.Values wrote shard_key values
+  # with term_to_binary; their first completed recovery re-encodes them.
+  # Remove once no supported release can carry the old encoding.
+  defp decode_legacy_shard_tag(value) do
+    case :erlang.binary_to_term(value) do
+      tag when is_integer(tag) -> {:ok, tag}
+      {tag, _start_key} when is_integer(tag) -> {:ok, tag}
+      _ -> {:error, :invalid_encoding}
+    end
+  rescue
+    ArgumentError -> {:error, :invalid_encoding}
   end
 end

--- a/lib/bedrock/control_plane/director/recovery/materializer_bootstrap_phase.ex
+++ b/lib/bedrock/control_plane/director/recovery/materializer_bootstrap_phase.ex
@@ -566,7 +566,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhase do
   # with term_to_binary; their first completed recovery re-encodes them.
   # Remove once no supported release can carry the old encoding.
   defp decode_legacy_shard_tag(value) do
-    case :erlang.binary_to_term(value) do
+    case :erlang.binary_to_term(value, [:safe]) do
       tag when is_integer(tag) -> {:ok, tag}
       {tag, _start_key} when is_integer(tag) -> {:ok, tag}
       _ -> {:error, :invalid_encoding}

--- a/lib/bedrock/control_plane/director/recovery/persistence_phase.ex
+++ b/lib/bedrock/control_plane/director/recovery/persistence_phase.ex
@@ -33,6 +33,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery.PersistencePhase do
   alias Bedrock.SystemKeys
   alias Bedrock.SystemKeys.ClusterBootstrap
   alias Bedrock.SystemKeys.ShardMetadata
+  alias Bedrock.SystemKeys.Values
 
   @impl true
   def execute(recovery_attempt, context) do
@@ -206,11 +207,11 @@ defmodule Bedrock.ControlPlane.Director.Recovery.PersistencePhase do
   @spec build_monolithic_keys(Tx.t(), Bedrock.epoch(), map()) :: Tx.t()
   defp build_monolithic_keys(tx, epoch, encoded_config) do
     tx
-    |> Tx.set(SystemKeys.config_monolithic(), :erlang.term_to_binary({epoch, encoded_config}))
-    |> Tx.set(SystemKeys.epoch_legacy(), :erlang.term_to_binary(epoch))
+    |> Tx.set(SystemKeys.config_monolithic(), Values.encode_structured({epoch, encoded_config}))
+    |> Tx.set(SystemKeys.epoch_legacy(), Values.encode_integer(epoch))
     |> Tx.set(
       SystemKeys.last_recovery_legacy(),
-      :erlang.term_to_binary(System.system_time(:millisecond))
+      Values.encode_integer(System.system_time(:millisecond))
     )
   end
 
@@ -229,83 +230,82 @@ defmodule Bedrock.ControlPlane.Director.Recovery.PersistencePhase do
       tx
       |> Tx.set(
         SystemKeys.cluster_coordinators(),
-        :erlang.term_to_binary(cluster_config.coordinators)
+        Values.encode_node_list(cluster_config.coordinators)
       )
-      |> Tx.set(SystemKeys.cluster_epoch(), :erlang.term_to_binary(epoch))
+      |> Tx.set(SystemKeys.cluster_epoch(), Values.encode_integer(epoch))
       |> Tx.set(
         SystemKeys.cluster_policies_volunteer_nodes(),
-        :erlang.term_to_binary(cluster_config.policies.allow_volunteer_nodes_to_join)
+        Values.encode_boolean(cluster_config.policies.allow_volunteer_nodes_to_join || false)
       )
       |> Tx.set(
         SystemKeys.cluster_parameters_desired_logs(),
-        :erlang.term_to_binary(cluster_config.parameters.desired_logs)
+        Values.encode_integer(cluster_config.parameters.desired_logs)
       )
       |> Tx.set(
         SystemKeys.cluster_parameters_desired_replication(),
-        :erlang.term_to_binary(cluster_config.parameters.desired_replication_factor)
+        Values.encode_integer(cluster_config.parameters.desired_replication_factor)
       )
       |> Tx.set(
         SystemKeys.cluster_parameters_desired_commit_proxies(),
-        :erlang.term_to_binary(cluster_config.parameters.desired_commit_proxies)
+        Values.encode_integer(cluster_config.parameters.desired_commit_proxies)
       )
       |> Tx.set(
         SystemKeys.cluster_parameters_desired_coordinators(),
-        :erlang.term_to_binary(cluster_config.parameters.desired_coordinators)
+        Values.encode_integer(cluster_config.parameters.desired_coordinators)
       )
       |> Tx.set(
         SystemKeys.cluster_parameters_desired_read_version_proxies(),
-        :erlang.term_to_binary(cluster_config.parameters.desired_read_version_proxies)
+        Values.encode_integer(cluster_config.parameters.desired_read_version_proxies)
       )
       |> Tx.set(
         SystemKeys.cluster_parameters_empty_transaction_timeout_ms(),
-        :erlang.term_to_binary(Map.get(cluster_config.parameters, :empty_transaction_timeout_ms, 1_000))
+        Values.encode_integer(Map.get(cluster_config.parameters, :empty_transaction_timeout_ms, 1_000))
       )
       |> Tx.set(
         SystemKeys.cluster_parameters_ping_rate_in_hz(),
-        :erlang.term_to_binary(cluster_config.parameters.ping_rate_in_hz)
+        Values.encode_integer(cluster_config.parameters.ping_rate_in_hz)
       )
       |> Tx.set(
         SystemKeys.cluster_parameters_retransmission_rate_in_hz(),
-        :erlang.term_to_binary(cluster_config.parameters.retransmission_rate_in_hz)
+        Values.encode_integer(cluster_config.parameters.retransmission_rate_in_hz)
       )
       |> Tx.set(
         SystemKeys.cluster_parameters_transaction_window_in_ms(),
-        :erlang.term_to_binary(cluster_config.parameters.transaction_window_in_ms)
+        Values.encode_integer(cluster_config.parameters.transaction_window_in_ms)
       )
 
     # Only durable layout config (services and id)
     tx =
       tx
-      |> Tx.set(SystemKeys.layout_services(), :erlang.term_to_binary(encoded_services))
-      |> Tx.set(SystemKeys.layout_id(), :erlang.term_to_binary(transaction_system_layout.id))
+      |> Tx.set(SystemKeys.layout_services(), Values.encode_structured(encoded_services))
+      |> Tx.set(SystemKeys.layout_id(), Values.encode_id(transaction_system_layout.id))
 
     tx =
       Enum.reduce(transaction_system_layout.logs, tx, fn {log_id, log_descriptor}, tx ->
-        encoded_descriptor =
-          log_descriptor
-          |> encode_log_descriptor_for_storage()
-          |> :erlang.term_to_binary()
-
-        Tx.set(tx, SystemKeys.layout_log(log_id), encoded_descriptor)
+        Tx.set(tx, SystemKeys.layout_log(log_id), Values.encode_tag_list(log_descriptor))
       end)
 
     # Shard keys use ceiling-search pattern
     tx = build_shard_keys(tx, transaction_system_layout.shard_layout)
 
     tx
-    |> Tx.set(SystemKeys.recovery_attempt(), :erlang.term_to_binary(1))
+    |> Tx.set(SystemKeys.recovery_attempt(), Values.encode_integer(1))
     |> Tx.set(
       SystemKeys.recovery_last_completed(),
-      :millisecond |> System.system_time() |> :erlang.term_to_binary()
+      Values.encode_integer(System.system_time(:millisecond))
     )
   end
 
-  defp encode_services_for_storage(services) when is_map(services), do: services
-
-  @spec encode_log_descriptor_for_storage([term()]) :: [term()]
-  defp encode_log_descriptor_for_storage(log_descriptor) do
-    # Log descriptors typically don't contain PIDs directly
-    log_descriptor
+  # Runtime PIDs are meaningless in durable storage: a later epoch cannot use
+  # them, so live statuses are stored as :unknown. Service refs are
+  # re-populated at runtime by the director.
+  defp encode_services_for_storage(services) when is_map(services) do
+    Map.new(services, fn {service_id, descriptor} ->
+      case descriptor do
+        %{status: {:up, pid}} when is_pid(pid) -> {service_id, %{descriptor | status: :unknown}}
+        _ -> {service_id, descriptor}
+      end
+    end)
   end
 
   # Creates shard_key(end_key) -> tag and shard(tag) -> ShardMetadata entries
@@ -316,8 +316,8 @@ defmodule Bedrock.ControlPlane.Director.Recovery.PersistencePhase do
 
   defp build_shard_keys(tx, shard_layout) when is_map(shard_layout) do
     Enum.reduce(shard_layout, tx, fn {end_key, {tag, start_key}}, tx ->
-      # Write shard_key(end_key) -> tag (for ceiling search)
-      tx = Tx.set(tx, SystemKeys.shard_key(end_key), :erlang.term_to_binary(tag))
+      # Write shard_key(end_key) -> {tag, start_key} (for ceiling search)
+      tx = Tx.set(tx, SystemKeys.shard_key(end_key), Values.encode_shard_key_entry(tag, start_key))
 
       # Write shard(tag) -> ShardMetadata (FlatBuffer encoded)
       # born_at is 0 for now - will be set properly once we track shard versions

--- a/lib/bedrock/control_plane/director/recovery/persistence_phase.ex
+++ b/lib/bedrock/control_plane/director/recovery/persistence_phase.ex
@@ -308,7 +308,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery.PersistencePhase do
     end)
   end
 
-  # Creates shard_key(end_key) -> tag and shard(tag) -> ShardMetadata entries
+  # Creates shard_key(end_key) -> {tag, start_key} and shard(tag) -> ShardMetadata entries
   # shard_layout format: %{end_key => {tag, start_key}}
   @spec build_shard_keys(Tx.t(), TransactionSystemLayout.shard_layout() | nil) :: Tx.t()
   defp build_shard_keys(tx, nil), do: tx

--- a/lib/bedrock/data_plane/commit_proxy/routing_data.ex
+++ b/lib/bedrock/data_plane/commit_proxy/routing_data.ex
@@ -30,6 +30,7 @@ defmodule Bedrock.DataPlane.CommitProxy.RoutingData do
 
   alias Bedrock.DataPlane.Log
   alias Bedrock.SystemKeys
+  alias Bedrock.SystemKeys.Values
 
   @type t :: %__MODULE__{
           shard_table: :ets.table(),
@@ -203,14 +204,18 @@ defmodule Bedrock.DataPlane.CommitProxy.RoutingData do
   defp apply_mutation({:set, key, value}, routing_data) do
     case SystemKeys.parse_key(key) do
       {:shard_key, end_key} ->
-        tag = :erlang.binary_to_term(value)
-        insert_shard(routing_data, end_key, tag)
+        # Undecodable values are ignored; the routing table keeps its last
+        # good entry rather than crashing the commit proxy.
+        case Values.decode_shard_key_entry(value) do
+          {:ok, {tag, _start_key}} -> insert_shard(routing_data, end_key, tag)
+          {:error, _} -> :ignored
+        end
+
         routing_data
 
       {:layout_log, log_id} ->
-        # layout_log stores the log descriptor (tags) as erlang term, not OtpRef
-        # Service refs are populated at runtime by the director, not from persisted data
-        _log_descriptor = :erlang.binary_to_term(value)
+        # The value (log descriptor tags) is not needed for routing; service
+        # refs are populated at runtime by the director, not from persisted data.
         insert_log(routing_data, log_id)
 
       _ ->

--- a/lib/bedrock/system_keys.ex
+++ b/lib/bedrock/system_keys.ex
@@ -204,11 +204,20 @@ defmodule Bedrock.SystemKeys do
   @doc """
   Parses a system key and extracts its type and parameter.
 
+  This is the inverse of the key generation functions above and covers every
+  key family written by the director's recovery persistence phase.
+
   Returns:
   - `{:layout_log, log_id}` for log keys
   - `{:shard_key, end_key}` for shard key mappings
   - `{:shard, tag}` for shard metadata keys
   - `{:materializer_key, end_key}` for materializer keys
+  - `:layout_services` / `:layout_id` for fixed layout keys
+  - `{:cluster, :coordinators | :epoch}` for fixed cluster keys
+  - `{:cluster_policy, :volunteer_nodes}` for cluster policies
+  - `{:cluster_parameter, name}` for known cluster parameters
+  - `{:recovery, :attempt | :state | :last_completed}` for recovery keys
+  - `:config_monolithic` / `:epoch_legacy` / `:last_recovery_legacy` for legacy keys
   - `:unknown` for unrecognized system keys
   - `:error` for non-system keys
   """
@@ -217,6 +226,15 @@ defmodule Bedrock.SystemKeys do
           | {:shard_key, String.t()}
           | {:shard, String.t()}
           | {:materializer_key, String.t()}
+          | :layout_services
+          | :layout_id
+          | {:cluster, :coordinators | :epoch}
+          | {:cluster_policy, :volunteer_nodes}
+          | {:cluster_parameter, atom()}
+          | {:recovery, :attempt | :state | :last_completed}
+          | :config_monolithic
+          | :epoch_legacy
+          | :last_recovery_legacy
           | :unknown
           | :error
   # Order matters: more specific prefixes first (shard_keys before shards)
@@ -224,7 +242,38 @@ defmodule Bedrock.SystemKeys do
   def parse_key(<<@system_prefix, "/shard_keys/", rest::binary>>), do: {:shard_key, rest}
   def parse_key(<<@system_prefix, "/shards/", rest::binary>>), do: {:shard, rest}
   def parse_key(<<@system_prefix, "/materializer_keys/", rest::binary>>), do: {:materializer_key, rest}
+  def parse_key(<<@system_prefix, "/layout/services">>), do: :layout_services
+  def parse_key(<<@system_prefix, "/layout/id">>), do: :layout_id
+  def parse_key(<<@system_prefix, "/cluster/coordinators">>), do: {:cluster, :coordinators}
+  def parse_key(<<@system_prefix, "/cluster/epoch">>), do: {:cluster, :epoch}
+  def parse_key(<<@system_prefix, "/cluster/policies/volunteer_nodes">>), do: {:cluster_policy, :volunteer_nodes}
+  def parse_key(<<@system_prefix, "/cluster/parameters/", rest::binary>>), do: parse_cluster_parameter(rest)
+  def parse_key(<<@system_prefix, "/recovery/attempt">>), do: {:recovery, :attempt}
+  def parse_key(<<@system_prefix, "/recovery/state">>), do: {:recovery, :state}
+  def parse_key(<<@system_prefix, "/recovery/last_completed">>), do: {:recovery, :last_completed}
+  def parse_key(<<@system_prefix, "/config">>), do: :config_monolithic
+  def parse_key(<<@system_prefix, "/epoch">>), do: :epoch_legacy
+  def parse_key(<<@system_prefix, "/last_recovery">>), do: :last_recovery_legacy
   def parse_key(<<@system_prefix, _rest::binary>>), do: :unknown
   def parse_key(key) when is_binary(key), do: :error
   def parse_key(_), do: :error
+
+  # Known cluster parameters only; unknown parameters are forward-compatible
+  @cluster_parameters ~w(
+    desired_logs
+    desired_replication
+    desired_commit_proxies
+    desired_coordinators
+    desired_read_version_proxies
+    empty_transaction_timeout_ms
+    ping_rate_in_hz
+    retransmission_rate_in_hz
+    transaction_window_in_ms
+  )
+
+  for name <- @cluster_parameters do
+    defp parse_cluster_parameter(unquote(name)), do: {:cluster_parameter, unquote(String.to_atom(name))}
+  end
+
+  defp parse_cluster_parameter(_), do: :unknown
 end

--- a/lib/bedrock/system_keys/values.ex
+++ b/lib/bedrock/system_keys/values.ex
@@ -1,0 +1,348 @@
+defmodule Bedrock.SystemKeys.Values do
+  @moduledoc """
+  Explicit value encodings for the `\\xFF/system` keyspace.
+
+  Every system-key value family gets a deliberate encoding instead of
+  `:erlang.term_to_binary/1`, which is BEAM-only and unsafe to decode from
+  durable storage. Encoders are used by trusted writers (the director's
+  recovery persistence phase) and raise on invalid input; decoders never
+  raise -- they return `{:ok, value}` or `{:error, reason}` so consumers can
+  skip malformed values.
+
+  ## Encodings by family
+
+  Simple scalar families use `Bedrock.Encoding.Tuple` (FDB tuple encoding:
+  self-describing type tags, language-neutral, order-preserving). The key
+  itself identifies the family, so no extra version byte is carried:
+
+    * integers -- epochs, cluster parameters, timestamps, recovery attempt
+    * booleans -- cluster policies (encoded as integer 0/1)
+    * atoms -- recovery state (encoded as string)
+    * ids -- layout id (integer or binary)
+    * node lists -- cluster coordinators (encoded as strings)
+    * tag lists -- log descriptors (lists of range tags)
+    * shard key entries -- `{tag, start_key}` tuples
+
+  Structured families (`config_monolithic`, `layout_services`) hold nested
+  maps/tuples with atoms, so they use a versioned explicit term encoding
+  (leading version byte, currently `0x01`). The codec supports exactly nil,
+  booleans, atoms, binaries, 64-bit integers, floats, tuples, lists, and
+  maps; PIDs, refs, and funs are rejected at encode time -- writers must
+  sanitize runtime references first.
+
+  FlatBuffer families (`shard/1` -> `Bedrock.SystemKeys.ShardMetadata`,
+  `materializer_key/1` -> `Bedrock.SystemKeys.MaterializerList`) are already
+  explicitly encoded and are passed through opaque here.
+
+  Atoms are re-created with `String.to_existing_atom/1` on decode; a string
+  that does not name an existing atom is a decode error (`{:error,
+  :unknown_atom}`), never a new atom -- durable bytes must not be able to
+  grow the atom table. The legitimate atom population (config field names,
+  service kinds, node names) already exists on any node that consumes these
+  values.
+  """
+
+  import Bitwise, only: [<<<: 2]
+
+  alias Bedrock.Encoding.Tuple, as: TupleEncoding
+
+  @structured_version 0x01
+
+  @typedoc "A parsed system key, as returned by `Bedrock.SystemKeys.parse_key/1`"
+  @type parsed_key ::
+          {:layout_log, String.t()}
+          | {:shard_key, String.t()}
+          | {:shard, String.t()}
+          | {:materializer_key, String.t()}
+          | :layout_services
+          | :layout_id
+          | {:cluster, :coordinators | :epoch}
+          | {:cluster_policy, :volunteer_nodes}
+          | {:cluster_parameter, atom()}
+          | {:recovery, :attempt | :state | :last_completed}
+          | :config_monolithic
+          | :epoch_legacy
+          | :last_recovery_legacy
+
+  @type decode_error ::
+          {:error, :invalid_encoding | :invalid_type | :unknown_atom | :unsupported_version | :unknown_family}
+
+  # ============================================================================
+  # Encoders (trusted writers; raise on invalid input)
+  # ============================================================================
+
+  @doc "Encodes an integer (epoch, parameter, timestamp, recovery attempt)."
+  @spec encode_integer(integer()) :: binary()
+  def encode_integer(i) when is_integer(i), do: TupleEncoding.pack(i)
+
+  @doc "Encodes a boolean policy value as integer 0/1."
+  @spec encode_boolean(boolean()) :: binary()
+  def encode_boolean(true), do: TupleEncoding.pack(1)
+  def encode_boolean(false), do: TupleEncoding.pack(0)
+
+  @doc "Encodes an atom as its string representation."
+  @spec encode_atom(atom()) :: binary()
+  def encode_atom(a) when is_atom(a), do: TupleEncoding.pack(Atom.to_string(a))
+
+  @doc "Encodes a layout id (integer or binary)."
+  @spec encode_id(integer() | binary()) :: binary()
+  def encode_id(id) when is_integer(id) or is_binary(id), do: TupleEncoding.pack(id)
+
+  @doc "Encodes a list of node atoms as strings (cluster coordinators)."
+  @spec encode_node_list([node()]) :: binary()
+  def encode_node_list(nodes) when is_list(nodes), do: TupleEncoding.pack(Enum.map(nodes, &Atom.to_string/1))
+
+  @doc "Encodes a list of integer range tags (log descriptor)."
+  @spec encode_tag_list([Bedrock.range_tag()]) :: binary()
+  def encode_tag_list(tags) when is_list(tags) do
+    if Enum.all?(tags, &is_integer/1) do
+      TupleEncoding.pack(tags)
+    else
+      raise ArgumentError, "tag list must contain only integers: #{inspect(tags)}"
+    end
+  end
+
+  @doc """
+  Encodes a shard key entry: `{tag, start_key}`.
+
+  The key carries the shard's `end_key`; the value carries the tag and the
+  range's start key so readers (materializer bootstrap) can reconstruct the
+  full shard layout without relying on adjacency.
+  """
+  @spec encode_shard_key_entry(Bedrock.range_tag(), Bedrock.key()) :: binary()
+  def encode_shard_key_entry(tag, start_key) when is_integer(tag) and is_binary(start_key),
+    do: TupleEncoding.pack({tag, start_key})
+
+  @doc """
+  Encodes a structured term (`config_monolithic`, `layout_services`) with a
+  leading version byte.
+
+  Supports nil, booleans, atoms, binaries, 64-bit integers, floats, tuples,
+  lists, and maps. Raises `ArgumentError` for anything else (PIDs, refs,
+  funs) -- writers must sanitize runtime references first.
+  """
+  @spec encode_structured(term()) :: binary()
+  def encode_structured(term), do: IO.iodata_to_binary([@structured_version | encode_term(term)])
+
+  # ============================================================================
+  # Decoders (never raise)
+  # ============================================================================
+
+  @doc "Decodes an integer value."
+  @spec decode_integer(binary()) :: {:ok, integer()} | decode_error()
+  def decode_integer(binary), do: safe_unpack(binary, &is_integer/1)
+
+  @doc "Decodes a boolean policy value."
+  @spec decode_boolean(binary()) :: {:ok, boolean()} | decode_error()
+  def decode_boolean(binary) do
+    case safe_unpack(binary, &(&1 in [0, 1])) do
+      {:ok, 1} -> {:ok, true}
+      {:ok, 0} -> {:ok, false}
+      error -> error
+    end
+  end
+
+  @doc "Decodes an atom value."
+  @spec decode_atom(binary()) :: {:ok, atom()} | decode_error()
+  def decode_atom(binary) do
+    with {:ok, string} <- safe_unpack(binary, &is_binary/1) do
+      existing_atom(string)
+    end
+  end
+
+  @doc "Decodes a layout id (integer or binary)."
+  @spec decode_id(binary()) :: {:ok, integer() | binary()} | decode_error()
+  def decode_id(binary), do: safe_unpack(binary, &(is_integer(&1) or is_binary(&1)))
+
+  @doc "Decodes a list of node atoms."
+  @spec decode_node_list(binary()) :: {:ok, [node()]} | decode_error()
+  def decode_node_list(binary) do
+    with {:ok, strings} <- safe_unpack(binary, &(is_list(&1) and Enum.all?(&1, fn s -> is_binary(s) end))) do
+      strings
+      |> Enum.reduce_while({:ok, []}, fn string, {:ok, acc} ->
+        case existing_atom(string) do
+          {:ok, node} -> {:cont, {:ok, [node | acc]}}
+          error -> {:halt, error}
+        end
+      end)
+      |> case do
+        {:ok, nodes} -> {:ok, Enum.reverse(nodes)}
+        error -> error
+      end
+    end
+  end
+
+  @doc "Decodes a list of integer range tags."
+  @spec decode_tag_list(binary()) :: {:ok, [Bedrock.range_tag()]} | decode_error()
+  def decode_tag_list(binary), do: safe_unpack(binary, &(is_list(&1) and Enum.all?(&1, fn t -> is_integer(t) end)))
+
+  @doc "Decodes a shard key entry to `{:ok, {tag, start_key}}`."
+  @spec decode_shard_key_entry(binary()) :: {:ok, {Bedrock.range_tag(), Bedrock.key()}} | decode_error()
+  def decode_shard_key_entry(binary),
+    do: safe_unpack(binary, &match?({tag, start_key} when is_integer(tag) and is_binary(start_key), &1))
+
+  @doc "Decodes a versioned structured term."
+  @spec decode_structured(binary()) :: {:ok, term()} | decode_error()
+  def decode_structured(<<@structured_version, payload::binary>>) do
+    case decode_term(payload) do
+      {:ok, term, <<>>} -> {:ok, term}
+      _ -> {:error, :invalid_encoding}
+    end
+  end
+
+  def decode_structured(<<_version, _rest::binary>>), do: {:error, :unsupported_version}
+  def decode_structured(_), do: {:error, :invalid_encoding}
+
+  @doc """
+  Decodes a value given its parsed system key (from
+  `Bedrock.SystemKeys.parse_key/1`).
+
+  FlatBuffer families (`{:shard, tag}` and `{:materializer_key, end_key}`)
+  are returned opaque -- their consumers decode them with the appropriate
+  schema module.
+  """
+  @spec decode_for(parsed_key(), binary()) :: {:ok, term()} | decode_error()
+  def decode_for({:shard_key, _end_key}, value), do: decode_shard_key_entry(value)
+  def decode_for({:shard, _tag}, value), do: {:ok, value}
+  def decode_for({:materializer_key, _end_key}, value), do: {:ok, value}
+  def decode_for({:layout_log, _log_id}, value), do: decode_tag_list(value)
+  def decode_for(:layout_services, value), do: decode_structured(value)
+  def decode_for(:layout_id, value), do: decode_id(value)
+  def decode_for({:cluster, :coordinators}, value), do: decode_node_list(value)
+  def decode_for({:cluster, :epoch}, value), do: decode_integer(value)
+  def decode_for({:cluster_policy, _name}, value), do: decode_boolean(value)
+  def decode_for({:cluster_parameter, _name}, value), do: decode_integer(value)
+  def decode_for({:recovery, :state}, value), do: decode_atom(value)
+  def decode_for({:recovery, _name}, value), do: decode_integer(value)
+  def decode_for(:config_monolithic, value), do: decode_structured(value)
+  def decode_for(:epoch_legacy, value), do: decode_integer(value)
+  def decode_for(:last_recovery_legacy, value), do: decode_integer(value)
+  # Defensive catch-all: a key family added to SystemKeys.parse_key/1 without
+  # a matching decoder must degrade to a skipped value, not a crash.
+  def decode_for(_parsed, _value), do: {:error, :unknown_family}
+
+  # ============================================================================
+  # Tuple-encoding safety wrapper
+  # ============================================================================
+
+  @spec safe_unpack(binary(), (term() -> boolean())) :: {:ok, term()} | decode_error()
+  defp safe_unpack(binary, valid?) when is_binary(binary) do
+    value = TupleEncoding.unpack(binary)
+
+    if valid?.(value) do
+      {:ok, value}
+    else
+      {:error, :invalid_type}
+    end
+  rescue
+    _ -> {:error, :invalid_encoding}
+  end
+
+  defp safe_unpack(_not_binary, _valid?), do: {:error, :invalid_encoding}
+
+  # Decoding durable bytes must never create atoms: only strings naming
+  # atoms that already exist on this node are accepted.
+  @spec existing_atom(String.t()) :: {:ok, atom()} | {:error, :unknown_atom}
+  defp existing_atom(string) do
+    {:ok, String.to_existing_atom(string)}
+  rescue
+    ArgumentError -> {:error, :unknown_atom}
+  end
+
+  # ============================================================================
+  # Versioned structured term codec (v1)
+  # ============================================================================
+
+  @t_nil 0x00
+  @t_true 0x01
+  @t_false 0x02
+  @t_atom 0x03
+  @t_binary 0x04
+  @t_int 0x05
+  @t_float 0x06
+  @t_tuple 0x07
+  @t_list 0x08
+  @t_map 0x09
+
+  @int_min -(1 <<< 63)
+  @int_max (1 <<< 63) - 1
+
+  @spec encode_term(term()) :: iodata()
+  defp encode_term(nil), do: <<@t_nil>>
+  defp encode_term(true), do: <<@t_true>>
+  defp encode_term(false), do: <<@t_false>>
+
+  defp encode_term(atom) when is_atom(atom) do
+    string = Atom.to_string(atom)
+    [<<@t_atom, byte_size(string)::16>>, string]
+  end
+
+  defp encode_term(binary) when is_binary(binary), do: [<<@t_binary, byte_size(binary)::32>>, binary]
+
+  defp encode_term(int) when is_integer(int) and int >= @int_min and int <= @int_max, do: <<@t_int, int::signed-64>>
+
+  defp encode_term(float) when is_float(float), do: <<@t_float, float::float-64>>
+
+  defp encode_term(tuple) when is_tuple(tuple) do
+    elements = Tuple.to_list(tuple)
+    [<<@t_tuple, length(elements)::16>> | Enum.map(elements, &encode_term/1)]
+  end
+
+  defp encode_term(list) when is_list(list), do: [<<@t_list, length(list)::32>> | Enum.map(list, &encode_term/1)]
+
+  defp encode_term(map) when is_map(map) and not is_struct(map) do
+    pairs = Enum.sort(Map.to_list(map))
+    [<<@t_map, length(pairs)::32>> | Enum.map(pairs, fn {k, v} -> [encode_term(k), encode_term(v)] end)]
+  end
+
+  defp encode_term(unsupported) do
+    raise ArgumentError, "unsupported term in structured system-key value: #{inspect(unsupported)}"
+  end
+
+  @spec decode_term(binary()) :: {:ok, term(), binary()} | :error
+  defp decode_term(<<@t_nil, rest::binary>>), do: {:ok, nil, rest}
+  defp decode_term(<<@t_true, rest::binary>>), do: {:ok, true, rest}
+  defp decode_term(<<@t_false, rest::binary>>), do: {:ok, false, rest}
+
+  defp decode_term(<<@t_atom, size::16, string::binary-size(size), rest::binary>>) do
+    case existing_atom(string) do
+      {:ok, atom} -> {:ok, atom, rest}
+      {:error, _} -> :error
+    end
+  end
+
+  defp decode_term(<<@t_binary, size::32, binary::binary-size(size), rest::binary>>), do: {:ok, binary, rest}
+  defp decode_term(<<@t_int, int::signed-64, rest::binary>>), do: {:ok, int, rest}
+  defp decode_term(<<@t_float, float::float-64, rest::binary>>), do: {:ok, float, rest}
+
+  defp decode_term(<<@t_tuple, count::16, rest::binary>>) do
+    with {:ok, elements, rest} <- decode_terms(rest, count, []) do
+      {:ok, List.to_tuple(elements), rest}
+    end
+  end
+
+  defp decode_term(<<@t_list, count::32, rest::binary>>), do: decode_terms(rest, count, [])
+
+  defp decode_term(<<@t_map, count::32, rest::binary>>), do: decode_map_pairs(rest, count, %{})
+
+  defp decode_term(_), do: :error
+
+  @spec decode_terms(binary(), non_neg_integer(), [term()]) :: {:ok, [term()], binary()} | :error
+  defp decode_terms(rest, 0, acc), do: {:ok, Enum.reverse(acc), rest}
+
+  defp decode_terms(binary, count, acc) do
+    with {:ok, term, rest} <- decode_term(binary) do
+      decode_terms(rest, count - 1, [term | acc])
+    end
+  end
+
+  @spec decode_map_pairs(binary(), non_neg_integer(), map()) :: {:ok, map(), binary()} | :error
+  defp decode_map_pairs(rest, 0, acc), do: {:ok, acc, rest}
+
+  defp decode_map_pairs(binary, count, acc) do
+    with {:ok, key, rest} <- decode_term(binary),
+         {:ok, value, rest} <- decode_term(rest) do
+      decode_map_pairs(rest, count - 1, Map.put(acc, key, value))
+    end
+  end
+end

--- a/lib/bedrock/system_keys/values.ex
+++ b/lib/bedrock/system_keys/values.ex
@@ -106,8 +106,9 @@ defmodule Bedrock.SystemKeys.Values do
   Encodes a shard key entry: `{tag, start_key}`.
 
   The key carries the shard's `end_key`; the value carries the tag and the
-  range's start key so readers (materializer bootstrap) can reconstruct the
-  full shard layout without relying on adjacency.
+  range's start key. (Readers currently rebuild start keys from adjacency —
+  the explicit start key exists so a future reader of a single entry does
+  not have to.)
   """
   @spec encode_shard_key_entry(Bedrock.range_tag(), Bedrock.key()) :: binary()
   def encode_shard_key_entry(tag, start_key) when is_integer(tag) and is_binary(start_key),

--- a/test/bedrock/control_plane/director/recovery/materializer_bootstrap_phase_test.exs
+++ b/test/bedrock/control_plane/director/recovery/materializer_bootstrap_phase_test.exs
@@ -539,4 +539,36 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhaseTest 
       assert RecoveryAttempt.system_shard_id() == 0
     end
   end
+
+  describe "shard_layout_from_entries/1" do
+    alias Bedrock.SystemKeys
+    alias Bedrock.SystemKeys.Values
+
+    test "decodes tuple-encoded shard values and rebuilds contiguous start keys" do
+      entries = [
+        {SystemKeys.shard_key(<<0xFF, 0xFF>>), Values.encode_shard_key_entry(0, "m")},
+        {SystemKeys.shard_key("m"), Values.encode_shard_key_entry(1, "")}
+      ]
+
+      assert {:ok, %{"m" => {1, ""}, <<0xFF, 0xFF>> => {0, "m"}}} =
+               MaterializerBootstrapPhase.shard_layout_from_entries(entries)
+    end
+
+    test "decodes legacy term_to_binary shard values in both historical shapes" do
+      entries = [
+        {SystemKeys.shard_key("m"), :erlang.term_to_binary(1)},
+        {SystemKeys.shard_key(<<0xFF, 0xFF>>), :erlang.term_to_binary({0, "m"})}
+      ]
+
+      assert {:ok, %{"m" => {1, ""}, <<0xFF, 0xFF>> => {0, "m"}}} =
+               MaterializerBootstrapPhase.shard_layout_from_entries(entries)
+    end
+
+    test "rejects values that decode in neither encoding" do
+      key = SystemKeys.shard_key("m")
+
+      assert {:error, {:invalid_shard_value, ^key}} =
+               MaterializerBootstrapPhase.shard_layout_from_entries([{key, "garbage"}])
+    end
+  end
 end

--- a/test/bedrock/control_plane/director/recovery/persistence_phase_test.exs
+++ b/test/bedrock/control_plane/director/recovery/persistence_phase_test.exs
@@ -4,6 +4,9 @@ defmodule Bedrock.ControlPlane.Director.Recovery.PersistencePhaseTest do
   import Bedrock.Test.ControlPlane.RecoveryTestSupport
 
   alias Bedrock.ControlPlane.Director.Recovery.PersistencePhase
+  alias Bedrock.DataPlane.Transaction
+  alias Bedrock.SystemKeys
+  alias Bedrock.SystemKeys.Values
 
   # Shared test data setup
   defp mock_transaction_system_layout do
@@ -59,6 +62,46 @@ defmodule Bedrock.ControlPlane.Director.Recovery.PersistencePhaseTest do
       # Pattern match tuple destructuring with expected stall reason
       assert {_, {:stalled, {:recovery_system_failed, :timeout}}} =
                PersistencePhase.execute(recovery_attempt, context)
+    end
+
+    test "every system-key value it writes decodes through Values.decode_for/2" do
+      recovery_attempt = base_recovery_attempt()
+      test_pid = self()
+
+      commit_fn = fn _proxy, _epoch, encoded_transaction ->
+        send(test_pid, {:committed, encoded_transaction})
+        {:ok, 1, 0}
+      end
+
+      context = Map.put(recovery_context(), :commit_transaction_fn, commit_fn)
+      assert {_, :completed} = PersistencePhase.execute(recovery_attempt, context)
+      assert_received {:committed, encoded_transaction}
+
+      sets =
+        encoded_transaction
+        |> Transaction.mutations!()
+        |> Enum.map(fn {:set, key, value} -> {key, value} end)
+
+      refute sets == []
+
+      # Every written value must decode via the family dispatched from its key;
+      # this is the writer/reader contract that masked the pre-fix shard_key bug.
+      decoded =
+        Map.new(sets, fn {key, value} ->
+          parsed = SystemKeys.parse_key(key)
+          refute parsed in [:unknown, :error], "wrote unparseable system key: #{inspect(key)}"
+          assert {:ok, decoded} = Values.decode_for(parsed, value), "value for #{inspect(key)} failed to decode"
+          {parsed, decoded}
+        end)
+
+      # Shard keys must decode to the exact {tag, start_key} the layout holds --
+      # the shape the materializer bootstrap cross-epoch read depends on.
+      assert decoded[{:shard_key, <<0xFF>>}] == {1, <<>>}
+      assert decoded[{:shard_key, <<0xFF, 0xFF>>}] == {0, <<0xFF>>}
+
+      # Services are sanitized: no live pid survives into durable storage.
+      assert %{"log_1" => %{status: :unknown}} = decoded[:layout_services]
+      assert decoded[{:layout_log, "log_1"}] == [1, 2]
     end
   end
 end

--- a/test/bedrock/data_plane/commit_proxy/routing_data_test.exs
+++ b/test/bedrock/data_plane/commit_proxy/routing_data_test.exs
@@ -3,6 +3,7 @@ defmodule Bedrock.DataPlane.CommitProxy.RoutingDataTest do
 
   alias Bedrock.DataPlane.CommitProxy.RoutingData
   alias Bedrock.SystemKeys
+  alias Bedrock.SystemKeys.Values
 
   describe "from_snapshot/1" do
     test "builds fully-populated routing data owned by the calling process" do
@@ -326,7 +327,7 @@ defmodule Bedrock.DataPlane.CommitProxy.RoutingDataTest do
     test "handles shard_key set mutation" do
       routing_data = RoutingData.new_empty()
       key = SystemKeys.shard_key("m")
-      value = :erlang.term_to_binary(42)
+      value = Values.encode_shard_key_entry(42, "")
       updates = [{100, [{:set, key, value}]}]
 
       updated = RoutingData.apply_mutations(routing_data, updates)
@@ -342,9 +343,9 @@ defmodule Bedrock.DataPlane.CommitProxy.RoutingDataTest do
       updates = [
         {100,
          [
-           {:set, SystemKeys.shard_key("a"), :erlang.term_to_binary(1)},
-           {:set, SystemKeys.shard_key("m"), :erlang.term_to_binary(2)},
-           {:set, SystemKeys.shard_key("z"), :erlang.term_to_binary(3)}
+           {:set, SystemKeys.shard_key("a"), Values.encode_shard_key_entry(1, "")},
+           {:set, SystemKeys.shard_key("m"), Values.encode_shard_key_entry(2, "")},
+           {:set, SystemKeys.shard_key("z"), Values.encode_shard_key_entry(3, "")}
          ]}
       ]
 
@@ -362,7 +363,7 @@ defmodule Bedrock.DataPlane.CommitProxy.RoutingDataTest do
       key = SystemKeys.layout_log("log-123")
       # layout_log stores log descriptor (tags) as erlang term
       log_descriptor = [0, 1]
-      value = :erlang.term_to_binary(log_descriptor)
+      value = Values.encode_tag_list(log_descriptor)
       updates = [{100, [{:set, key, value}]}]
 
       updated = RoutingData.apply_mutations(routing_data, updates)
@@ -381,8 +382,8 @@ defmodule Bedrock.DataPlane.CommitProxy.RoutingDataTest do
       updates = [
         {100,
          [
-           {:set, SystemKeys.layout_log("log-1"), :erlang.term_to_binary([0])},
-           {:set, SystemKeys.layout_log("log-2"), :erlang.term_to_binary([1])}
+           {:set, SystemKeys.layout_log("log-1"), Values.encode_tag_list([0])},
+           {:set, SystemKeys.layout_log("log-2"), Values.encode_tag_list([1])}
          ]}
       ]
 
@@ -432,9 +433,9 @@ defmodule Bedrock.DataPlane.CommitProxy.RoutingDataTest do
       routing_data = RoutingData.new_empty()
 
       updates = [
-        {100, [{:set, SystemKeys.shard_key("a"), :erlang.term_to_binary(1)}]},
-        {101, [{:set, SystemKeys.shard_key("b"), :erlang.term_to_binary(2)}]},
-        {102, [{:set, SystemKeys.shard_key("a"), :erlang.term_to_binary(99)}]}
+        {100, [{:set, SystemKeys.shard_key("a"), Values.encode_shard_key_entry(1, "")}]},
+        {101, [{:set, SystemKeys.shard_key("b"), Values.encode_shard_key_entry(2, "")}]},
+        {102, [{:set, SystemKeys.shard_key("a"), Values.encode_shard_key_entry(99, "")}]}
       ]
 
       updated = RoutingData.apply_mutations(routing_data, updates)
@@ -494,10 +495,10 @@ defmodule Bedrock.DataPlane.CommitProxy.RoutingDataTest do
       updates = [
         {100,
          [
-           {:set, SystemKeys.shard_key("m"), :erlang.term_to_binary(1)},
-           {:set, SystemKeys.layout_log("log-1"), :erlang.term_to_binary([0])},
-           {:set, SystemKeys.shard_key("z"), :erlang.term_to_binary(2)},
-           {:set, SystemKeys.layout_log("log-2"), :erlang.term_to_binary([1])}
+           {:set, SystemKeys.shard_key("m"), Values.encode_shard_key_entry(1, "")},
+           {:set, SystemKeys.layout_log("log-1"), Values.encode_tag_list([0])},
+           {:set, SystemKeys.shard_key("z"), Values.encode_shard_key_entry(2, "")},
+           {:set, SystemKeys.layout_log("log-2"), Values.encode_tag_list([1])}
          ]}
       ]
 

--- a/test/bedrock/system_keys/values_test.exs
+++ b/test/bedrock/system_keys/values_test.exs
@@ -1,0 +1,250 @@
+defmodule Bedrock.SystemKeys.ValuesTest do
+  use ExUnit.Case, async: true
+  use ExUnitProperties
+
+  alias Bedrock.SystemKeys
+  alias Bedrock.SystemKeys.Values
+
+  describe "integer round-trip" do
+    property "encodes and decodes any integer" do
+      check all(i <- integer()) do
+        assert {:ok, ^i} = i |> Values.encode_integer() |> Values.decode_integer()
+      end
+    end
+
+    test "large timestamps round-trip" do
+      ts = System.system_time(:millisecond)
+      assert {:ok, ^ts} = ts |> Values.encode_integer() |> Values.decode_integer()
+    end
+
+    test "decoding a non-integer value returns an error" do
+      assert {:error, _} = Values.decode_integer(Values.encode_id("not-an-int"))
+    end
+  end
+
+  describe "boolean round-trip" do
+    test "true and false round-trip" do
+      assert {:ok, true} = true |> Values.encode_boolean() |> Values.decode_boolean()
+      assert {:ok, false} = false |> Values.encode_boolean() |> Values.decode_boolean()
+    end
+
+    test "decoding a non-boolean value returns an error" do
+      assert {:error, _} = Values.decode_boolean(Values.encode_integer(7))
+    end
+  end
+
+  describe "atom round-trip" do
+    property "atoms round-trip as strings" do
+      check all(a <- member_of([:completed, :running, :stalled, :a@host])) do
+        assert {:ok, ^a} = a |> Values.encode_atom() |> Values.decode_atom()
+      end
+    end
+
+    test "decoding a string that names no existing atom errors and creates no atom" do
+      string = "bedrock_values_test_never_an_atom_#{System.unique_integer([:positive])}"
+
+      assert {:error, :unknown_atom} = Values.decode_atom(Values.encode_id(string))
+      assert_raise ArgumentError, fn -> String.to_existing_atom(string) end
+    end
+  end
+
+  describe "id round-trip" do
+    property "binary ids round-trip" do
+      check all(id <- binary()) do
+        assert {:ok, ^id} = id |> Values.encode_id() |> Values.decode_id()
+      end
+    end
+
+    property "integer ids round-trip" do
+      check all(id <- non_negative_integer()) do
+        assert {:ok, ^id} = id |> Values.encode_id() |> Values.decode_id()
+      end
+    end
+  end
+
+  describe "node list round-trip" do
+    property "lists of node atoms round-trip" do
+      check all(nodes <- list_of(member_of([:a@host, :b@host, :c@other]))) do
+        assert {:ok, ^nodes} = nodes |> Values.encode_node_list() |> Values.decode_node_list()
+      end
+    end
+
+    test "decoding a non-list returns an error" do
+      assert {:error, _} = Values.decode_node_list(Values.encode_integer(1))
+    end
+
+    test "a node name that is not an existing atom errors and creates no atom" do
+      string = "unknown_node_#{System.unique_integer([:positive])}@nowhere"
+      encoded = Bedrock.Encoding.Tuple.pack([string])
+
+      assert {:error, :unknown_atom} = Values.decode_node_list(encoded)
+      assert_raise ArgumentError, fn -> String.to_existing_atom(string) end
+    end
+  end
+
+  describe "tag list round-trip (log descriptors)" do
+    property "lists of integer tags round-trip" do
+      check all(tags <- list_of(non_negative_integer())) do
+        assert {:ok, ^tags} = tags |> Values.encode_tag_list() |> Values.decode_tag_list()
+      end
+    end
+
+    test "decoding a list containing non-integers returns an error" do
+      assert {:error, _} = Values.decode_tag_list(Values.encode_node_list([:a@host]))
+    end
+  end
+
+  describe "shard key entry round-trip" do
+    property "{tag, start_key} round-trips" do
+      check all(
+              tag <- non_negative_integer(),
+              start_key <- binary()
+            ) do
+        assert {:ok, {^tag, ^start_key}} =
+                 tag
+                 |> Values.encode_shard_key_entry(start_key)
+                 |> Values.decode_shard_key_entry()
+      end
+    end
+
+    test "decoding a bare integer returns an error" do
+      assert {:error, _} = Values.decode_shard_key_entry(Values.encode_integer(7))
+    end
+  end
+
+  describe "structured round-trip (versioned)" do
+    property "nested config-shaped terms round-trip" do
+      check all(term <- structured_term()) do
+        assert {:ok, ^term} = term |> Values.encode_structured() |> Values.decode_structured()
+      end
+    end
+
+    test "config_monolithic shape round-trips" do
+      config = {4, %{coordinators: [:a@host], parameters: %{desired_logs: 2}, policies: %{}}}
+      assert {:ok, ^config} = config |> Values.encode_structured() |> Values.decode_structured()
+    end
+
+    test "service map shape round-trips" do
+      services = %{
+        "log-1" => %{kind: :log, status: :unknown, last_seen: {:worker_1, :a@host}},
+        "mat-1" => %{kind: :materializer, status: :down, last_seen: nil}
+      }
+
+      assert {:ok, ^services} = services |> Values.encode_structured() |> Values.decode_structured()
+    end
+
+    test "encoding a pid raises (writers must sanitize)" do
+      assert_raise ArgumentError, fn -> Values.encode_structured(%{status: {:up, self()}}) end
+    end
+
+    test "unsupported version byte returns an error" do
+      <<_version, rest::binary>> = Values.encode_structured(%{})
+      assert {:error, _} = Values.decode_structured(<<255, rest::binary>>)
+    end
+
+    test "truncated payload returns an error" do
+      encoded = Values.encode_structured({1, %{a: [1, 2, 3]}})
+      truncated = binary_part(encoded, 0, byte_size(encoded) - 2)
+      assert {:error, _} = Values.decode_structured(truncated)
+    end
+
+    test "an atom payload naming no existing atom errors and creates no atom" do
+      string = "bedrock_structured_never_an_atom_#{System.unique_integer([:positive])}"
+      # v1 wire format: version byte 0x01, atom tag 0x03, 16-bit length, bytes
+      payload = <<0x01, 0x03, byte_size(string)::16, string::binary>>
+
+      assert {:error, :invalid_encoding} = Values.decode_structured(payload)
+      assert_raise ArgumentError, fn -> String.to_existing_atom(string) end
+    end
+  end
+
+  describe "decode_for/2 family dispatch" do
+    test "dispatches every family PersistencePhase writes" do
+      assert {:ok, {7, "a"}} = Values.decode_for({:shard_key, "m"}, Values.encode_shard_key_entry(7, "a"))
+      assert {:ok, "opaque"} = Values.decode_for({:shard, "3"}, "opaque")
+      assert {:ok, "opaque"} = Values.decode_for({:materializer_key, "m"}, "opaque")
+      assert {:ok, [0, 1]} = Values.decode_for({:layout_log, "log-1"}, Values.encode_tag_list([0, 1]))
+      assert {:ok, %{}} = Values.decode_for(:layout_services, Values.encode_structured(%{}))
+      assert {:ok, "layout-abc"} = Values.decode_for(:layout_id, Values.encode_id("layout-abc"))
+      assert {:ok, [:a@host]} = Values.decode_for({:cluster, :coordinators}, Values.encode_node_list([:a@host]))
+      assert {:ok, 4} = Values.decode_for({:cluster, :epoch}, Values.encode_integer(4))
+      assert {:ok, true} = Values.decode_for({:cluster_policy, :volunteer_nodes}, Values.encode_boolean(true))
+      assert {:ok, 2} = Values.decode_for({:cluster_parameter, :desired_logs}, Values.encode_integer(2))
+      assert {:ok, 1} = Values.decode_for({:recovery, :attempt}, Values.encode_integer(1))
+      assert {:ok, :completed} = Values.decode_for({:recovery, :state}, Values.encode_atom(:completed))
+      assert {:ok, 123} = Values.decode_for({:recovery, :last_completed}, Values.encode_integer(123))
+      assert {:ok, {4, %{}}} = Values.decode_for(:config_monolithic, Values.encode_structured({4, %{}}))
+      assert {:ok, 4} = Values.decode_for(:epoch_legacy, Values.encode_integer(4))
+      assert {:ok, 123} = Values.decode_for(:last_recovery_legacy, Values.encode_integer(123))
+    end
+
+    test "a parsed key family without a decoder returns an error instead of raising" do
+      assert {:error, :unknown_family} = Values.decode_for({:future_family, "x"}, "anything")
+    end
+
+    property "garbage bytes never raise, for any parsed key family" do
+      families = [
+        {:shard_key, "m"},
+        {:layout_log, "log-1"},
+        :layout_services,
+        :layout_id,
+        {:cluster, :coordinators},
+        {:cluster, :epoch},
+        {:cluster_policy, :volunteer_nodes},
+        {:cluster_parameter, :desired_logs},
+        {:recovery, :attempt},
+        {:recovery, :state},
+        {:recovery, :last_completed},
+        :config_monolithic,
+        :epoch_legacy,
+        :last_recovery_legacy
+      ]
+
+      check all(
+              garbage <- binary(min_length: 1),
+              parsed <- member_of(families)
+            ) do
+        # Must return a tagged result -- never raise or exit
+        result = Values.decode_for(parsed, garbage)
+        assert match?({:ok, _}, result) or match?({:error, _}, result)
+      end
+    end
+  end
+
+  describe "no term_to_binary in encoded output" do
+    test "encoded values are not decodable as external term format" do
+      # BERT payloads start with 131; none of our encodings should
+      refute match?(<<131, _::binary>>, Values.encode_integer(7))
+      refute match?(<<131, _::binary>>, Values.encode_structured(%{a: 1}))
+      refute match?(<<131, _::binary>>, Values.encode_shard_key_entry(1, ""))
+    end
+  end
+
+  # A generator approximating the shapes stored in config_monolithic /
+  # layout_services: maps and tuples of atoms, binaries, integers, lists.
+  defp structured_term do
+    leaf =
+      one_of([
+        constant(nil),
+        boolean(),
+        integer(),
+        binary(),
+        member_of([:log, :materializer, :down, :unknown, :a@host])
+      ])
+
+    tree(leaf, fn child ->
+      one_of([
+        list_of(child, max_length: 3),
+        map_of(one_of([binary(), member_of([:kind, :status, :last_seen])]), child, max_length: 3),
+        bind(list_of(child, max_length: 3), fn elems -> constant(List.to_tuple(elems)) end)
+      ])
+    end)
+  end
+
+  # Sanity: SystemKeys.parse_key output feeds decode_for
+  test "parse_key output is accepted by decode_for" do
+    key = SystemKeys.shard_key("m")
+    parsed = SystemKeys.parse_key(key)
+    assert {:ok, {7, ""}} = Values.decode_for(parsed, Values.encode_shard_key_entry(7, ""))
+  end
+end

--- a/test/bedrock/system_keys_test.exs
+++ b/test/bedrock/system_keys_test.exs
@@ -239,6 +239,61 @@ defmodule Bedrock.SystemKeysTest do
         assert SystemKeys.parse_key(key) == {:materializer_key, end_key}
       end
     end
+
+    test "every fixed key family written by PersistencePhase round-trips" do
+      fixed_keys = [
+        {SystemKeys.layout_services(), :layout_services},
+        {SystemKeys.layout_id(), :layout_id},
+        {SystemKeys.cluster_coordinators(), {:cluster, :coordinators}},
+        {SystemKeys.cluster_epoch(), {:cluster, :epoch}},
+        {SystemKeys.cluster_policies_volunteer_nodes(), {:cluster_policy, :volunteer_nodes}},
+        {SystemKeys.cluster_parameters_desired_logs(), {:cluster_parameter, :desired_logs}},
+        {SystemKeys.cluster_parameters_desired_replication(), {:cluster_parameter, :desired_replication}},
+        {SystemKeys.cluster_parameters_desired_commit_proxies(), {:cluster_parameter, :desired_commit_proxies}},
+        {SystemKeys.cluster_parameters_desired_coordinators(), {:cluster_parameter, :desired_coordinators}},
+        {SystemKeys.cluster_parameters_desired_read_version_proxies(),
+         {:cluster_parameter, :desired_read_version_proxies}},
+        {SystemKeys.cluster_parameters_empty_transaction_timeout_ms(),
+         {:cluster_parameter, :empty_transaction_timeout_ms}},
+        {SystemKeys.cluster_parameters_ping_rate_in_hz(), {:cluster_parameter, :ping_rate_in_hz}},
+        {SystemKeys.cluster_parameters_retransmission_rate_in_hz(), {:cluster_parameter, :retransmission_rate_in_hz}},
+        {SystemKeys.cluster_parameters_transaction_window_in_ms(), {:cluster_parameter, :transaction_window_in_ms}},
+        {SystemKeys.recovery_attempt(), {:recovery, :attempt}},
+        {SystemKeys.recovery_state(), {:recovery, :state}},
+        {SystemKeys.recovery_last_completed(), {:recovery, :last_completed}},
+        {SystemKeys.config_monolithic(), :config_monolithic},
+        {SystemKeys.epoch_legacy(), :epoch_legacy},
+        {SystemKeys.last_recovery_legacy(), :last_recovery_legacy}
+      ]
+
+      for {key, expected} <- fixed_keys do
+        assert SystemKeys.parse_key(key) == expected,
+               "Expected #{inspect(key)} to parse as #{inspect(expected)}"
+      end
+    end
+
+    test "parse → generate inverse holds for parametrized families" do
+      # parse result carries everything needed to regenerate the exact key
+      key = SystemKeys.layout_log("log-xyz")
+      {:layout_log, id} = SystemKeys.parse_key(key)
+      assert SystemKeys.layout_log(id) == key
+
+      key = SystemKeys.shard_key("some-end-key")
+      {:shard_key, end_key} = SystemKeys.parse_key(key)
+      assert SystemKeys.shard_key(end_key) == key
+
+      key = SystemKeys.shard(42)
+      {:shard, tag} = SystemKeys.parse_key(key)
+      assert SystemKeys.shards_prefix() <> tag == key
+
+      key = SystemKeys.materializer_key("mat-end")
+      {:materializer_key, end_key} = SystemKeys.parse_key(key)
+      assert SystemKeys.materializer_key(end_key) == key
+    end
+
+    test "unknown cluster parameters parse as :unknown" do
+      assert SystemKeys.parse_key(SystemKeys.system_prefix() <> "/cluster/parameters/future_knob") == :unknown
+    end
   end
 
   describe "key consistency" do


### PR DESCRIPTION
## Why

Everything the director persists under `\xFF/system` — shard boundaries, log layout, cluster config — is stored as `term_to_binary` blobs. That format is unversioned, readable only by the BEAM, and dangerous to decode from durable bytes (it can grow the atom table, and a malformed blob raises mid-recovery). Phase B is about to make this keyspace the authoritative shard map that proxies and materializers live off, so the values need to become real, deliberate durable formats first. There is also a latent writer/reader mismatch hiding here: the persistence phase writes a bare tag for `shard_key` values while readers want `{tag, start_key}` — it only works today because the reader falls back to reconstructing start keys by adjacency.

## What

A new `Bedrock.SystemKeys.Values` module gives every value family one explicit encoding, and all writers/readers go through it:

- Scalars (epochs, parameters, timestamps, booleans, ids, node lists, log tag lists) use FDB tuple encoding — self-describing and language-neutral; the key identifies the family, so no version byte is needed.
- Structured families (`config_monolithic`, `layout_services`) use a versioned term codec (leading `0x01` byte) covering nil, booleans, atoms, binaries, int64, floats, tuples, lists, maps. PIDs are rejected at encode time, and persistence now sanitizes live service statuses to `:unknown` before writing — runtime references never reach storage.
- FlatBuffer families (shard metadata, materializer lists) pass through untouched.
- `shard_key` values become tuple-encoded `{tag, start_key}`, closing the writer/reader mismatch.
- `SystemKeys.parse_key/1` now covers every key family the persistence phase writes (it knew 4 of ~20).

Decoders never raise: atoms come back only via `String.to_existing_atom` (durable bytes cannot grow the atom table), and every decoder returns `{:ok, _}` or `{:error, reason}` so consumers skip bad values instead of crashing.

## How

The write path (`PersistencePhase`) swaps each `term_to_binary` call for the family's encoder. The two read paths swap in matching decoders: the commit proxy's `RoutingData` ignores undecodable shard values (keeps its last good entry), and the materializer bootstrap's shard-layout read moves into `shard_layout_from_entries/1` — a pure, directly-tested function that decodes each entry and rebuilds contiguous start keys from sorted end keys. That function keeps a narrow legacy fallback: clusters that wrote shard keys before this change still decode (both historical shapes), and their first completed recovery rewrites everything in the new encoding — after which the fallback is dead weight to remove in a later release. This fallback is the one deliberate divergence from the original phase-a commit, which could assume no cross-epoch reader of the old format; on develop that reader exists and works today, so upgrades must not brick it.

A writer/reader contract test decodes the persistence phase's actual committed transaction through `Values.decode_for/2` for every key it writes — the seam that let the bare-tag bug hide is now pinned shut.

Ticket: bedrock-q67.20.2 · Port of bedrock-ri40 (phase-a commits 7c6acbab + 13facee5, PR #107, gate-audited there) · TDD: schema/round-trip/contract/legacy-fallback tests first (29 red), then lib (full suite 2579 green, credo --strict + dialyzer clean).