### PR TITLE
Metadata window distribution: resolver → commit proxy (bedrock-q67.20.4)

### DIFF
--- a/lib/bedrock/data_plane/commit_proxy/finalization.ex
+++ b/lib/bedrock/data_plane/commit_proxy/finalization.ex
@@ -48,7 +48,7 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization do
                           [Transaction.encoded()],
                           [metadata_mutations()],
                           keyword() ->
-                            {:ok, [non_neg_integer()], [MetadataAccumulator.entry()]}
+                            {:ok, [non_neg_integer()], Resolver.metadata_window()}
                             | {:error, term()}
                             | {:failure, :timeout, Resolver.ref()}
                             | {:failure, :unavailable, Resolver.ref()})
@@ -184,15 +184,17 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization do
   ## Metadata Distribution
 
   During conflict resolution, metadata mutations (keys with \\xFF prefix) are extracted
-  from each transaction and sent to the resolver. The resolver returns differential
-  metadata updates that should be merged into the caller's metadata state.
+  from each transaction and sent to the resolver along with the caller's `metadata_ack`
+  ({stable proxy identity, highest confirmed window version}). The resolver returns a
+  differential metadata window (or nil) whose entries are applied to the routing data;
+  the window itself is handed to the caller's `metadata_merge_fn` (defaults to a no-op)
+  for in-order merging into structured metadata state.
 
   ## Parameters
 
     - `batch`: Transaction batch with commit version details from the sequencer
-    - `transaction_system_layout`: System configuration including resolvers and log servers
-    - `metadata`: Current metadata state (list of accumulated metadata entries)
-    - `opts`: Optional functions for testing and configuration overrides
+    - `opts`: Required configuration (epoch, sequencer, resolver_layout, routing_data)
+      plus optional functions for testing and configuration overrides
 
   ## Returns
 
@@ -212,6 +214,8 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization do
             resolver_layout: ResolverLayout.t(),
             routing_data: RoutingData.t(),
             resolver_fn: resolver_fn(),
+            metadata_ack: Resolver.metadata_ack(),
+            metadata_merge_fn: (Resolver.metadata_window() -> :ok),
             batch_log_push_fn: log_push_batch_fn(),
             abort_reply_fn: abort_reply_fn(),
             success_reply_fn: success_reply_fn(),
@@ -310,8 +314,8 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization do
            [],
            opts
          ) do
-      {:ok, _aborted, metadata_updates} ->
-        plan = apply_metadata_updates(plan, metadata_updates, opts)
+      {:ok, _aborted, metadata_window} ->
+        plan = apply_metadata_window(plan, metadata_window, opts)
         split_and_notify_aborts_with_set(plan, MapSet.new(), opts)
 
       {:error, reason} ->
@@ -346,9 +350,9 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization do
            metadata_per_tx,
            opts
          ) do
-      {:ok, aborted, metadata_updates} ->
+      {:ok, aborted, metadata_window} ->
         aborted_set = MapSet.new(aborted)
-        plan = apply_metadata_updates(plan, metadata_updates, opts)
+        plan = apply_metadata_window(plan, metadata_window, opts)
         split_and_notify_aborts_with_set(plan, aborted_set, opts)
 
       {:error, reason} ->
@@ -357,9 +361,9 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization do
   end
 
   # Sharded multi-resolver path
-  # Note: In sharded mode, metadata is extracted but each resolver only sees
-  # the metadata relevant to its key range. For simplicity, we pass empty
-  # metadata lists to sharded resolvers and don't aggregate metadata updates.
+  # Note: In sharded mode every resolver receives the FULL metadata_per_tx
+  # (metadata is not sharded), so each maintains a duplicate accumulator and
+  # their reply windows are merged conservatively below.
   def resolve_conflicts(
         %FinalizationPlan{stage: :ready_for_resolution} = plan,
         epoch,
@@ -404,8 +408,8 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization do
            resolvers,
            opts
          ) do
-      {:ok, aborted_set, metadata_updates} ->
-        plan = apply_metadata_updates(plan, metadata_updates, opts)
+      {:ok, aborted_set, metadata_window} ->
+        plan = apply_metadata_window(plan, metadata_window, opts)
         split_and_notify_aborts_with_set(plan, aborted_set, opts)
 
       {:error, reason} ->
@@ -413,10 +417,24 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization do
     end
   end
 
-  @spec apply_metadata_updates(FinalizationPlan.t(), [MetadataAccumulator.entry()], keyword()) ::
+  @spec apply_metadata_window(FinalizationPlan.t(), Resolver.metadata_window(), keyword()) ::
           FinalizationPlan.t()
-  defp apply_metadata_updates(plan, metadata_updates, _opts) do
-    trace_metadata_updates_received(plan.commit_version, metadata_updates)
+  defp apply_metadata_window(plan, metadata_window, opts) do
+    entries =
+      case metadata_window do
+        nil -> []
+        {_from, _to, entries} -> entries
+      end
+
+    trace_metadata_updates_received(plan.commit_version, entries)
+
+    # Hand the window to the caller's merge function so the commit proxy can
+    # fold it (in version order, gap-checked) into its structured metadata
+    # state. Applied at resolution time (like the routing data below): the
+    # resolver has already accumulated these mutations, regardless of how the
+    # rest of the batch fares.
+    metadata_merge_fn = Keyword.get(opts, :metadata_merge_fn, fn _window -> :ok end)
+    if metadata_window != nil, do: metadata_merge_fn.(metadata_window)
 
     routing_data = %RoutingData{
       shard_table: plan.shard_table,
@@ -425,12 +443,12 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization do
       replication_factor: plan.replication_factor
     }
 
-    updated_routing_data = RoutingData.apply_mutations(routing_data, metadata_updates)
+    updated_routing_data = RoutingData.apply_mutations(routing_data, entries)
 
     %{
       plan
       | stage: :conflicts_resolved,
-        metadata_updates: metadata_updates,
+        metadata_updates: entries,
         log_map: updated_routing_data.log_map,
         log_services: updated_routing_data.log_services
     }
@@ -444,7 +462,7 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization do
           Bedrock.version(),
           [{start_key :: Bedrock.key(), Resolver.ref()}],
           keyword()
-        ) :: {:ok, MapSet.t(non_neg_integer()), [MetadataAccumulator.entry()]} | {:error, term()}
+        ) :: {:ok, MapSet.t(non_neg_integer()), Resolver.metadata_window()} | {:error, term()}
   defp call_all_resolvers_with_map(
          resolver_transaction_map,
          metadata_per_tx,
@@ -466,9 +484,9 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization do
       end,
       timeout: timeout
     )
-    |> Enum.reduce_while({:ok, MapSet.new(), []}, fn
-      {:ok, {:ok, aborted, metadata_updates}}, {:ok, acc_aborted, acc_metadata} ->
-        {:cont, {:ok, Enum.into(aborted, acc_aborted), acc_metadata ++ metadata_updates}}
+    |> Enum.reduce_while({:ok, MapSet.new(), nil}, fn
+      {:ok, {:ok, aborted, metadata_window}}, {:ok, acc_aborted, acc_window} ->
+        {:cont, {:ok, Enum.into(aborted, acc_aborted), merge_metadata_windows(acc_window, metadata_window)}}
 
       {:ok, {:error, reason}}, _ ->
         {:halt, {:error, reason}}
@@ -476,6 +494,20 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization do
       {:exit, reason}, _ ->
         {:halt, {:error, {:resolver_exit, reason}}}
     end)
+  end
+
+  # Sharded resolvers each see the full metadata_per_tx and maintain
+  # independent accumulators, so their windows largely duplicate one another.
+  # Merge conservatively: entries sorted by version (the proxy's per-entry
+  # version guard makes duplicates no-ops) and the WEAKEST coverage claim
+  # (max from_version) so that a gap at any resolver is still detected.
+  @spec merge_metadata_windows(Resolver.metadata_window(), Resolver.metadata_window()) :: Resolver.metadata_window()
+  defp merge_metadata_windows(nil, window), do: window
+  defp merge_metadata_windows(window, nil), do: window
+
+  defp merge_metadata_windows({from_a, to_a, entries_a}, {from_b, to_b, entries_b}) do
+    from = if from_a == nil, do: from_b, else: if(from_b == nil, do: from_a, else: max(from_a, from_b))
+    {from, max(to_a, to_b), Enum.sort_by(entries_a ++ entries_b, &elem(&1, 0))}
   end
 
   @spec call_resolver_with_retry(
@@ -487,7 +519,7 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization do
           [metadata_mutations()],
           keyword(),
           non_neg_integer()
-        ) :: {:ok, [non_neg_integer()], [MetadataAccumulator.entry()]} | {:error, term()}
+        ) :: {:ok, [non_neg_integer()], Resolver.metadata_window()} | {:error, term()}
   defp call_resolver_with_retry(
          ref,
          epoch,
@@ -502,10 +534,16 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization do
     resolver_fn = Keyword.get(opts, :resolver_fn, &Resolver.resolve_transactions/7)
     max_attempts = Keyword.get(opts, :max_attempts, 3)
 
+    # The stable proxy identity plus the highest metadata window version it has
+    # confirmed applying. Retried calls re-carry the same ack, so a reply lost
+    # to a timeout is simply re-sent by the resolver - no window is ever skipped.
+    metadata_ack = Keyword.get(opts, :metadata_ack, {self(), nil})
+
     timeout_in_ms = timeout_fn.(attempts_used)
 
     case resolver_fn.(ref, epoch, last_version, commit_version, filtered_transactions, metadata_per_tx,
-           timeout: timeout_in_ms
+           timeout: timeout_in_ms,
+           metadata_ack: metadata_ack
          ) do
       {:ok, _, _} = success ->
         success

--- a/lib/bedrock/data_plane/commit_proxy/metadata.ex
+++ b/lib/bedrock/data_plane/commit_proxy/metadata.ex
@@ -1,0 +1,273 @@
+defmodule Bedrock.DataPlane.CommitProxy.Metadata do
+  @moduledoc """
+  Structured system metadata maintained by the commit proxy.
+
+  The resolver distributes version-ordered windows of committed `\\xFF`
+  system-key mutations back to each commit proxy (see
+  `Bedrock.DataPlane.Resolver.MetadataAccumulator`). This module reduces those
+  updates into a structured, parsed view that mirrors the key families the
+  director writes during recovery persistence
+  (`Bedrock.ControlPlane.Director.Recovery.PersistencePhase`).
+
+  ## Structure
+
+  - `version` - highest commit version applied so far (nil until first update)
+  - `shards` - `shard_key(end_key) -> tag` ceiling-search shard map
+  - `shard_metadata` - `shard(tag) -> encoded ShardMetadata` (kept encoded;
+    FlatBuffer)
+  - `materializers` - `materializer_key(end_key) -> encoded value` (kept encoded)
+  - `logs` - `layout_log(log_id) -> decoded log descriptor`
+  - `services` - decoded `layout_services` map
+  - `layout_id` - decoded `layout_id`
+  - `cluster` - decoded fixed cluster keys (`:coordinators`, `:epoch`)
+  - `policies` - decoded cluster policies (`:volunteer_nodes`)
+  - `parameters` - decoded cluster parameters (`:desired_logs`, ...)
+  - `recovery` - decoded recovery keys (`:attempt`, `:state`, `:last_completed`)
+  - `legacy` - decoded legacy keys (`:config_monolithic`, `:epoch_legacy`,
+    `:last_recovery_legacy`)
+
+  ## Semantics
+
+  Updates are applied in version order; entries at or below the already-applied
+  `version` are skipped, which makes application idempotent when the resolver
+  re-sends a window to a new caller. Within a version, mutations apply in order
+  (later mutation wins).
+
+  - `{:set, key, value}` - parses the key and stores the (decoded) value
+  - `{:clear, key}` - removes the corresponding entry
+  - `{:clear_range, start_key, end_key}` - removes every known entry whose full
+    system key falls within `[start_key, end_key)`
+  - Unknown or unparseable system keys are ignored (forward compatibility) and
+    counted in the returned stats; the same goes for values that fail to
+    decode (see `Bedrock.SystemKeys.Values`) and `{:atomic, ...}` mutations,
+    which are not supported for structured metadata.
+  """
+
+  alias Bedrock.SystemKeys
+  alias Bedrock.SystemKeys.Values
+
+  @type family ::
+          :shard_key
+          | :shard
+          | :materializer_key
+          | :layout_log
+          | :layout_services
+          | :layout_id
+          | :cluster
+          | :cluster_policy
+          | :cluster_parameter
+          | :recovery
+          | :legacy
+
+  @type stats :: %{applied: non_neg_integer(), families: [family()], skipped_keys: [Bedrock.key()]}
+
+  @type t :: %__MODULE__{
+          version: Bedrock.version() | nil,
+          shards: %{Bedrock.key() => term()},
+          shard_metadata: %{String.t() => binary()},
+          materializers: %{Bedrock.key() => binary()},
+          logs: %{String.t() => term()},
+          services: term() | nil,
+          layout_id: term() | nil,
+          cluster: %{atom() => term()},
+          policies: %{atom() => term()},
+          parameters: %{atom() => term()},
+          recovery: %{atom() => term()},
+          legacy: %{atom() => term()}
+        }
+
+  defstruct version: nil,
+            shards: %{},
+            shard_metadata: %{},
+            materializers: %{},
+            logs: %{},
+            services: nil,
+            layout_id: nil,
+            cluster: %{},
+            policies: %{},
+            parameters: %{},
+            recovery: %{},
+            legacy: %{}
+
+  @doc "Creates empty structured metadata."
+  @spec new() :: t()
+  def new, do: %__MODULE__{}
+
+  @doc """
+  Reduces version-ordered metadata updates into the structured metadata.
+
+  Takes updates as returned by the resolver: a list of
+  `{version, [mutation]}` entries in version order (oldest first). Entries with
+  a version at or below the already-applied `version` are skipped.
+
+  Returns `{updated_metadata, stats}` where stats counts applied mutations (with
+  their key families) and skipped unknown/unsupported keys.
+  """
+  @spec apply_updates(t(), [{Bedrock.version(), [term()]}]) :: {t(), stats()}
+  def apply_updates(%__MODULE__{} = metadata, updates) do
+    initial = {metadata, %{applied: 0, families: [], skipped_keys: []}}
+
+    {metadata, stats} =
+      Enum.reduce(updates, initial, fn {version, mutations}, {metadata, stats} = acc ->
+        if metadata.version != nil and version <= metadata.version do
+          acc
+        else
+          {metadata, stats} = Enum.reduce(mutations, {metadata, stats}, &apply_mutation/2)
+          {%{metadata | version: version}, stats}
+        end
+      end)
+
+    {metadata,
+     %{stats | families: Enum.uniq(Enum.reverse(stats.families)), skipped_keys: Enum.reverse(stats.skipped_keys)}}
+  end
+
+  # ============================================================================
+  # Mutation application
+  # ============================================================================
+
+  defp apply_mutation({:set, key, value}, {metadata, stats}) do
+    with parsed when parsed not in [:unknown, :error] <- SystemKeys.parse_key(key),
+         {:ok, decoded} <- Values.decode_for(parsed, value) do
+      applied(family_of(parsed), {put_entry(metadata, parsed, decoded), stats})
+    else
+      _ -> skip(key, {metadata, stats})
+    end
+  end
+
+  defp apply_mutation({:clear, key}, {metadata, stats}) do
+    case SystemKeys.parse_key(key) do
+      parsed when parsed in [:unknown, :error] -> skip(key, {metadata, stats})
+      parsed -> applied(family_of(parsed), {delete_entry(metadata, parsed), stats})
+    end
+  end
+
+  defp apply_mutation({:clear_range, start_key, end_key}, {metadata, stats}) do
+    in_range =
+      metadata
+      |> known_entries()
+      |> Enum.filter(fn {full_key, _parsed} -> full_key >= start_key and full_key < end_key end)
+
+    metadata = Enum.reduce(in_range, metadata, fn {_full_key, parsed}, metadata -> delete_entry(metadata, parsed) end)
+
+    families = Enum.map(in_range, fn {_full_key, parsed} -> family_of(parsed) end)
+    {metadata, %{stats | applied: stats.applied + 1, families: Enum.reverse(families, stats.families)}}
+  end
+
+  # Atomic operations are not supported for structured metadata
+  defp apply_mutation({:atomic, _op, key, _value}, {metadata, stats}), do: skip(key, {metadata, stats})
+
+  defp skip(key, {metadata, stats}), do: {metadata, %{stats | skipped_keys: [key | stats.skipped_keys]}}
+
+  defp applied(family, {metadata, stats}),
+    do: {metadata, %{stats | applied: stats.applied + 1, families: [family | stats.families]}}
+
+  defp family_of({family, _param}), do: family
+
+  defp family_of(legacy) when legacy in [:config_monolithic, :epoch_legacy, :last_recovery_legacy], do: :legacy
+
+  defp family_of(family) when is_atom(family), do: family
+
+  # ============================================================================
+  # Entry storage (parsed key -> struct slot)
+  # ============================================================================
+
+  # Values arrive decoded per family by Bedrock.SystemKeys.Values, except
+  # shard/1 (FlatBuffer ShardMetadata) and materializer_key/1, which are kept
+  # encoded. A shard_key value decodes to {tag, start_key}; only the tag is
+  # kept, since the shards slot is the ceiling-search routing view.
+  defp put_entry(metadata, {:shard_key, end_key}, {tag, _start_key}),
+    do: %{metadata | shards: Map.put(metadata.shards, end_key, tag)}
+
+  defp put_entry(metadata, {:shard, tag}, value),
+    do: %{metadata | shard_metadata: Map.put(metadata.shard_metadata, tag, value)}
+
+  defp put_entry(metadata, {:materializer_key, end_key}, value),
+    do: %{metadata | materializers: Map.put(metadata.materializers, end_key, value)}
+
+  defp put_entry(metadata, {:layout_log, log_id}, value), do: %{metadata | logs: Map.put(metadata.logs, log_id, value)}
+
+  defp put_entry(metadata, :layout_services, value), do: %{metadata | services: value}
+  defp put_entry(metadata, :layout_id, value), do: %{metadata | layout_id: value}
+
+  defp put_entry(metadata, {:cluster, name}, value), do: %{metadata | cluster: Map.put(metadata.cluster, name, value)}
+
+  defp put_entry(metadata, {:cluster_policy, name}, value),
+    do: %{metadata | policies: Map.put(metadata.policies, name, value)}
+
+  defp put_entry(metadata, {:cluster_parameter, name}, value),
+    do: %{metadata | parameters: Map.put(metadata.parameters, name, value)}
+
+  defp put_entry(metadata, {:recovery, name}, value),
+    do: %{metadata | recovery: Map.put(metadata.recovery, name, value)}
+
+  defp put_entry(metadata, legacy, value) when legacy in [:config_monolithic, :epoch_legacy, :last_recovery_legacy],
+    do: %{metadata | legacy: Map.put(metadata.legacy, legacy, value)}
+
+  defp delete_entry(metadata, {:shard_key, end_key}), do: %{metadata | shards: Map.delete(metadata.shards, end_key)}
+
+  defp delete_entry(metadata, {:shard, tag}), do: %{metadata | shard_metadata: Map.delete(metadata.shard_metadata, tag)}
+
+  defp delete_entry(metadata, {:materializer_key, end_key}),
+    do: %{metadata | materializers: Map.delete(metadata.materializers, end_key)}
+
+  defp delete_entry(metadata, {:layout_log, log_id}), do: %{metadata | logs: Map.delete(metadata.logs, log_id)}
+  defp delete_entry(metadata, :layout_services), do: %{metadata | services: nil}
+  defp delete_entry(metadata, :layout_id), do: %{metadata | layout_id: nil}
+  defp delete_entry(metadata, {:cluster, name}), do: %{metadata | cluster: Map.delete(metadata.cluster, name)}
+  defp delete_entry(metadata, {:cluster_policy, name}), do: %{metadata | policies: Map.delete(metadata.policies, name)}
+
+  defp delete_entry(metadata, {:cluster_parameter, name}),
+    do: %{metadata | parameters: Map.delete(metadata.parameters, name)}
+
+  defp delete_entry(metadata, {:recovery, name}), do: %{metadata | recovery: Map.delete(metadata.recovery, name)}
+
+  defp delete_entry(metadata, legacy) when legacy in [:config_monolithic, :epoch_legacy, :last_recovery_legacy],
+    do: %{metadata | legacy: Map.delete(metadata.legacy, legacy)}
+
+  # ============================================================================
+  # clear_range support: enumerate every stored entry with its full system key
+  # ============================================================================
+
+  defp known_entries(metadata) do
+    Enum.concat([
+      Enum.map(metadata.shards, fn {end_key, _} -> {SystemKeys.shard_key(end_key), {:shard_key, end_key}} end),
+      Enum.map(metadata.shard_metadata, fn {tag, _} -> {SystemKeys.shards_prefix() <> tag, {:shard, tag}} end),
+      Enum.map(metadata.materializers, fn {end_key, _} ->
+        {SystemKeys.materializer_key(end_key), {:materializer_key, end_key}}
+      end),
+      Enum.map(metadata.logs, fn {log_id, _} -> {SystemKeys.layout_log(log_id), {:layout_log, log_id}} end),
+      if(metadata.services == nil, do: [], else: [{SystemKeys.layout_services(), :layout_services}]),
+      if(metadata.layout_id == nil, do: [], else: [{SystemKeys.layout_id(), :layout_id}]),
+      Enum.map(metadata.cluster, fn {name, _} -> {cluster_key(name), {:cluster, name}} end),
+      Enum.map(metadata.policies, fn {name, _} -> {policy_key(name), {:cluster_policy, name}} end),
+      Enum.map(metadata.parameters, fn {name, _} -> {parameter_key(name), {:cluster_parameter, name}} end),
+      Enum.map(metadata.recovery, fn {name, _} -> {recovery_key(name), {:recovery, name}} end),
+      Enum.map(metadata.legacy, fn {name, _} -> {legacy_key(name), name} end)
+    ])
+  end
+
+  defp cluster_key(:coordinators), do: SystemKeys.cluster_coordinators()
+  defp cluster_key(:epoch), do: SystemKeys.cluster_epoch()
+
+  defp policy_key(:volunteer_nodes), do: SystemKeys.cluster_policies_volunteer_nodes()
+
+  defp parameter_key(:desired_logs), do: SystemKeys.cluster_parameters_desired_logs()
+  defp parameter_key(:desired_replication), do: SystemKeys.cluster_parameters_desired_replication()
+  defp parameter_key(:desired_commit_proxies), do: SystemKeys.cluster_parameters_desired_commit_proxies()
+  defp parameter_key(:desired_coordinators), do: SystemKeys.cluster_parameters_desired_coordinators()
+  defp parameter_key(:desired_read_version_proxies), do: SystemKeys.cluster_parameters_desired_read_version_proxies()
+
+  defp parameter_key(:empty_transaction_timeout_ms), do: SystemKeys.cluster_parameters_empty_transaction_timeout_ms()
+
+  defp parameter_key(:ping_rate_in_hz), do: SystemKeys.cluster_parameters_ping_rate_in_hz()
+  defp parameter_key(:retransmission_rate_in_hz), do: SystemKeys.cluster_parameters_retransmission_rate_in_hz()
+  defp parameter_key(:transaction_window_in_ms), do: SystemKeys.cluster_parameters_transaction_window_in_ms()
+
+  defp recovery_key(:attempt), do: SystemKeys.recovery_attempt()
+  defp recovery_key(:state), do: SystemKeys.recovery_state()
+  defp recovery_key(:last_completed), do: SystemKeys.recovery_last_completed()
+
+  defp legacy_key(:config_monolithic), do: SystemKeys.config_monolithic()
+  defp legacy_key(:epoch_legacy), do: SystemKeys.epoch_legacy()
+  defp legacy_key(:last_recovery_legacy), do: SystemKeys.last_recovery_legacy()
+end

--- a/lib/bedrock/data_plane/commit_proxy/server.ex
+++ b/lib/bedrock/data_plane/commit_proxy/server.ex
@@ -47,12 +47,13 @@ defmodule Bedrock.DataPlane.CommitProxy.Server do
   import Bedrock.DataPlane.CommitProxy.Finalization, only: [finalize_batch: 2]
 
   import Bedrock.DataPlane.CommitProxy.Telemetry,
-    only: [trace_metadata: 0, trace_metadata: 1]
+    only: [trace_metadata: 0, trace_metadata: 1, trace_metadata_applied: 2, trace_unknown_key_skipped: 1]
 
   import Bedrock.Internal.GenServer.Replies
 
   alias Bedrock.Cluster
   alias Bedrock.DataPlane.CommitProxy.Batch
+  alias Bedrock.DataPlane.CommitProxy.Metadata
   alias Bedrock.DataPlane.CommitProxy.ResolverLayout
   alias Bedrock.DataPlane.CommitProxy.RoutingData
   alias Bedrock.DataPlane.CommitProxy.State
@@ -199,6 +200,7 @@ defmodule Bedrock.DataPlane.CommitProxy.Server do
   @spec handle_info(
           :timeout
           | {:routing_data_update, RoutingData.t()}
+          | {:metadata_updates, {Bedrock.version() | nil, Bedrock.version(), [term()]}}
           | {:finalization_failed, term()}
           | {:DOWN, reference(), :process, pid(), term()},
           State.t()
@@ -240,6 +242,14 @@ defmodule Bedrock.DataPlane.CommitProxy.Server do
     noreply(%{t | routing_data: updated_routing_data})
   end
 
+  def handle_info({:metadata_updates, window}, %{mode: :running} = t) do
+    noreply(apply_metadata_window(t, window), timeout: t.empty_transaction_timeout_ms)
+  end
+
+  def handle_info({:metadata_updates, window}, t) do
+    noreply(apply_metadata_window(t, window))
+  end
+
   def handle_info({:DOWN, _ref, :process, director_pid, _reason}, %{director: director_pid} = t) do
     # Director has died - this commit proxy should terminate gracefully
     {:stop, :normal, t}
@@ -263,7 +273,8 @@ defmodule Bedrock.DataPlane.CommitProxy.Server do
       epoch: epoch,
       sequencer: sequencer,
       resolver_layout: resolver_layout,
-      routing_data: routing_data
+      routing_data: routing_data,
+      metadata: %{version: applied_metadata_version}
     } = state
 
     Task.start_link(fn ->
@@ -273,7 +284,12 @@ defmodule Bedrock.DataPlane.CommitProxy.Server do
              epoch: epoch,
              sequencer: sequencer,
              resolver_layout: resolver_layout,
-             routing_data: routing_data
+             routing_data: routing_data,
+             # Stable proxy identity (this server, not the per-batch task) plus
+             # the metadata version this proxy has confirmed applying - the
+             # resolver keys its progress and differential windows off this.
+             metadata_ack: {server_pid, applied_metadata_version},
+             metadata_merge_fn: fn window -> send(server_pid, {:metadata_updates, window}) end
            ) do
         {:ok, _n_aborts, _n_oks, updated_routing_data} ->
           send(server_pid, {:routing_data_update, updated_routing_data})
@@ -282,6 +298,43 @@ defmodule Bedrock.DataPlane.CommitProxy.Server do
           send(server_pid, {:finalization_failed, reason})
       end
     end)
+  end
+
+  # Folds a resolver metadata window into the proxy's structured metadata.
+  # Applied in the server process so windows from concurrent finalization
+  # tasks are serialized. Windows can arrive out of commit-version order (the
+  # tasks race to this mailbox), but every window covers (from, to] starting
+  # at a version this proxy had already confirmed applying, so a late-arriving
+  # earlier window is a subset of what has been applied - the per-entry
+  # version guard inside Metadata.apply_updates makes it a no-op.
+  #
+  # A window whose from_version exceeds what this proxy has applied means the
+  # resolver pruned history this proxy never saw (only possible after this
+  # proxy was expired for lagging beyond the retention horizon). Its metadata
+  # can never be completed differentially, so fail fast: the director-driven
+  # recovery rebuilds proxies with full state.
+  @spec apply_metadata_window(
+          State.t(),
+          {Bedrock.version() | nil, Bedrock.version(), [term()]}
+        ) :: State.t() | no_return()
+  defp apply_metadata_window(t, {from_version, to_version, entries}) do
+    applied_version = t.metadata.version
+
+    if from_version != nil and (applied_version == nil or from_version > applied_version) do
+      exit({:metadata_coverage_gap, %{from_version: from_version, applied_version: applied_version}})
+    end
+
+    {metadata, stats} = Metadata.apply_updates(t.metadata, entries)
+
+    if stats.applied > 0, do: trace_metadata_applied(stats.applied, stats.families)
+    if stats.skipped_keys != [], do: trace_unknown_key_skipped(stats.skipped_keys)
+
+    # The window covers through to_version even when the last entry is older;
+    # acking to_version lets the resolver prune its window fully. Out-of-order
+    # windows keep this monotone.
+    version = if metadata.version == nil or to_version > metadata.version, do: to_version, else: metadata.version
+
+    %{t | metadata: %{metadata | version: version}}
   end
 
   @spec reply_fn(GenServer.from()) :: Batch.reply_fn()

--- a/lib/bedrock/data_plane/commit_proxy/state.ex
+++ b/lib/bedrock/data_plane/commit_proxy/state.ex
@@ -2,6 +2,7 @@ defmodule Bedrock.DataPlane.CommitProxy.State do
   @moduledoc false
 
   alias Bedrock.DataPlane.CommitProxy.Batch
+  alias Bedrock.DataPlane.CommitProxy.Metadata
   alias Bedrock.DataPlane.CommitProxy.ResolverLayout
   alias Bedrock.DataPlane.CommitProxy.RoutingData
 
@@ -19,7 +20,8 @@ defmodule Bedrock.DataPlane.CommitProxy.State do
           empty_transaction_timeout_ms: non_neg_integer(),
           mode: mode(),
           lock_token: binary(),
-          routing_data: RoutingData.t() | nil
+          routing_data: RoutingData.t() | nil,
+          metadata: Metadata.t()
         }
   defstruct cluster: nil,
             director: nil,
@@ -32,5 +34,6 @@ defmodule Bedrock.DataPlane.CommitProxy.State do
             empty_transaction_timeout_ms: nil,
             mode: :locked,
             lock_token: nil,
-            routing_data: nil
+            routing_data: nil,
+            metadata: %Metadata{}
 end

--- a/lib/bedrock/data_plane/commit_proxy/telemetry.ex
+++ b/lib/bedrock/data_plane/commit_proxy/telemetry.ex
@@ -54,6 +54,24 @@ defmodule Bedrock.DataPlane.CommitProxy.Telemetry do
     )
   end
 
+  @spec trace_metadata_applied(count :: non_neg_integer(), families :: [atom()]) :: :ok
+  def trace_metadata_applied(count, families) do
+    Telemetry.execute(
+      [:bedrock, :data_plane, :commit_proxy, :metadata_applied],
+      %{count: count},
+      Map.put(trace_metadata(), :families, families)
+    )
+  end
+
+  @spec trace_unknown_key_skipped(keys :: [Bedrock.key()]) :: :ok
+  def trace_unknown_key_skipped(keys) do
+    Telemetry.execute(
+      [:bedrock, :data_plane, :commit_proxy, :unknown_key_skipped],
+      %{count: length(keys)},
+      Map.put(trace_metadata(), :keys, keys)
+    )
+  end
+
   @spec trace_metadata_updates_received(
           commit_version :: Bedrock.version(),
           metadata_updates :: [term()]

--- a/lib/bedrock/data_plane/resolver.ex
+++ b/lib/bedrock/data_plane/resolver.ex
@@ -14,9 +14,15 @@ defmodule Bedrock.DataPlane.Resolver do
   ## Metadata Distribution
 
   The Resolver also acts as a distribution point for system metadata mutations
-  (keys with \\xFF prefix). Each request includes metadata mutations per transaction,
-  and the response includes differential metadata updates for the calling proxy.
-
+  (keys with \\xFF prefix). Each request includes metadata mutations per
+  transaction plus a `metadata_ack` - the calling commit proxy's stable
+  identity (its server pid, not the per-batch finalization task pid) and the
+  highest metadata window version that proxy has confirmed applying. The
+  response includes a differential metadata window covering everything since
+  the confirmed version, or `nil` when there is nothing to report. Because
+  progress only advances via acks, lost replies are re-sent on the proxy's
+  next call and concurrent in-flight windows overlap (out-of-order arrival at
+  the proxy is lossless).
   """
 
   alias Bedrock.DataPlane.Resolver.MetadataAccumulator
@@ -26,6 +32,24 @@ defmodule Bedrock.DataPlane.Resolver do
 
   @type metadata_mutations :: [Bedrock.Internal.TransactionBuilder.Tx.mutation()]
 
+  @typedoc """
+  The calling proxy's stable identity and the highest metadata window
+  `to_version` it has confirmed applying (nil if none yet).
+  """
+  @type metadata_ack :: {proxy_id :: pid(), applied_version :: Bedrock.version() | nil}
+
+  @typedoc """
+  A differential window of metadata mutations covering `(from_version,
+  to_version]`. `from_version` is nil when coverage starts at the beginning of
+  the resolver's history; a `from_version` beyond what the proxy has applied
+  signals an unrecoverable coverage gap (the resolver pruned history the proxy
+  never confirmed).
+  """
+  @type metadata_window ::
+          {from_version :: Bedrock.version() | nil, to_version :: Bedrock.version(),
+           entries :: [MetadataAccumulator.entry()]}
+          | nil
+
   @spec resolve_transactions(
           ref(),
           epoch :: Bedrock.epoch(),
@@ -33,13 +57,14 @@ defmodule Bedrock.DataPlane.Resolver do
           commit_version :: Bedrock.version(),
           [Transaction.encoded()],
           metadata_per_tx :: [metadata_mutations()],
-          opts :: [timeout: Bedrock.timeout_in_ms()]
+          opts :: [timeout: Bedrock.timeout_in_ms(), metadata_ack: metadata_ack()]
         ) ::
-          {:ok, aborted :: [transaction_index :: non_neg_integer()], metadata_updates :: [MetadataAccumulator.entry()]}
+          {:ok, aborted :: [transaction_index :: non_neg_integer()], metadata_window()}
           | {:failure, :timeout, ref()}
           | {:failure, :unavailable, ref()}
   def resolve_transactions(ref, epoch, last_version, commit_version, transaction_summaries, metadata_per_tx, opts \\ []) do
     timeout = opts[:timeout] || :infinity
+    metadata_ack = opts[:metadata_ack] || {self(), nil}
 
     :telemetry.span(
       [:bedrock, :data_plane, :resolver, :call, :resolve_transactions],
@@ -54,12 +79,13 @@ defmodule Bedrock.DataPlane.Resolver do
       fn ->
         ref
         |> GenServer.call(
-          {:resolve_transactions, epoch, {last_version, commit_version}, transaction_summaries, metadata_per_tx},
+          {:resolve_transactions, epoch, {last_version, commit_version}, transaction_summaries, metadata_per_tx,
+           metadata_ack},
           timeout
         )
         |> case do
-          {:ok, aborted, metadata_updates} ->
-            {{:ok, aborted, metadata_updates}, %{aborted: aborted}}
+          {:ok, aborted, metadata_window} ->
+            {{:ok, aborted, metadata_window}, %{aborted: aborted}}
 
           {:error, reason} ->
             {{:error, reason}, %{}}

--- a/lib/bedrock/data_plane/resolver/metadata_accumulator.ex
+++ b/lib/bedrock/data_plane/resolver/metadata_accumulator.ex
@@ -102,27 +102,42 @@ defmodule Bedrock.DataPlane.Resolver.MetadataAccumulator do
   end
 
   @doc """
-  Removes all entries with versions strictly before the given version.
+  Removes all entries with versions at or below the given version.
 
-  This prunes old entries that are no longer needed, keeping memory bounded.
+  This prunes entries every proxy has confirmed applying (they can never be
+  requested again - `mutations_since/2` is exclusive), keeping memory bounded.
 
   ## Parameters
     - `accumulator` - The accumulator to prune
-    - `before_version` - Remove entries with versions < this version
+    - `through_version` - Remove entries with versions <= this version
 
   ## Examples
 
       iex> acc = new()
       iex>   |> append(v(1), [{:set, <<0xFF, "a">>, "1"}])
       iex>   |> append(v(2), [{:set, <<0xFF, "b">>, "2"}])
-      iex>   |> prune_before(v(2))
+      iex>   |> prune_through(v(1))
       iex> length(entries(acc))
       1
   """
-  @spec prune_before(t(), Bedrock.version()) :: t()
-  def prune_before(%__MODULE__{reversed_entries: reversed} = accumulator, before_version) do
-    # Keep entries where version >= before_version (from newest end)
-    pruned = Enum.take_while(reversed, fn {version, _} -> version >= before_version end)
+  @spec prune_through(t(), Bedrock.version()) :: t()
+  def prune_through(%__MODULE__{reversed_entries: reversed} = accumulator, through_version) do
+    # Keep entries where version > through_version (from newest end)
+    pruned = Enum.take_while(reversed, fn {version, _} -> version > through_version end)
     %{accumulator | reversed_entries: pruned}
+  end
+
+  @doc """
+  Returns the newest entry version at or below the given version, or nil if
+  there is none.
+
+  Used to record the exact coverage lost by a `prune_through/2` call: a proxy
+  whose ack is at or above this version has confirmed every discarded entry,
+  even when the prune version itself (a commit-stream version) is far ahead of
+  its ack.
+  """
+  @spec newest_version_at_or_below(t(), Bedrock.version()) :: Bedrock.version() | nil
+  def newest_version_at_or_below(%__MODULE__{reversed_entries: reversed}, version) do
+    Enum.find_value(reversed, fn {v, _} -> if v <= version, do: v end)
   end
 end

--- a/lib/bedrock/data_plane/resolver/server.ex
+++ b/lib/bedrock/data_plane/resolver/server.ex
@@ -28,6 +28,7 @@ defmodule Bedrock.DataPlane.Resolver.Server do
 
   import Bedrock.Internal.GenServer.Replies
 
+  alias Bedrock.DataPlane.Resolver
   alias Bedrock.DataPlane.Resolver.Conflicts
   alias Bedrock.DataPlane.Resolver.MetadataAccumulator
   alias Bedrock.DataPlane.Resolver.State
@@ -104,13 +105,21 @@ defmodule Bedrock.DataPlane.Resolver.Server do
   end
 
   @impl true
-  def handle_call({:resolve_transactions, epoch, {_last_version, _next_version}, _transactions, _metadata}, _from, t)
+  def handle_call(
+        {:resolve_transactions, epoch, {_last_version, _next_version}, _transactions, _metadata, _ack},
+        _from,
+        t
+      )
       when epoch != t.epoch do
     reply(t, {:error, {:epoch_mismatch, expected: t.epoch, received: epoch}})
   end
 
   @impl true
-  def handle_call({:resolve_transactions, epoch, {last_version, next_version}, transactions, metadata_per_tx}, from, t)
+  def handle_call(
+        {:resolve_transactions, epoch, {last_version, next_version}, transactions, metadata_per_tx, metadata_ack},
+        from,
+        t
+      )
       when t.mode == :running and epoch == t.epoch and last_version == t.last_version do
     emit_received(transactions, next_version)
 
@@ -118,10 +127,8 @@ defmodule Bedrock.DataPlane.Resolver.Server do
     |> Validation.check_transactions()
     |> case do
       :ok ->
-        proxy_pid = elem(from, 0)
-
         noreply(t,
-          continue: {:process_ready, {next_version, transactions, metadata_per_tx, proxy_pid, reply_fn(from)}}
+          continue: {:process_ready, {next_version, transactions, metadata_per_tx, metadata_ack, reply_fn(from)}}
         )
 
       {:error, reason} ->
@@ -131,7 +138,11 @@ defmodule Bedrock.DataPlane.Resolver.Server do
   end
 
   @impl true
-  def handle_call({:resolve_transactions, epoch, {last_version, next_version}, transactions, metadata_per_tx}, from, t)
+  def handle_call(
+        {:resolve_transactions, epoch, {last_version, next_version}, transactions, metadata_per_tx, metadata_ack},
+        from,
+        t
+      )
       when t.mode == :running and epoch == t.epoch and is_binary(last_version) and last_version > t.last_version do
     emit_waiting_list(transactions, next_version)
 
@@ -139,8 +150,7 @@ defmodule Bedrock.DataPlane.Resolver.Server do
     |> Validation.check_transactions()
     |> case do
       :ok ->
-        proxy_pid = elem(from, 0)
-        data = {next_version, transactions, metadata_per_tx, proxy_pid}
+        data = {next_version, transactions, metadata_per_tx, metadata_ack}
 
         {new_waiting, _timeout} =
           WaitingList.insert(
@@ -162,13 +172,16 @@ defmodule Bedrock.DataPlane.Resolver.Server do
   end
 
   @impl true
-  def handle_call({:resolve_transactions, epoch, {last_version, _next_version}, transactions, _metadata}, from, t)
+  def handle_call(
+        {:resolve_transactions, epoch, {last_version, _next_version}, transactions, _metadata, metadata_ack},
+        _from,
+        t
+      )
       when t.mode == :running and epoch == t.epoch and is_binary(last_version) and last_version < t.last_version do
-    # All transactions aborted due to stale version - return differential metadata for the proxy
-    proxy_pid = elem(from, 0)
-    {metadata_updates, t} = get_metadata_updates_for_proxy(t, proxy_pid)
+    # All transactions aborted due to stale version - return a differential metadata window for the proxy
+    {metadata_window, t} = get_metadata_window_for_proxy(t, metadata_ack)
     aborted_indices = Enum.to_list(0..(length(transactions) - 1))
-    reply(t, {:ok, aborted_indices, metadata_updates})
+    reply(t, {:ok, aborted_indices, metadata_window})
   end
 
   @impl true
@@ -192,7 +205,7 @@ defmodule Bedrock.DataPlane.Resolver.Server do
   end
 
   @impl true
-  def handle_continue({:process_ready, {next_version, transactions, metadata_per_tx, proxy_pid, reply_fn}}, t) do
+  def handle_continue({:process_ready, {next_version, transactions, metadata_per_tx, metadata_ack, reply_fn}}, t) do
     emit_processing(transactions, next_version)
 
     {conflicts, aborted} = resolve(t.conflicts, transactions, next_version)
@@ -202,21 +215,21 @@ defmodule Bedrock.DataPlane.Resolver.Server do
     # Accumulate metadata from non-aborted transactions
     t = accumulate_committed_metadata(t, next_version, metadata_per_tx, aborted)
 
-    # Get differential updates for this proxy and update its progress
-    {metadata_updates, t} = get_metadata_updates_for_proxy(t, proxy_pid)
+    # Get the differential window for this proxy and record its confirmed progress
+    {metadata_window, t} = get_metadata_window_for_proxy(t, metadata_ack)
 
-    reply_fn.({:ok, aborted, metadata_updates})
+    reply_fn.({:ok, aborted, metadata_window})
     emit_reply_sent(transactions, aborted, next_version)
 
     case WaitingList.remove(t.waiting, next_version) do
       {updated_waiting, nil} ->
         noreply(%{t | waiting: updated_waiting}, continue: :next_timeout)
 
-      {updated_waiting, {_deadline, reply_fn, {waiting_next_version, transactions, metadata_per_tx, proxy_pid}}} ->
+      {updated_waiting, {_deadline, reply_fn, {waiting_next_version, transactions, metadata_per_tx, metadata_ack}}} ->
         emit_waiting_resolved(transactions, [], waiting_next_version)
 
         noreply(%{t | waiting: updated_waiting},
-          continue: {:process_ready, {waiting_next_version, transactions, metadata_per_tx, proxy_pid, reply_fn}}
+          continue: {:process_ready, {waiting_next_version, transactions, metadata_per_tx, metadata_ack, reply_fn}}
         )
     end
   end
@@ -270,31 +283,135 @@ defmodule Bedrock.DataPlane.Resolver.Server do
     end
   end
 
-  # Gets differential metadata updates for a proxy and updates its progress
-  @spec get_metadata_updates_for_proxy(State.t(), pid()) :: {[MetadataAccumulator.entry()], State.t()}
-  defp get_metadata_updates_for_proxy(t, proxy_pid) do
-    last_seen = Map.get(t.proxy_progress, proxy_pid)
-    updates = MetadataAccumulator.mutations_since(t.metadata_window, last_seen)
+  # Builds the differential metadata window for a proxy and records its
+  # confirmed progress.
+  #
+  # The window covers (from, t.last_version] where `from` is the version the
+  # proxy has CONFIRMED applying (its ack). Progress advances only via acks, so
+  # a reply lost to a call timeout is simply re-sent on the proxy's next call,
+  # and windows to concurrently in-flight batches overlap - out-of-order
+  # arrival at the proxy is lossless (its per-entry version guard skips
+  # already-applied entries).
+  #
+  # If pruning has discarded entries the proxy never confirmed (only possible
+  # after the proxy was expired from proxy_progress), the window's
+  # from_version is the pruned floor - above the proxy's applied version -
+  # which the proxy detects as an unrecoverable coverage gap.
+  @spec get_metadata_window_for_proxy(State.t(), Resolver.metadata_ack()) ::
+          {Resolver.metadata_window(), State.t()}
+  defp get_metadata_window_for_proxy(t, {proxy_id, acked}) do
+    t =
+      t
+      |> record_proxy_progress(proxy_id, acked)
+      |> expire_stale_proxies()
+      |> prune_metadata_window()
 
-    # Update proxy progress to current version
-    updated_progress = Map.put(t.proxy_progress, proxy_pid, t.last_version)
-    t = %{t | proxy_progress: updated_progress}
+    # Serve the differential from the RECORDED (monotone) ack: a retried call
+    # can carry a stale ack, but the proxy's applied version is at least every
+    # ack it has ever sent, so entries at or below the recorded ack are
+    # already applied there. (The requesting proxy was just recorded, so it
+    # cannot have been expired above.)
+    {acked, _last_seen} = Map.fetch!(t.proxy_progress, proxy_id)
 
-    # Prune metadata window based on minimum progress across all proxies
-    t = prune_metadata_window(t)
+    floor = t.metadata_pruned_through
+    gap? = floor != nil and (acked == nil or acked < floor)
+    from = if gap?, do: floor, else: acked
+    entries = MetadataAccumulator.mutations_since(t.metadata_window, from)
 
-    {updates, t}
+    window = if entries == [] and not gap?, do: nil, else: {from, t.last_version, entries}
+
+    {window, t}
   end
 
-  # Prunes the metadata window based on the minimum version seen by any proxy
+  @spec record_proxy_progress(State.t(), pid(), Bedrock.version() | nil) :: State.t()
+  defp record_proxy_progress(t, proxy_id, acked) do
+    updated_progress =
+      Map.update(t.proxy_progress, proxy_id, {acked, t.last_version}, fn {prev_acked, _} ->
+        {max_ack(prev_acked, acked), t.last_version}
+      end)
+
+    %{t | proxy_progress: updated_progress}
+  end
+
+  # Acks are monotone per proxy; a retried call may carry a stale ack.
+  defp max_ack(nil, acked), do: acked
+  defp max_ack(prev, nil), do: prev
+  defp max_ack(prev, acked), do: max(prev, acked)
+
+  # Drops proxies not seen within the version retention horizon so a dead (or
+  # pathologically stalled) proxy neither leaks a progress entry nor blocks
+  # window pruning forever. A live proxy calls at least once per empty-batch
+  # interval, far inside the horizon.
+  @spec expire_stale_proxies(State.t()) :: State.t()
+  defp expire_stale_proxies(t) do
+    case retention_cutoff(t) do
+      nil ->
+        t
+
+      cutoff ->
+        %{t | proxy_progress: Map.filter(t.proxy_progress, fn {_pid, {_acked, seen}} -> seen >= cutoff end)}
+    end
+  end
+
+  # The version retention horizon, or nil while the version stream is still
+  # inside the first horizon.
+  @spec retention_cutoff(State.t()) :: Bedrock.version() | nil
+  defp retention_cutoff(t) do
+    retention = t.version_retention_ms * 1000
+
+    if Version.to_integer(t.last_version) >= retention do
+      Version.subtract(t.last_version, retention)
+    end
+  end
+
+  # Prunes the metadata window through the minimum version confirmed by every
+  # known proxy, CAPPED at the retention horizon. A proxy that has confirmed
+  # nothing (nil ack) blocks pruning until it confirms or expires.
+  #
+  # The cap makes gap detection symmetric with proxy expiry: no entry younger
+  # than the retention horizon is ever discarded, so a proxy calling within
+  # retention (any live proxy - the empty-batch cadence is far inside it) can
+  # never observe a gap. Without it, acks alone could prune an entry before a
+  # proxy the resolver has not yet HEARD FROM (epoch start: one proxy commits
+  # and acks metadata before another's first call) ever saw it, gap-exiting a
+  # healthy proxy. Memory stays bounded: at most one retention horizon of
+  # metadata entries is retained beyond what acks allow.
   @spec prune_metadata_window(State.t()) :: State.t()
-  defp prune_metadata_window(%{proxy_progress: progress} = t) when map_size(progress) == 0 do
-    t
-  end
+  defp prune_metadata_window(%{proxy_progress: progress} = t) when map_size(progress) == 0, do: t
 
   defp prune_metadata_window(t) do
-    min_version = t.proxy_progress |> Map.values() |> Enum.min()
-    updated_window = MetadataAccumulator.prune_before(t.metadata_window, min_version)
-    %{t | metadata_window: updated_window}
+    t.proxy_progress
+    |> Map.values()
+    |> Enum.map(fn {acked, _seen} -> acked end)
+    |> Enum.min()
+    |> cap_at_retention_cutoff(t)
+    |> case do
+      nil ->
+        t
+
+      min_acked ->
+        # Record the newest ENTRY version being discarded, not min_acked
+        # itself: acks are window to_versions (commit-stream versions, coarser
+        # than entry versions), so min_acked can run far ahead of the last
+        # entry it covers. Using it as the gap floor would fail returning
+        # laggards that confirmed every discarded entry - a spurious full
+        # recovery. A proxy acked >= this floor has everything discarded.
+        discarded = MetadataAccumulator.newest_version_at_or_below(t.metadata_window, min_acked)
+
+        %{
+          t
+          | metadata_window: MetadataAccumulator.prune_through(t.metadata_window, min_acked),
+            metadata_pruned_through: max_ack(t.metadata_pruned_through, discarded)
+        }
+    end
+  end
+
+  defp cap_at_retention_cutoff(nil, _t), do: nil
+
+  defp cap_at_retention_cutoff(min_acked, t) do
+    case retention_cutoff(t) do
+      nil -> nil
+      cutoff -> min(min_acked, cutoff)
+    end
   end
 end

--- a/lib/bedrock/data_plane/resolver/state.ex
+++ b/lib/bedrock/data_plane/resolver/state.ex
@@ -9,10 +9,21 @@ defmodule Bedrock.DataPlane.Resolver.State do
   ## Metadata Distribution
 
   The resolver also tracks system metadata mutations (keys with \\xFF prefix)
-  and distributes differential updates to commit proxies:
+  and distributes differential window updates to commit proxies:
 
-  - `proxy_progress` - Maps proxy PIDs to their last seen metadata version
-  - `metadata_window` - Accumulated metadata mutations in version order
+  - `proxy_progress` - Maps each commit proxy server pid (stable per epoch) to
+    `{acked, last_seen}`: the highest window version the proxy has confirmed
+    applying (nil if none) and the resolver version at its most recent call.
+    Entries not seen within the version retention horizon are expired,
+    bounding the map to ~live proxies and unblocking window pruning.
+  - `metadata_window` - Accumulated metadata mutations in version order,
+    pruned through the minimum confirmed ack across known proxies, capped at
+    the retention horizon (no entry younger than the horizon is discarded, so
+    a proxy calling within retention never observes a coverage gap)
+  - `metadata_pruned_through` - The newest entry version ever discarded by
+    pruning (nil if no entry has been discarded). A proxy whose ack falls
+    below this floor can no longer be served a complete differential; a proxy
+    acked at or above it has confirmed every discarded entry.
   """
 
   alias Bedrock.DataPlane.Resolver.Conflicts
@@ -31,8 +42,11 @@ defmodule Bedrock.DataPlane.Resolver.State do
           sweep_interval_ms: pos_integer(),
           version_retention_ms: pos_integer(),
           last_sweep_time: integer(),
-          proxy_progress: %{pid() => Bedrock.version()},
-          metadata_window: MetadataAccumulator.t()
+          proxy_progress: %{
+            pid() => {acked :: Bedrock.version() | nil, last_seen :: Bedrock.version()}
+          },
+          metadata_window: MetadataAccumulator.t(),
+          metadata_pruned_through: Bedrock.version() | nil
         }
   defstruct conflicts: nil,
             last_version: nil,
@@ -45,5 +59,6 @@ defmodule Bedrock.DataPlane.Resolver.State do
             version_retention_ms: nil,
             last_sweep_time: nil,
             proxy_progress: %{},
-            metadata_window: nil
+            metadata_window: nil,
+            metadata_pruned_through: nil
 end

--- a/test/bedrock/control_plane/director/recovery/persistence_phase_test.exs
+++ b/test/bedrock/control_plane/director/recovery/persistence_phase_test.exs
@@ -4,6 +4,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery.PersistencePhaseTest do
   import Bedrock.Test.ControlPlane.RecoveryTestSupport
 
   alias Bedrock.ControlPlane.Director.Recovery.PersistencePhase
+  alias Bedrock.DataPlane.CommitProxy.Metadata
   alias Bedrock.DataPlane.CommitProxy.RoutingData
   alias Bedrock.DataPlane.Transaction
   alias Bedrock.Key
@@ -214,6 +215,25 @@ defmodule Bedrock.ControlPlane.Director.Recovery.PersistencePhaseTest do
 
       log_keys = store |> range_read(SystemKeys.layout_logs_prefix()) |> Enum.map(&elem(&1, 0))
       assert log_keys == [SystemKeys.layout_log("log_1")]
+    end
+
+    test "shrinking shard layout leaves exactly 2 entries visible to proxy Metadata" do
+      mutations = captured_system_mutations(base_recovery_attempt())
+
+      stale_writes = [
+        {:set, SystemKeys.shard_key(<<0x40>>), Values.encode_shard_key_entry(2, <<>>)},
+        {:set, SystemKeys.shard_key(<<0x80>>), Values.encode_shard_key_entry(3, <<0x40>>)},
+        {:set, SystemKeys.shard_key(<<0xFF, 0xFF>>), Values.encode_shard_key_entry(4, <<0x80>>)}
+      ]
+
+      {metadata, _stats} =
+        Metadata.apply_updates(Metadata.new(), [
+          {Bedrock.DataPlane.Version.from_integer(1), stale_writes},
+          {Bedrock.DataPlane.Version.from_integer(2), mutations}
+        ])
+
+      assert metadata.shards == %{<<0xFF>> => 1, <<0xFF, 0xFF>> => 0}
+      assert metadata.shard_metadata |> Map.keys() |> Enum.sort() == ["0", "1"]
     end
 
     test "shrinking shard layout leaves exactly 2 entries visible to RoutingData ETS" do

--- a/test/bedrock/data_plane/commit_proxy/finalization/core_test.exs
+++ b/test/bedrock/data_plane/commit_proxy/finalization/core_test.exs
@@ -46,7 +46,7 @@ defmodule Bedrock.DataPlane.CommitProxy.FinalizationCoreTest do
       assert commit_version == Version.from_integer(100)
       assert is_list(summaries)
       assert Keyword.has_key?(opts, :timeout)
-      {:ok, aborted_indices, []}
+      {:ok, aborted_indices, nil}
     end
   end
 
@@ -146,7 +146,7 @@ defmodule Bedrock.DataPlane.CommitProxy.FinalizationCoreTest do
 
       mock_resolver_fn = fn resolver, _epoch, _last_version, _commit_version, _summaries, _metadata_per_tx, _opts ->
         assert resolver == :test_resolver
-        {:ok, [], []}
+        {:ok, [], nil}
       end
 
       assert {:ok, 0, 0, _routing_data} =
@@ -190,7 +190,7 @@ defmodule Bedrock.DataPlane.CommitProxy.FinalizationCoreTest do
       # Mock resolver that aborts both transactions
       mock_resolver_fn = fn resolver, _epoch, _last_version, _commit_version, _summaries, _metadata_per_tx, _opts ->
         assert resolver == :test_resolver
-        {:ok, [0, 1], []}
+        {:ok, [0, 1], nil}
       end
 
       assert {:ok, 2, 0, _routing_data} =
@@ -221,7 +221,7 @@ defmodule Bedrock.DataPlane.CommitProxy.FinalizationCoreTest do
 
       mock_resolver_fn = fn resolver, _epoch, _last_version, _commit_version, _summaries, _metadata_per_tx, _opts ->
         assert resolver == :test_resolver
-        {:ok, [], []}
+        {:ok, [], nil}
       end
 
       mock_log_push_fn = fn _last_version, _tx_by_log, _commit_version, _opts ->
@@ -251,7 +251,7 @@ defmodule Bedrock.DataPlane.CommitProxy.FinalizationCoreTest do
 
       mock_resolver_fn = fn resolver, _epoch, _last_version, _commit_version, _summaries, _metadata_per_tx, _opts ->
         assert resolver == :test_resolver
-        {:ok, [], []}
+        {:ok, [], nil}
       end
 
       mock_log_push_fn = fn _last_version, _tx_by_log, _commit_version, _opts ->
@@ -296,7 +296,7 @@ defmodule Bedrock.DataPlane.CommitProxy.FinalizationCoreTest do
                             _metadata_per_tx,
                             _opts ->
         send(test_pid, {:resolver_called, last_version, received_commit_version})
-        {:ok, [], []}
+        {:ok, [], nil}
       end
 
       # Mock log push function that captures version parameters

--- a/test/bedrock/data_plane/commit_proxy/finalization/log_push_test.exs
+++ b/test/bedrock/data_plane/commit_proxy/finalization/log_push_test.exs
@@ -45,7 +45,7 @@ defmodule Bedrock.DataPlane.CommitProxy.FinalizationLogPushTest do
     {
       fn :test_sequencer, _epoch, _commit_version, _opts -> :ok end,
       fn :test_resolver, _epoch, _last_version, _commit_version, _summaries, _metadata_per_tx, _opts ->
-        {:ok, [], []}
+        {:ok, [], nil}
       end
     }
   end
@@ -182,7 +182,7 @@ defmodule Bedrock.DataPlane.CommitProxy.FinalizationLogPushTest do
         assert length(summaries) == 3
         assert Keyword.has_key?(opts, :timeout)
         # Abort middle transaction
-        {:ok, [1], []}
+        {:ok, [1], nil}
       end
 
       sequencer_notify_fn = fn :test_sequencer, _epoch, ^expected_version, _opts -> :ok end
@@ -592,7 +592,7 @@ defmodule Bedrock.DataPlane.CommitProxy.FinalizationLogPushTest do
         )
 
       resolver_fn = fn :test_resolver, _epoch, _last_version, _commit_version, _summaries, _metadata_per_tx, _opts ->
-        {:ok, [], []}
+        {:ok, [], nil}
       end
 
       routing_data = Support.build_routing_data(layout)

--- a/test/bedrock/data_plane/commit_proxy/finalization/metadata_test.exs
+++ b/test/bedrock/data_plane/commit_proxy/finalization/metadata_test.exs
@@ -102,7 +102,7 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization.MetadataTest do
       # Mock resolver that captures metadata_per_tx
       mock_resolver_fn = fn _resolver, _epoch, _last_version, _commit_version, _summaries, metadata_per_tx, _opts ->
         send(test_pid, {:metadata_received, metadata_per_tx})
-        {:ok, [], []}
+        {:ok, [], nil}
       end
 
       assert {:ok, 0, 1, _routing_data} =
@@ -147,7 +147,7 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization.MetadataTest do
 
       mock_resolver_fn = fn _resolver, _epoch, _last_version, _commit_version, _summaries, metadata_per_tx, _opts ->
         send(test_pid, {:metadata_received, metadata_per_tx})
-        {:ok, [], []}
+        {:ok, [], nil}
       end
 
       assert {:ok, 0, 1, _routing_data} =
@@ -189,15 +189,14 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization.MetadataTest do
           {reply_fn, tx_binary, task}
         ])
 
-      # Mock resolver returns metadata updates (stored in plan.metadata_updates)
+      # Mock resolver returns a metadata window (entries stored in plan.metadata_updates)
       commit_version = Version.from_integer(100)
 
-      metadata_updates = [
-        {commit_version, [{:set, <<0xFF, "system_key">>, "system_value"}]}
-      ]
+      metadata_window =
+        {nil, commit_version, [{commit_version, [{:set, <<0xFF, "system_key">>, "system_value"}]}]}
 
       mock_resolver_fn = fn _resolver, _epoch, _last_version, _commit_version, _summaries, _metadata_per_tx, _opts ->
-        {:ok, [], metadata_updates}
+        {:ok, [], metadata_window}
       end
 
       assert {:ok, 0, 1, _returned_routing_data} =
@@ -231,7 +230,7 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization.MetadataTest do
         ])
 
       mock_resolver_fn = fn _resolver, _epoch, _last_version, _commit_version, _summaries, _metadata_per_tx, _opts ->
-        {:ok, [], []}
+        {:ok, [], nil}
       end
 
       assert {:ok, 0, 1, _returned_routing_data} =
@@ -265,7 +264,7 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization.MetadataTest do
 
       # Resolver returns no metadata updates
       mock_resolver_fn = fn _resolver, _epoch, _last_version, _commit_version, _summaries, _metadata_per_tx, _opts ->
-        {:ok, [], []}
+        {:ok, [], nil}
       end
 
       assert {:ok, 0, 1, _returned_routing_data} =
@@ -326,7 +325,7 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization.MetadataTest do
 
       mock_resolver_fn = fn _resolver, _epoch, _last_version, _commit_version, _summaries, metadata_per_tx, _opts ->
         send(test_pid, {:metadata_received, metadata_per_tx})
-        {:ok, [], []}
+        {:ok, [], nil}
       end
 
       assert {:ok, 0, 3, _routing_data} =
@@ -378,7 +377,7 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization.MetadataTest do
       # Mock resolver captures metadata
       mock_resolver_fn = fn _resolver, _epoch, _last_version, _commit_version, _summaries, metadata_per_tx, _opts ->
         send(test_pid, {:metadata_received, metadata_per_tx})
-        {:ok, [], []}
+        {:ok, [], nil}
       end
 
       assert {:ok, 0, 0, _routing_data} =
@@ -436,7 +435,7 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization.MetadataTest do
 
       mock_resolver_fn = fn _resolver, _epoch, _last_version, _commit_version, _summaries, metadata_per_tx, _opts ->
         send(test_pid, {:metadata_received, metadata_per_tx})
-        {:ok, [], []}
+        {:ok, [], nil}
       end
 
       assert {:ok, 0, 1, _routing_data} =

--- a/test/bedrock/data_plane/commit_proxy/finalization/resolver_retry_test.exs
+++ b/test/bedrock/data_plane/commit_proxy/finalization/resolver_retry_test.exs
@@ -80,7 +80,7 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization.ResolverRetryTest do
         if attempt < 2 do
           {:error, :timeout}
         else
-          {:ok, [], []}
+          {:ok, [], nil}
         end
       end
 
@@ -122,7 +122,7 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization.ResolverRetryTest do
         if attempt < 2 do
           {:error, :unavailable}
         else
-          {:ok, [], []}
+          {:ok, [], nil}
         end
       end
 
@@ -162,7 +162,7 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization.ResolverRetryTest do
           # Alternative failure format used by some resolver implementations
           {:failure, :timeout, :test_resolver}
         else
-          {:ok, [], []}
+          {:ok, [], nil}
         end
       end
 
@@ -410,7 +410,7 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization.ResolverRetryTest do
         if attempt < 3 do
           {:error, :timeout}
         else
-          {:ok, [], []}
+          {:ok, [], nil}
         end
       end
 
@@ -469,7 +469,7 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization.ResolverRetryTest do
         if attempt < 2 do
           {:error, :timeout}
         else
-          {:ok, [], []}
+          {:ok, [], nil}
         end
       end
 

--- a/test/bedrock/data_plane/commit_proxy/finalization/sharded_resolution_and_edge_cases_test.exs
+++ b/test/bedrock/data_plane/commit_proxy/finalization/sharded_resolution_and_edge_cases_test.exs
@@ -89,7 +89,7 @@ defmodule Bedrock.DataPlane.CommitProxy.FinalizationShardedResolutionAndEdgeCase
 
       resolver_fn = fn ref, 1, @last_commit_version, @commit_version, transactions, metadata, _opts ->
         send(test_pid, {:resolved, ref, transactions, metadata})
-        {:ok, [], []}
+        {:ok, [], nil}
       end
 
       opts = base_opts(sharded_layout(), routing_data(), resolver_fn: resolver_fn)
@@ -109,8 +109,8 @@ defmodule Bedrock.DataPlane.CommitProxy.FinalizationShardedResolutionAndEdgeCase
         ])
 
       resolver_fn = fn
-        :resolver_a, _epoch, _last, _commit, _txns, _metadata, _opts -> {:ok, [0], []}
-        :resolver_b, _epoch, _last, _commit, _txns, _metadata, _opts -> {:ok, [1], []}
+        :resolver_a, _epoch, _last, _commit, _txns, _metadata, _opts -> {:ok, [0], nil}
+        :resolver_b, _epoch, _last, _commit, _txns, _metadata, _opts -> {:ok, [1], nil}
       end
 
       opts = base_opts(sharded_layout(), routing_data(), resolver_fn: resolver_fn)
@@ -128,7 +128,7 @@ defmodule Bedrock.DataPlane.CommitProxy.FinalizationShardedResolutionAndEdgeCase
           {reply_fn(self(), :tx1), encode_tx("zebra", "v1")}
         ])
 
-      resolver_fn = fn _ref, _epoch, _last, _commit, _txns, _metadata, _opts -> {:ok, [], []} end
+      resolver_fn = fn _ref, _epoch, _last, _commit, _txns, _metadata, _opts -> {:ok, [], nil} end
 
       opts = base_opts(sharded_layout(), routing_data(), resolver_fn: resolver_fn)
 
@@ -146,7 +146,7 @@ defmodule Bedrock.DataPlane.CommitProxy.FinalizationShardedResolutionAndEdgeCase
         ])
 
       resolver_fn = fn
-        :resolver_a, _epoch, _last, _commit, _txns, _metadata, _opts -> {:ok, [], []}
+        :resolver_a, _epoch, _last, _commit, _txns, _metadata, _opts -> {:ok, [], nil}
         :resolver_b, _epoch, _last, _commit, _txns, _metadata, _opts -> {:error, :resolver_crashed}
       end
 
@@ -185,7 +185,7 @@ defmodule Bedrock.DataPlane.CommitProxy.FinalizationShardedResolutionAndEdgeCase
 
       batch = batch_with([{reply_fn(self(), :tx0), no_mutations_tx}])
 
-      resolver_fn = fn _ref, _epoch, _last, _commit, _txns, _metadata, _opts -> {:ok, [], []} end
+      resolver_fn = fn _ref, _epoch, _last, _commit, _txns, _metadata, _opts -> {:ok, [], nil} end
 
       opts = base_opts(single_layout(), routing_data(), resolver_fn: resolver_fn)
 
@@ -208,7 +208,7 @@ defmodule Bedrock.DataPlane.CommitProxy.FinalizationShardedResolutionAndEdgeCase
 
       batch = batch_with([{reply_fn(self(), :tx0), hostile_tx}])
 
-      resolver_fn = fn _ref, _epoch, _last, _commit, _txns, _metadata, _opts -> {:ok, [], []} end
+      resolver_fn = fn _ref, _epoch, _last, _commit, _txns, _metadata, _opts -> {:ok, [], nil} end
 
       opts = base_opts(single_layout(), routing_data(), resolver_fn: resolver_fn)
 
@@ -234,7 +234,7 @@ defmodule Bedrock.DataPlane.CommitProxy.FinalizationShardedResolutionAndEdgeCase
       batch = batch_with([{reply_fn(self(), :tx0), spanning_tx}])
       test_pid = self()
 
-      resolver_fn = fn _ref, _epoch, _last, _commit, _txns, _metadata, _opts -> {:ok, [], []} end
+      resolver_fn = fn _ref, _epoch, _last, _commit, _txns, _metadata, _opts -> {:ok, [], nil} end
 
       log_push_fn = fn _last, transactions_by_log, _commit, _opts ->
         send(test_pid, {:pushed, transactions_by_log})
@@ -269,7 +269,7 @@ defmodule Bedrock.DataPlane.CommitProxy.FinalizationShardedResolutionAndEdgeCase
       batch = batch_with([{reply_fn(self(), :tx0), atomic_tx}])
       test_pid = self()
 
-      resolver_fn = fn _ref, _epoch, _last, _commit, _txns, _metadata, _opts -> {:ok, [], []} end
+      resolver_fn = fn _ref, _epoch, _last, _commit, _txns, _metadata, _opts -> {:ok, [], nil} end
 
       log_push_fn = fn _last, transactions_by_log, _commit, _opts ->
         send(test_pid, {:pushed, transactions_by_log})
@@ -293,7 +293,7 @@ defmodule Bedrock.DataPlane.CommitProxy.FinalizationShardedResolutionAndEdgeCase
     batch = batch_with([{reply_fn(self(), :tx0), encode_tx("key", "value")}])
     test_pid = self()
 
-    resolver_fn = fn _ref, _epoch, _last, _commit, _txns, _metadata, _opts -> {:ok, [], []} end
+    resolver_fn = fn _ref, _epoch, _last, _commit, _txns, _metadata, _opts -> {:ok, [], nil} end
 
     log_push_fn = fn _last, transactions_by_log, _commit, _opts ->
       send(test_pid, {:pushed, transactions_by_log})

--- a/test/bedrock/data_plane/commit_proxy/metadata_distribution_integration_test.exs
+++ b/test/bedrock/data_plane/commit_proxy/metadata_distribution_integration_test.exs
@@ -1,0 +1,254 @@
+defmodule Bedrock.DataPlane.CommitProxy.MetadataDistributionIntegrationTest do
+  @moduledoc """
+  End-to-end integration tests for the \\xFF system metadata distribution
+  pipeline (bedrock-q67.15).
+
+  A committed transaction carrying a system-key mutation flows through:
+
+      commit proxy (extract) -> resolver (MetadataAccumulator) ->
+      commit proxy (parse + apply into structured State.metadata)
+
+  Uses a real Sequencer.Server, a real Resolver.Server, and a real
+  CommitProxy.Server; only the log is faked (established seam).
+  """
+  use ExUnit.Case, async: false
+
+  import Bedrock.Test.TelemetryTestHelper
+
+  alias Bedrock.DataPlane.CommitProxy.Metadata
+  alias Bedrock.DataPlane.CommitProxy.ResolverLayout
+  alias Bedrock.DataPlane.CommitProxy.Server, as: CommitProxyServer
+  alias Bedrock.DataPlane.Resolver.MetadataAccumulator
+  alias Bedrock.DataPlane.Resolver.Server, as: ResolverServer
+  alias Bedrock.DataPlane.Sequencer.Server, as: SequencerServer
+  alias Bedrock.DataPlane.Transaction
+  alias Bedrock.DataPlane.Version
+  alias Bedrock.SystemKeys
+  alias Bedrock.SystemKeys.Values
+
+  defmodule TestCluster do
+    @moduledoc false
+    def otp_name(component) when is_atom(component), do: :"metadata_dist_test_#{component}"
+  end
+
+  # Fake log that always accepts pushes (established DI seam)
+  defmodule FakeLog do
+    @moduledoc false
+    use GenServer
+
+    def start_link(_opts), do: GenServer.start_link(__MODULE__, %{})
+
+    def init(state), do: {:ok, state}
+
+    def handle_call({:push, _transaction, _last_commit_version, _kcv}, _from, state), do: {:reply, :ok, state}
+  end
+
+  setup do
+    director = self()
+    epoch = 1
+    lock_token = :crypto.strong_rand_bytes(32)
+
+    sequencer =
+      start_supervised!(
+        {SequencerServer,
+         [
+           cluster: TestCluster,
+           otp_name: :metadata_dist_test_sequencer,
+           director: director,
+           epoch: epoch,
+           last_committed_version: Version.zero()
+         ]}
+      )
+
+    resolver =
+      start_supervised!(
+        {ResolverServer,
+         [
+           lock_token: lock_token,
+           key_range: {"", <<0xFF, 0xFF>>},
+           epoch: epoch,
+           last_version: Version.zero(),
+           director: director,
+           cluster: TestCluster
+         ]}
+      )
+
+    log = start_supervised!({FakeLog, []})
+
+    resolver_layout = ResolverLayout.from_layout(%{resolvers: [{"", resolver}]})
+
+    # Single shard (tag 0) covering the entire keyspace, system keys included
+    routing_snapshot = %{
+      shard_layout: %{<<0xFF, 0xFF>> => {0, <<>>}},
+      log_map: %{0 => "log_1"},
+      log_services: %{"log_1" => log},
+      replication_factor: 1
+    }
+
+    proxy =
+      start_supervised!(
+        CommitProxyServer.child_spec(
+          cluster: TestCluster,
+          director: director,
+          epoch: epoch,
+          instance: 0,
+          max_latency_in_ms: 1,
+          max_per_batch: 10,
+          empty_transaction_timeout_ms: 60_000,
+          lock_token: lock_token,
+          sequencer: sequencer,
+          resolver_layout: resolver_layout
+        )
+      )
+
+    :ok = GenServer.call(proxy, {:recover_from, lock_token, sequencer, resolver_layout, routing_snapshot})
+
+    %{proxy: proxy, resolver: resolver, epoch: epoch}
+  end
+
+  defp encode_tx(mutations, conflict_key) do
+    Transaction.encode(%{
+      mutations: mutations,
+      read_conflicts: [],
+      write_conflicts: [{conflict_key, conflict_key <> <<0>>}]
+    })
+  end
+
+  defp commit!(proxy, epoch, mutations, conflict_key) do
+    assert {:ok, version, _index} = GenServer.call(proxy, {:commit, epoch, encode_tx(mutations, conflict_key)}, 5_000)
+
+    version
+  end
+
+  # Poll until condition is met (metadata application is asynchronous)
+  defp wait_until(condition_fn, timeout \\ 2_000) do
+    deadline = System.monotonic_time(:millisecond) + timeout
+    do_wait_until(condition_fn, deadline)
+  end
+
+  defp do_wait_until(condition_fn, deadline) do
+    if condition_fn.() do
+      :ok
+    else
+      if System.monotonic_time(:millisecond) < deadline do
+        Process.sleep(10)
+        do_wait_until(condition_fn, deadline)
+      else
+        flunk("Condition not met before timeout")
+      end
+    end
+  end
+
+  defp proxy_metadata(proxy), do: :sys.get_state(proxy).metadata
+
+  test "system-key mutation flows commit -> resolver accumulator -> parsed proxy metadata", %{
+    proxy: proxy,
+    resolver: resolver,
+    epoch: epoch
+  } do
+    shard_key = SystemKeys.shard_key("m")
+    encoded_tag = Values.encode_shard_key_entry(7, "")
+
+    version =
+      commit!(
+        proxy,
+        epoch,
+        [{:set, "user_key", "user_value"}, {:set, shard_key, encoded_tag}],
+        "user_key"
+      )
+
+    # 1. The resolver's MetadataAccumulator captured the system-key mutation
+    #    at the batch's commit version.
+    resolver_entries = MetadataAccumulator.entries(:sys.get_state(resolver).metadata_window)
+    assert {^version, [{:set, ^shard_key, ^encoded_tag}]} = List.keyfind(resolver_entries, version, 0)
+
+    # 2. The commit proxy's post-batch state contains the PARSED structured entry.
+    wait_until(fn -> proxy_metadata(proxy).shards != %{} end)
+
+    assert %Metadata{shards: %{"m" => 7}, version: ^version} = proxy_metadata(proxy)
+
+    # 3. The resolver tracks progress under the commit proxy SERVER's stable
+    #    identity, not the per-batch finalization task pid (bedrock-q67.16).
+    assert %{^proxy => {_acked, _last_seen}} = :sys.get_state(resolver).proxy_progress
+  end
+
+  test "metadata updates arrive ordered across multiple batches; later value wins", %{
+    proxy: proxy,
+    epoch: epoch
+  } do
+    shard_key = SystemKeys.shard_key("m")
+
+    _v1 = commit!(proxy, epoch, [{:set, shard_key, Values.encode_shard_key_entry(7, "")}], "key_a")
+    wait_until(fn -> proxy_metadata(proxy).shards == %{"m" => 7} end)
+
+    v2 = commit!(proxy, epoch, [{:set, shard_key, Values.encode_shard_key_entry(9, "")}], "key_b")
+    wait_until(fn -> proxy_metadata(proxy).shards == %{"m" => 9} end)
+
+    assert %Metadata{shards: %{"m" => 9}, version: ^v2} = proxy_metadata(proxy)
+  end
+
+  test "a non-system mutation never pollutes metadata", %{proxy: proxy, resolver: resolver, epoch: epoch} do
+    commit!(proxy, epoch, [{:set, "plain_key", "plain_value"}], "plain_key")
+
+    # Give the pipeline a moment to (incorrectly) deliver anything
+    Process.sleep(100)
+
+    assert MetadataAccumulator.entries(:sys.get_state(resolver).metadata_window) == []
+    assert proxy_metadata(proxy) == Metadata.new()
+  end
+
+  test "multiple key families parse into their structured slots", %{proxy: proxy, epoch: epoch} do
+    mutations = [
+      {:set, SystemKeys.shard_key("g"), Values.encode_shard_key_entry(3, "")},
+      {:set, SystemKeys.layout_log("log-abc"), Values.encode_tag_list([0, 1])},
+      {:set, SystemKeys.layout_services(), Values.encode_structured(%{"log-abc" => %{kind: :log}})},
+      {:set, SystemKeys.cluster_epoch(), Values.encode_integer(1)},
+      {:set, SystemKeys.cluster_parameters_desired_logs(), Values.encode_integer(2)},
+      {:set, SystemKeys.recovery_attempt(), Values.encode_integer(1)}
+    ]
+
+    version = commit!(proxy, epoch, mutations, "families_key")
+
+    wait_until(fn -> proxy_metadata(proxy).version == version end)
+
+    metadata = proxy_metadata(proxy)
+    assert metadata.shards == %{"g" => 3}
+    assert metadata.logs == %{"log-abc" => [0, 1]}
+    assert metadata.services == %{"log-abc" => %{kind: :log}}
+    assert metadata.cluster == %{epoch: 1}
+    assert metadata.parameters == %{desired_logs: 2}
+    assert metadata.recovery == %{attempt: 1}
+  end
+
+  test "unknown system keys are ignored and counted in telemetry", %{proxy: proxy, epoch: epoch} do
+    attach_telemetry_reflector(
+      self(),
+      [
+        [:bedrock, :data_plane, :commit_proxy, :metadata_applied],
+        [:bedrock, :data_plane, :commit_proxy, :unknown_key_skipped]
+      ],
+      "metadata-distribution-telemetry"
+    )
+
+    mutations = [
+      {:set, SystemKeys.shard_key("z"), Values.encode_shard_key_entry(5, "")},
+      {:set, <<0xFF, "/system/future/feature">>, "opaque"}
+    ]
+
+    version = commit!(proxy, epoch, mutations, "telemetry_key")
+
+    wait_until(fn -> proxy_metadata(proxy).version == version end)
+
+    metadata = proxy_metadata(proxy)
+    assert metadata.shards == %{"z" => 5}
+    refute Map.has_key?(metadata.shards, "/system/future/feature")
+
+    {measurements, meta} = expect_telemetry([:bedrock, :data_plane, :commit_proxy, :metadata_applied], 2_000)
+    assert measurements.count == 1
+    assert :shard_key in meta.families
+
+    {measurements, meta} = expect_telemetry([:bedrock, :data_plane, :commit_proxy, :unknown_key_skipped], 2_000)
+    assert measurements.count == 1
+    assert meta.keys == [<<0xFF, "/system/future/feature">>]
+  end
+end

--- a/test/bedrock/data_plane/commit_proxy/metadata_test.exs
+++ b/test/bedrock/data_plane/commit_proxy/metadata_test.exs
@@ -1,0 +1,225 @@
+defmodule Bedrock.DataPlane.CommitProxy.MetadataTest do
+  use ExUnit.Case, async: true
+
+  alias Bedrock.DataPlane.CommitProxy.Metadata
+  alias Bedrock.DataPlane.Version
+  alias Bedrock.SystemKeys
+  alias Bedrock.SystemKeys.Values
+
+  defp v(n), do: Version.from_integer(n)
+
+  defp shard_val(tag, start_key \\ ""), do: Values.encode_shard_key_entry(tag, start_key)
+
+  defp apply!(metadata, updates) do
+    {metadata, _stats} = Metadata.apply_updates(metadata, updates)
+    metadata
+  end
+
+  describe "apply_updates/2 with sets" do
+    test "parses every key family PersistencePhase writes into its structured slot" do
+      mutations = [
+        {:set, SystemKeys.shard_key("m"), shard_val(7)},
+        {:set, SystemKeys.shard(3), "raw-shard-metadata"},
+        {:set, SystemKeys.materializer_key("m"), "raw-materializers"},
+        {:set, SystemKeys.layout_log("log-1"), Values.encode_tag_list([0, 1])},
+        {:set, SystemKeys.layout_services(), Values.encode_structured(%{"log-1" => %{kind: :log}})},
+        {:set, SystemKeys.layout_id(), Values.encode_id("layout-abc")},
+        {:set, SystemKeys.cluster_coordinators(), Values.encode_node_list([:a@host])},
+        {:set, SystemKeys.cluster_epoch(), Values.encode_integer(4)},
+        {:set, SystemKeys.cluster_policies_volunteer_nodes(), Values.encode_boolean(true)},
+        {:set, SystemKeys.cluster_parameters_desired_logs(), Values.encode_integer(2)},
+        {:set, SystemKeys.cluster_parameters_desired_replication(), Values.encode_integer(3)},
+        {:set, SystemKeys.cluster_parameters_desired_commit_proxies(), Values.encode_integer(1)},
+        {:set, SystemKeys.cluster_parameters_desired_coordinators(), Values.encode_integer(1)},
+        {:set, SystemKeys.cluster_parameters_desired_read_version_proxies(), Values.encode_integer(1)},
+        {:set, SystemKeys.cluster_parameters_empty_transaction_timeout_ms(), Values.encode_integer(1_000)},
+        {:set, SystemKeys.cluster_parameters_ping_rate_in_hz(), Values.encode_integer(10)},
+        {:set, SystemKeys.cluster_parameters_retransmission_rate_in_hz(), Values.encode_integer(5)},
+        {:set, SystemKeys.cluster_parameters_transaction_window_in_ms(), Values.encode_integer(5_000)},
+        {:set, SystemKeys.recovery_attempt(), Values.encode_integer(1)},
+        {:set, SystemKeys.recovery_state(), Values.encode_atom(:completed)},
+        {:set, SystemKeys.recovery_last_completed(), Values.encode_integer(123)},
+        {:set, SystemKeys.config_monolithic(), Values.encode_structured({4, %{}})},
+        {:set, SystemKeys.epoch_legacy(), Values.encode_integer(4)},
+        {:set, SystemKeys.last_recovery_legacy(), Values.encode_integer(123)}
+      ]
+
+      {metadata, stats} = Metadata.apply_updates(Metadata.new(), [{v(1), mutations}])
+
+      assert metadata.version == v(1)
+      assert metadata.shards == %{"m" => 7}
+      # shard/materializer values are kept encoded (FlatBuffer / opaque)
+      assert metadata.shard_metadata == %{"3" => "raw-shard-metadata"}
+      assert metadata.materializers == %{"m" => "raw-materializers"}
+      assert metadata.logs == %{"log-1" => [0, 1]}
+      assert metadata.services == %{"log-1" => %{kind: :log}}
+      assert metadata.layout_id == "layout-abc"
+      assert metadata.cluster == %{coordinators: [:a@host], epoch: 4}
+      assert metadata.policies == %{volunteer_nodes: true}
+
+      assert metadata.parameters == %{
+               desired_logs: 2,
+               desired_replication: 3,
+               desired_commit_proxies: 1,
+               desired_coordinators: 1,
+               desired_read_version_proxies: 1,
+               empty_transaction_timeout_ms: 1_000,
+               ping_rate_in_hz: 10,
+               retransmission_rate_in_hz: 5,
+               transaction_window_in_ms: 5_000
+             }
+
+      assert metadata.recovery == %{attempt: 1, state: :completed, last_completed: 123}
+      assert metadata.legacy == %{config_monolithic: {4, %{}}, epoch_legacy: 4, last_recovery_legacy: 123}
+
+      assert stats.applied == length(mutations)
+      assert stats.skipped_keys == []
+
+      assert Enum.sort(stats.families) ==
+               Enum.sort([
+                 :shard_key,
+                 :shard,
+                 :materializer_key,
+                 :layout_log,
+                 :layout_services,
+                 :layout_id,
+                 :cluster,
+                 :cluster_policy,
+                 :cluster_parameter,
+                 :recovery,
+                 :legacy
+               ])
+    end
+
+    test "later version wins and version advances" do
+      metadata =
+        Metadata.new()
+        |> apply!([{v(1), [{:set, SystemKeys.shard_key("m"), shard_val(7)}]}])
+        |> apply!([{v(2), [{:set, SystemKeys.shard_key("m"), shard_val(9)}]}])
+
+      assert metadata.shards == %{"m" => 9}
+      assert metadata.version == v(2)
+    end
+
+    test "entries at or below the applied version are skipped (idempotent redelivery)" do
+      window = [
+        {v(1), [{:set, SystemKeys.shard_key("m"), shard_val(7)}]},
+        {v(2), [{:set, SystemKeys.shard_key("m"), shard_val(9)}]}
+      ]
+
+      metadata = apply!(Metadata.new(), window)
+
+      # Resolver re-sends the whole window (e.g. to a new finalization task)
+      {redelivered, stats} = Metadata.apply_updates(metadata, window)
+
+      assert redelivered == metadata
+      assert stats.applied == 0
+    end
+
+    test "within a version, later mutation wins" do
+      metadata =
+        apply!(Metadata.new(), [
+          {v(1), [{:set, SystemKeys.shard_key("m"), shard_val(7)}, {:set, SystemKeys.shard_key("m"), shard_val(8)}]}
+        ])
+
+      assert metadata.shards == %{"m" => 8}
+    end
+  end
+
+  describe "apply_updates/2 with clears" do
+    test "clear removes the corresponding entry" do
+      metadata =
+        apply!(Metadata.new(), [
+          {v(1),
+           [
+             {:set, SystemKeys.shard_key("m"), shard_val(7)},
+             {:set, SystemKeys.layout_log("log-1"), Values.encode_tag_list([0])},
+             {:set, SystemKeys.layout_id(), Values.encode_id("layout-abc")}
+           ]},
+          {v(2), [{:clear, SystemKeys.shard_key("m")}, {:clear, SystemKeys.layout_id()}]}
+        ])
+
+      assert metadata.shards == %{}
+      assert metadata.layout_id == nil
+      assert metadata.logs == %{"log-1" => [0]}
+    end
+
+    test "clear_range removes every known entry whose full key is in [start, end)" do
+      metadata =
+        apply!(Metadata.new(), [
+          {v(1),
+           [
+             {:set, SystemKeys.shard_key("a"), shard_val(1)},
+             {:set, SystemKeys.shard_key("m"), shard_val(2)},
+             {:set, SystemKeys.shard_key("z"), shard_val(3)},
+             {:set, SystemKeys.layout_log("log-1"), Values.encode_tag_list([0])}
+           ]}
+        ])
+
+      {metadata, stats} =
+        Metadata.apply_updates(metadata, [
+          {v(2), [{:clear_range, SystemKeys.shard_key("a"), SystemKeys.shard_key("z")}]}
+        ])
+
+      # Range end is exclusive: "a" and "m" cleared, "z" survives
+      assert metadata.shards == %{"z" => 3}
+      assert metadata.logs == %{"log-1" => [0]}
+      assert stats.applied == 1
+      assert stats.families == [:shard_key]
+    end
+  end
+
+  describe "apply_updates/2 forward compatibility" do
+    test "unknown system keys are ignored and counted" do
+      unknown_key = <<0xFF, "/system/future/feature">>
+      non_system_metadata_key = <<0xFF, "not-a-system-key">>
+
+      {metadata, stats} =
+        Metadata.apply_updates(Metadata.new(), [
+          {v(1),
+           [
+             {:set, SystemKeys.shard_key("m"), shard_val(7)},
+             {:set, unknown_key, "opaque"},
+             {:clear, non_system_metadata_key}
+           ]}
+        ])
+
+      assert metadata.shards == %{"m" => 7}
+      assert stats.applied == 1
+      assert stats.skipped_keys == [unknown_key, non_system_metadata_key]
+    end
+
+    test "atomic mutations are not applied to structured metadata" do
+      key = SystemKeys.shard_key("m")
+
+      {metadata, stats} = Metadata.apply_updates(Metadata.new(), [{v(1), [{:atomic, :add, key, <<1>>}]}])
+
+      assert metadata.shards == %{}
+      assert stats.applied == 0
+      assert stats.skipped_keys == [key]
+    end
+
+    test "values that fail to decode are skipped and counted, never raise" do
+      key = SystemKeys.shard_key("m")
+
+      {metadata, stats} =
+        Metadata.apply_updates(Metadata.new(), [
+          {v(1), [{:set, key, "garbage-not-an-encoded-value"}, {:set, SystemKeys.cluster_epoch(), <<0xFF, 0xFF>>}]}
+        ])
+
+      assert metadata.shards == %{}
+      assert metadata.cluster == %{}
+      assert stats.applied == 0
+      assert stats.skipped_keys == [key, SystemKeys.cluster_epoch()]
+    end
+
+    test "unknown cluster parameters are ignored and counted" do
+      key = SystemKeys.system_prefix() <> "/cluster/parameters/future_knob"
+
+      {metadata, stats} = Metadata.apply_updates(Metadata.new(), [{v(1), [{:set, key, Values.encode_integer(1)}]}])
+
+      assert metadata.parameters == %{}
+      assert stats.skipped_keys == [key]
+    end
+  end
+end

--- a/test/bedrock/data_plane/commit_proxy/metadata_window_application_test.exs
+++ b/test/bedrock/data_plane/commit_proxy/metadata_window_application_test.exs
@@ -1,0 +1,81 @@
+defmodule Bedrock.DataPlane.CommitProxy.MetadataWindowApplicationTest do
+  @moduledoc """
+  Pins the commit proxy server's application of resolver metadata windows
+  (bedrock-q67.16).
+
+  Windows arrive from per-batch finalization tasks and can therefore reach the
+  server mailbox out of commit-version order. The protocol makes that safe by
+  construction: every window covers `(from_version, to_version]` starting at
+  the version this proxy last CONFIRMED applying, so concurrent in-flight
+  windows overlap and a late-arriving earlier window is a subset of what has
+  already been applied - the per-entry version guard skips it.
+
+  The one unrecoverable case is a coverage gap (`from_version` beyond what the
+  proxy has applied): the resolver has pruned history this proxy never saw, so
+  its metadata can never be completed differentially. The proxy fails fast
+  (exit -> director-driven recovery rebuilds it with full state).
+  """
+  use ExUnit.Case, async: true
+
+  alias Bedrock.DataPlane.CommitProxy.Metadata
+  alias Bedrock.DataPlane.CommitProxy.Server
+  alias Bedrock.DataPlane.CommitProxy.State
+  alias Bedrock.DataPlane.Version
+  alias Bedrock.SystemKeys
+  alias Bedrock.SystemKeys.Values
+
+  defp v(n), do: Version.from_integer(n)
+
+  defp state(metadata) do
+    %State{
+      cluster: __MODULE__,
+      director: self(),
+      epoch: 1,
+      empty_transaction_timeout_ms: 1_000,
+      mode: :running,
+      metadata: metadata
+    }
+  end
+
+  defp shard_set(key, tag), do: {:set, SystemKeys.shard_key(key), Values.encode_shard_key_entry(tag, "")}
+
+  defp apply_window(state, window) do
+    {:noreply, updated, _timeout} = Server.handle_info({:metadata_updates, window}, state)
+    updated
+  end
+
+  test "overlapping windows apply idempotently; a late-arriving earlier window is a no-op" do
+    e1 = {v(1), [shard_set("a", 1)]}
+    e2 = {v(2), [shard_set("a", 2)]}
+
+    # Batch 2's window (same ack, superset) wins the race to the mailbox.
+    updated = apply_window(state(Metadata.new()), {nil, v(2), [e1, e2]})
+    assert %Metadata{shards: %{"a" => 2}, version: version} = updated.metadata
+    assert version == v(2)
+
+    # Batch 1's window arrives late: subset of what is applied - no effect.
+    updated = apply_window(updated, {nil, v(1), [e1]})
+    assert %Metadata{shards: %{"a" => 2}, version: version} = updated.metadata
+    assert version == v(2)
+  end
+
+  test "applied version advances to the window's to_version, not just the last entry's version" do
+    # The window covers through v(3) even though the last mutation is at v(1);
+    # acking v(3) lets the resolver prune fully.
+    updated = apply_window(state(Metadata.new()), {nil, v(3), [{v(1), [shard_set("a", 1)]}]})
+    assert %Metadata{shards: %{"a" => 1}, version: version} = updated.metadata
+    assert version == v(3)
+  end
+
+  test "a window whose from_version exceeds the applied version is a coverage gap: fail fast" do
+    initial = apply_window(state(Metadata.new()), {nil, v(1), [{v(1), [shard_set("a", 1)]}]})
+
+    assert {:metadata_coverage_gap, _} =
+             catch_exit(Server.handle_info({:metadata_updates, {v(5), v(6), [{v(6), [shard_set("a", 6)]}]}}, initial))
+  end
+
+  test "a gap is detected even when the window carries no entries" do
+    assert {:metadata_coverage_gap, _} =
+             catch_exit(Server.handle_info({:metadata_updates, {v(5), v(6), []}}, state(Metadata.new())))
+  end
+end

--- a/test/bedrock/data_plane/commit_proxy/sequencer_notification_test.exs
+++ b/test/bedrock/data_plane/commit_proxy/sequencer_notification_test.exs
@@ -29,7 +29,7 @@ defmodule Bedrock.DataPlane.CommitProxy.SequencerNotificationTest do
     [
       epoch: 1,
       resolver_layout: %ResolverLayout.Single{resolver_ref: :test_resolver},
-      resolver_fn: fn _, _, _, _, _, _, _ -> {:ok, [], []} end,
+      resolver_fn: fn _, _, _, _, _, _, _ -> {:ok, [], nil} end,
       batch_log_push_fn: fn _, _, _, _ -> :ok end
     ]
   end

--- a/test/bedrock/data_plane/commit_proxy/server_test.exs
+++ b/test/bedrock/data_plane/commit_proxy/server_test.exs
@@ -29,13 +29,14 @@ defmodule Bedrock.DataPlane.CommitProxy.ServerTest do
     def init(state), do: {:ok, state}
 
     def handle_call(
-          {:resolve_transactions, _epoch, {_last_version, _next_version}, _transactions, _metadata_per_tx},
+          {:resolve_transactions, _epoch, {_last_version, _next_version}, _transactions, _metadata_per_tx,
+           {_proxy_id, _acked_version}},
           _from,
           state
         ) do
       # Accept all transactions (no conflicts since we use unique keys in tests)
       # Return empty list = no aborted transaction indices, empty metadata updates
-      {:reply, {:ok, [], []}, state}
+      {:reply, {:ok, [], nil}, state}
     end
   end
 

--- a/test/bedrock/data_plane/resolver/metadata_accumulator_test.exs
+++ b/test/bedrock/data_plane/resolver/metadata_accumulator_test.exs
@@ -93,7 +93,7 @@ defmodule Bedrock.DataPlane.Resolver.MetadataAccumulatorTest do
     end
   end
 
-  describe "prune_before/2" do
+  describe "prune_through/2" do
     setup do
       acc =
         MetadataAccumulator.new()
@@ -105,29 +105,29 @@ defmodule Bedrock.DataPlane.Resolver.MetadataAccumulatorTest do
       {:ok, acc: acc}
     end
 
-    test "removes entries before specified version", %{acc: acc} do
-      acc = MetadataAccumulator.prune_before(acc, v(3))
+    test "removes entries at or below the specified version", %{acc: acc} do
+      acc = MetadataAccumulator.prune_through(acc, v(2))
 
       assert length(entries(acc)) == 2
       versions = Enum.map(entries(acc), fn {ver, _} -> ver end)
       assert versions == [v(3), v(4)]
     end
 
-    test "keeps all entries when pruning before first version", %{acc: acc} do
-      acc = MetadataAccumulator.prune_before(acc, v(0))
+    test "keeps all entries when pruning through a version before the first", %{acc: acc} do
+      acc = MetadataAccumulator.prune_through(acc, v(0))
 
       assert length(entries(acc)) == 4
     end
 
-    test "removes all entries when pruning at or after last version", %{acc: acc} do
-      acc = MetadataAccumulator.prune_before(acc, v(100))
+    test "removes all entries when pruning through the last version or later", %{acc: acc} do
+      acc = MetadataAccumulator.prune_through(acc, v(100))
 
       assert entries(acc) == []
     end
 
-    test "prune_before is idempotent", %{acc: acc} do
-      acc1 = MetadataAccumulator.prune_before(acc, v(2))
-      acc2 = MetadataAccumulator.prune_before(acc1, v(2))
+    test "prune_through is idempotent", %{acc: acc} do
+      acc1 = MetadataAccumulator.prune_through(acc, v(2))
+      acc2 = MetadataAccumulator.prune_through(acc1, v(2))
 
       assert acc1 == acc2
     end
@@ -147,7 +147,7 @@ defmodule Bedrock.DataPlane.Resolver.MetadataAccumulatorTest do
       assert length(updates) == 2
 
       # Prune old entries now that client is at v(3)
-      acc = MetadataAccumulator.prune_before(acc, v(2))
+      acc = MetadataAccumulator.prune_through(acc, v(1))
 
       # Add new mutations
       acc = MetadataAccumulator.append(acc, v(4), [{:set, <<0xFF, "d">>, "4"}])

--- a/test/bedrock/data_plane/resolver/metadata_window_distribution_test.exs
+++ b/test/bedrock/data_plane/resolver/metadata_window_distribution_test.exs
@@ -1,0 +1,272 @@
+defmodule Bedrock.DataPlane.Resolver.MetadataWindowDistributionTest do
+  @moduledoc """
+  Pins the resolver's metadata-window distribution protocol (bedrock-q67.16).
+
+  ## Protocol
+
+  Every resolve call carries a `metadata_ack: {proxy_id, applied_version}` -
+  the COMMIT PROXY SERVER's identity (stable per epoch, not the ephemeral
+  per-batch finalization task pid) and the highest window `to_version` that
+  proxy has confirmed applying. The resolver replies with a window
+  `{from_version, to_version, entries}` (or `nil` when there is nothing to
+  report) covering `(from_version, to_version]`.
+
+  Because differentials are computed from the CONFIRMED-applied version:
+
+  - a reply lost to a call timeout is simply re-sent on the proxy's next call
+    (progress only advances via acks - timeout-retry safe);
+  - two in-flight batches carrying the same ack receive overlapping windows,
+    so out-of-order arrival at the proxy is lossless by construction (the
+    proxy's per-entry version guard skips already-applied entries);
+  - once a proxy confirms, the window is pruned through the minimum confirmed
+    ack, and steady-state replies are `nil` - O(new updates) per batch.
+
+  Proxies not seen within the resolver's version retention are expired from
+  `proxy_progress` (bounding it to ~live proxies and unblocking pruning). A
+  returning laggard whose ack predates the pruned floor receives a window with
+  `from_version > its applied version` - the gap signal that forces the proxy
+  to fail fast rather than continue with silently incomplete metadata.
+  """
+  use ExUnit.Case, async: true
+
+  alias Bedrock.DataPlane.Resolver
+  alias Bedrock.DataPlane.Resolver.MetadataAccumulator
+  alias Bedrock.DataPlane.Resolver.Server, as: ResolverServer
+  alias Bedrock.DataPlane.Transaction
+  alias Bedrock.DataPlane.Version
+  alias Bedrock.SystemKeys.Values
+
+  defp start_resolver(opts \\ []) do
+    start_supervised!(
+      {ResolverServer,
+       [
+         lock_token: :crypto.strong_rand_bytes(32),
+         key_range: {"", <<0xFF, 0xFF>>},
+         epoch: 1,
+         last_version: Version.zero(),
+         director: self(),
+         cluster: __MODULE__
+       ] ++ opts}
+    )
+  end
+
+  defp encode_tx(key) do
+    Transaction.encode(%{
+      mutations: [{:set, key, "v"}],
+      read_conflicts: [],
+      write_conflicts: [{key, key <> <<0>>}]
+    })
+  end
+
+  # Resolve from a fresh pid, exactly like a commit proxy finalization task
+  # does - the metadata_ack carries the stable proxy identity, not this pid.
+  defp resolve_from_fresh_task(resolver, last_v, next_v, key, metadata, ack) do
+    parent = self()
+
+    spawn_link(fn ->
+      result =
+        Resolver.resolve_transactions(resolver, 1, last_v, next_v, [encode_tx(key)], [metadata], metadata_ack: ack)
+
+      send(parent, {:resolved, result})
+    end)
+
+    assert_receive {:resolved, result}, 2_000
+    result
+  end
+
+  defp v(n), do: Version.from_integer(n)
+
+  setup do
+    %{
+      proxy: spawn_link(fn -> Process.sleep(:infinity) end),
+      m1: {:set, <<0xFF, "/system/shard_keys/a">>, Values.encode_shard_key_entry(1, "")},
+      m2: {:set, <<0xFF, "/system/shard_keys/b">>, Values.encode_shard_key_entry(2, "")},
+      m3: {:set, <<0xFF, "/system/shard_keys/c">>, Values.encode_shard_key_entry(3, "")}
+    }
+  end
+
+  test "windows are differential against the acked version; quiescent batches carry no window", %{
+    proxy: proxy,
+    m1: m1,
+    m2: m2
+  } do
+    resolver = start_resolver()
+
+    assert {:ok, [], {nil, to1, [{to1_entry, [^m1]}]}} =
+             resolve_from_fresh_task(resolver, v(0), v(1), "k1", [m1], {proxy, nil})
+
+    assert to1 == v(1)
+    assert to1_entry == v(1)
+
+    # Proxy confirmed v(1): only the new update rides the next reply.
+    assert {:ok, [], {from2, to2, [{entry_v2, [^m2]}]}} =
+             resolve_from_fresh_task(resolver, v(1), v(2), "k2", [m2], {proxy, v(1)})
+
+    assert {from2, to2, entry_v2} == {v(1), v(2), v(2)}
+
+    # Quiescence: everything confirmed, no new metadata - no window at all.
+    assert {:ok, [], nil} = resolve_from_fresh_task(resolver, v(2), v(3), "k3", [], {proxy, v(2)})
+  end
+
+  test "unconfirmed updates are re-sent: a reply lost to a call timeout cannot open a gap", %{
+    proxy: proxy,
+    m1: m1,
+    m2: m2
+  } do
+    resolver = start_resolver()
+
+    assert {:ok, [], {nil, _, [{_, [^m1]}]}} = resolve_from_fresh_task(resolver, v(0), v(1), "k1", [m1], {proxy, nil})
+
+    # The proxy never applied the first window (call timed out; reply lost).
+    # Its next call carries the same ack - the resolver re-sends everything
+    # since the confirmed version, so the second window is a superset of the
+    # first and out-of-order arrival at the proxy is equally harmless.
+    assert {:ok, [], {nil, to2, [{e1, [^m1]}, {e2, [^m2]}]}} =
+             resolve_from_fresh_task(resolver, v(1), v(2), "k2", [m2], {proxy, nil})
+
+    assert {to2, e1, e2} == {v(2), v(1), v(2)}
+  end
+
+  test "proxy_progress is keyed by stable proxy identity and the window is pruned to confirmed progress", %{
+    proxy: proxy,
+    m1: m1,
+    m2: m2,
+    m3: m3
+  } do
+    # 1ms retention = 1000 versions; pruning is capped at the retention
+    # horizon, so drive the version stream past it.
+    resolver = start_resolver(version_retention_ms: 1)
+
+    assert {:ok, [], _} = resolve_from_fresh_task(resolver, v(0), v(1), "k1", [m1], {proxy, nil})
+    assert {:ok, [], _} = resolve_from_fresh_task(resolver, v(1), v(2), "k2", [m2], {proxy, v(1)})
+    assert {:ok, [], _} = resolve_from_fresh_task(resolver, v(2), v(2500), "k3", [m3], {proxy, v(2)})
+
+    state = :sys.get_state(resolver)
+
+    # One entry per proxy - not one per finalization task pid.
+    assert [{^proxy, {acked, last_seen}}] = Map.to_list(state.proxy_progress)
+    assert {acked, last_seen} == {v(2), v(2500)}
+
+    # Entries at or below the confirmed version (and older than the retention
+    # horizon) are pruned.
+    assert [{entry_version, [^m3]}] = MetadataAccumulator.entries(state.metadata_window)
+    assert entry_version == v(2500)
+  end
+
+  test "acks are monotone per proxy: a retried call carrying a stale ack neither regresses progress nor re-sends", %{
+    proxy: proxy,
+    m1: m1,
+    m2: m2
+  } do
+    resolver = start_resolver()
+
+    assert {:ok, [], {nil, _, [{_, [^m1]}]}} = resolve_from_fresh_task(resolver, v(0), v(1), "k1", [m1], {proxy, nil})
+    assert {:ok, [], {_, _, [{_, [^m2]}]}} = resolve_from_fresh_task(resolver, v(1), v(2), "k2", [m2], {proxy, v(1)})
+
+    # Proxy confirmed through v(2); window pruned through v(2).
+    assert {:ok, [], nil} = resolve_from_fresh_task(resolver, v(2), v(3), "k3", [], {proxy, v(2)})
+
+    # A late retry re-carries the OLD ack v(1) (its reply was lost before the
+    # proxy advanced). Recorded progress must not regress - the proxy already
+    # applied through v(2) - and the resolver serves from the recorded ack,
+    # so nothing is re-sent and no gap is signalled.
+    assert {:ok, [], nil} = resolve_from_fresh_task(resolver, v(3), v(4), "k4", [], {proxy, v(1)})
+
+    assert %{^proxy => {acked, _seen}} = :sys.get_state(resolver).proxy_progress
+    assert acked == v(2)
+  end
+
+  test "pruning is capped at the retention horizon: acks alone cannot discard entries a not-yet-seen proxy needs", %{
+    m1: m1
+  } do
+    # 1ms retention = 1000 versions. At epoch start one proxy can commit and
+    # ack metadata before another proxy's FIRST call ever reaches the
+    # resolver; only the retention cap keeps that entry alive for it.
+    resolver = start_resolver(version_retention_ms: 1)
+    proxy_a = spawn_link(fn -> Process.sleep(:infinity) end)
+    proxy_b = spawn_link(fn -> Process.sleep(:infinity) end)
+
+    assert {:ok, [], {nil, _, [{_, [^m1]}]}} =
+             resolve_from_fresh_task(resolver, v(0), v(1000), "k1", [m1], {proxy_a, nil})
+
+    # proxy_a confirms v(1000) while the entry is still inside the horizon
+    # (cutoff v(500)): the ack alone must NOT discard it.
+    assert {:ok, [], nil} = resolve_from_fresh_task(resolver, v(1000), v(1500), "k2", [], {proxy_a, v(1000)})
+
+    # proxy_b's first-ever call: full window, not a gap.
+    assert {:ok, [], {nil, to, [{entry_version, [^m1]}]}} =
+             resolve_from_fresh_task(resolver, v(1500), v(1600), "k3", [], {proxy_b, nil})
+
+    assert {to, entry_version} == {v(1600), v(1000)}
+  end
+
+  test "a returning expired proxy whose ack covers every discarded entry gets a differential, not a gap", %{
+    m1: m1
+  } do
+    # 1ms retention = 1000 versions. Only ONE metadata entry ever exists (at
+    # v(1)); proxy_a confirms it via a window whose to_version is far ahead
+    # (windows cover through the resolver's last_version, not the last entry).
+    resolver = start_resolver(version_retention_ms: 1)
+    proxy_a = spawn_link(fn -> Process.sleep(:infinity) end)
+    proxy_b = spawn_link(fn -> Process.sleep(:infinity) end)
+
+    assert {:ok, [], {nil, to_b, [{_, [^m1]}]}} =
+             resolve_from_fresh_task(resolver, v(0), v(1), "k1", [m1], {proxy_b, nil})
+
+    assert to_b == v(1)
+
+    # proxy_b confirms v(1), then goes quiet.
+    assert {:ok, [], nil} = resolve_from_fresh_task(resolver, v(1), v(2), "k2", [], {proxy_b, v(1)})
+
+    # proxy_a first calls late: its window covers (nil, v(1500)] with the same
+    # single entry, so it acks v(1500) - far beyond the entry's version.
+    assert {:ok, [], {nil, to_a, [{_, [^m1]}]}} =
+             resolve_from_fresh_task(resolver, v(2), v(1500), "k3", [], {proxy_a, nil})
+
+    assert to_a == v(1500)
+
+    # proxy_b (seen at v(2)) falls out of the horizon; pruning follows
+    # proxy_a's ack v(1500), discarding the entry at v(1).
+    assert {:ok, [], nil} = resolve_from_fresh_task(resolver, v(1500), v(3100), "k4", [], {proxy_a, v(1500)})
+
+    state = :sys.get_state(resolver)
+    refute Map.has_key?(state.proxy_progress, proxy_b)
+    assert MetadataAccumulator.entries(state.metadata_window) == []
+
+    # proxy_b returns with ack v(1): it confirmed the only entry ever
+    # discarded, so it missed NOTHING - it must get a plain (empty)
+    # differential, not a gap-marked window that would force a full recovery.
+    assert {:ok, [], nil} = resolve_from_fresh_task(resolver, v(3100), v(3200), "k5", [], {proxy_b, v(1)})
+  end
+
+  test "proxies not seen within version retention expire; a returning laggard gets a gap-marked window", %{
+    m1: m1,
+    m2: m2,
+    m3: m3
+  } do
+    # 1ms retention = 1000 versions (versions are microsecond-based).
+    resolver = start_resolver(version_retention_ms: 1)
+    proxy_a = spawn_link(fn -> Process.sleep(:infinity) end)
+    proxy_b = spawn_link(fn -> Process.sleep(:infinity) end)
+
+    assert {:ok, [], _} = resolve_from_fresh_task(resolver, v(0), v(1), "k1", [m1], {proxy_a, nil})
+    assert {:ok, [], _} = resolve_from_fresh_task(resolver, v(1), v(2), "k2", [], {proxy_b, nil})
+    assert {:ok, [], _} = resolve_from_fresh_task(resolver, v(2), v(3), "k3", [m2], {proxy_a, v(1)})
+
+    # proxy_b (last seen at v(2)) falls out of the retention horizon; pruning
+    # then follows proxy_a's confirmed progress alone.
+    assert {:ok, [], _} = resolve_from_fresh_task(resolver, v(3), v(5000), "k4", [m3], {proxy_a, v(3)})
+
+    state = :sys.get_state(resolver)
+    refute Map.has_key?(state.proxy_progress, proxy_b)
+    assert [{entry_version, [^m3]}] = MetadataAccumulator.entries(state.metadata_window)
+    assert entry_version == v(5000)
+
+    # proxy_b returns with an ack below the pruned floor: the window's
+    # from_version exceeds what proxy_b applied - the proxy-side gap signal.
+    assert {:ok, [], {from, to, [{_, [^m3]}]}} =
+             resolve_from_fresh_task(resolver, v(5000), v(5001), "k5", [], {proxy_b, nil})
+
+    assert {from, to} == {v(3), v(5001)}
+  end
+end

--- a/test/support/data_plane/finalization_test_support.ex
+++ b/test/support/data_plane/finalization_test_support.ex
@@ -46,12 +46,13 @@ defmodule Bedrock.Test.DataPlane.FinalizationTestSupport do
     def init(:ok), do: {:ok, %{}}
 
     def handle_call(
-          {:resolve_transactions, _epoch, {_last_version, _commit_version}, _transaction_summaries},
+          {:resolve_transactions, _epoch, {_last_version, _commit_version}, _transaction_summaries, _metadata_per_tx,
+           {_proxy_id, _acked_version}},
           _from,
           state
         ) do
-      # Return no conflicts (empty list) for simple test scenarios
-      {:reply, {:ok, []}, state}
+      # Return no conflicts and no metadata window for simple test scenarios
+      {:reply, {:ok, [], nil}, state}
     end
   end
 


### PR DESCRIPTION
## Why

The commit proxy needs a live, structured copy of the `\xFF/system` keyspace — it's how Phase B will let proxies answer "which shard owns this key" without the director spoon-feeding them ETS tables. Half of that pipeline already exists on develop: resolvers collect committed system-key mutations and hand them back on each resolve call. But the half that exists is broken in three compounding ways: the resolver tracks each proxy's progress by the *calling pid*, and every batch calls from a fresh finalization task — so the "last seen" is always nil, the **entire metadata history is re-sent with every batch**, the progress map **gains one dead pid per batch forever**, and pruning **never advances**. The proxy side then discards most of what arrives. Before the shard map can ride this pipe, the pipe has to actually work.

## What

- **A window protocol with real identity.** Each resolve call now carries `{proxy server pid, highest window version the proxy has confirmed applying}`. The resolver replies with a differential window `(confirmed, latest]` — or nothing, when the proxy is caught up.
- **Progress only advances on confirmation.** A reply lost to a timeout is simply re-sent on the proxy's next call; overlapping in-flight windows are harmless because the proxy skips already-applied versions. Nothing can be skipped, nothing needs replaying.
- **Bounded memory on both ends.** The resolver prunes its window through the minimum version *every* proxy has confirmed — capped at the version-retention horizon so a proxy the resolver hasn't heard from yet can never be handed a gap. Proxies silent past the horizon are expired so a dead proxy can't pin the window forever. If pruning ever does outrun a proxy (only possible after it was expired for lagging), the window says so and the proxy exits into director-driven recovery rather than silently missing metadata.
- **Structured metadata at the proxy.** A new `CommitProxy.Metadata` module folds windows — in the server process, so racing finalization tasks serialize — into a parsed view of every system-key family (shards, logs, services, cluster config), version-guarded so replays are no-ops, with unknown keys skipped and counted for forward compatibility.

## How

The proxy's finalization task passes the ack and a merge callback into `resolve_transactions`; the resolver records `{acked, last_seen}` per proxy server pid, appends committed system-key mutations to its accumulator, and computes each reply's window from the *recorded monotone* ack (a retried call may carry a stale one). Sharded resolvers each return their own window; the proxy merges conservatively — latest `from`, earliest `to`, entries deduplicated by version — so the merged ack never claims more than every resolver has actually served. The gap floor is recorded as the newest *entry* version ever discarded (not the prune version itself), so a laggard that confirmed everything discarded isn't spuriously failed into recovery.

An end-to-end integration test drives a real sequencer, resolver, and commit proxy: a committed system-key mutation lands in the resolver's accumulator and appears parsed in the proxy's state, keyed under the proxy server's stable identity. The protocol suite pins differential/empty steady-state windows, timeout-retry re-send, ack monotonicity, laggard expiry, and the gap fail-fast.

Ticket: bedrock-q67.20.4 · Port of bedrock-q67.15 + q67.16 (phase-a PRs #105/#106, gate-audited there; final state at d708ee4a — deliberately excludes q67.17's sharded hold/confirm, next in the stack) · TDD: ported protocol/integration tests first (15+ red), lib after; full suite 2617 green, credo --strict + dialyzer clean.