### PR TITLE
Clear stale system-key entries on recovery rewrite (bedrock-q67.20.3)

### DIFF
--- a/lib/bedrock/control_plane/director/recovery/persistence_phase.ex
+++ b/lib/bedrock/control_plane/director/recovery/persistence_phase.ex
@@ -28,6 +28,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery.PersistencePhase do
   alias Bedrock.DataPlane.Transaction
   alias Bedrock.Internal.Id
   alias Bedrock.Internal.TransactionBuilder.Tx
+  alias Bedrock.KeyRange
   alias Bedrock.ObjectStorage
   alias Bedrock.ObjectStorage.LocalFilesystem
   alias Bedrock.SystemKeys
@@ -280,6 +281,8 @@ defmodule Bedrock.ControlPlane.Director.Recovery.PersistencePhase do
       |> Tx.set(SystemKeys.layout_services(), Values.encode_structured(encoded_services))
       |> Tx.set(SystemKeys.layout_id(), Values.encode_id(transaction_system_layout.id))
 
+    tx = clear_prefix(tx, SystemKeys.layout_logs_prefix())
+
     tx =
       Enum.reduce(transaction_system_layout.logs, tx, fn {log_id, log_descriptor}, tx ->
         Tx.set(tx, SystemKeys.layout_log(log_id), Values.encode_tag_list(log_descriptor))
@@ -308,13 +311,31 @@ defmodule Bedrock.ControlPlane.Director.Recovery.PersistencePhase do
     end)
   end
 
+  # Rewritten-every-recovery keyed families are cleared before their entries
+  # are written so a shrinking layout leaves no stale entries behind. The clear
+  # and the rewrite land in the same system transaction, so readers never
+  # observe a gap.
+  @spec clear_prefix(Tx.t(), Bedrock.key()) :: Tx.t()
+  defp clear_prefix(tx, prefix) do
+    {start_key, end_key} = KeyRange.from_prefix(prefix)
+    Tx.clear_range(tx, start_key, end_key)
+  end
+
   # Creates shard_key(end_key) -> {tag, start_key} and shard(tag) -> ShardMetadata entries
   # shard_layout format: %{end_key => {tag, start_key}}
+  #
+  # A nil or empty layout means shard management is not active for this
+  # recovery, so existing entries are left untouched rather than cleared.
   @spec build_shard_keys(Tx.t(), TransactionSystemLayout.shard_layout() | nil) :: Tx.t()
   defp build_shard_keys(tx, nil), do: tx
   defp build_shard_keys(tx, shard_layout) when map_size(shard_layout) == 0, do: tx
 
   defp build_shard_keys(tx, shard_layout) when is_map(shard_layout) do
+    tx =
+      tx
+      |> clear_prefix(SystemKeys.shard_keys_prefix())
+      |> clear_prefix(SystemKeys.shards_prefix())
+
     Enum.reduce(shard_layout, tx, fn {end_key, {tag, start_key}}, tx ->
       # Write shard_key(end_key) -> {tag, start_key} (for ceiling search)
       tx = Tx.set(tx, SystemKeys.shard_key(end_key), Values.encode_shard_key_entry(tag, start_key))

--- a/lib/bedrock/data_plane/commit_proxy/routing_data.ex
+++ b/lib/bedrock/data_plane/commit_proxy/routing_data.ex
@@ -239,5 +239,38 @@ defmodule Bedrock.DataPlane.CommitProxy.RoutingData do
     end
   end
 
+  # Mirrors Metadata's clear_range semantics: delete every known entry whose
+  # full system key falls in [start_key, end_key). Recovery rewrites use this
+  # to drop stale shard/log entries before re-writing the current layout.
+  defp apply_mutation({:clear_range, start_key, end_key}, routing_data) do
+    routing_data
+    |> clear_shards_in_range(start_key, end_key)
+    |> clear_logs_in_range(start_key, end_key)
+  end
+
   defp apply_mutation(_mutation, routing_data), do: routing_data
+
+  defp clear_shards_in_range(%__MODULE__{shard_table: table} = routing_data, start_key, end_key) do
+    for {shard_end_key, _tag} <- :ets.tab2list(table),
+        full_key = SystemKeys.shard_key(shard_end_key),
+        full_key >= start_key and full_key < end_key do
+      :ets.delete(table, shard_end_key)
+    end
+
+    routing_data
+  end
+
+  defp clear_logs_in_range(%__MODULE__{log_map: log_map} = routing_data, start_key, end_key) do
+    log_map
+    |> Map.values()
+    |> Enum.filter(fn log_id ->
+      full_key = SystemKeys.layout_log(log_id)
+      full_key >= start_key and full_key < end_key
+    end)
+    |> Enum.reduce(routing_data, fn log_id, routing_data ->
+      routing_data
+      |> remove_log(log_id)
+      |> delete_log_service(log_id)
+    end)
+  end
 end

--- a/test/bedrock/control_plane/director/recovery/persistence_phase_test.exs
+++ b/test/bedrock/control_plane/director/recovery/persistence_phase_test.exs
@@ -4,7 +4,10 @@ defmodule Bedrock.ControlPlane.Director.Recovery.PersistencePhaseTest do
   import Bedrock.Test.ControlPlane.RecoveryTestSupport
 
   alias Bedrock.ControlPlane.Director.Recovery.PersistencePhase
+  alias Bedrock.DataPlane.CommitProxy.RoutingData
   alias Bedrock.DataPlane.Transaction
+  alias Bedrock.Key
+  alias Bedrock.KeyRange
   alias Bedrock.SystemKeys
   alias Bedrock.SystemKeys.Values
 
@@ -80,7 +83,10 @@ defmodule Bedrock.ControlPlane.Director.Recovery.PersistencePhaseTest do
       sets =
         encoded_transaction
         |> Transaction.mutations!()
-        |> Enum.map(fn {:set, key, value} -> {key, value} end)
+        |> Enum.flat_map(fn
+          {:set, key, value} -> [{key, value}]
+          _ -> []
+        end)
 
       refute sets == []
 
@@ -102,6 +108,177 @@ defmodule Bedrock.ControlPlane.Director.Recovery.PersistencePhaseTest do
       # Services are sanitized: no live pid survives into durable storage.
       assert %{"log_1" => %{status: :unknown}} = decoded[:layout_services]
       assert decoded[{:layout_log, "log_1"}] == [1, 2]
+    end
+  end
+
+  # Capture the mutations of the system transaction PersistencePhase commits.
+  defp captured_system_mutations(recovery_attempt) do
+    test_pid = self()
+
+    commit_fn = fn _proxy, _epoch, encoded_transaction ->
+      send(test_pid, {:committed, encoded_transaction})
+      {:ok, 1, 0}
+    end
+
+    context = Map.put(recovery_context(), :commit_transaction_fn, commit_fn)
+    assert {_, :completed} = PersistencePhase.execute(recovery_attempt, context)
+    assert_received {:committed, encoded_transaction}
+    Transaction.mutations!(encoded_transaction)
+  end
+
+  # Apply set/clear/clear_range mutations, in order, to a flat key -> value map
+  # (a stand-in for the materializer's durable key space).
+  defp apply_to_store(store, mutations) do
+    Enum.reduce(mutations, store, fn
+      {:set, key, value}, store ->
+        Map.put(store, key, value)
+
+      {:clear, key}, store ->
+        Map.delete(store, key)
+
+      {:clear_range, start_key, end_key}, store ->
+        Map.reject(store, fn {key, _} -> key >= start_key and key < end_key end)
+    end)
+  end
+
+  # Range read over [prefix, strinc(prefix)) -- the same semantics as the
+  # materializer bootstrap cross-epoch read (default_get_shard_layout).
+  defp range_read(store, prefix) do
+    {start_key, end_key} = KeyRange.from_prefix(prefix)
+
+    store
+    |> Enum.filter(fn {key, _} -> key >= start_key and key < end_key end)
+    |> Enum.sort()
+  end
+
+  describe "stale entry clearing on recovery rewrite" do
+    test "clears each rewritten keyed family's prefix before writing its entries" do
+      mutations = captured_system_mutations(base_recovery_attempt())
+
+      for prefix <- [
+            SystemKeys.shard_keys_prefix(),
+            SystemKeys.shards_prefix(),
+            SystemKeys.layout_logs_prefix()
+          ] do
+        {clear_start, clear_end} = KeyRange.from_prefix(prefix)
+
+        clear_index =
+          Enum.find_index(mutations, fn
+            {:clear_range, ^clear_start, ^clear_end} -> true
+            _ -> false
+          end)
+
+        assert clear_index, "expected clear_range over #{inspect(prefix)}"
+
+        first_set_index =
+          Enum.find_index(mutations, fn
+            {:set, key, _} -> String.starts_with?(key, prefix)
+            _ -> false
+          end)
+
+        assert first_set_index, "expected set mutations under #{inspect(prefix)}"
+
+        assert clear_index < first_set_index,
+               "clear_range over #{inspect(prefix)} must precede its set mutations"
+      end
+    end
+
+    test "shrinking shard layout (3 -> 2) leaves exactly 2 entries visible to the bootstrap range read" do
+      # Previous epoch persisted 3 shards; the third ends at <<0x80>>.
+      stale_store =
+        %{}
+        |> Map.put(SystemKeys.shard_key(<<0x40>>), Values.encode_shard_key_entry(2, <<>>))
+        |> Map.put(SystemKeys.shard_key(<<0x80>>), Values.encode_shard_key_entry(3, <<0x40>>))
+        |> Map.put(SystemKeys.shard_key(<<0xFF, 0xFF>>), Values.encode_shard_key_entry(4, <<0x80>>))
+        |> Map.put(SystemKeys.shard(2), "stale-shard-metadata-2")
+        |> Map.put(SystemKeys.shard(3), "stale-shard-metadata-3")
+        |> Map.put(SystemKeys.shard(4), "stale-shard-metadata-4")
+        |> Map.put(SystemKeys.layout_log("old_log"), Values.encode_tag_list([9]))
+
+      # This epoch's layout has only 2 shards (see mock_transaction_system_layout/0).
+      mutations = captured_system_mutations(base_recovery_attempt())
+      store = apply_to_store(stale_store, mutations)
+
+      # (a) Bootstrap cross-epoch read: exactly the 2 current shard_key entries.
+      assert [
+               {shard_key_1, _},
+               {shard_key_2, _}
+             ] = range_read(store, SystemKeys.shard_keys_prefix())
+
+      assert shard_key_1 == SystemKeys.shard_key(<<0xFF>>)
+      assert shard_key_2 == SystemKeys.shard_key(<<0xFF, 0xFF>>)
+
+      # Stale shard metadata and layout_log entries are gone too.
+      shard_tags = store |> range_read(SystemKeys.shards_prefix()) |> Enum.map(&elem(&1, 0))
+      assert shard_tags == [SystemKeys.shard(0), SystemKeys.shard(1)]
+
+      log_keys = store |> range_read(SystemKeys.layout_logs_prefix()) |> Enum.map(&elem(&1, 0))
+      assert log_keys == [SystemKeys.layout_log("log_1")]
+    end
+
+    test "shrinking shard layout leaves exactly 2 entries visible to RoutingData ETS" do
+      mutations = captured_system_mutations(base_recovery_attempt())
+
+      routing_data = RoutingData.new_empty()
+      RoutingData.insert_shard(routing_data, <<0x40>>, 2)
+      RoutingData.insert_shard(routing_data, <<0x80>>, 3)
+      RoutingData.insert_shard(routing_data, <<0xFF, 0xFF>>, 4)
+
+      updated = RoutingData.apply_mutations(routing_data, [{1, mutations}])
+
+      assert :ets.tab2list(updated.shard_table) == [{<<0xFF>>, 1}, {<<0xFF, 0xFF>>, 0}]
+
+      RoutingData.cleanup(routing_data)
+    end
+
+    test "cleared prefix ranges do not cover any other system-key family" do
+      # shard_keys/ and shards/ are byte-prefix siblings (common prefix
+      # "shard"); layout/logs/ neighbors layout/id and layout/services. The
+      # strinc bound must keep each cleared range strictly within its own
+      # family: '_' (0x5F) < 's' (0x73) puts strinc("...shard_keys/") =
+      # "...shard_keys0" below every "...shards/" key.
+      cleared_prefixes = [
+        SystemKeys.shard_keys_prefix(),
+        SystemKeys.shards_prefix(),
+        SystemKeys.layout_logs_prefix()
+      ]
+
+      other_family_keys = [
+        SystemKeys.shard_key(<<>>),
+        SystemKeys.shard_key(<<0xFF, 0xFF>>),
+        SystemKeys.shard("0"),
+        SystemKeys.layout_log("log_1"),
+        SystemKeys.layout_services(),
+        SystemKeys.layout_id(),
+        SystemKeys.materializer_key(<<>>),
+        SystemKeys.materializer_key(<<0xFF, 0xFF>>)
+      ]
+
+      for prefix <- cleared_prefixes,
+          key <- other_family_keys,
+          not String.starts_with?(key, prefix) do
+        range = KeyRange.from_prefix(prefix)
+
+        refute KeyRange.contains?(range, key),
+               "clear_range over #{inspect(prefix)} would clear foreign family key #{inspect(key)}"
+      end
+    end
+
+    test "prefix range end is exact: a key at strinc(prefix) is not cleared" do
+      prefix = SystemKeys.shard_keys_prefix()
+      boundary_key = Key.strinc(prefix)
+
+      # A neighbor key exactly at the exclusive range end must survive, as must
+      # the key just below the prefix (the prefix itself minus the trailing "/").
+      below_key = binary_part(prefix, 0, byte_size(prefix) - 1)
+
+      store = %{boundary_key => "at-range-end", below_key => "below-range-start"}
+
+      mutations = captured_system_mutations(base_recovery_attempt())
+      store = apply_to_store(store, mutations)
+
+      assert store[boundary_key] == "at-range-end"
+      assert store[below_key] == "below-range-start"
     end
   end
 end

--- a/test/bedrock/control_plane/director/recovery/persistence_phase_test.exs
+++ b/test/bedrock/control_plane/director/recovery/persistence_phase_test.exs
@@ -237,30 +237,33 @@ defmodule Bedrock.ControlPlane.Director.Recovery.PersistencePhaseTest do
       # strinc bound must keep each cleared range strictly within its own
       # family: '_' (0x5F) < 's' (0x73) puts strinc("...shard_keys/") =
       # "...shard_keys0" below every "...shards/" key.
-      cleared_prefixes = [
-        SystemKeys.shard_keys_prefix(),
-        SystemKeys.shards_prefix(),
-        SystemKeys.layout_logs_prefix()
-      ]
+      cleared_prefixes = %{
+        shard_key: SystemKeys.shard_keys_prefix(),
+        shard: SystemKeys.shards_prefix(),
+        layout_log: SystemKeys.layout_logs_prefix()
+      }
 
-      other_family_keys = [
-        SystemKeys.shard_key(<<>>),
-        SystemKeys.shard_key(<<0xFF, 0xFF>>),
-        SystemKeys.shard("0"),
-        SystemKeys.layout_log("log_1"),
-        SystemKeys.layout_services(),
-        SystemKeys.layout_id(),
-        SystemKeys.materializer_key(<<>>),
-        SystemKeys.materializer_key(<<0xFF, 0xFF>>)
-      ]
+      keys_by_family = %{
+        shard_key: [SystemKeys.shard_key(<<>>), SystemKeys.shard_key(<<0xFF, 0xFF>>)],
+        shard: [SystemKeys.shard("0")],
+        layout_log: [SystemKeys.layout_log("log_1")],
+        layout_services: [SystemKeys.layout_services()],
+        layout_id: [SystemKeys.layout_id()],
+        materializer_key: [SystemKeys.materializer_key(<<>>), SystemKeys.materializer_key(<<0xFF, 0xFF>>)]
+      }
 
-      for prefix <- cleared_prefixes,
-          key <- other_family_keys,
-          not String.starts_with?(key, prefix) do
+      # Foreignness is decided by family identity, not by whether the key
+      # happens to share the prefix's bytes — so an over-broad prefix
+      # definition (e.g. layout_logs_prefix returning "layout/") fails here
+      # instead of being filtered out of the comparison.
+      for {cleared_family, prefix} <- cleared_prefixes,
+          {family, keys} <- keys_by_family,
+          family != cleared_family,
+          key <- keys do
         range = KeyRange.from_prefix(prefix)
 
         refute KeyRange.contains?(range, key),
-               "clear_range over #{inspect(prefix)} would clear foreign family key #{inspect(key)}"
+               "clear_range over #{inspect(prefix)} would clear #{family} key #{inspect(key)}"
       end
     end
 

--- a/test/bedrock/data_plane/commit_proxy/routing_data_test.exs
+++ b/test/bedrock/data_plane/commit_proxy/routing_data_test.exs
@@ -479,12 +479,102 @@ defmodule Bedrock.DataPlane.CommitProxy.RoutingDataTest do
     test "ignores unsupported mutation types" do
       routing_data = RoutingData.new_empty()
 
-      # clear_range not supported
-      updates = [{100, [{:clear_range, "start", "end"}]}]
+      # atomic ops are not routing-relevant
+      updates = [{100, [{:atomic, :add, "key", <<1>>}]}]
 
       updated = RoutingData.apply_mutations(routing_data, updates)
 
       assert updated == routing_data
+
+      RoutingData.cleanup(routing_data)
+    end
+
+    test "clear_range removes shard entries whose full key falls in range" do
+      routing_data = RoutingData.new_empty()
+      RoutingData.insert_shard(routing_data, "a", 1)
+      RoutingData.insert_shard(routing_data, "m", 2)
+      RoutingData.insert_shard(routing_data, "z", 3)
+
+      # Clear [shard_key("a"), shard_key("z")) - end is exclusive, so "z" survives
+      updates = [{100, [{:clear_range, SystemKeys.shard_key("a"), SystemKeys.shard_key("z")}]}]
+
+      updated = RoutingData.apply_mutations(routing_data, updates)
+
+      assert :ets.tab2list(updated.shard_table) == [{"z", 3}]
+
+      RoutingData.cleanup(routing_data)
+    end
+
+    test "clear_range over the shard_keys prefix removes all shard entries" do
+      routing_data = RoutingData.new_empty()
+      RoutingData.insert_shard(routing_data, "m", 1)
+      RoutingData.insert_shard(routing_data, <<0xFF, 0xFF>>, 2)
+
+      {start_key, end_key} = Bedrock.KeyRange.from_prefix(SystemKeys.shard_keys_prefix())
+      updates = [{100, [{:clear_range, start_key, end_key}]}]
+
+      updated = RoutingData.apply_mutations(routing_data, updates)
+
+      assert :ets.tab2list(updated.shard_table) == []
+
+      RoutingData.cleanup(routing_data)
+    end
+
+    test "clear_range removes layout_log entries in range, reindexing log_map and dropping services" do
+      routing_data =
+        RoutingData.new_empty()
+        |> RoutingData.insert_log("log-a")
+        |> RoutingData.insert_log("log-b")
+        |> RoutingData.insert_log("log-c")
+        |> RoutingData.put_log_service("log-a", {:log_a, :n1@host})
+        |> RoutingData.put_log_service("log-b", {:log_b, :n2@host})
+
+      # Clear [layout_log("log-a"), layout_log("log-c")) - "log-c" survives
+      updates = [{100, [{:clear_range, SystemKeys.layout_log("log-a"), SystemKeys.layout_log("log-c")}]}]
+
+      updated = RoutingData.apply_mutations(routing_data, updates)
+
+      assert updated.log_map == %{0 => "log-c"}
+      assert updated.log_services == %{}
+
+      RoutingData.cleanup(routing_data)
+    end
+
+    test "clear_range outside routing families leaves routing data unchanged" do
+      routing_data = RoutingData.new_empty()
+      RoutingData.insert_shard(routing_data, "m", 1)
+      routing_data = RoutingData.insert_log(routing_data, "log-1")
+
+      updates = [{100, [{:clear_range, "user/a", "user/z"}]}]
+
+      updated = RoutingData.apply_mutations(routing_data, updates)
+
+      assert :ets.tab2list(updated.shard_table) == [{"m", 1}]
+      assert updated.log_map == %{0 => "log-1"}
+
+      RoutingData.cleanup(routing_data)
+    end
+
+    test "recovery-style rewrite: clear_range then sets shrinks 3 shards to 2" do
+      routing_data = RoutingData.new_empty()
+      RoutingData.insert_shard(routing_data, "g", 1)
+      RoutingData.insert_shard(routing_data, "p", 2)
+      RoutingData.insert_shard(routing_data, <<0xFF, 0xFF>>, 3)
+
+      {start_key, end_key} = Bedrock.KeyRange.from_prefix(SystemKeys.shard_keys_prefix())
+
+      updates = [
+        {100,
+         [
+           {:clear_range, start_key, end_key},
+           {:set, SystemKeys.shard_key("m"), Values.encode_shard_key_entry(10, "")},
+           {:set, SystemKeys.shard_key(<<0xFF, 0xFF>>), Values.encode_shard_key_entry(11, "m")}
+         ]}
+      ]
+
+      updated = RoutingData.apply_mutations(routing_data, updates)
+
+      assert :ets.tab2list(updated.shard_table) == [{"m", 10}, {<<0xFF, 0xFF>>, 11}]
 
       RoutingData.cleanup(routing_data)
     end

--- a/test/bedrock/data_plane/materializer/olivine/index_update_test.exs
+++ b/test/bedrock/data_plane/materializer/olivine/index_update_test.exs
@@ -151,6 +151,29 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.IndexUpdateTest do
       # keys_removed counts first-page (b, c), middle-page (d, e, f) and last-page (g, h) keys
       assert update.keys_removed == 7
     end
+
+    test "clear_range followed by sets of in-range keys in the same batch keeps only the re-set keys", %{
+      database: database
+    } do
+      # The recovery-rewrite pattern: one transaction clear_ranges a keyed
+      # family, then re-writes the current entries. The re-set keys must
+      # survive (set overwrites the pending :clear for the same key) and
+      # subset keys that are not re-written must be gone.
+      {index, allocator} = build_index([{1, ["a", "b", "c"]}])
+
+      update =
+        run_mutations(index, allocator, database, [
+          {:clear_range, "a", "d"},
+          {:set, "b", "rewritten-b"},
+          {:set, "d", "new-d"}
+        ])
+
+      {final_index, final_db, _allocator, _modified} = IndexUpdate.finish(update)
+
+      assert all_keys(final_index) == ["b", "d"]
+      assert {:ok, _page, locator} = Index.locator_for_key(final_index, "b")
+      assert {:ok, "rewritten-b"} = Database.load_value(final_db, locator)
+    end
   end
 
   describe "page 0 protection during range clears" do


### PR DESCRIPTION
## Why

Every recovery rewrites the durable shard map and log layout under `\xFF/system`, but it only ever *adds* keys — it never removes the ones a smaller layout no longer has. As long as layouts only grow, nobody notices. The moment a layout shrinks (fewer shards, a retired log), the old entries stay behind as ghosts, and the next epoch's bootstrap read — which trusts this keyspace as its source of truth — would resurrect shards and logs that no longer exist. Phase B makes this keyspace the *authoritative* shard map, so ghosts stop being cosmetic and become wrong routing.

## What

Two halves, writer and reader:

- **Writer**: the persistence phase now clears each rewritten-every-recovery family (`shard_keys/`, `shards/`, `layout/logs/`) with a range-clear immediately before re-writing its entries — inside the same system transaction, so no reader can ever observe the gap between "cleared" and "rewritten". A nil/empty layout means shard management isn't active for that recovery, and existing entries are deliberately left alone.
- **Reader**: the commit proxy's `RoutingData` learns to apply `{:clear_range, start, end}` mutations — it walks its known shard and log entries, reconstructs each one's full system key, and drops the ones inside the range. Without this, the very clear the writer now emits would stream through the resolver to the proxy and bounce off.

## How

`clear_prefix/2` turns a key-family prefix into a `[start, end)` range via `KeyRange.from_prefix` and adds one `Tx.clear_range` to the system transaction. The tests pin the subtle parts: a boundary test proves each cleared range stays strictly inside its own family (`shard_keys/` and `shards/` are byte-prefix siblings — the range bound must not leak from one into the other), a shrink test drives a real captured system transaction over a store seeded with a larger stale layout and asserts exactly the current entries survive (both in the durable store view and in the proxy's ETS routing view), and `single-key families (layout/id, layout/services)` are confirmed untouched since they overwrite in place. One ported test asserting the same shrink invariant through the proxy's structured `Metadata` state is deferred to the next PR in the stack, which introduces that module — the `RoutingData` twin of that test lands here.

Ticket: bedrock-q67.20.3 · Port of bedrock-q67.18 (phase-a commits df2d3239 + d708ee4a, PR #110, gate-audited there) · TDD: shrink/boundary tests applied first (8 red), lib after (full suite 2590 green, credo --strict + dialyzer clean).