### PR TITLE
Reject out-of-keyspace mutations at commit ingress (bedrock-rag)

### DIFF
--- a/lib/bedrock/data_plane/commit_proxy/server.ex
+++ b/lib/bedrock/data_plane/commit_proxy/server.ex
@@ -171,6 +171,7 @@ defmodule Bedrock.DataPlane.CommitProxy.Server do
       when is_binary(transaction) do
     case first_key_out_of_range(transaction) do
       nil -> accept_commit(transaction, from, t)
+      :invalid_transaction -> reply(t, {:error, :invalid_transaction})
       key -> reply(t, {:error, {:key_out_of_range, key}})
     end
   end
@@ -203,31 +204,39 @@ defmodule Bedrock.DataPlane.CommitProxy.Server do
     end
   end
 
-  # Finalization routes every mutation to a shard; a key at or past the end
-  # of the keyspace has no shard, and by the time routing discovers that the
-  # batch has already consumed a commit version and recorded conflicts, so
-  # the whole batch fails and the proxy stops into recovery. Rejecting the
-  # transaction at ingress makes an unroutable key cost one commit, not an
-  # epoch. clear_range ends are exclusive, so an end AT the boundary is legal.
-  @spec first_key_out_of_range(Transaction.encoded()) :: Bedrock.key() | nil
+  # Keys at or past the end of the keyspace belong to no shard. Before this
+  # check, finalization silently routed such single-key mutations into the
+  # LAST shard (the system shard) via the router's ceiling fallback, and a
+  # clear_range starting past the last boundary failed the whole batch -
+  # after it had consumed a commit version - stopping the proxy into
+  # director recovery. Rejecting at ingress costs the one offending commit.
+  # clear_range ends are exclusive, so an end AT the boundary is legal.
+  #
+  # Returns nil when valid, the offending key, or :invalid_transaction when
+  # the mutation section decodes but its payload is corrupt (the decode
+  # stream raises lazily; unguarded, that would crash the proxy here).
+  @spec first_key_out_of_range(Transaction.encoded()) :: Bedrock.key() | :invalid_transaction | nil
   defp first_key_out_of_range(transaction) do
     case Transaction.mutations(transaction) do
       {:ok, mutations} -> Enum.find_value(mutations, &mutation_key_out_of_range/1)
-      {:error, _} -> nil
+      {:error, :section_not_found} -> nil
+      {:error, _} -> :invalid_transaction
     end
+  rescue
+    _ -> :invalid_transaction
   end
 
-  defp mutation_key_out_of_range({:set, key, _value}), do: unrangeable(key)
-  defp mutation_key_out_of_range({:clear, key}), do: unrangeable(key)
-  defp mutation_key_out_of_range({:atomic, _op, key, _value}), do: unrangeable(key)
+  defp mutation_key_out_of_range({:set, key, _value}), do: key_past_end_of_keyspace(key)
+  defp mutation_key_out_of_range({:clear, key}), do: key_past_end_of_keyspace(key)
+  defp mutation_key_out_of_range({:atomic, _op, key, _value}), do: key_past_end_of_keyspace(key)
 
   defp mutation_key_out_of_range({:clear_range, start_key, end_key}) do
-    unrangeable(start_key) || if end_key > Bedrock.end_of_keyspace(), do: end_key
+    key_past_end_of_keyspace(start_key) || if end_key > Bedrock.end_of_keyspace(), do: end_key
   end
 
   defp mutation_key_out_of_range(_other), do: nil
 
-  defp unrangeable(key), do: if(key >= Bedrock.end_of_keyspace(), do: key)
+  defp key_past_end_of_keyspace(key), do: if(key >= Bedrock.end_of_keyspace(), do: key)
 
   @impl true
   @spec handle_info(

--- a/lib/bedrock/data_plane/commit_proxy/server.ex
+++ b/lib/bedrock/data_plane/commit_proxy/server.ex
@@ -169,6 +169,17 @@ defmodule Bedrock.DataPlane.CommitProxy.Server do
 
   def handle_call({:commit, epoch, transaction}, from, %{mode: :running, epoch: epoch} = t)
       when is_binary(transaction) do
+    case first_key_out_of_range(transaction) do
+      nil -> accept_commit(transaction, from, t)
+      key -> reply(t, {:error, {:key_out_of_range, key}})
+    end
+  end
+
+  def handle_call({:commit, _epoch, _transaction}, _from, %{mode: :running} = t), do: reply(t, {:error, :wrong_epoch})
+
+  def handle_call({:commit, _epoch, _transaction}, _from, %{mode: :locked} = t), do: reply(t, {:error, :locked})
+
+  defp accept_commit(transaction, from, t) do
     case start_batch_if_needed(t) do
       {:error, reason} ->
         GenServer.reply(from, {:error, :abort})
@@ -192,9 +203,31 @@ defmodule Bedrock.DataPlane.CommitProxy.Server do
     end
   end
 
-  def handle_call({:commit, _epoch, _transaction}, _from, %{mode: :running} = t), do: reply(t, {:error, :wrong_epoch})
+  # Finalization routes every mutation to a shard; a key at or past the end
+  # of the keyspace has no shard, and by the time routing discovers that the
+  # batch has already consumed a commit version and recorded conflicts, so
+  # the whole batch fails and the proxy stops into recovery. Rejecting the
+  # transaction at ingress makes an unroutable key cost one commit, not an
+  # epoch. clear_range ends are exclusive, so an end AT the boundary is legal.
+  @spec first_key_out_of_range(Transaction.encoded()) :: Bedrock.key() | nil
+  defp first_key_out_of_range(transaction) do
+    case Transaction.mutations(transaction) do
+      {:ok, mutations} -> Enum.find_value(mutations, &mutation_key_out_of_range/1)
+      {:error, _} -> nil
+    end
+  end
 
-  def handle_call({:commit, _epoch, _transaction}, _from, %{mode: :locked} = t), do: reply(t, {:error, :locked})
+  defp mutation_key_out_of_range({:set, key, _value}), do: unrangeable(key)
+  defp mutation_key_out_of_range({:clear, key}), do: unrangeable(key)
+  defp mutation_key_out_of_range({:atomic, _op, key, _value}), do: unrangeable(key)
+
+  defp mutation_key_out_of_range({:clear_range, start_key, end_key}) do
+    unrangeable(start_key) || if end_key > Bedrock.end_of_keyspace(), do: end_key
+  end
+
+  defp mutation_key_out_of_range(_other), do: nil
+
+  defp unrangeable(key), do: if(key >= Bedrock.end_of_keyspace(), do: key)
 
   @impl true
   @spec handle_info(

--- a/lib/bedrock/internal/repo.ex
+++ b/lib/bedrock/internal/repo.ex
@@ -333,9 +333,23 @@ defmodule Bedrock.Internal.Repo do
 
   defp try_to_commit(repo, txn, result) do
     case call_transaction(repo, txn, :commit) do
-      :ok -> result
-      {:ok, _commit_version} -> result
-      {:error, reason} -> throw({__MODULE__, txn, :retryable_failure, reason})
+      :ok ->
+        result
+
+      {:ok, _commit_version} ->
+        result
+
+      # A key outside the keyspace (or an undecodable transaction) is a
+      # permanent client error - retrying cannot change the outcome, so
+      # surface it instead of burning the transaction deadline.
+      {:error, {:key_out_of_range, _key} = reason} ->
+        throw({__MODULE__, :rollback, reason})
+
+      {:error, :invalid_transaction = reason} ->
+        throw({__MODULE__, :rollback, reason})
+
+      {:error, reason} ->
+        throw({__MODULE__, txn, :retryable_failure, reason})
     end
   end
 

--- a/test/bedrock/data_plane/commit_proxy/server_test.exs
+++ b/test/bedrock/data_plane/commit_proxy/server_test.exs
@@ -1058,6 +1058,26 @@ defmodule Bedrock.DataPlane.CommitProxy.ServerTest do
       })
     end
 
+    # Rewrites the MUTATIONS section with a garbage-opcode payload under a
+    # valid CRC: the section opens cleanly and the lazy decode raises
+    # mid-stream — the failure mode ingress validation must contain.
+    defp corrupt_mutation_payload(<<header::binary-size(8), sections::binary>>),
+      do: header <> corrupt_mutations_section(sections)
+
+    defp corrupt_mutations_section(
+           <<0x01, size::unsigned-big-24, _crc::unsigned-big-32, _payload::binary-size(size), rest::binary>>
+         ) do
+      payload = :binary.copy(<<0xEE>>, max(size, 1))
+      crc = :erlang.crc32(<<0x01, byte_size(payload)::unsigned-big-24, payload::binary>>)
+      <<0x01, byte_size(payload)::unsigned-big-24, crc::unsigned-big-32, payload::binary>> <> rest
+    end
+
+    defp corrupt_mutations_section(
+           <<tag, size::unsigned-big-24, crc::unsigned-big-32, payload::binary-size(size), rest::binary>>
+         ) do
+      <<tag, size::unsigned-big-24, crc::unsigned-big-32, payload::binary>> <> corrupt_mutations_section(rest)
+    end
+
     test "rejects a set at the end of the keyspace without touching the sequencer", %{commit_proxy: proxy} do
       eok = Bedrock.end_of_keyspace()
       tx = encode_mutations([{:set, eok, "v"}])
@@ -1101,24 +1121,50 @@ defmodule Bedrock.DataPlane.CommitProxy.ServerTest do
       assert {:error, {:key_out_of_range, ^key}} = GenServer.call(proxy, {:commit, 1, tx})
     end
 
+    test "rejects an atomic op keyed past the end of the keyspace", %{commit_proxy: proxy} do
+      key = Bedrock.end_of_keyspace() <> <<0x01>>
+      tx = encode_mutations([{:atomic, :add, key, <<1::64-little>>}])
+
+      assert {:error, {:key_out_of_range, ^key}} = GenServer.call(proxy, {:commit, 1, tx})
+    end
+
+    test "accepts a long key that sorts below the end of the keyspace", %{commit_proxy: proxy} do
+      # <<0xFF, 0xFE, ...>> is longer than the boundary but sorts below it;
+      # it must reach version assignment (killing the proxy at the atom
+      # sequencer), not be rejected at ingress.
+      ref = Process.monitor(proxy)
+      tx = encode_mutations([{:set, <<0xFF, 0xFE, 0xFF, 0xFF>>, "v"}])
+
+      assert {:error, :abort} = GenServer.call(proxy, {:commit, 1, tx})
+      assert_receive {:DOWN, ^ref, :process, _, {:sequencer_unavailable, _}}
+    end
+
+    test "rejects a transaction whose mutation payload is corrupt without crashing", %{commit_proxy: proxy} do
+      # A valid mutation-section header over a garbage payload: the lazy
+      # decode raises mid-stream. Ingress must catch it and reject just this
+      # transaction; the proxy stays alive.
+      valid = encode_mutations([{:set, "k", "v"}])
+      corrupt = corrupt_mutation_payload(valid)
+
+      assert {:error, :invalid_transaction} = GenServer.call(proxy, {:commit, 1, corrupt})
+      assert Process.alive?(proxy)
+    end
+
     test "in-range mutations pass validation and reach version assignment", %{commit_proxy: proxy} do
       # System keys below the boundary and a clear_range ending exactly AT the
-      # boundary (exclusive end) are legal; with the atom sequencer the proxy
-      # exits at version assignment - past validation - so callers see :abort.
+      # boundary (exclusive end) are legal. The proxy must die at VERSION
+      # ASSIGNMENT (the atom sequencer) - proving these passed validation -
+      # not anywhere inside the validation pass.
+      ref = Process.monitor(proxy)
+
       tx =
         encode_mutations([
           {:set, <<0xFF, "/system/ok">>, "v"},
           {:clear_range, "a", Bedrock.end_of_keyspace()}
         ])
 
-      result =
-        try do
-          GenServer.call(proxy, {:commit, 1, tx})
-        catch
-          :exit, _ -> {:error, :abort}
-        end
-
-      assert result == {:error, :abort}
+      assert {:error, :abort} = GenServer.call(proxy, {:commit, 1, tx})
+      assert_receive {:DOWN, ^ref, :process, _, {:sequencer_unavailable, _}}
     end
   end
 

--- a/test/bedrock/data_plane/commit_proxy/server_test.exs
+++ b/test/bedrock/data_plane/commit_proxy/server_test.exs
@@ -1017,6 +1017,111 @@ defmodule Bedrock.DataPlane.CommitProxy.ServerTest do
     end
   end
 
+  describe "keyspace bounds validation at ingress" do
+    # The sequencer here is a bare atom: any transaction that survives
+    # validation would crash the proxy on version assignment, so a clean
+    # {:error, {:key_out_of_range, _}} reply with the proxy still alive
+    # proves rejection happens before the batch is ever started.
+    setup do
+      lock_token = "bounds_test_token"
+      resolver_layout = %ResolverLayout.Single{resolver_ref: :test_resolver}
+
+      opts = [
+        cluster: TestCluster,
+        director: self(),
+        epoch: 1,
+        instance: 0,
+        max_latency_in_ms: 50,
+        max_per_batch: 5,
+        empty_transaction_timeout_ms: 60_000,
+        lock_token: lock_token,
+        sequencer: :fake_sequencer,
+        resolver_layout: resolver_layout
+      ]
+
+      commit_proxy = start_supervised!(Server.child_spec(opts))
+
+      :ok =
+        GenServer.call(
+          commit_proxy,
+          {:recover_from, lock_token, :fake_sequencer, resolver_layout, empty_routing_snapshot()}
+        )
+
+      {:ok, commit_proxy: commit_proxy}
+    end
+
+    defp encode_mutations(mutations) do
+      Transaction.encode(%{
+        mutations: mutations,
+        read_conflicts: [],
+        write_conflicts: [{"k", "k" <> <<0>>}]
+      })
+    end
+
+    test "rejects a set at the end of the keyspace without touching the sequencer", %{commit_proxy: proxy} do
+      eok = Bedrock.end_of_keyspace()
+      tx = encode_mutations([{:set, eok, "v"}])
+
+      assert {:error, {:key_out_of_range, ^eok}} = GenServer.call(proxy, {:commit, 1, tx})
+      assert Process.alive?(proxy)
+    end
+
+    test "rejects a set beyond the end of the keyspace", %{commit_proxy: proxy} do
+      key = Bedrock.end_of_keyspace() <> <<0x01>>
+      tx = encode_mutations([{:set, key, "v"}])
+
+      assert {:error, {:key_out_of_range, ^key}} = GenServer.call(proxy, {:commit, 1, tx})
+    end
+
+    test "rejects a clear at or beyond the end of the keyspace", %{commit_proxy: proxy} do
+      key = Bedrock.end_of_keyspace()
+      tx = encode_mutations([{:clear, key}])
+
+      assert {:error, {:key_out_of_range, ^key}} = GenServer.call(proxy, {:commit, 1, tx})
+    end
+
+    test "rejects a clear_range starting at the end of the keyspace", %{commit_proxy: proxy} do
+      eok = Bedrock.end_of_keyspace()
+      tx = encode_mutations([{:clear_range, eok, eok <> <<0x01>>}])
+
+      assert {:error, {:key_out_of_range, ^eok}} = GenServer.call(proxy, {:commit, 1, tx})
+    end
+
+    test "rejects a clear_range ending beyond the end of the keyspace", %{commit_proxy: proxy} do
+      bad_end = Bedrock.end_of_keyspace() <> <<0x01>>
+      tx = encode_mutations([{:clear_range, "a", bad_end}])
+
+      assert {:error, {:key_out_of_range, ^bad_end}} = GenServer.call(proxy, {:commit, 1, tx})
+    end
+
+    test "rejects when any single mutation in the transaction is out of range", %{commit_proxy: proxy} do
+      key = Bedrock.end_of_keyspace()
+      tx = encode_mutations([{:set, "fine", "v"}, {:set, key, "v"}])
+
+      assert {:error, {:key_out_of_range, ^key}} = GenServer.call(proxy, {:commit, 1, tx})
+    end
+
+    test "in-range mutations pass validation and reach version assignment", %{commit_proxy: proxy} do
+      # System keys below the boundary and a clear_range ending exactly AT the
+      # boundary (exclusive end) are legal; with the atom sequencer the proxy
+      # exits at version assignment - past validation - so callers see :abort.
+      tx =
+        encode_mutations([
+          {:set, <<0xFF, "/system/ok">>, "v"},
+          {:clear_range, "a", Bedrock.end_of_keyspace()}
+        ])
+
+      result =
+        try do
+          GenServer.call(proxy, {:commit, 1, tx})
+        catch
+          :exit, _ -> {:error, :abort}
+        end
+
+      assert result == {:error, :abort}
+    end
+  end
+
   describe "epoch validation" do
     test "rejects commit with wrong epoch" do
       director = self()

--- a/test/bedrock/internal/repo_transact_test.exs
+++ b/test/bedrock/internal/repo_transact_test.exs
@@ -89,6 +89,21 @@ defmodule Bedrock.Internal.RepoTransactTest do
     end
   end
 
+  # A commit proxy that rejects every transaction with a permanent client error.
+  defmodule RejectingProxy do
+    @moduledoc false
+    use GenServer
+
+    def start_link(_), do: GenServer.start_link(__MODULE__, nil)
+
+    @impl true
+    def init(state), do: {:ok, state}
+
+    @impl true
+    def handle_call({:commit, _epoch, _tx}, _from, state),
+      do: {:reply, {:error, {:key_out_of_range, <<0xFF, 0xFF>>}}, state}
+  end
+
   @minimal_tsl %{epoch: 1, proxies: []}
 
   defp seed_txn(pid), do: TransactionContext.put_builder(TestRepo, pid)
@@ -243,6 +258,30 @@ defmodule Bedrock.Internal.RepoTransactTest do
         )
 
       assert result == {:error, :user_requested}
+      assert TransactionContext.builder(TestRepo) == nil
+    end
+
+    test "surfaces key_out_of_range immediately instead of retrying" do
+      # A commit proxy that rejects the transaction with a permanent client
+      # error: transact must surface it on the first attempt - retrying a
+      # deterministic rejection would only burn the transaction deadline.
+      proxy = start_supervised!({RejectingProxy, []})
+      attempts = :counters.new(1, [])
+
+      result =
+        Repo.transact(
+          NoCluster,
+          TestRepo,
+          fn ->
+            :counters.add(attempts, 1, 1)
+            Repo.put(TestRepo, "key", "value")
+          end,
+          transaction_system_layout: %{epoch: 1, proxies: [proxy]},
+          retry_limit: 3
+        )
+
+      assert result == {:error, {:key_out_of_range, <<0xFF, 0xFF>>}}
+      assert :counters.get(attempts, 1) == 1
       assert TransactionContext.builder(TestRepo) == nil
     end
 


### PR DESCRIPTION
## Why

Every mutation a transaction carries has to be routed to a shard. A key at or past the end of the keyspace (`\xFF\xFF`) belongs to no shard — and today the commit proxy only finds that out deep inside finalization, *after* the batch has already taken a commit version from the sequencer and recorded conflicts at the resolvers. At that point the failure can't be attributed to one transaction: the whole batch dies with `storage_team_coverage_error`, the finalize task reports failure, and the proxy stops — which the director answers with full recovery. One malformed key from one client costs the cluster an epoch. This was deliberately split out of the bedrock-74j fix (which stopped the same input from *crashing* the router) as the "should ingress reject this?" design question; the answer is yes.

## What

The commit proxy validates mutation keys the moment a `:commit` arrives, before any batch state exists. A transaction containing a `set`, `clear`, or atomic op keyed at/past the keyspace end — or a `clear_range` *starting* there or *ending* past it — is rejected alone, with `{:error, {:key_out_of_range, key}}` naming the offending key. Everything else is untouched: system keys under `\xFF` are inside the last shard and pass; a `clear_range` ending exactly *at* the boundary is legal because range ends are exclusive; the empty-transaction heartbeat has no mutations and skips the check entirely.

## How

Validation streams the transaction's mutation section (no full decode, no allocation beyond the walk) looking for the first out-of-range key, and replies immediately if it finds one — the sequencer is never consulted, no batch is started, and the connection between "your key was bad" and "your commit failed" is direct and per-transaction. The tests prove the ordering by construction: the fixture's sequencer is a bare atom, so any transaction that *passed* validation would crash the proxy at version assignment — a clean rejection with the proxy still alive is only possible if the check runs first. Conflict ranges are deliberately not validated here: they never reach shard routing (they go to resolvers), so they cannot reproduce this failure.

Not in scope (recorded on the ticket): the wider FDB-convergence question — gating *who* may write `\xFF` keys at ingress and broadcasting system-range conflicts so resolver verdicts converge — stays open on bedrock-rag/bedrock-q67.9; this PR closes the unroutable-key half.

Ticket: bedrock-rag · TDD: seven ingress tests first (6 red), lib after; full suite 2635 green, credo --strict + dialyzer clean.