### PR TITLE
Rewrite README to tell the Bedrock story

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,15 +2,21 @@
 
 [![Elixir CI](https://github.com/bedrock-kv/bedrock/actions/workflows/elixir_ci.yaml/badge.svg)](https://github.com/bedrock-kv/bedrock/actions/workflows/elixir_ci.yaml)
 [![Coverage Status](https://coveralls.io/repos/github/bedrock-kv/bedrock/badge.png?branch=develop)](https://coveralls.io/github/bedrock-kv/bedrock?branch=develop)
+[![Hex.pm](https://img.shields.io/hexpm/v/bedrock.svg)](https://hex.pm/packages/bedrock)
 
-Bedrock is an embedded, distributed key-value store with guarantees beyond ACID.
-It features consistent reads, strict serialization, transactions across the
-key-space and a simple API.
+Bedrock is a distributed key-value store that runs *inside* your Elixir
+application. It takes the transaction architecture that made
+[FoundationDB](https://apple.github.io/foundationdb/) legendary — strictly
+serializable ACID transactions across the entire key-space, over an unbundled
+sequencer / log / storage design — and rebuilds it natively on the BEAM, with
+one modern twist: **durable history lives in object storage.**
 
-## Installation
-
-If [available in Hex](https://hex.pm/docs/publish), the package can be installed
-by adding `bedrock` to your list of dependencies in `mix.exs`:
+Local disks hold only a few seconds of write-ahead log. Everything committed
+flows into immutable chunks in S3-compatible storage (or the local
+filesystem), and the WAL continuously trims itself behind that durable floor.
+There is no external database to operate and no fleet to manage: add a
+dependency, join your supervision tree, and every node of your cluster shares
+one transactional key-space.
 
 ```elixir
 def deps do
@@ -20,47 +26,171 @@ def deps do
 end
 ```
 
-## Example
+## A taste
+
+Define a cluster and a repo, add them to your supervision tree, and you have a
+database:
+
+```elixir
+defmodule MyApp.Cluster do
+  use Bedrock.Cluster, otp_app: :my_app, name: "my_app"
+end
+
+defmodule MyApp.Repo do
+  use Bedrock.Repo, cluster: MyApp.Cluster
+end
+```
+
+Transactions read from a consistent snapshot, see their own writes, and either
+commit atomically or not at all — across any keys, on any node:
+
+```elixir
+MyApp.Repo.transact(fn ->
+  balance = MyApp.Repo.get("alice/balance")
+  MyApp.Repo.put("alice/balance", debit(balance, 10))
+  MyApp.Repo.put("bob/balance", credit(balance, 10))
+  {:ok, :transferred}
+end)
+```
+
+Familiar FoundationDB layers come along for the ride: `Bedrock.Directory` and
+`Bedrock.Keyspace` for organizing data, key selectors, range reads, and atomic
+operations (`add`, `min`, `max`, `append_if_fits`, `compare_and_clear`, ...)
+for building higher-level abstractions without read-write conflicts.
+
+**Try it live:** the class-scheduling tutorial (adapted from FoundationDB's
+classic) builds a working enrollment system in a notebook — no setup beyond
+clicking the badge.
 
 [![Run in Livebook](https://livebook.dev/badge/v1/blue.svg)](https://livebook.dev/run?url=https%3A%2F%2Fraw.githubusercontent.com%2Fbedrock-kv%2Fbedrock%2Frefs%2Fheads%2Fdevelop%2Flivebooks%2Fclass_scheduling.livemd)
 
-## Durability Foundation Guides
+## Why Bedrock
 
-- [Durability Foundation Overview](guides/durability-foundation.md)
-- [Durability Profile Contract](guides/durability-profile.md)
-- [S3 Object Storage Backend](guides/object-storage-s3.md)
-- [Async Persistence Queue](guides/async-persistence-queue.md)
-- [Distributed Durability Suite](guides/distributed-durability-tests.md)
+**The FoundationDB model, kept.** A single sequencer hands out global
+versions (a Lamport clock), commit proxies batch transactions, resolvers
+detect MVCC conflicts over key ranges, logs make commits durable, and
+materializers serve reads — each a separate, independently recoverable
+process. Optimistic concurrency means no locks and no deadlocks; conflicts
+are detected at commit time. The result is strict serializability: the
+strongest isolation guarantee a database can offer.
 
-## Durability Defaults
+**Durability, modernized.** A commit is acknowledged only after *every*
+required log has appended it to its write-ahead log and fsynced. From there,
+a known-committed-version watermark gates everything downstream: nothing
+enters object storage or a materializer's disk unless it is known to be
+committed, so recovery never has to undo derived state. Every five seconds,
+each log slices its recent transactions per shard and writes them to object
+storage — and because every replica sees the same versions and computes the
+same cuts, replicas produce *byte-identical* chunks, so "that file already
+exists" counts as success. Once chunks are confirmed, the WAL trims itself: a
+log's disk footprint tracks a few seconds of traffic, not the cluster's
+lifetime.
 
-- Runtime durability mode defaults to `:strict`.
-- Unsupported durability mode values resolve to `:strict`.
-- Use explicit relaxed mode for local development or single-node rollout only:
+**Restarts that don't scale with history.** Recovery replays only the
+untrimmed WAL tail — seconds of transactions — never the whole history.
+Surviving materializers are handed back their shards and resume streaming
+from where they stopped; only a genuinely lost shard rebuilds from chunks. A
+typical restart converges in under a second regardless of how old the cluster
+is.
+
+**Pure BEAM.** No ports, no NIFs to a storage engine, no sidecar processes.
+Distribution rides on Erlang distribution; supervision, recovery, and
+backpressure are OTP all the way down. If you can run an Elixir node, you can
+run Bedrock.
+
+## How a write becomes durable
+
+1. A commit proxy pushes the transaction to every required log; the client is
+   acknowledged only after each log has fsynced its WAL.
+2. The sequencer tracks the highest version confirmed on every log — the
+   known committed version — and everything downstream waits for it.
+3. On five-second version boundaries, each log's shards flush everything at
+   or below the cut to object storage as immutable, replica-identical chunks.
+4. Confirmed chunks raise the durable floor; the log recycles every WAL
+   segment that falls entirely below it.
+5. Materializers stream each shard continuously — chunks for history, the
+   in-memory buffer for recent data — and serve reads without ever touching
+   the WAL.
+
+The [Durability Foundation guide](guides/durability-foundation.md) tells this
+story end to end, including what happens on restart.
+
+## Object storage
+
+The local filesystem is the default backend. To point durable history at any
+S3-compatible store (AWS S3, MinIO, ...):
 
 ```elixir
-config :bedrock, MyCluster,
+config :bedrock, Bedrock.ObjectStorage,
+  backend: :s3,
+  s3: [
+    bucket: "bedrock",
+    access_key_id: "...",
+    secret_access_key: "...",
+    region: "us-east-1"
+  ]
+```
+
+See the [S3 Object Storage guide](guides/object-storage-s3.md) for
+conditional-write semantics and the full option set.
+
+## Production configuration
+
+Bedrock validates a durability profile at startup — replication factor, log
+count, and persistent paths for coordinator, log, and materializer roles. The
+default mode is `:strict`, which fails fast when requirements are not met.
+For local development or a single-node rollout, relax it explicitly:
+
+```elixir
+config :bedrock, MyApp.Cluster,
   durability_mode: :relaxed
 ```
 
-Commit acknowledgments are gated by WAL durability: a log server acknowledges
-only after the WAL append is written and fsynced. Async object persistence
-remains separate and does not gate commit ACKs.
+Details in the [Durability Profile guide](guides/durability-profile.md).
 
-## S3/MinIO Tests
+## Documentation
 
-S3-focused tests use a local MinIO process and are tagged with `:s3`.
+The guides are organized in three tiers — quick reads for orientation, guides
+for tasks, deep dives for internals:
 
-Install MinIO test binaries:
+- **Start here:** [User's Perspective](guides/quick-reads/users-perspective.md) ·
+  [Transaction Basics](guides/quick-reads/transactions.md) ·
+  [System Layout](guides/quick-reads/transaction-system-layout.md)
+- **Architecture:** [Data Plane](guides/quick-reads/data-plane.md) ·
+  [Control Plane](guides/quick-reads/control-plane.md) ·
+  [Recovery](guides/quick-reads/recovery.md)
+- **Durability:** [Durability Foundation](guides/durability-foundation.md) ·
+  [Durability Profile](guides/durability-profile.md) ·
+  [S3 Backend](guides/object-storage-s3.md) ·
+  [Async Persistence Queue](guides/async-persistence-queue.md)
+- **Deep dives:** [Architecture](guides/deep-dives/architecture.md) ·
+  [Transactions](guides/deep-dives/transactions.md) ·
+  [Recovery](guides/deep-dives/recovery.md) ·
+  [Cluster Startup](guides/deep-dives/cluster-startup.md)
+
+The full index lives in [guides/ai-start-here.md](guides/ai-start-here.md) and
+the [glossary](guides/glossary.md).
+
+## Status
+
+Bedrock is pre-1.0 and under active development. The transaction system, the
+durability pipeline, and the S3 backend are exercised by unit, MinIO-backed
+integration, and distributed durability test suites — but the API may still
+shift between minor versions. We'd love early feedback.
+
+## Development and testing
 
 ```bash
-MIX_ENV=test mix minio_server.download --arch darwin-arm64 --version latest
+mix test                    # default suite
+mix test --include s3       # + MinIO-backed S3 integration tests
 ```
 
-Run S3 tests:
+S3-tagged tests need a local MinIO binary
+(`MIX_ENV=test mix minio_server.download --arch darwin-arm64 --version latest`)
+and are skipped automatically when it isn't available. The distributed
+durability suite is documented in
+[guides/distributed-durability-tests.md](guides/distributed-durability-tests.md).
 
-```bash
-mix test --include s3
-```
+## License
 
-If MinIO is not available, tests tagged `:s3` are skipped automatically.
+Bedrock is released under the [MIT License](LICENSE).


### PR DESCRIPTION
## Why

The README led with durability-mode defaults and MinIO test setup — the merge notes of the most recent initiative — and never said what Bedrock *is*. A newcomer got one vague sentence, no code, and config trivia.

## What

A first-contact rewrite built on three pillars:

1. **The FoundationDB lineage** — the unbundled sequencer/log/storage transaction architecture, strict serializability, optimistic MVCC — named explicitly, since it locates the project instantly for the right audience (and the livebook already credits FDB's tutorial).
2. **Object-storage-native durability** — the actual novel bit: WAL as a seconds-deep buffer, byte-identical replica chunks, self-trimming logs, restarts that replay only the tail. Drawn directly from `guides/durability-foundation.md`.
3. **Pure BEAM / embedded** — add a dep, join your supervision tree, no external database fleet.

Structure: hero pitch → code-first example (cluster/repo/transact, verified against the actual `Repo` API) → livebook badge with context → Why Bedrock → life-of-a-write → object storage & production config (demoted from the top) → three-tier documentation map → status → dev/testing → license.

All factual claims were cross-checked against `lib/` and the guides (which were themselves fact-checked against the code this week). Notably: `Repo.get` returns a bare value (the old quick-read `fetch` example doesn't exist on `Repo`).

## Notes for review

- "converges in under a second" restart claim is carried over from the durability guide's narrative; happy to soften if we'd rather not commit to it in the README.
- Added a Hex version badge and an explicit MIT license section.