### PR TITLE
Version-guard routing data under the resolver window path

### DIFF
--- a/lib/bedrock/data_plane/commit_proxy/finalization.ex
+++ b/lib/bedrock/data_plane/commit_proxy/finalization.ex
@@ -205,7 +205,7 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization do
 
   ## Returns
 
-    - `{:ok, n_aborts, n_successes, updated_routing_data}` - Pipeline completed with updated routing
+    - `{:ok, n_aborts, n_successes}` - Pipeline completed
     - `{:error, finalization_error()}` - Pipeline failed; all pending clients notified of failure
 
   ## Error Handling
@@ -234,7 +234,7 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization do
             timeout: non_neg_integer()
           ]
         ) ::
-          {:ok, n_aborts :: non_neg_integer(), n_oks :: non_neg_integer(), updated_routing_data :: RoutingData.t()}
+          {:ok, n_aborts :: non_neg_integer(), n_oks :: non_neg_integer()}
           | {:error, finalization_error()}
   def finalize_batch(batch, opts) do
     trace_commit_proxy_batch_started(batch.commit_version, length(batch.buffer), Time.now_in_ms())
@@ -256,9 +256,9 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization do
     end
     |> :timer.tc()
     |> case do
-      {n_usec, {:ok, n_aborts, n_oks, updated_routing_data}} ->
+      {n_usec, {:ok, n_aborts, n_oks}} ->
         trace_commit_proxy_batch_finished(batch.commit_version, n_aborts, n_oks, n_usec)
-        {:ok, n_aborts, n_oks, updated_routing_data}
+        {:ok, n_aborts, n_oks}
 
       {n_usec, {:error, reason}} ->
         trace_commit_proxy_batch_failed(batch, reason, n_usec)
@@ -1187,22 +1187,18 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization do
   # Result Extraction and Error Handling
   # ============================================================================
 
+  # The plan's window-updated routing fields are deliberately NOT returned:
+  # the server folds windows into its own routing data (version-guarded, in
+  # the same step that advances its ack), so a post-push replacement from a
+  # racing task could only clobber newer state (bedrock-q67.24).
   @spec extract_result_or_handle_error(FinalizationPlan.t(), keyword()) ::
-          {:ok, non_neg_integer(), non_neg_integer(), RoutingData.t()}
+          {:ok, non_neg_integer(), non_neg_integer()}
           | {:error, finalization_error()}
   def extract_result_or_handle_error(%FinalizationPlan{stage: :completed} = plan, _opts) do
-    # Table is managed by commit proxy server - no cleanup needed here
     n_aborts = plan.aborted_count
     n_successes = plan.transaction_count - n_aborts
 
-    updated_routing_data = %RoutingData{
-      shard_table: plan.shard_table,
-      log_map: plan.log_map,
-      log_services: plan.log_services,
-      replication_factor: plan.replication_factor
-    }
-
-    {:ok, n_aborts, n_successes, updated_routing_data}
+    {:ok, n_aborts, n_successes}
   end
 
   def extract_result_or_handle_error(%FinalizationPlan{stage: :failed} = plan, opts), do: handle_error(plan, opts)

--- a/lib/bedrock/data_plane/commit_proxy/routing_data.ex
+++ b/lib/bedrock/data_plane/commit_proxy/routing_data.ex
@@ -130,11 +130,18 @@ defmodule Bedrock.DataPlane.CommitProxy.RoutingData do
 
   @doc """
   Adds a log to the log_map at the next available index.
+
+  Idempotent by log id: a re-set of an already-known log (a legitimate
+  layout_log update, or the same entry seen again) keeps its index instead
+  of appending a duplicate that would corrupt golden-ratio routing.
   """
   @spec insert_log(t(), Log.id()) :: t()
   def insert_log(%__MODULE__{log_map: log_map} = routing_data, log_id) do
-    next_index = map_size(log_map)
-    %{routing_data | log_map: Map.put(log_map, next_index, log_id)}
+    if Enum.any?(log_map, fn {_index, id} -> id == log_id end) do
+      routing_data
+    else
+      %{routing_data | log_map: Map.put(log_map, map_size(log_map), log_id)}
+    end
   end
 
   @doc """

--- a/lib/bedrock/data_plane/commit_proxy/server.ex
+++ b/lib/bedrock/data_plane/commit_proxy/server.ex
@@ -266,7 +266,6 @@ defmodule Bedrock.DataPlane.CommitProxy.Server do
   @impl true
   @spec handle_info(
           :timeout
-          | {:routing_data_update, RoutingData.t()}
           | {:metadata_updates, {Bedrock.version() | nil, Bedrock.version(), [term()]}}
           | {:metadata_deferred, Bedrock.version(), [term()]}
           | {:finalization_failed, term()}
@@ -300,10 +299,6 @@ defmodule Bedrock.DataPlane.CommitProxy.Server do
     finalize_batch_async(batch, t)
 
     maybe_set_empty_transaction_timeout(%{t | batch: nil})
-  end
-
-  def handle_info({:routing_data_update, updated_routing_data}, t) do
-    noreply_resuming_cadence(%{t | routing_data: updated_routing_data})
   end
 
   def handle_info({:metadata_updates, window}, t) do
@@ -367,8 +362,8 @@ defmodule Bedrock.DataPlane.CommitProxy.Server do
                send(server_pid, {:metadata_deferred, version, mutations})
              end
            ) do
-        {:ok, _n_aborts, _n_oks, updated_routing_data} ->
-          send(server_pid, {:routing_data_update, updated_routing_data})
+        {:ok, _n_aborts, _n_oks} ->
+          :ok
 
         {:error, reason} ->
           send(server_pid, {:finalization_failed, reason})
@@ -376,13 +371,20 @@ defmodule Bedrock.DataPlane.CommitProxy.Server do
     end)
   end
 
-  # Folds a resolver metadata window into the proxy's structured metadata.
-  # Applied in the server process so windows from concurrent finalization
-  # tasks are serialized. Windows can arrive out of commit-version order (the
-  # tasks race to this mailbox), but every window covers (from, to] starting
-  # at a version this proxy had already confirmed applying, so a late-arriving
-  # earlier window is a subset of what has been applied - the per-entry
-  # version guard inside Metadata.apply_updates makes it a no-op.
+  # Folds a resolver metadata window into the proxy's structured metadata AND
+  # its routing data, in one step. Applied in the server process so windows
+  # from concurrent finalization tasks are serialized. Windows can arrive out
+  # of commit-version order (the tasks race to this mailbox), but every window
+  # covers (from, to] starting at a version this proxy had already confirmed
+  # applying, so a late-arriving earlier window is a subset of what has been
+  # applied - entries at or below the applied version are dropped before
+  # application, which keeps the non-idempotent parts of routing data (log
+  # index assignment) exact under overlapping windows.
+  #
+  # Advancing routing data here, atomically with the ack version, is what
+  # lets finalize_batch_async snapshot the pair consistently: a batch whose
+  # ack promises the resolver will not re-send version N's entries always
+  # holds routing data that already includes them (bedrock-q67.24).
   #
   # A window whose from_version exceeds what this proxy has applied means the
   # resolver pruned history this proxy never saw (only possible after this
@@ -400,7 +402,13 @@ defmodule Bedrock.DataPlane.CommitProxy.Server do
       exit({:metadata_coverage_gap, %{from_version: from_version, applied_version: applied_version}})
     end
 
-    {metadata, stats} = Metadata.apply_updates(t.metadata, entries)
+    new_entries =
+      if applied_version == nil,
+        do: entries,
+        else: Enum.filter(entries, fn {entry_version, _mutations} -> entry_version > applied_version end)
+
+    {metadata, stats} = Metadata.apply_updates(t.metadata, new_entries)
+    routing_data = RoutingData.apply_mutations(t.routing_data, new_entries)
 
     if stats.applied > 0, do: trace_metadata_applied(stats.applied, stats.families)
     if stats.skipped_keys != [], do: trace_unknown_key_skipped(stats.skipped_keys)
@@ -415,7 +423,7 @@ defmodule Bedrock.DataPlane.CommitProxy.Server do
     # settled version across resolvers) - stop re-sending it.
     deferred_metadata = Enum.drop_while(t.deferred_metadata, fn {v, _mutations} -> v <= version end)
 
-    %{t | metadata: %{metadata | version: version}, deferred_metadata: deferred_metadata}
+    %{t | metadata: %{metadata | version: version}, routing_data: routing_data, deferred_metadata: deferred_metadata}
   end
 
   @spec add_deferred_metadata(State.t(), Bedrock.version(), [term()]) :: State.t()

--- a/test/bedrock/data_plane/commit_proxy/finalization/core_test.exs
+++ b/test/bedrock/data_plane/commit_proxy/finalization/core_test.exs
@@ -124,7 +124,7 @@ defmodule Bedrock.DataPlane.CommitProxy.FinalizationCoreTest do
           end
         end)
 
-      assert {:ok, 1, 1, _routing_data} =
+      assert {:ok, 1, 1} =
                Finalization.finalize_batch(
                  batch,
                  epoch: 1,
@@ -149,7 +149,7 @@ defmodule Bedrock.DataPlane.CommitProxy.FinalizationCoreTest do
         {:ok, [], nil}
       end
 
-      assert {:ok, 0, 0, _routing_data} =
+      assert {:ok, 0, 0} =
                Finalization.finalize_batch(
                  batch,
                  epoch: 1,
@@ -193,7 +193,7 @@ defmodule Bedrock.DataPlane.CommitProxy.FinalizationCoreTest do
         {:ok, [0, 1], nil}
       end
 
-      assert {:ok, 2, 0, _routing_data} =
+      assert {:ok, 2, 0} =
                Finalization.finalize_batch(
                  batch,
                  epoch: 1,
@@ -305,7 +305,7 @@ defmodule Bedrock.DataPlane.CommitProxy.FinalizationCoreTest do
         :ok
       end
 
-      assert {:ok, 0, 1, _routing_data} =
+      assert {:ok, 0, 1} =
                Finalization.finalize_batch(
                  batch,
                  epoch: 1,

--- a/test/bedrock/data_plane/commit_proxy/finalization/log_push_test.exs
+++ b/test/bedrock/data_plane/commit_proxy/finalization/log_push_test.exs
@@ -75,7 +75,7 @@ defmodule Bedrock.DataPlane.CommitProxy.FinalizationLogPushTest do
 
       routing_data = Support.build_routing_data(transaction_system_layout)
 
-      assert {:ok, 0, 3, _routing_data} =
+      assert {:ok, 0, 3} =
                Finalization.finalize_batch(
                  batch,
                  epoch: 1,
@@ -117,7 +117,7 @@ defmodule Bedrock.DataPlane.CommitProxy.FinalizationLogPushTest do
 
       routing_data = Support.build_routing_data(layout)
 
-      assert {:ok, 0, 1, _routing_data} =
+      assert {:ok, 0, 1} =
                Finalization.finalize_batch(
                  batch,
                  epoch: 1,
@@ -156,7 +156,7 @@ defmodule Bedrock.DataPlane.CommitProxy.FinalizationLogPushTest do
 
       routing_data = Support.build_routing_data(layout)
 
-      assert {:ok, 0, 1, _routing_data} =
+      assert {:ok, 0, 1} =
                Finalization.finalize_batch(
                  batch,
                  epoch: 1,
@@ -219,7 +219,7 @@ defmodule Bedrock.DataPlane.CommitProxy.FinalizationLogPushTest do
       routing_data = Support.build_routing_data(layout)
 
       # Should have 1 abort (transaction 1) and 2 successes (transactions 0, 2)
-      assert {:ok, 1, 2, _routing_data} =
+      assert {:ok, 1, 2} =
                Finalization.finalize_batch(
                  batch,
                  epoch: 1,

--- a/test/bedrock/data_plane/commit_proxy/finalization/metadata_test.exs
+++ b/test/bedrock/data_plane/commit_proxy/finalization/metadata_test.exs
@@ -105,7 +105,7 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization.MetadataTest do
         {:ok, [], nil}
       end
 
-      assert {:ok, 0, 1, _routing_data} =
+      assert {:ok, 0, 1} =
                Finalization.finalize_batch(
                  batch,
                  epoch: 1,
@@ -150,7 +150,7 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization.MetadataTest do
         {:ok, [], nil}
       end
 
-      assert {:ok, 0, 1, _routing_data} =
+      assert {:ok, 0, 1} =
                Finalization.finalize_batch(
                  batch,
                  epoch: 1,
@@ -199,7 +199,7 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization.MetadataTest do
         {:ok, [], metadata_window}
       end
 
-      assert {:ok, 0, 1, _returned_routing_data} =
+      assert {:ok, 0, 1} =
                Finalization.finalize_batch(
                  batch,
                  epoch: 1,
@@ -233,7 +233,7 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization.MetadataTest do
         {:ok, [], nil}
       end
 
-      assert {:ok, 0, 1, _returned_routing_data} =
+      assert {:ok, 0, 1} =
                Finalization.finalize_batch(
                  batch,
                  epoch: 1,
@@ -267,7 +267,7 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization.MetadataTest do
         {:ok, [], nil}
       end
 
-      assert {:ok, 0, 1, _returned_routing_data} =
+      assert {:ok, 0, 1} =
                Finalization.finalize_batch(
                  batch,
                  epoch: 1,
@@ -328,7 +328,7 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization.MetadataTest do
         {:ok, [], nil}
       end
 
-      assert {:ok, 0, 3, _routing_data} =
+      assert {:ok, 0, 3} =
                Finalization.finalize_batch(
                  batch,
                  epoch: 1,
@@ -380,7 +380,7 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization.MetadataTest do
         {:ok, [], nil}
       end
 
-      assert {:ok, 0, 0, _routing_data} =
+      assert {:ok, 0, 0} =
                Finalization.finalize_batch(
                  batch,
                  epoch: 1,
@@ -438,7 +438,7 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization.MetadataTest do
         {:ok, [], nil}
       end
 
-      assert {:ok, 0, 1, _routing_data} =
+      assert {:ok, 0, 1} =
                Finalization.finalize_batch(
                  batch,
                  epoch: 1,

--- a/test/bedrock/data_plane/commit_proxy/finalization/resolver_retry_test.exs
+++ b/test/bedrock/data_plane/commit_proxy/finalization/resolver_retry_test.exs
@@ -87,7 +87,7 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization.ResolverRetryTest do
       batch = Support.create_test_batch(100, 99)
 
       # Should succeed after retry
-      assert {:ok, 0, 1, _routing_data} =
+      assert {:ok, 0, 1} =
                Finalization.finalize_batch(
                  batch,
                  epoch: 1,
@@ -128,7 +128,7 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization.ResolverRetryTest do
 
       batch = Support.create_test_batch(100, 99)
 
-      assert {:ok, 0, 1, _routing_data} =
+      assert {:ok, 0, 1} =
                Finalization.finalize_batch(
                  batch,
                  epoch: 1,
@@ -168,7 +168,7 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization.ResolverRetryTest do
 
       batch = Support.create_test_batch(100, 99)
 
-      assert {:ok, 0, 1, _routing_data} =
+      assert {:ok, 0, 1} =
                Finalization.finalize_batch(
                  batch,
                  epoch: 1,
@@ -424,7 +424,7 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization.ResolverRetryTest do
 
       batch = Support.create_test_batch(100, 99)
 
-      assert {:ok, 0, 1, _routing_data} =
+      assert {:ok, 0, 1} =
                Finalization.finalize_batch(
                  batch,
                  epoch: 1,
@@ -490,7 +490,7 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization.ResolverRetryTest do
           {reply_fn2, tx2_binary, task2}
         ])
 
-      assert {:ok, 0, 2, _routing_data} =
+      assert {:ok, 0, 2} =
                Finalization.finalize_batch(
                  batch,
                  epoch: 1,

--- a/test/bedrock/data_plane/commit_proxy/finalization/sharded_resolution_and_edge_cases_test.exs
+++ b/test/bedrock/data_plane/commit_proxy/finalization/sharded_resolution_and_edge_cases_test.exs
@@ -94,7 +94,7 @@ defmodule Bedrock.DataPlane.CommitProxy.FinalizationShardedResolutionAndEdgeCase
 
       opts = base_opts(sharded_layout(), routing_data(), resolver_fn: resolver_fn)
 
-      assert {:ok, 0, 0, _routing_data} = Finalization.finalize_batch(empty_batch(), opts)
+      assert {:ok, 0, 0} = Finalization.finalize_batch(empty_batch(), opts)
 
       assert_receive {:resolved, :resolver_a, [], []}
       assert_receive {:resolved, :resolver_b, [], []}
@@ -115,7 +115,7 @@ defmodule Bedrock.DataPlane.CommitProxy.FinalizationShardedResolutionAndEdgeCase
 
       opts = base_opts(sharded_layout(), routing_data(), resolver_fn: resolver_fn)
 
-      assert {:ok, 2, 0, _routing_data} = Finalization.finalize_batch(batch, opts)
+      assert {:ok, 2, 0} = Finalization.finalize_batch(batch, opts)
 
       assert_receive {:tx0, {:error, :aborted}}
       assert_receive {:tx1, {:error, :aborted}}
@@ -132,7 +132,7 @@ defmodule Bedrock.DataPlane.CommitProxy.FinalizationShardedResolutionAndEdgeCase
 
       opts = base_opts(sharded_layout(), routing_data(), resolver_fn: resolver_fn)
 
-      assert {:ok, 0, 2, _routing_data} = Finalization.finalize_batch(batch, opts)
+      assert {:ok, 0, 2} = Finalization.finalize_batch(batch, opts)
 
       assert_receive {:tx0, {:ok, @commit_version, 0}}
       assert_receive {:tx1, {:ok, @commit_version, 1}}
@@ -182,7 +182,7 @@ defmodule Bedrock.DataPlane.CommitProxy.FinalizationShardedResolutionAndEdgeCase
           metadata_confirms: confirms
         )
 
-      assert {:ok, 0, 1, _routing_data} = Finalization.finalize_batch(batch, opts)
+      assert {:ok, 0, 1} = Finalization.finalize_batch(batch, opts)
 
       # No speculative metadata reaches any resolver; both get the hold flag
       # (this batch carries metadata) and the proxy's pending confirmations.
@@ -222,7 +222,7 @@ defmodule Bedrock.DataPlane.CommitProxy.FinalizationShardedResolutionAndEdgeCase
           metadata_deferred_fn: metadata_deferred_fn
         )
 
-      assert {:ok, 1, 1, _routing_data} = Finalization.finalize_batch(batch, opts)
+      assert {:ok, 1, 1} = Finalization.finalize_batch(batch, opts)
 
       assert_receive {:deferred, @commit_version, [{:set, <<0xFF, "/committed">>, "meta"}]}
     end
@@ -249,7 +249,7 @@ defmodule Bedrock.DataPlane.CommitProxy.FinalizationShardedResolutionAndEdgeCase
 
       opts = base_opts(sharded_layout(), routing_data(), resolver_fn: resolver_fn, metadata_merge_fn: metadata_merge_fn)
 
-      assert {:ok, 0, 0, _routing_data} = Finalization.finalize_batch(empty_batch(), opts)
+      assert {:ok, 0, 0} = Finalization.finalize_batch(empty_batch(), opts)
 
       from90 = v.(90)
       to96 = v.(96)
@@ -287,7 +287,7 @@ defmodule Bedrock.DataPlane.CommitProxy.FinalizationShardedResolutionAndEdgeCase
 
       opts = base_opts(single_layout(), routing_data(), resolver_fn: resolver_fn)
 
-      assert {:ok, 0, 1, _routing_data} = Finalization.finalize_batch(batch, opts)
+      assert {:ok, 0, 1} = Finalization.finalize_batch(batch, opts)
       assert_receive {:tx0, {:ok, @commit_version, 0}}
     end
   end
@@ -342,7 +342,7 @@ defmodule Bedrock.DataPlane.CommitProxy.FinalizationShardedResolutionAndEdgeCase
       opts =
         base_opts(single_layout(), routing_data, resolver_fn: resolver_fn, batch_log_push_fn: log_push_fn)
 
-      assert {:ok, 0, 1, _routing_data} = Finalization.finalize_batch(batch, opts)
+      assert {:ok, 0, 1} = Finalization.finalize_batch(batch, opts)
 
       assert_receive {:pushed, %{"log_1" => encoded}}
 
@@ -377,7 +377,7 @@ defmodule Bedrock.DataPlane.CommitProxy.FinalizationShardedResolutionAndEdgeCase
       opts =
         base_opts(single_layout(), routing_data, resolver_fn: resolver_fn, batch_log_push_fn: log_push_fn)
 
-      assert {:ok, 0, 1, _routing_data} = Finalization.finalize_batch(batch, opts)
+      assert {:ok, 0, 1} = Finalization.finalize_batch(batch, opts)
 
       assert_receive {:pushed, %{"log_1" => encoded}}
       assert Enum.to_list(Transaction.mutations!(encoded)) == [{:atomic, :add, "counter", <<1::64-little>>}]
@@ -400,7 +400,7 @@ defmodule Bedrock.DataPlane.CommitProxy.FinalizationShardedResolutionAndEdgeCase
 
     opts = base_opts(single_layout(), routing_data, resolver_fn: resolver_fn, batch_log_push_fn: log_push_fn)
 
-    assert {:ok, 0, 1, _routing_data} = Finalization.finalize_batch(batch, opts)
+    assert {:ok, 0, 1} = Finalization.finalize_batch(batch, opts)
 
     assert_receive {:pushed, %{"log_1" => encoded}}
     assert Enum.to_list(Transaction.mutations!(encoded)) == [{:set, "key", "value"}]

--- a/test/bedrock/data_plane/commit_proxy/metadata_window_application_test.exs
+++ b/test/bedrock/data_plane/commit_proxy/metadata_window_application_test.exs
@@ -18,6 +18,7 @@ defmodule Bedrock.DataPlane.CommitProxy.MetadataWindowApplicationTest do
   use ExUnit.Case, async: true
 
   alias Bedrock.DataPlane.CommitProxy.Metadata
+  alias Bedrock.DataPlane.CommitProxy.RoutingData
   alias Bedrock.DataPlane.CommitProxy.Server
   alias Bedrock.DataPlane.CommitProxy.State
   alias Bedrock.DataPlane.Version
@@ -33,11 +34,14 @@ defmodule Bedrock.DataPlane.CommitProxy.MetadataWindowApplicationTest do
       epoch: 1,
       empty_transaction_timeout_ms: 1_000,
       mode: :running,
-      metadata: metadata
+      metadata: metadata,
+      routing_data: RoutingData.new_empty()
     }
   end
 
   defp shard_set(key, tag), do: {:set, SystemKeys.shard_key(key), Values.encode_shard_key_entry(tag, "")}
+
+  defp log_set(log_id), do: {:set, SystemKeys.layout_log(log_id), Values.encode_tag_list([1])}
 
   defp apply_window(state, window) do
     {:noreply, updated, _timeout} = Server.handle_info({:metadata_updates, window}, state)
@@ -77,5 +81,56 @@ defmodule Bedrock.DataPlane.CommitProxy.MetadataWindowApplicationTest do
   test "a gap is detected even when the window carries no entries" do
     assert {:metadata_coverage_gap, _} =
              catch_exit(Server.handle_info({:metadata_updates, {v(5), v(6), []}}, state(Metadata.new())))
+  end
+
+  test "window entries update routing data in the same step that advances the ack" do
+    # A batch snapshots (routing_data, metadata.version) together at spawn.
+    # The resolver keys its differential windows off the version, so routing
+    # state must advance atomically with it - otherwise a batch could hold an
+    # ack that promises entries its routing data never saw (bedrock-q67.24).
+    updated = apply_window(state(Metadata.new()), {nil, v(1), [{v(1), [shard_set("a", 7), log_set("log_a")]}]})
+
+    assert updated.metadata.version == v(1)
+    assert updated.routing_data.log_map == %{0 => "log_a"}
+    assert :ets.lookup(updated.routing_data.shard_table, "a") == [{"a", 7}]
+  end
+
+  test "a re-delivered window does not duplicate log entries" do
+    window = {nil, v(1), [{v(1), [log_set("log_a")]}]}
+
+    updated = apply_window(state(Metadata.new()), window)
+    updated = apply_window(updated, window)
+
+    assert updated.routing_data.log_map == %{0 => "log_a"}
+  end
+
+  test "an overlapping superset window applies only entries newer than the applied version" do
+    e1 = {v(1), [log_set("log_a")]}
+    e2 = {v(2), [log_set("log_b")]}
+
+    updated = apply_window(state(Metadata.new()), {nil, v(1), [e1]})
+    updated = apply_window(updated, {nil, v(2), [e1, e2]})
+
+    assert updated.routing_data.log_map == %{0 => "log_a", 1 => "log_b"}
+  end
+
+  test "re-setting the same layout_log key at a newer version does not duplicate the log" do
+    # A mid-epoch writer may legitimately re-set a layout_log key (e.g. a tag
+    # change). The log keeps its index; only genuinely new logs append.
+    updated = apply_window(state(Metadata.new()), {nil, v(1), [{v(1), [log_set("log_a")]}]})
+    updated = apply_window(updated, {v(1), v(2), [{v(2), [log_set("log_a"), log_set("log_b")]}]})
+
+    assert updated.routing_data.log_map == %{0 => "log_a", 1 => "log_b"}
+  end
+
+  test "a stale routing-data replacement message can no longer clobber window-applied state" do
+    # Finalization tasks used to send {:routing_data_update, struct} after log
+    # push; racing tasks made the last writer win, silently dropping log-map
+    # changes. The message is retired - if one arrives, it is ignored.
+    updated = apply_window(state(Metadata.new()), {nil, v(1), [{v(1), [log_set("log_a")]}]})
+
+    assert {:noreply, after_stale} = Server.handle_info({:routing_data_update, RoutingData.new_empty()}, updated)
+
+    assert after_stale.routing_data.log_map == %{0 => "log_a"}
   end
 end

--- a/test/bedrock/data_plane/commit_proxy/sequencer_notification_test.exs
+++ b/test/bedrock/data_plane/commit_proxy/sequencer_notification_test.exs
@@ -63,7 +63,7 @@ defmodule Bedrock.DataPlane.CommitProxy.SequencerNotificationTest do
       routing_data = Support.build_routing_data(layout)
       opts = create_finalization_opts()
 
-      assert {:ok, 0, 0, _metadata} =
+      assert {:ok, 0, 0} =
                Finalization.finalize_batch(batch, opts ++ [routing_data: routing_data, sequencer: layout.sequencer])
 
       assert_receive {:sequencer_notified, 100}, 100


### PR DESCRIPTION
## Why

A commit proxy learns shard and log routing from metadata windows the resolvers relay with each batch. Today that works only by luck: shard and log keys change solely in recovery's system transaction, whose content equals the unlock snapshot. Once the Distributor starts mutating them mid-epoch (bedrock-q67.21), two holes in the window path become real:

1. **Staleness race.** A finalization task applied its window during resolution but the server only replaced its routing struct from a message the task sent *after* log push. A batch spawned in between held an ack that promised "the resolver won't re-send version N's entries" alongside routing data that had never seen them. Worse, racing tasks' replacement messages were last-writer-wins: a log-map change could be *permanently* dropped, and the resolver — already acked past it — would never re-send it.
2. **No idempotence.** Overlapping windows to concurrent batches are a designed feature of the protocol, but `insert_log` appended at the next free index every time it saw a log — a re-delivered or re-set `layout_log` entry produced a duplicate index and corrupted golden-ratio log placement.

## What

The server's window handler now does three things in one step: drop entries at or below its applied version, fold the remainder into **both** its structured metadata and its routing data, and advance the applied version. Because a batch snapshots `(applied version, routing data)` together at spawn, the pair is now consistent by construction — an ack can no longer promise entries the routing data hasn't seen. The post-push `{:routing_data_update}` replacement message is retired entirely, and `finalize_batch` returns just `{:ok, n_aborts, n_oks}`. Batches still apply their own window in-task, so a batch that commits a shard split routes its own log push with that split visible. `insert_log` is now idempotent by log id.

## How

This mirrors how FoundationDB orders the same flow: resolvers relay prior-version state mutations with each resolution reply, and the proxy folds them into `keyInfo`/`txnStateStore` in strict version order inside a single-threaded, batch-ordered pipeline — batch N+1 cannot enter tag assignment until batch N's metadata effects are applied (`Resolver.actor.cpp` `applyStateTxnsToBatchReply`, `CommitProxyServer.actor.cpp` `applyMetadataEffect`). Bedrock's version filter plus single-owner application in the server process is the same guarantee for the server's state; the existing coverage-gap fail-fast (resolver pruned history the proxy never saw → exit into director recovery) is unchanged.

Cold-audited with adversarial interleaving analysis: the (ack, routing) invariant holds by induction over every enumerated schedule. The audit confirmed one residual outside this diff's reach — the shared ETS shard table has multiple unordered writers (tasks, server, and a lazy log-index cache inside the router), which admits a late older write clobbering a newer tag. That is benign today for the same reason the original holes were, and is fixed next in this stack by versioning the shard rows themselves.

Ticket: bedrock-q67.24 (blocks bedrock-q67.21). Stacked on #154.