### PR TITLE
Gate system-keyspace writes behind system-mode commits

### DIFF
--- a/.github/workflows/elixir_ci.yaml
+++ b/.github/workflows/elixir_ci.yaml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ "main", "develop" ]
   pull_request:
-    branches: [ "main", "develop", "feature/q67-phase-b-prereqs", "q67.20**" ]
+    branches: [ "main", "develop", "feature/q67-phase-b-prereqs", "q67**", "rag**" ]
   workflow_dispatch:
   schedule:
     - cron: "0 7 * * 1"

--- a/lib/bedrock.ex
+++ b/lib/bedrock.ex
@@ -65,10 +65,25 @@ defmodule Bedrock do
   This binary value is lexicographically greater than any valid key and is used
   to represent unbounded key ranges. For ergonomics, the atom `:end` is also
   accepted in the public API and is automatically converted to this sentinel.
+
+  This sentinel bounds *reads* and *system-mode commits*. A user-mode
+  `clear_range` may end no later than `end_of_user_keyspace/0` — an end past
+  it is rejected at commit ingress with `{:key_out_of_range, key}`.
   """
   @end_of_keyspace <<0xFF, 0xFF>>
   @spec end_of_keyspace() :: key()
   def end_of_keyspace, do: @end_of_keyspace
+
+  @doc """
+  The exclusive upper bound of the user-writable keyspace.
+
+  Every key at or above this value is reserved for system metadata and may
+  only be written by system-mode commits. It is a valid exclusive end for a
+  user `clear_range`, mirroring how `end_of_keyspace/0` bounds system commits.
+  """
+  @end_of_user_keyspace <<0xFF>>
+  @spec end_of_user_keyspace() :: key()
+  def end_of_user_keyspace, do: @end_of_user_keyspace
 
   @doc """
   Creates a key range from a minimum inclusive key to a maximum exclusive key.

--- a/lib/bedrock/control_plane/director/recovery/persistence_phase.ex
+++ b/lib/bedrock/control_plane/director/recovery/persistence_phase.ex
@@ -353,10 +353,14 @@ defmodule Bedrock.ControlPlane.Director.Recovery.PersistencePhase do
   defp submit_system_transaction(_system_transaction, [], _epoch, _context), do: {:error, :no_commit_proxies}
 
   defp submit_system_transaction(encoded_transaction, proxies, epoch, context) when is_list(proxies) do
-    commit_fn = Map.get(context, :commit_transaction_fn, &CommitProxy.commit/3)
+    commit_fn = Map.get(context, :commit_transaction_fn, &commit_in_system_mode/3)
 
     proxies
     |> Enum.random()
     |> commit_fn.(epoch, encoded_transaction)
   end
+
+  # Recovery is a system writer: user-mode commits cannot touch \xFF keys.
+  defp commit_in_system_mode(proxy, epoch, encoded_transaction),
+    do: CommitProxy.commit(proxy, epoch, encoded_transaction, mode: :system)
 end

--- a/lib/bedrock/data_plane/commit_proxy.ex
+++ b/lib/bedrock/data_plane/commit_proxy.ex
@@ -46,8 +46,36 @@ defmodule Bedrock.DataPlane.CommitProxy do
   def recover_from(commit_proxy, lock_token, sequencer, resolver_layout, routing_snapshot),
     do: call(commit_proxy, {:recover_from, lock_token, sequencer, resolver_layout, routing_snapshot}, :infinity)
 
-  @spec commit(commit_proxy_ref :: ref(), epoch :: Bedrock.epoch(), transaction :: Transaction.encoded()) ::
+  @doc """
+  Submits a transaction for commit.
+
+  By default the commit is bounded to the user keyspace: any mutation keyed
+  at or above `Bedrock.end_of_user_keyspace()` is rejected at ingress.
+  Passing `mode: :system` extends the legal range to
+  `Bedrock.end_of_keyspace()`, admitting writes to `\\xFF` system keys. The
+  mode is asserted by the caller — like FoundationDB's `ACCESS_SYSTEM_KEYS`
+  option it guards against accidental system writes, not hostile ones. Only
+  system components (recovery's persistence phase, and eventually the
+  Distributor) commit in system mode.
+
+  Atomic operations on system keys are rejected in every mode: the metadata
+  pipeline replays only sets and clears, so an atomic would let durable
+  state diverge from every metadata view built from the commit stream.
+  """
+  @spec commit(
+          commit_proxy_ref :: ref(),
+          epoch :: Bedrock.epoch(),
+          transaction :: Transaction.encoded(),
+          opts :: [mode: :user | :system]
+        ) ::
           {:ok, version :: Bedrock.version(), index :: non_neg_integer()}
-          | {:error, :wrong_epoch | :timeout | :unavailable}
-  def commit(commit_proxy, epoch, transaction), do: call(commit_proxy, {:commit, epoch, transaction}, :infinity)
+          | {:error, :wrong_epoch | :locked | :abort | :timeout | :unavailable}
+          | {:error, {:key_out_of_range | :atomic_on_system_key, Bedrock.key()}}
+          | {:error, :invalid_transaction}
+  def commit(commit_proxy, epoch, transaction, opts \\ []) do
+    case Keyword.get(opts, :mode, :user) do
+      mode when mode in [:user, :system] -> call(commit_proxy, {:commit, epoch, transaction, mode}, :infinity)
+      other -> raise ArgumentError, "invalid commit mode: #{inspect(other)}"
+    end
+  end
 end

--- a/lib/bedrock/data_plane/commit_proxy/server.ex
+++ b/lib/bedrock/data_plane/commit_proxy/server.ex
@@ -144,7 +144,8 @@ defmodule Bedrock.DataPlane.CommitProxy.Server do
   @impl true
   @spec handle_call(
           {:recover_from, binary(), pid(), ResolverLayout.t(), RoutingData.snapshot()}
-          | {:commit, Bedrock.transaction()},
+          | {:commit, Bedrock.epoch(), Bedrock.transaction()}
+          | {:commit, Bedrock.epoch(), Bedrock.transaction(), :user | :system},
           GenServer.from(),
           State.t()
         ) ::
@@ -167,18 +168,23 @@ defmodule Bedrock.DataPlane.CommitProxy.Server do
     end
   end
 
-  def handle_call({:commit, epoch, transaction}, from, %{mode: :running, epoch: epoch} = t)
-      when is_binary(transaction) do
-    case first_key_out_of_range(transaction) do
+  def handle_call({:commit, epoch, transaction}, from, t),
+    do: handle_call({:commit, epoch, transaction, :user}, from, t)
+
+  def handle_call({:commit, epoch, transaction, commit_mode}, from, %{mode: :running, epoch: epoch} = t)
+      when is_binary(transaction) and commit_mode in [:user, :system] do
+    case first_rejected_mutation(transaction, commit_mode) do
       nil -> accept_commit(transaction, from, t)
       :invalid_transaction -> reply(t, {:error, :invalid_transaction})
-      key -> reply(t, {:error, {:key_out_of_range, key}})
+      {reason, key} -> reply(t, {:error, {reason, key}})
     end
   end
 
-  def handle_call({:commit, _epoch, _transaction}, _from, %{mode: :running} = t), do: reply(t, {:error, :wrong_epoch})
+  def handle_call({:commit, _epoch, _transaction, _commit_mode}, _from, %{mode: :running} = t),
+    do: reply(t, {:error, :wrong_epoch})
 
-  def handle_call({:commit, _epoch, _transaction}, _from, %{mode: :locked} = t), do: reply(t, {:error, :locked})
+  def handle_call({:commit, _epoch, _transaction, _commit_mode}, _from, %{mode: :locked} = t),
+    do: reply(t, {:error, :locked})
 
   defp accept_commit(transaction, from, t) do
     case start_batch_if_needed(t) do
@@ -204,21 +210,32 @@ defmodule Bedrock.DataPlane.CommitProxy.Server do
     end
   end
 
-  # Keys at or past the end of the keyspace belong to no shard. Before this
+  # The legal write range depends on who is committing: user commits end at
+  # the system boundary, system commits at the end of the keyspace. Keys past
+  # the commit's bound belong to no shard the caller may touch. Before this
   # check, finalization silently routed such single-key mutations into the
   # LAST shard (the system shard) via the router's ceiling fallback, and a
   # clear_range starting past the last boundary failed the whole batch -
   # after it had consumed a commit version - stopping the proxy into
   # director recovery. Rejecting at ingress costs the one offending commit.
-  # clear_range ends are exclusive, so an end AT the boundary is legal.
+  # clear_range ends are exclusive, so an end AT the bound is legal.
   #
-  # Returns nil when valid, the offending key, or :invalid_transaction when
-  # the mutation section decodes but its payload is corrupt (the decode
-  # stream raises lazily; unguarded, that would crash the proxy here).
-  @spec first_key_out_of_range(Transaction.encoded()) :: Bedrock.key() | :invalid_transaction | nil
-  defp first_key_out_of_range(transaction) do
+  # Atomics on system keys are rejected in EVERY mode: the metadata pipeline
+  # (Metadata, RoutingData, and every view fed by the commit stream) replays
+  # only sets and clears, while the materializer would apply the atomic
+  # durably - the two copies of truth would silently diverge.
+  #
+  # Returns nil when valid, {reason, key} for the offending mutation, or
+  # :invalid_transaction when the mutation section decodes but its payload
+  # is corrupt (the decode stream raises lazily; unguarded, that would
+  # crash the proxy here).
+  @spec first_rejected_mutation(Transaction.encoded(), :user | :system) ::
+          {:key_out_of_range | :atomic_on_system_key, Bedrock.key()} | :invalid_transaction | nil
+  defp first_rejected_mutation(transaction, commit_mode) do
+    bound = keyspace_bound(commit_mode)
+
     case Transaction.mutations(transaction) do
-      {:ok, mutations} -> Enum.find_value(mutations, &mutation_key_out_of_range/1)
+      {:ok, mutations} -> Enum.find_value(mutations, &rejected_mutation(&1, bound))
       {:error, :section_not_found} -> nil
       {:error, _} -> :invalid_transaction
     end
@@ -226,17 +243,25 @@ defmodule Bedrock.DataPlane.CommitProxy.Server do
     _ -> :invalid_transaction
   end
 
-  defp mutation_key_out_of_range({:set, key, _value}), do: key_past_end_of_keyspace(key)
-  defp mutation_key_out_of_range({:clear, key}), do: key_past_end_of_keyspace(key)
-  defp mutation_key_out_of_range({:atomic, _op, key, _value}), do: key_past_end_of_keyspace(key)
+  defp keyspace_bound(:user), do: Bedrock.end_of_user_keyspace()
+  defp keyspace_bound(:system), do: Bedrock.end_of_keyspace()
 
-  defp mutation_key_out_of_range({:clear_range, start_key, end_key}) do
-    key_past_end_of_keyspace(start_key) || if end_key > Bedrock.end_of_keyspace(), do: end_key
+  defp rejected_mutation({:set, key, _value}, bound), do: key_past_bound(key, bound)
+  defp rejected_mutation({:clear, key}, bound), do: key_past_bound(key, bound)
+
+  defp rejected_mutation({:atomic, _op, key, _value}, bound) do
+    key_past_bound(key, bound) ||
+      if key >= Bedrock.end_of_user_keyspace(), do: {:atomic_on_system_key, key}
   end
 
-  defp mutation_key_out_of_range(_other), do: nil
+  # No catch-all clause: a mutation shape this validator does not know is
+  # caught by the rescue above and rejected as :invalid_transaction, so a
+  # future mutation type fails closed instead of bypassing the gate.
+  defp rejected_mutation({:clear_range, start_key, end_key}, bound) do
+    key_past_bound(start_key, bound) || if end_key > bound, do: {:key_out_of_range, end_key}
+  end
 
-  defp key_past_end_of_keyspace(key), do: if(key >= Bedrock.end_of_keyspace(), do: key)
+  defp key_past_bound(key, bound), do: if(key >= bound, do: {:key_out_of_range, key})
 
   @impl true
   @spec handle_info(

--- a/lib/bedrock/internal/repo.ex
+++ b/lib/bedrock/internal/repo.ex
@@ -339,10 +339,14 @@ defmodule Bedrock.Internal.Repo do
       {:ok, _commit_version} ->
         result
 
-      # A key outside the keyspace (or an undecodable transaction) is a
-      # permanent client error - retrying cannot change the outcome, so
-      # surface it instead of burning the transaction deadline.
+      # A key outside the caller's legal range, an atomic op aimed at a
+      # system key, or an undecodable transaction is a permanent client
+      # error - retrying cannot change the outcome, so surface it instead
+      # of burning the transaction deadline.
       {:error, {:key_out_of_range, _key} = reason} ->
+        throw({__MODULE__, :rollback, reason})
+
+      {:error, {:atomic_on_system_key, _key} = reason} ->
         throw({__MODULE__, :rollback, reason})
 
       {:error, :invalid_transaction = reason} ->

--- a/test/bedrock/control_plane/director/recovery/persistence_phase_test.exs
+++ b/test/bedrock/control_plane/director/recovery/persistence_phase_test.exs
@@ -110,6 +110,34 @@ defmodule Bedrock.ControlPlane.Director.Recovery.PersistencePhaseTest do
       assert %{"log_1" => %{status: :unknown}} = decoded[:layout_services]
       assert decoded[{:layout_log, "log_1"}] == [1, 2]
     end
+
+    test "commits the system transaction in system mode by default" do
+      # Without an injected commit fn, the phase must reach the proxy through
+      # the system-mode commit path: user-mode commits cannot write \xFF keys.
+      test_pid = self()
+
+      stub_proxy =
+        spawn_link(fn ->
+          receive do
+            {:"$gen_call", from, {:commit, epoch, encoded_transaction, mode}} ->
+              send(test_pid, {:committed, epoch, encoded_transaction, mode})
+              GenServer.reply(from, {:ok, 1, 0})
+          end
+        end)
+
+      recovery_attempt =
+        base_recovery_attempt()
+        |> with_proxies([stub_proxy])
+        |> put_in([Access.key!(:transaction_system_layout), :proxies], [stub_proxy])
+
+      assert {_, :completed} = PersistencePhase.execute(recovery_attempt, recovery_context())
+      assert_received {:committed, _epoch, encoded_transaction, :system}
+
+      assert Enum.any?(Transaction.mutations!(encoded_transaction), fn
+               {:set, <<0xFF, _::binary>>, _} -> true
+               _ -> false
+             end)
+    end
   end
 
   # Capture the mutations of the system transaction PersistencePhase commits.

--- a/test/bedrock/data_plane/commit_proxy/metadata_distribution_integration_test.exs
+++ b/test/bedrock/data_plane/commit_proxy/metadata_distribution_integration_test.exs
@@ -114,8 +114,11 @@ defmodule Bedrock.DataPlane.CommitProxy.MetadataDistributionIntegrationTest do
     })
   end
 
+  # System mode: these transactions write \xFF metadata keys, which
+  # user-mode commits are rejected for at ingress.
   defp commit!(proxy, epoch, mutations, conflict_key) do
-    assert {:ok, version, _index} = GenServer.call(proxy, {:commit, epoch, encode_tx(mutations, conflict_key)}, 5_000)
+    assert {:ok, version, _index} =
+             GenServer.call(proxy, {:commit, epoch, encode_tx(mutations, conflict_key), :system}, 5_000)
 
     version
   end

--- a/test/bedrock/data_plane/commit_proxy/server_test.exs
+++ b/test/bedrock/data_plane/commit_proxy/server_test.exs
@@ -1128,14 +1128,24 @@ defmodule Bedrock.DataPlane.CommitProxy.ServerTest do
       assert {:error, {:key_out_of_range, ^key}} = GenServer.call(proxy, {:commit, 1, tx})
     end
 
-    test "accepts a long key that sorts below the end of the keyspace", %{commit_proxy: proxy} do
-      # <<0xFF, 0xFE, ...>> is longer than the boundary but sorts below it;
+    test "accepts a long user key that sorts below the system boundary", %{commit_proxy: proxy} do
+      # <<0xFE, 0xFF, ...>> is longer than the boundary but sorts below it;
       # it must reach version assignment (killing the proxy at the atom
       # sequencer), not be rejected at ingress.
       ref = Process.monitor(proxy)
-      tx = encode_mutations([{:set, <<0xFF, 0xFE, 0xFF, 0xFF>>, "v"}])
+      tx = encode_mutations([{:set, <<0xFE, 0xFF, 0xFF, 0xFF>>, "v"}])
 
       assert {:error, :abort} = GenServer.call(proxy, {:commit, 1, tx})
+      assert_receive {:DOWN, ^ref, :process, _, {:sequencer_unavailable, _}}
+    end
+
+    test "accepts a long system key that sorts below the end of the keyspace", %{commit_proxy: proxy} do
+      # Same length-vs-order check at the system bound: <<0xFF, 0xFE, ...>>
+      # sorts below <<0xFF, 0xFF>> despite being longer.
+      ref = Process.monitor(proxy)
+      tx = encode_mutations([{:set, <<0xFF, 0xFE, 0xFF, 0xFF>>, "v"}])
+
+      assert {:error, :abort} = GenServer.call(proxy, {:commit, 1, tx, :system})
       assert_receive {:DOWN, ^ref, :process, _, {:sequencer_unavailable, _}}
     end
 
@@ -1150,11 +1160,58 @@ defmodule Bedrock.DataPlane.CommitProxy.ServerTest do
       assert Process.alive?(proxy)
     end
 
-    test "in-range mutations pass validation and reach version assignment", %{commit_proxy: proxy} do
-      # System keys below the boundary and a clear_range ending exactly AT the
-      # boundary (exclusive end) are legal. The proxy must die at VERSION
-      # ASSIGNMENT (the atom sequencer) - proving these passed validation -
-      # not anywhere inside the validation pass.
+    test "in-range user mutations pass validation and reach version assignment", %{commit_proxy: proxy} do
+      # Keys below the system boundary and a clear_range ending exactly AT
+      # the boundary (exclusive end) are legal for user commits. The proxy
+      # must die at VERSION ASSIGNMENT (the atom sequencer) - proving these
+      # passed validation - not anywhere inside the validation pass.
+      ref = Process.monitor(proxy)
+
+      tx =
+        encode_mutations([
+          {:set, "user/ok", "v"},
+          {:atomic, :add, "user/counter", <<1::64-little>>},
+          {:clear_range, "a", Bedrock.end_of_user_keyspace()}
+        ])
+
+      assert {:error, :abort} = GenServer.call(proxy, {:commit, 1, tx})
+      assert_receive {:DOWN, ^ref, :process, _, {:sequencer_unavailable, _}}
+    end
+
+    test "rejects a user commit that writes a system key", %{commit_proxy: proxy} do
+      key = <<0xFF, "/system/shard_keys/x">>
+      tx = encode_mutations([{:set, key, "v"}])
+
+      assert {:error, {:key_out_of_range, ^key}} = GenServer.call(proxy, {:commit, 1, tx})
+      assert Process.alive?(proxy)
+    end
+
+    test "rejects a user clear that targets the reserved range below the system prefix", %{commit_proxy: proxy} do
+      # The whole range at and above <<0xFF>> is reserved, not just \xff/system.
+      key = <<0xFF, 0x00>>
+      tx = encode_mutations([{:clear, key}])
+
+      assert {:error, {:key_out_of_range, ^key}} = GenServer.call(proxy, {:commit, 1, tx})
+    end
+
+    test "rejects a user clear_range that crosses into system space", %{commit_proxy: proxy} do
+      bad_end = <<0xFF, 0x00>>
+      tx = encode_mutations([{:clear_range, "a", bad_end}])
+
+      assert {:error, {:key_out_of_range, ^bad_end}} = GenServer.call(proxy, {:commit, 1, tx})
+    end
+
+    test "rejects a user clear_range starting at the system boundary", %{commit_proxy: proxy} do
+      boundary = Bedrock.end_of_user_keyspace()
+      tx = encode_mutations([{:clear_range, boundary, boundary <> <<0x01>>}])
+
+      assert {:error, {:key_out_of_range, ^boundary}} = GenServer.call(proxy, {:commit, 1, tx})
+    end
+
+    test "system-mode commits may write system keys", %{commit_proxy: proxy} do
+      # A system commit's legal range extends to the end of the keyspace: the
+      # set on a system key and the clear_range ending AT the end of the
+      # keyspace must both reach version assignment.
       ref = Process.monitor(proxy)
 
       tx =
@@ -1163,8 +1220,30 @@ defmodule Bedrock.DataPlane.CommitProxy.ServerTest do
           {:clear_range, "a", Bedrock.end_of_keyspace()}
         ])
 
-      assert {:error, :abort} = GenServer.call(proxy, {:commit, 1, tx})
+      assert {:error, :abort} = GenServer.call(proxy, {:commit, 1, tx, :system})
       assert_receive {:DOWN, ^ref, :process, _, {:sequencer_unavailable, _}}
+    end
+
+    test "system mode is still bounded by the end of the keyspace", %{commit_proxy: proxy} do
+      eok = Bedrock.end_of_keyspace()
+      tx = encode_mutations([{:set, eok, "v"}])
+
+      assert {:error, {:key_out_of_range, ^eok}} = GenServer.call(proxy, {:commit, 1, tx, :system})
+      assert Process.alive?(proxy)
+    end
+
+    test "rejects atomics on system keys even in system mode", %{commit_proxy: proxy} do
+      key = <<0xFF, "/system/counter">>
+      tx = encode_mutations([{:atomic, :add, key, <<1::64-little>>}])
+
+      assert {:error, {:atomic_on_system_key, ^key}} = GenServer.call(proxy, {:commit, 1, tx, :system})
+      assert Process.alive?(proxy)
+    end
+
+    test "system-mode commits respect epoch and lock checks", %{commit_proxy: proxy} do
+      tx = encode_mutations([{:set, <<0xFF, "/system/ok">>, "v"}])
+
+      assert {:error, :wrong_epoch} = GenServer.call(proxy, {:commit, 99, tx, :system})
     end
   end
 

--- a/test/bedrock/data_plane/commit_proxy/sharded_metadata_distribution_integration_test.exs
+++ b/test/bedrock/data_plane/commit_proxy/sharded_metadata_distribution_integration_test.exs
@@ -128,7 +128,9 @@ defmodule Bedrock.DataPlane.CommitProxy.ShardedMetadataDistributionIntegrationTe
     })
   end
 
-  defp commit(proxy, epoch, tx), do: GenServer.call(proxy, {:commit, epoch, tx}, 5_000)
+  # System mode: these transactions write \xFF metadata keys, which
+  # user-mode commits are rejected for at ingress.
+  defp commit(proxy, epoch, tx), do: GenServer.call(proxy, {:commit, epoch, tx, :system}, 5_000)
 
   defp commit!(proxy, epoch, tx) do
     assert {:ok, version, _index} = commit(proxy, epoch, tx)

--- a/test/bedrock/data_plane/commit_proxy_test.exs
+++ b/test/bedrock/data_plane/commit_proxy_test.exs
@@ -17,7 +17,7 @@ defmodule Bedrock.DataPlane.CommitProxyTest do
       {:reply, :ok, state}
     end
 
-    def handle_call({:commit, _transaction}, _from, state) do
+    def handle_call({:commit, _epoch, _transaction, mode}, _from, state) when mode in [:user, :system] do
       {:reply, {:ok, 1, 0}, state}
     end
   end
@@ -37,6 +37,23 @@ defmodule Bedrock.DataPlane.CommitProxyTest do
       }
 
       assert :ok = CommitProxy.recover_from(pid, "test_lock_token", sequencer, resolver_layout, routing_snapshot)
+    end
+  end
+
+  describe "commit/4" do
+    test "sends user mode by default and the given mode when provided" do
+      {:ok, pid} = MockCommitProxy.start_link([])
+
+      assert {:ok, 1, 0} = CommitProxy.commit(pid, 1, "tx")
+      assert {:ok, 1, 0} = CommitProxy.commit(pid, 1, "tx", mode: :system)
+    end
+
+    test "raises on an invalid commit mode at the call site" do
+      {:ok, pid} = MockCommitProxy.start_link([])
+
+      assert_raise ArgumentError, "invalid commit mode: :bogus", fn ->
+        CommitProxy.commit(pid, 1, "tx", mode: :bogus)
+      end
     end
   end
 end

--- a/test/bedrock/internal/repo_transact_test.exs
+++ b/test/bedrock/internal/repo_transact_test.exs
@@ -89,19 +89,18 @@ defmodule Bedrock.Internal.RepoTransactTest do
     end
   end
 
-  # A commit proxy that rejects every transaction with a permanent client error.
+  # A commit proxy that rejects every transaction with the configured error.
   defmodule RejectingProxy do
     @moduledoc false
     use GenServer
 
-    def start_link(_), do: GenServer.start_link(__MODULE__, nil)
+    def start_link(error), do: GenServer.start_link(__MODULE__, error)
 
     @impl true
-    def init(state), do: {:ok, state}
+    def init(error), do: {:ok, error}
 
     @impl true
-    def handle_call({:commit, _epoch, _tx}, _from, state),
-      do: {:reply, {:error, {:key_out_of_range, <<0xFF, 0xFF>>}}, state}
+    def handle_call({:commit, _epoch, _tx, _mode}, _from, error), do: {:reply, {:error, error}, error}
   end
 
   @minimal_tsl %{epoch: 1, proxies: []}
@@ -265,7 +264,7 @@ defmodule Bedrock.Internal.RepoTransactTest do
       # A commit proxy that rejects the transaction with a permanent client
       # error: transact must surface it on the first attempt - retrying a
       # deterministic rejection would only burn the transaction deadline.
-      proxy = start_supervised!({RejectingProxy, []})
+      proxy = start_supervised!({RejectingProxy, {:key_out_of_range, <<0xFF, 0xFF>>}})
       attempts = :counters.new(1, [])
 
       result =
@@ -281,6 +280,30 @@ defmodule Bedrock.Internal.RepoTransactTest do
         )
 
       assert result == {:error, {:key_out_of_range, <<0xFF, 0xFF>>}}
+      assert :counters.get(attempts, 1) == 1
+      assert TransactionContext.builder(TestRepo) == nil
+    end
+
+    test "surfaces atomic_on_system_key immediately instead of retrying" do
+      # Same permanent-rejection contract as key_out_of_range: an atomic op
+      # aimed at a system key is deterministic, so retrying cannot succeed.
+      key = <<0xFF, "/system/counter">>
+      proxy = start_supervised!({RejectingProxy, {:atomic_on_system_key, key}})
+      attempts = :counters.new(1, [])
+
+      result =
+        Repo.transact(
+          NoCluster,
+          TestRepo,
+          fn ->
+            :counters.add(attempts, 1, 1)
+            Repo.put(TestRepo, "key", "value")
+          end,
+          transaction_system_layout: %{epoch: 1, proxies: [proxy]},
+          retry_limit: 3
+        )
+
+      assert result == {:error, {:atomic_on_system_key, key}}
       assert :counters.get(attempts, 1) == 1
       assert TransactionContext.builder(TestRepo) == nil
     end


### PR DESCRIPTION
## Why

The `\xFF/system` keyspace is about to become the authoritative shard map, with every commit proxy building its routing table from system-key mutations as they commit. Today nothing stops an ordinary client from writing those keys: a stray `Repo.put` to `\xFF/system/shard_keys/...` would flow straight into every proxy's routing table. Worse, an *atomic* op (like `add`) on a system key slips past every metadata view — the metadata pipeline replays only sets and clears, so the materializer would apply the atomic durably while every proxy's view of the same key stayed unchanged. Two copies of the truth, silently diverging.

## What

Commits now carry a mode, and the mode decides how far the legal write range extends:

- **User commits** (the default, and the only thing `Repo`/Gateway produce) are bounded at `<<0xFF>>`. Any mutation at or past it — including a `clear_range` that crosses into system space — is rejected at ingress with `{:error, {:key_out_of_range, key}}`, before a commit version is consumed.
- **System commits** (`mode: :system`) extend the bound to `<<0xFF, 0xFF>>`. Recovery's persistence phase — the one legitimate system writer today — commits this way; the future Distributor will too.
- **Atomics aimed at system keys are rejected in every mode** with `{:error, {:atomic_on_system_key, key}}`.

`Repo.transact` treats both errors as permanent (no retry), and `Bedrock.end_of_user_keyspace/0` names the user bound next to `end_of_keyspace/0`.

## How

This is FoundationDB's `ACCESS_SYSTEM_KEYS` gate, moved one step stronger. In FDB the flag is client-asserted and checked in the client library (`ReadYourWrites`' `getMaxWriteKey()` widens from `normalKeys.end` to `systemKeys.end`); it guards against accidental system writes, not hostile ones. Bedrock keeps the same trust model but enforces at the proxy, so every ingress path is covered regardless of client. The implementation is one function: the ingress validator picks its bound from the commit mode and reuses the existing out-of-range check, so gating adds no new machinery — a user writing `\xFF` gets the same error as anyone writing past the end of the keyspace, which is exactly what FDB reports (`key_outside_legal_range`).

The atomic ban is deliberately more conservative than FDB, which transforms versionstamp ops into plain sets *before* its metadata check and treats non-versionstamp atomics on system keys as ordinary (non-metadata) writes. Bedrock has no versionstamp mutations yet, so a blanket ban costs nothing today and closes the divergence hole completely; if a `\xff/metadataVersion`-style feature lands later, it should adopt FDB's transform-at-ingress approach.

Unknown future mutation shapes fail closed: the validator has no catch-all clause, so an unrecognized shape is rejected as `:invalid_transaction` rather than bypassing the gate.

Ticket: bedrock-rag (integrity half, from the 2026-08-19 gap audit). Cold-audited; FDB claims verified against `NativeAPI.actor.cpp`, `ReadYourWrites.actor.cpp`, `CommitProxyServer.actor.cpp`, and `ApplyMetadataMutation.h`.