### PR TITLE
Version shard-table rows so unordered writers converge

### DIFF
--- a/lib/bedrock/data_plane/commit_proxy/routing_data.ex
+++ b/lib/bedrock/data_plane/commit_proxy/routing_data.ex
@@ -16,8 +16,12 @@ defmodule Bedrock.DataPlane.CommitProxy.RoutingData do
 
   ## Shard Updates
 
-  - `insert_shard/3` - Adds or updates a shard entry
-  - `delete_shard/2` - Removes a shard entry
+  Shard rows are `{end_key, tag, version}`, written last-writer-wins by
+  version so concurrent unordered writers (finalization tasks and the server)
+  converge; clears leave `:deleted` tombstones that lookups skip.
+
+  - `insert_shard/4` - Adds or updates a shard entry
+  - `delete_shard/3` - Tombstones a shard entry
 
   ## Log Updates
 
@@ -66,8 +70,10 @@ defmodule Bedrock.DataPlane.CommitProxy.RoutingData do
       }) do
     shard_table = :ets.new(:shard_keys, [:ordered_set, :public])
 
+    # Snapshot rows carry a nil version: they predate every committed window
+    # entry of the epoch, so any versioned write wins over them.
     Enum.each(shard_layout, fn {end_key, {tag, _start_key}} ->
-      :ets.insert(shard_table, {end_key, tag})
+      :ets.insert(shard_table, {end_key, tag, nil})
     end)
 
     %__MODULE__{
@@ -109,23 +115,51 @@ defmodule Bedrock.DataPlane.CommitProxy.RoutingData do
   end
 
   @doc """
-  Inserts or updates a shard entry in the routing table.
+  Inserts or updates a shard entry in the routing table, last-writer-wins by
+  version.
 
-  Called from apply_mutations/2 when processing shard_key mutations.
+  The shard table is written by concurrent, unordered writers (finalization
+  tasks and the commit proxy server), so a plain overwrite would let a late
+  write of an older version clobber a newer tag permanently - the resolver
+  has already been acked past it and will never re-send it. The per-row
+  version guard makes each row converge to its newest write regardless of
+  arrival order. Called from apply_mutations/2 for shard_key mutations.
   """
-  @spec insert_shard(t(), binary(), term()) :: true
-  def insert_shard(%__MODULE__{shard_table: table}, end_key, tag) do
-    :ets.insert(table, {end_key, tag})
+  @spec insert_shard(t(), binary(), term(), Bedrock.version() | nil) :: true
+  def insert_shard(%__MODULE__{shard_table: table}, end_key, tag, version) do
+    put_row_if_newer(table, end_key, tag, version)
   end
 
   @doc """
-  Deletes a shard entry from the routing table.
+  Deletes a shard entry from the routing table by writing a tombstone,
+  last-writer-wins by version.
 
-  Called from apply_mutations/2 when processing shard_key clear mutations.
+  Physically removing the row would let a late write of an older version
+  resurrect the boundary; the tombstone keeps the version to lose against.
+  Router lookups treat tombstoned rows as absent. Tombstones live until the
+  next recovery rebuilds the table from a fresh snapshot.
   """
-  @spec delete_shard(t(), binary()) :: true
-  def delete_shard(%__MODULE__{shard_table: table}, end_key) do
-    :ets.delete(table, end_key)
+  @spec delete_shard(t(), binary(), Bedrock.version()) :: true
+  def delete_shard(%__MODULE__{shard_table: table}, end_key, version) do
+    put_row_if_newer(table, end_key, :deleted, version)
+  end
+
+  # Atomic per-row last-writer-wins: insert_new wins the empty-row race;
+  # otherwise select_replace atomically swaps the row unless the stored
+  # version is newer. Equal versions overwrite: a transaction's mutations
+  # apply in order, so within one version the later mutation must win
+  # (recovery's clear-then-rewrite pattern), and every writer replays the
+  # same sequence, so equal-version interleavings still converge on its
+  # final mutation. Snapshot rows carry a nil version and lose to any
+  # committed version (atoms sort below binaries).
+  defp put_row_if_newer(table, end_key, tag, version) do
+    row = {end_key, tag, version}
+
+    if not :ets.insert_new(table, row) do
+      :ets.select_replace(table, [{{end_key, :_, :"$1"}, [{:"=<", :"$1", {:const, version}}], [{:const, row}]}])
+    end
+
+    true
   end
 
   @doc """
@@ -201,20 +235,20 @@ defmodule Bedrock.DataPlane.CommitProxy.RoutingData do
 
   Updated routing data with applied mutations.
   """
-  @spec apply_mutations(t(), [{term(), [term()]}]) :: t()
+  @spec apply_mutations(t(), [{Bedrock.version(), [term()]}]) :: t()
   def apply_mutations(%__MODULE__{} = routing_data, updates) do
-    Enum.reduce(updates, routing_data, fn {_version, mutations}, acc ->
-      Enum.reduce(mutations, acc, &apply_mutation/2)
+    Enum.reduce(updates, routing_data, fn {version, mutations}, acc ->
+      Enum.reduce(mutations, acc, &apply_mutation(&1, &2, version))
     end)
   end
 
-  defp apply_mutation({:set, key, value}, routing_data) do
+  defp apply_mutation({:set, key, value}, routing_data, version) do
     case SystemKeys.parse_key(key) do
       {:shard_key, end_key} ->
         # Undecodable values are ignored; the routing table keeps its last
         # good entry rather than crashing the commit proxy.
         case Values.decode_shard_key_entry(value) do
-          {:ok, {tag, _start_key}} -> insert_shard(routing_data, end_key, tag)
+          {:ok, {tag, _start_key}} -> insert_shard(routing_data, end_key, tag, version)
           {:error, _} -> :ignored
         end
 
@@ -230,10 +264,10 @@ defmodule Bedrock.DataPlane.CommitProxy.RoutingData do
     end
   end
 
-  defp apply_mutation({:clear, key}, routing_data) do
+  defp apply_mutation({:clear, key}, routing_data, version) do
     case SystemKeys.parse_key(key) do
       {:shard_key, end_key} ->
-        delete_shard(routing_data, end_key)
+        delete_shard(routing_data, end_key, version)
         routing_data
 
       {:layout_log, log_id} ->
@@ -249,19 +283,19 @@ defmodule Bedrock.DataPlane.CommitProxy.RoutingData do
   # Mirrors Metadata's clear_range semantics: delete every known entry whose
   # full system key falls in [start_key, end_key). Recovery rewrites use this
   # to drop stale shard/log entries before re-writing the current layout.
-  defp apply_mutation({:clear_range, start_key, end_key}, routing_data) do
+  defp apply_mutation({:clear_range, start_key, end_key}, routing_data, version) do
     routing_data
-    |> clear_shards_in_range(start_key, end_key)
+    |> clear_shards_in_range(start_key, end_key, version)
     |> clear_logs_in_range(start_key, end_key)
   end
 
-  defp apply_mutation(_mutation, routing_data), do: routing_data
+  defp apply_mutation(_mutation, routing_data, _version), do: routing_data
 
-  defp clear_shards_in_range(%__MODULE__{shard_table: table} = routing_data, start_key, end_key) do
-    for {shard_end_key, _tag} <- :ets.tab2list(table),
+  defp clear_shards_in_range(%__MODULE__{shard_table: table} = routing_data, start_key, end_key, version) do
+    for {shard_end_key, _tag, _version} <- :ets.tab2list(table),
         full_key = SystemKeys.shard_key(shard_end_key),
         full_key >= start_key and full_key < end_key do
-      :ets.delete(table, shard_end_key)
+      delete_shard(routing_data, shard_end_key, version)
     end
 
     routing_data

--- a/lib/bedrock/data_plane/shard_router.ex
+++ b/lib/bedrock/data_plane/shard_router.ex
@@ -4,11 +4,18 @@ defmodule Bedrock.DataPlane.ShardRouter do
 
   ## Shard Lookup
 
-  Uses an ETS ordered_set table for O(log n) ceiling search. Each entry is `{end_key, tag}`
-  where `end_key` is the exclusive upper bound for that shard.
+  Uses an ETS ordered_set table for O(log n) ceiling search. Each entry is
+  `{end_key, tag, version}` where `end_key` is the exclusive upper bound for
+  that shard and `version` is the commit version that wrote the row.
+
+  A cleared boundary is kept as a `{end_key, :deleted, version}` tombstone
+  rather than removed: the shard table is written by concurrent, unordered
+  writers (finalization tasks and the commit proxy server), and the per-row
+  version is what lets a late write of an older version lose. Every
+  navigation step here treats tombstones as absent.
 
   To find the shard for a key:
-  1. Find the first entry where `end_key >= key`
+  1. Find the first live entry where `end_key > key`
   2. Return that entry's tag
 
   ## Log Selection
@@ -74,9 +81,8 @@ defmodule Bedrock.DataPlane.ShardRouter do
   @doc ~S"""
   Looks up the shard tag for a key using ETS ceiling search.
 
-  The ETS table must be an ordered_set with entries in one of two formats:
-  - `{end_key, tag}` - uncached format
-  - `{end_key, {tag, log_indices}}` - cached format (after `get_logs_for_key/4` call)
+  The ETS table must be an ordered_set with `{end_key, tag, version}` entries;
+  tombstoned rows (`tag == :deleted`) are skipped.
 
   Shard ranges are `[min, max)` - start inclusive, end exclusive.
 
@@ -91,7 +97,7 @@ defmodule Bedrock.DataPlane.ShardRouter do
 
   ## Examples
 
-      # Table has: {"m", 0}, {"\xff", 1}
+      # Table has: {"m", 0, v}, {"\xff", 1, v}
       # Shard 0 covers ["", "m"), Shard 1 covers ["m", "\xff")
       iex> lookup_shard(table, "apple")
       0
@@ -103,113 +109,42 @@ defmodule Bedrock.DataPlane.ShardRouter do
   """
   @spec lookup_shard(:ets.table(), binary()) :: non_neg_integer()
   def lookup_shard(table, key) when is_binary(key) do
-    # Find first end_key > key (strictly greater)
+    # Find first live end_key > key (strictly greater)
     # With [min, max) ranges, end_key is exclusive, so we want end_key > key
-    case :ets.next(table, key) do
-      :"$end_of_table" ->
-        # Key is beyond all boundaries - fall back to last entry
-        lookup_last(table)
+    case next_live(table, key) do
+      :none ->
+        # Key is beyond all live boundaries - fall back to the last live entry
+        case last_live(table) do
+          :none -> raise_no_live_boundaries(table)
+          {_end_key, tag} -> tag
+        end
 
-      next_key ->
-        # Found the shard whose end_key > key, meaning key is in this shard's range
-        extract_tag(:ets.lookup_element(table, next_key, 2))
+      {_end_key, tag} ->
+        tag
     end
   end
 
-  defp lookup_last(table) do
-    case :ets.last(table) do
-      :"$end_of_table" -> raise "Empty shard_keys table"
-      last_key -> extract_tag(:ets.lookup_element(table, last_key, 2))
-    end
-  end
-
-  # Extract tag from either cached or uncached format
-  # Tags can be integers or strings depending on test setup
-  defp extract_tag({tag, _log_indices}), do: tag
-  defp extract_tag(tag), do: tag
-
-  @doc ~S"""
-  Looks up all shard tags that overlap with a key range.
-
-  Used for range mutations (clear_range) that may span multiple shards.
-  Returns a list of tags for all shards that intersect the range [start_key, end_key).
-
-  ## Parameters
-
-    - `table` - ETS table reference with `{end_key, tag}` entries
-    - `start_key` - Start of the range (inclusive)
-    - `end_key` - End of the range (exclusive)
-
-  ## Returns
-
-  List of shard tags that the range intersects with.
-
-  ## Examples
-
-      # Table has: {"d", 0}, {"h", 1}, {"m", 2}, {"\xff", 3}
-      iex> lookup_shards_for_range(table, "a", "c")
-      [0]
-      iex> lookup_shards_for_range(table, "c", "f")
-      [0, 1]
-
-  """
-  @spec lookup_shards_for_range(:ets.table(), binary(), binary()) :: [non_neg_integer()]
-  def lookup_shards_for_range(table, start_key, end_key) when is_binary(start_key) and is_binary(end_key) do
-    # Find the first shard that contains start_key
-    first_tag = lookup_shard(table, start_key)
-
-    # If start_key == end_key (empty range), just return the start shard
-    if start_key >= end_key do
-      [first_tag]
+  # An all-tombstones table is distinct from an empty one: it is transiently
+  # reachable while a concurrent writer is between a rewrite's clear_range
+  # and its sets, and the crash lands there in the routing batch task.
+  defp raise_no_live_boundaries(table) do
+    if :ets.info(table, :size) == 0 do
+      raise "Empty shard_keys table"
     else
-      # Collect all shards from first_tag until we find one that contains end_key
-      collect_shards_in_range(table, start_key, end_key, first_tag)
+      raise "No live shard boundaries in shard_keys table (all tombstoned)"
     end
-  end
-
-  # Collect all shard tags that overlap with the range [start_key, end_key)
-  @spec collect_shards_in_range(:ets.table(), binary(), binary(), non_neg_integer()) ::
-          [non_neg_integer()]
-  defp collect_shards_in_range(table, start_key, end_key, _first_tag) do
-    # Get all entries from the table
-    entries = :ets.tab2list(table)
-
-    # Sort by end_key
-    sorted = Enum.sort_by(entries, fn {ek, _tag_or_cached} -> ek end)
-
-    # Find shards that overlap with [start_key, end_key)
-    # With [min, max) semantics:
-    # - A shard with end_key E covers [prev_end, E)
-    # - Shard overlaps [start_key, end_key) if: shard_end_key > start_key
-    sorted
-    |> Enum.filter(fn {shard_end_key, _tag_or_cached} ->
-      # Shard must extend past start_key (strictly greater because end is exclusive)
-      shard_end_key > start_key
-    end)
-    |> Enum.reduce_while([], fn {shard_end_key, tag_or_cached}, acc ->
-      tag = extract_tag(tag_or_cached)
-      acc = [tag | acc]
-
-      # If this shard's end_key >= end_key, we've covered the whole range
-      if shard_end_key >= end_key do
-        {:halt, acc}
-      else
-        {:cont, acc}
-      end
-    end)
-    |> Enum.reverse()
   end
 
   @doc ~S"""
   Returns shards overlapping a key range, with their boundaries.
 
-  Unlike `lookup_shards_for_range/3` which returns only tags, this function
-  returns `{tag, shard_start, shard_end}` tuples to enable clamping range
-  mutations to shard boundaries.
+  Returns `{tag, shard_start, shard_end}` tuples to enable clamping range
+  mutations to shard boundaries. Tombstoned boundaries are treated as absent:
+  the shard structure is defined by live rows only.
 
   ## Parameters
 
-    - `table` - ETS table reference with `{end_key, tag}` entries
+    - `table` - ETS table reference with `{end_key, tag, version}` entries
     - `start_key` - Start of the range (inclusive)
     - `end_key` - End of the range (exclusive)
 
@@ -217,11 +152,11 @@ defmodule Bedrock.DataPlane.ShardRouter do
 
   List of `{tag, shard_start, shard_end}` tuples for all shards that
   overlap [start_key, end_key). Returns `[]` when the range lies entirely
-  beyond shard coverage (start_key >= every shard's exclusive end_key).
+  beyond shard coverage (start_key >= every live shard's exclusive end_key).
 
   ## Examples
 
-      # Table has: {"d", 0}, {"h", 1}, {"m", 2}, {"\xff", 3}
+      # Table has: {"d", 0, v}, {"h", 1, v}, {"m", 2, v}, {"\xff", 3, v}
       # Shards: 0 = ["", "d"), 1 = ["d", "h"), 2 = ["h", "m"), 3 = ["m", "\xff")
       iex> lookup_shards_with_ranges(table, "a", "c")
       [{0, "", "d"}]
@@ -232,97 +167,67 @@ defmodule Bedrock.DataPlane.ShardRouter do
   @spec lookup_shards_with_ranges(:ets.table(), binary(), binary()) ::
           [{non_neg_integer(), binary(), binary()}]
   def lookup_shards_with_ranges(table, start_key, end_key) when is_binary(start_key) and is_binary(end_key) do
-    # Find first end_key > start_key (the shard containing start_key)
-    case :ets.next(table, start_key) do
-      :"$end_of_table" ->
-        # start_key is at or beyond every shard's exclusive upper bound:
+    case next_live(table, start_key) do
+      :none ->
+        # start_key is at or beyond every live shard's exclusive upper bound:
         # the range intersects no shard.
         []
 
-      first_end ->
-        # Find the start boundary of the first shard (previous key in table, or "" if first)
-        first_start = find_shard_start(table, first_end)
-        collect_shards_with_ranges(table, first_end, end_key, first_start, [])
+      {first_end, first_tag} ->
+        # The first shard starts at the previous live boundary, or "" if none.
+        first_start =
+          case prev_live(table, first_end) do
+            :none -> ""
+            {prev_end, _tag} -> prev_end
+          end
+
+        collect_shards_with_ranges(table, first_end, first_tag, end_key, first_start, [])
     end
   end
 
-  # Find the start of a shard (the previous end_key in the table, or "" if first)
-  defp find_shard_start(table, shard_end) do
-    case :ets.prev(table, shard_end) do
-      :"$end_of_table" -> ""
-      prev_key -> prev_key
-    end
-  end
+  defp collect_shards_with_ranges(table, shard_end, tag, end_key, shard_start, acc) do
+    acc = [{tag, shard_start, shard_end} | acc]
 
-  defp collect_shards_with_ranges(_table, :"$end_of_table", _end_key, _prev_end, acc) do
-    Enum.reverse(acc)
-  end
-
-  defp collect_shards_with_ranges(table, shard_end, end_key, shard_start, acc) when shard_end >= end_key do
-    # Last shard - includes the end_key
-    tag = extract_tag(:ets.lookup_element(table, shard_end, 2))
-    Enum.reverse([{tag, shard_start, shard_end} | acc])
-  end
-
-  defp collect_shards_with_ranges(table, shard_end, end_key, shard_start, acc) do
-    tag = extract_tag(:ets.lookup_element(table, shard_end, 2))
-    next_end = :ets.next(table, shard_end)
-    # Current shard_end becomes the start of the next shard
-    collect_shards_with_ranges(table, next_end, end_key, shard_end, [{tag, shard_start, shard_end} | acc])
-  end
-
-  @doc """
-  Routes a key to its logs using shard lookup and golden ratio log selection.
-
-  Uses lazy caching: first call computes log_indices and caches in ETS,
-  subsequent calls use the cached value. The ETS entry format changes from
-  `{end_key, tag}` to `{end_key, {tag, log_indices}}` after first access.
-
-  ## Parameters
-
-    - `shard_table` - ETS table with `{end_key, tag}` or `{end_key, {tag, log_indices}}` entries
-    - `key` - The key to route
-    - `log_map` - Map from log index to log_id (`%{0 => "log-a", 1 => "log-b", ...}`)
-    - `replication_factor` - How many logs to return
-
-  ## Returns
-
-  List of log_ids that should store data for this key.
-
-  """
-  @spec get_logs_for_key(:ets.table(), binary(), %{non_neg_integer() => binary()}, non_neg_integer()) ::
-          [binary()]
-  def get_logs_for_key(shard_table, key, log_map, replication_factor) do
-    n = map_size(log_map)
-    end_key = find_end_key(shard_table, key)
-
-    log_indices =
-      case :ets.lookup(shard_table, end_key) do
-        [{_, {_tag, cached_indices}}] ->
-          # Already cached - use it
-          cached_indices
-
-        [{_, tag}] when is_integer(tag) ->
-          # Not cached - compute, cache, return
-          indices = get_log_indices(tag, n, replication_factor)
-          :ets.insert(shard_table, {end_key, {tag, indices}})
-          indices
+    if shard_end >= end_key do
+      Enum.reverse(acc)
+    else
+      case next_live(table, shard_end) do
+        :none -> Enum.reverse(acc)
+        # The current live end is the next shard's start.
+        {next_end, next_tag} -> collect_shards_with_ranges(table, next_end, next_tag, end_key, shard_end, acc)
       end
-
-    Enum.map(log_indices, &Map.fetch!(log_map, &1))
+    end
   end
 
-  # Find the end_key for the shard containing key
-  defp find_end_key(table, key) do
-    case :ets.next(table, key) do
-      :"$end_of_table" ->
-        case :ets.last(table) do
-          :"$end_of_table" -> raise "Empty shard_keys table"
-          last_key -> last_key
-        end
+  # Live-row navigation: step over tombstones in either direction.
 
-      next_key ->
-        next_key
+  defp next_live(table, key) do
+    case :ets.next(table, key) do
+      :"$end_of_table" -> :none
+      end_key -> live_or_continue(table, end_key, &next_live/2)
+    end
+  end
+
+  defp prev_live(table, key) do
+    case :ets.prev(table, key) do
+      :"$end_of_table" -> :none
+      end_key -> live_or_continue(table, end_key, &prev_live/2)
+    end
+  end
+
+  defp last_live(table) do
+    case :ets.last(table) do
+      :"$end_of_table" -> :none
+      end_key -> live_or_continue(table, end_key, &prev_live/2)
+    end
+  end
+
+  defp live_or_continue(table, end_key, continue) do
+    case :ets.lookup(table, end_key) do
+      [{^end_key, :deleted, _version}] -> continue.(table, end_key)
+      [{^end_key, tag, _version}] -> {end_key, tag}
+      # The row was replaced-in-flight or removed; keep walking.
+      [] -> continue.(table, end_key)
     end
   end
 end

--- a/test/bedrock/control_plane/director/recovery/persistence_phase_test.exs
+++ b/test/bedrock/control_plane/director/recovery/persistence_phase_test.exs
@@ -268,13 +268,15 @@ defmodule Bedrock.ControlPlane.Director.Recovery.PersistencePhaseTest do
       mutations = captured_system_mutations(base_recovery_attempt())
 
       routing_data = RoutingData.new_empty()
-      RoutingData.insert_shard(routing_data, <<0x40>>, 2)
-      RoutingData.insert_shard(routing_data, <<0x80>>, 3)
-      RoutingData.insert_shard(routing_data, <<0xFF, 0xFF>>, 4)
+      RoutingData.insert_shard(routing_data, <<0x40>>, 2, nil)
+      RoutingData.insert_shard(routing_data, <<0x80>>, 3, nil)
+      RoutingData.insert_shard(routing_data, <<0xFF, 0xFF>>, 4, nil)
 
-      updated = RoutingData.apply_mutations(routing_data, [{1, mutations}])
+      v1 = Bedrock.DataPlane.Version.from_integer(1)
+      updated = RoutingData.apply_mutations(routing_data, [{v1, mutations}])
 
-      assert :ets.tab2list(updated.shard_table) == [{<<0xFF>>, 1}, {<<0xFF, 0xFF>>, 0}]
+      live = for {k, tag, _v} <- :ets.tab2list(updated.shard_table), tag != :deleted, do: {k, tag}
+      assert live == [{<<0xFF>>, 1}, {<<0xFF, 0xFF>>, 0}]
 
       RoutingData.cleanup(routing_data)
     end

--- a/test/bedrock/data_plane/commit_proxy/finalization/data_transformation_test.exs
+++ b/test/bedrock/data_plane/commit_proxy/finalization/data_transformation_test.exs
@@ -32,7 +32,7 @@ defmodule Bedrock.DataPlane.CommitProxy.FinalizationDataTransformationTest do
   defp build_routing_data(logs) do
     table = :ets.new(:test_shard_keys, [:ordered_set, :public])
     # Default shard layout covering entire keyspace with a single shard (tag 0)
-    :ets.insert(table, {<<0xFF, 0xFF>>, 0})
+    :ets.insert(table, {<<0xFF, 0xFF>>, 0, nil})
 
     log_map =
       logs

--- a/test/bedrock/data_plane/commit_proxy/metadata_window_application_test.exs
+++ b/test/bedrock/data_plane/commit_proxy/metadata_window_application_test.exs
@@ -92,7 +92,7 @@ defmodule Bedrock.DataPlane.CommitProxy.MetadataWindowApplicationTest do
 
     assert updated.metadata.version == v(1)
     assert updated.routing_data.log_map == %{0 => "log_a"}
-    assert :ets.lookup(updated.routing_data.shard_table, "a") == [{"a", 7}]
+    assert :ets.lookup(updated.routing_data.shard_table, "a") == [{"a", 7, v(1)}]
   end
 
   test "a re-delivered window does not duplicate log entries" do

--- a/test/bedrock/data_plane/commit_proxy/routing_data_test.exs
+++ b/test/bedrock/data_plane/commit_proxy/routing_data_test.exs
@@ -2,8 +2,51 @@ defmodule Bedrock.DataPlane.CommitProxy.RoutingDataTest do
   use ExUnit.Case, async: true
 
   alias Bedrock.DataPlane.CommitProxy.RoutingData
+  alias Bedrock.DataPlane.ShardRouter
+  alias Bedrock.DataPlane.Version
   alias Bedrock.SystemKeys
   alias Bedrock.SystemKeys.Values
+
+  defp v(n), do: Version.from_integer(n)
+
+  # Live shard boundaries as {end_key, tag}, hiding tombstones and versions.
+  defp live_shards(table), do: for({k, tag, _v} <- :ets.tab2list(table), tag != :deleted, do: {k, tag})
+
+  describe "versioned shard writes (last-writer-wins)" do
+    # Finalization tasks and the server write the shared shard table without
+    # any ordering between them; per-row version guards make the row converge
+    # to the newest write no matter the arrival order (bedrock-q67.24).
+    setup do
+      routing_data = RoutingData.new_empty()
+      RoutingData.insert_shard(routing_data, <<0xFF, 0xFF>>, 0, v(1))
+      on_exit(fn -> RoutingData.cleanup(routing_data) end)
+      {:ok, routing_data: routing_data}
+    end
+
+    test "a late write of an older version cannot clobber a newer tag", %{routing_data: rd} do
+      RoutingData.insert_shard(rd, "m", 7, v(5))
+      RoutingData.insert_shard(rd, "m", 3, v(2))
+
+      assert ShardRouter.lookup_shard(rd.shard_table, "a") == 7
+    end
+
+    test "a clear tombstones the boundary and an older late set cannot resurrect it", %{routing_data: rd} do
+      RoutingData.insert_shard(rd, "m", 7, v(2))
+      RoutingData.delete_shard(rd, "m", v(5))
+      RoutingData.insert_shard(rd, "m", 7, v(3))
+
+      # The boundary at "m" is gone: keys below it route to the next live shard.
+      assert ShardRouter.lookup_shard(rd.shard_table, "a") == 0
+    end
+
+    test "a newer set revives a tombstoned boundary", %{routing_data: rd} do
+      RoutingData.insert_shard(rd, "m", 7, v(2))
+      RoutingData.delete_shard(rd, "m", v(3))
+      RoutingData.insert_shard(rd, "m", 9, v(4))
+
+      assert ShardRouter.lookup_shard(rd.shard_table, "a") == 9
+    end
+  end
 
   describe "from_snapshot/1" do
     test "builds fully-populated routing data owned by the calling process" do
@@ -17,7 +60,7 @@ defmodule Bedrock.DataPlane.CommitProxy.RoutingDataTest do
       routing_data = RoutingData.from_snapshot(snapshot)
 
       assert :ets.info(routing_data.shard_table, :owner) == self()
-      assert :ets.tab2list(routing_data.shard_table) == [{"m", 1}, {<<0xFF, 0xFF>>, 0}]
+      assert :ets.tab2list(routing_data.shard_table) == [{"m", 1, nil}, {<<0xFF, 0xFF>>, 0, nil}]
       assert routing_data.log_map == %{0 => "log-a", 1 => "log-b"}
       assert routing_data.log_services == %{"log-a" => {:log_a, :node1}, "log-b" => {:log_b, :node2}}
       assert routing_data.replication_factor == 2
@@ -294,10 +337,10 @@ defmodule Bedrock.DataPlane.CommitProxy.RoutingDataTest do
         |> RoutingData.put_log_service("log-2", {:log_2, :n2@host})
         |> RoutingData.put_log_service("log-3", {:log_3, :n3@host})
 
-      # Add shard entries (via existing insert_shard/3)
-      RoutingData.insert_shard(routing_data, "m", 0)
-      RoutingData.insert_shard(routing_data, "z", 1)
-      RoutingData.insert_shard(routing_data, <<0xFF, 0xFF>>, 2)
+      # Add shard entries
+      RoutingData.insert_shard(routing_data, "m", 0, v(1))
+      RoutingData.insert_shard(routing_data, "z", 1, v(1))
+      RoutingData.insert_shard(routing_data, <<0xFF, 0xFF>>, 2, v(1))
 
       # Set replication factor
       routing_data = RoutingData.set_replication_factor(routing_data, 3)
@@ -313,7 +356,7 @@ defmodule Bedrock.DataPlane.CommitProxy.RoutingDataTest do
 
       assert routing_data.replication_factor == 3
 
-      assert :ets.tab2list(routing_data.shard_table) == [
+      assert live_shards(routing_data.shard_table) == [
                {"m", 0},
                {"z", 1},
                {<<0xFF, 0xFF>>, 2}
@@ -328,11 +371,11 @@ defmodule Bedrock.DataPlane.CommitProxy.RoutingDataTest do
       routing_data = RoutingData.new_empty()
       key = SystemKeys.shard_key("m")
       value = Values.encode_shard_key_entry(42, "")
-      updates = [{100, [{:set, key, value}]}]
+      updates = [{v(100), [{:set, key, value}]}]
 
       updated = RoutingData.apply_mutations(routing_data, updates)
 
-      assert :ets.lookup(updated.shard_table, "m") == [{"m", 42}]
+      assert :ets.lookup(updated.shard_table, "m") == [{"m", 42, v(100)}]
 
       RoutingData.cleanup(routing_data)
     end
@@ -341,7 +384,7 @@ defmodule Bedrock.DataPlane.CommitProxy.RoutingDataTest do
       routing_data = RoutingData.new_empty()
 
       updates = [
-        {100,
+        {v(100),
          [
            {:set, SystemKeys.shard_key("a"), Values.encode_shard_key_entry(1, "")},
            {:set, SystemKeys.shard_key("m"), Values.encode_shard_key_entry(2, "")},
@@ -351,9 +394,9 @@ defmodule Bedrock.DataPlane.CommitProxy.RoutingDataTest do
 
       updated = RoutingData.apply_mutations(routing_data, updates)
 
-      assert :ets.lookup(updated.shard_table, "a") == [{"a", 1}]
-      assert :ets.lookup(updated.shard_table, "m") == [{"m", 2}]
-      assert :ets.lookup(updated.shard_table, "z") == [{"z", 3}]
+      assert :ets.lookup(updated.shard_table, "a") == [{"a", 1, v(100)}]
+      assert :ets.lookup(updated.shard_table, "m") == [{"m", 2, v(100)}]
+      assert :ets.lookup(updated.shard_table, "z") == [{"z", 3, v(100)}]
 
       RoutingData.cleanup(routing_data)
     end
@@ -364,7 +407,7 @@ defmodule Bedrock.DataPlane.CommitProxy.RoutingDataTest do
       # layout_log stores log descriptor (tags) as erlang term
       log_descriptor = [0, 1]
       value = Values.encode_tag_list(log_descriptor)
-      updates = [{100, [{:set, key, value}]}]
+      updates = [{v(100), [{:set, key, value}]}]
 
       updated = RoutingData.apply_mutations(routing_data, updates)
 
@@ -380,7 +423,7 @@ defmodule Bedrock.DataPlane.CommitProxy.RoutingDataTest do
       routing_data = RoutingData.new_empty()
 
       updates = [
-        {100,
+        {v(100),
          [
            {:set, SystemKeys.layout_log("log-1"), Values.encode_tag_list([0])},
            {:set, SystemKeys.layout_log("log-2"), Values.encode_tag_list([1])}
@@ -398,14 +441,15 @@ defmodule Bedrock.DataPlane.CommitProxy.RoutingDataTest do
 
     test "handles shard_key clear mutation" do
       routing_data = RoutingData.new_empty()
-      RoutingData.insert_shard(routing_data, "m", 42)
+      RoutingData.insert_shard(routing_data, "m", 42, v(1))
 
       key = SystemKeys.shard_key("m")
-      updates = [{100, [{:clear, key}]}]
+      updates = [{v(100), [{:clear, key}]}]
 
       updated = RoutingData.apply_mutations(routing_data, updates)
 
-      assert :ets.lookup(updated.shard_table, "m") == []
+      assert :ets.lookup(updated.shard_table, "m") == [{"m", :deleted, v(100)}]
+      assert live_shards(updated.shard_table) == []
 
       RoutingData.cleanup(routing_data)
     end
@@ -417,7 +461,7 @@ defmodule Bedrock.DataPlane.CommitProxy.RoutingDataTest do
         |> RoutingData.put_log_service("log-123", {:my_log, :node@host})
 
       key = SystemKeys.layout_log("log-123")
-      updates = [{100, [{:clear, key}]}]
+      updates = [{v(100), [{:clear, key}]}]
 
       updated = RoutingData.apply_mutations(routing_data, updates)
 
@@ -433,16 +477,16 @@ defmodule Bedrock.DataPlane.CommitProxy.RoutingDataTest do
       routing_data = RoutingData.new_empty()
 
       updates = [
-        {100, [{:set, SystemKeys.shard_key("a"), Values.encode_shard_key_entry(1, "")}]},
-        {101, [{:set, SystemKeys.shard_key("b"), Values.encode_shard_key_entry(2, "")}]},
-        {102, [{:set, SystemKeys.shard_key("a"), Values.encode_shard_key_entry(99, "")}]}
+        {v(100), [{:set, SystemKeys.shard_key("a"), Values.encode_shard_key_entry(1, "")}]},
+        {v(101), [{:set, SystemKeys.shard_key("b"), Values.encode_shard_key_entry(2, "")}]},
+        {v(102), [{:set, SystemKeys.shard_key("a"), Values.encode_shard_key_entry(99, "")}]}
       ]
 
       updated = RoutingData.apply_mutations(routing_data, updates)
 
       # Later version (102) overwrites earlier (100)
-      assert :ets.lookup(updated.shard_table, "a") == [{"a", 99}]
-      assert :ets.lookup(updated.shard_table, "b") == [{"b", 2}]
+      assert :ets.lookup(updated.shard_table, "a") == [{"a", 99, v(102)}]
+      assert :ets.lookup(updated.shard_table, "b") == [{"b", 2, v(101)}]
 
       RoutingData.cleanup(routing_data)
     end
@@ -451,7 +495,7 @@ defmodule Bedrock.DataPlane.CommitProxy.RoutingDataTest do
       routing_data = RoutingData.new_empty()
 
       # Unknown system key
-      updates = [{100, [{:set, "\xff/system/unknown/foo", "bar"}]}]
+      updates = [{v(100), [{:set, "\xff/system/unknown/foo", "bar"}]}]
 
       updated = RoutingData.apply_mutations(routing_data, updates)
 
@@ -466,7 +510,7 @@ defmodule Bedrock.DataPlane.CommitProxy.RoutingDataTest do
     test "ignores non-system keys" do
       routing_data = RoutingData.new_empty()
 
-      updates = [{100, [{:set, "user/data", "value"}]}]
+      updates = [{v(100), [{:set, "user/data", "value"}]}]
 
       updated = RoutingData.apply_mutations(routing_data, updates)
 
@@ -480,7 +524,7 @@ defmodule Bedrock.DataPlane.CommitProxy.RoutingDataTest do
       routing_data = RoutingData.new_empty()
 
       # atomic ops are not routing-relevant
-      updates = [{100, [{:atomic, :add, "key", <<1>>}]}]
+      updates = [{v(100), [{:atomic, :add, "key", <<1>>}]}]
 
       updated = RoutingData.apply_mutations(routing_data, updates)
 
@@ -491,31 +535,31 @@ defmodule Bedrock.DataPlane.CommitProxy.RoutingDataTest do
 
     test "clear_range removes shard entries whose full key falls in range" do
       routing_data = RoutingData.new_empty()
-      RoutingData.insert_shard(routing_data, "a", 1)
-      RoutingData.insert_shard(routing_data, "m", 2)
-      RoutingData.insert_shard(routing_data, "z", 3)
+      RoutingData.insert_shard(routing_data, "a", 1, v(1))
+      RoutingData.insert_shard(routing_data, "m", 2, v(1))
+      RoutingData.insert_shard(routing_data, "z", 3, v(1))
 
       # Clear [shard_key("a"), shard_key("z")) - end is exclusive, so "z" survives
-      updates = [{100, [{:clear_range, SystemKeys.shard_key("a"), SystemKeys.shard_key("z")}]}]
+      updates = [{v(100), [{:clear_range, SystemKeys.shard_key("a"), SystemKeys.shard_key("z")}]}]
 
       updated = RoutingData.apply_mutations(routing_data, updates)
 
-      assert :ets.tab2list(updated.shard_table) == [{"z", 3}]
+      assert live_shards(updated.shard_table) == [{"z", 3}]
 
       RoutingData.cleanup(routing_data)
     end
 
     test "clear_range over the shard_keys prefix removes all shard entries" do
       routing_data = RoutingData.new_empty()
-      RoutingData.insert_shard(routing_data, "m", 1)
-      RoutingData.insert_shard(routing_data, <<0xFF, 0xFF>>, 2)
+      RoutingData.insert_shard(routing_data, "m", 1, v(1))
+      RoutingData.insert_shard(routing_data, <<0xFF, 0xFF>>, 2, v(1))
 
       {start_key, end_key} = Bedrock.KeyRange.from_prefix(SystemKeys.shard_keys_prefix())
-      updates = [{100, [{:clear_range, start_key, end_key}]}]
+      updates = [{v(100), [{:clear_range, start_key, end_key}]}]
 
       updated = RoutingData.apply_mutations(routing_data, updates)
 
-      assert :ets.tab2list(updated.shard_table) == []
+      assert live_shards(updated.shard_table) == []
 
       RoutingData.cleanup(routing_data)
     end
@@ -530,7 +574,7 @@ defmodule Bedrock.DataPlane.CommitProxy.RoutingDataTest do
         |> RoutingData.put_log_service("log-b", {:log_b, :n2@host})
 
       # Clear [layout_log("log-a"), layout_log("log-c")) - "log-c" survives
-      updates = [{100, [{:clear_range, SystemKeys.layout_log("log-a"), SystemKeys.layout_log("log-c")}]}]
+      updates = [{v(100), [{:clear_range, SystemKeys.layout_log("log-a"), SystemKeys.layout_log("log-c")}]}]
 
       updated = RoutingData.apply_mutations(routing_data, updates)
 
@@ -542,14 +586,14 @@ defmodule Bedrock.DataPlane.CommitProxy.RoutingDataTest do
 
     test "clear_range outside routing families leaves routing data unchanged" do
       routing_data = RoutingData.new_empty()
-      RoutingData.insert_shard(routing_data, "m", 1)
+      RoutingData.insert_shard(routing_data, "m", 1, v(1))
       routing_data = RoutingData.insert_log(routing_data, "log-1")
 
-      updates = [{100, [{:clear_range, "user/a", "user/z"}]}]
+      updates = [{v(100), [{:clear_range, "user/a", "user/z"}]}]
 
       updated = RoutingData.apply_mutations(routing_data, updates)
 
-      assert :ets.tab2list(updated.shard_table) == [{"m", 1}]
+      assert live_shards(updated.shard_table) == [{"m", 1}]
       assert updated.log_map == %{0 => "log-1"}
 
       RoutingData.cleanup(routing_data)
@@ -557,14 +601,14 @@ defmodule Bedrock.DataPlane.CommitProxy.RoutingDataTest do
 
     test "recovery-style rewrite: clear_range then sets shrinks 3 shards to 2" do
       routing_data = RoutingData.new_empty()
-      RoutingData.insert_shard(routing_data, "g", 1)
-      RoutingData.insert_shard(routing_data, "p", 2)
-      RoutingData.insert_shard(routing_data, <<0xFF, 0xFF>>, 3)
+      RoutingData.insert_shard(routing_data, "g", 1, v(1))
+      RoutingData.insert_shard(routing_data, "p", 2, v(1))
+      RoutingData.insert_shard(routing_data, <<0xFF, 0xFF>>, 3, v(1))
 
       {start_key, end_key} = Bedrock.KeyRange.from_prefix(SystemKeys.shard_keys_prefix())
 
       updates = [
-        {100,
+        {v(100),
          [
            {:clear_range, start_key, end_key},
            {:set, SystemKeys.shard_key("m"), Values.encode_shard_key_entry(10, "")},
@@ -574,7 +618,7 @@ defmodule Bedrock.DataPlane.CommitProxy.RoutingDataTest do
 
       updated = RoutingData.apply_mutations(routing_data, updates)
 
-      assert :ets.tab2list(updated.shard_table) == [{"m", 10}, {<<0xFF, 0xFF>>, 11}]
+      assert live_shards(updated.shard_table) == [{"m", 10}, {<<0xFF, 0xFF>>, 11}]
 
       RoutingData.cleanup(routing_data)
     end
@@ -583,7 +627,7 @@ defmodule Bedrock.DataPlane.CommitProxy.RoutingDataTest do
       routing_data = RoutingData.new_empty()
 
       updates = [
-        {100,
+        {v(100),
          [
            {:set, SystemKeys.shard_key("m"), Values.encode_shard_key_entry(1, "")},
            {:set, SystemKeys.layout_log("log-1"), Values.encode_tag_list([0])},
@@ -595,8 +639,8 @@ defmodule Bedrock.DataPlane.CommitProxy.RoutingDataTest do
       updated = RoutingData.apply_mutations(routing_data, updates)
 
       # Shard entries
-      assert :ets.lookup(updated.shard_table, "m") == [{"m", 1}]
-      assert :ets.lookup(updated.shard_table, "z") == [{"z", 2}]
+      assert :ets.lookup(updated.shard_table, "m") == [{"m", 1, v(100)}]
+      assert :ets.lookup(updated.shard_table, "z") == [{"z", 2, v(100)}]
       # Log entries - only log_map populated, not log_services
       assert updated.log_map == %{0 => "log-1", 1 => "log-2"}
       assert updated.log_services == %{}

--- a/test/bedrock/data_plane/commit_proxy/server_test.exs
+++ b/test/bedrock/data_plane/commit_proxy/server_test.exs
@@ -1318,7 +1318,7 @@ defmodule Bedrock.DataPlane.CommitProxy.ServerTest do
       # reference built in another process is invalid after that process dies,
       # and is never valid on another node.
       assert :ets.info(routing_data.shard_table, :owner) == commit_proxy
-      assert :ets.tab2list(routing_data.shard_table) == [{<<0xFF, 0xFF>>, 0}]
+      assert :ets.tab2list(routing_data.shard_table) == [{<<0xFF, 0xFF>>, 0, nil}]
       assert routing_data.log_map == %{0 => "log-1"}
       assert routing_data.log_services == %{"log-1" => {:log_1, :node1}}
     end

--- a/test/bedrock/data_plane/shard_router_test.exs
+++ b/test/bedrock/data_plane/shard_router_test.exs
@@ -2,6 +2,47 @@ defmodule Bedrock.DataPlane.ShardRouterTest do
   use ExUnit.Case, async: true
 
   alias Bedrock.DataPlane.ShardRouter
+  alias Bedrock.DataPlane.Version
+
+  @v0 Version.from_integer(0)
+
+  describe "tombstone-aware lookups" do
+    # Cleared boundaries stay in the table as {end_key, :deleted, version}
+    # tombstones so a late write of an older version cannot resurrect them;
+    # every navigation step must treat them as absent (bedrock-q67.24).
+    setup do
+      table = :ets.new(:tombstone_shards, [:ordered_set, :public])
+      v1 = Version.from_integer(1)
+      :ets.insert(table, {"d", 0, v1})
+      :ets.insert(table, {"h", :deleted, v1})
+      :ets.insert(table, {"m", 2, v1})
+      :ets.insert(table, {<<0xFF>>, 3, v1})
+      {:ok, table: table}
+    end
+
+    test "lookup_shard skips a tombstoned boundary", %{table: table} do
+      # "h" is gone: ["d", "m") is one shard now, owned by tag 2.
+      assert ShardRouter.lookup_shard(table, "e") == 2
+      assert ShardRouter.lookup_shard(table, "a") == 0
+    end
+
+    test "the last-entry fallback skips trailing tombstones", %{table: table} do
+      :ets.insert(table, {<<0xFF>>, :deleted, Version.from_integer(2)})
+
+      assert ShardRouter.lookup_shard(table, <<0xFF, 0x01>>) == 2
+    end
+
+    test "lookup_shards_with_ranges treats tombstoned boundaries as absent", %{table: table} do
+      assert ShardRouter.lookup_shards_with_ranges(table, "a", "z") ==
+               [{0, "", "d"}, {2, "d", "m"}, {3, "m", <<0xFF>>}]
+    end
+
+    test "a range lying beyond all live boundaries intersects no shard", %{table: table} do
+      :ets.insert(table, {<<0xFF>>, :deleted, Version.from_integer(2)})
+
+      assert ShardRouter.lookup_shards_with_ranges(table, "n", "z") == []
+    end
+  end
 
   describe "get_log_indices/3 - golden ratio log selection" do
     test "returns empty list when replication factor is 0" do
@@ -99,8 +140,8 @@ defmodule Bedrock.DataPlane.ShardRouterTest do
 
       # Shard ranges are [min, max) - start inclusive, end exclusive
       # Tag 0 covers ["", "m"), tag 1 covers ["m", \xff)
-      :ets.insert(table, {"m", 0})
-      :ets.insert(table, {"\xff", 1})
+      :ets.insert(table, {"m", 0, @v0})
+      :ets.insert(table, {"\xff", 1, @v0})
 
       on_exit(fn ->
         try do
@@ -145,7 +186,7 @@ defmodule Bedrock.DataPlane.ShardRouterTest do
 
       try do
         # Single shard covers ["", \xff)
-        :ets.insert(table, {"\xff", 0})
+        :ets.insert(table, {"\xff", 0, @v0})
 
         assert ShardRouter.lookup_shard(table, "") == 0
         assert ShardRouter.lookup_shard(table, "any_key") == 0
@@ -162,11 +203,11 @@ defmodule Bedrock.DataPlane.ShardRouterTest do
         # 5 shards with [min, max) ranges:
         # Tag 0: ["", "b"), Tag 1: ["b", "d"), Tag 2: ["d", "f"),
         # Tag 3: ["f", "h"), Tag 4: ["h", \xff)
-        :ets.insert(table, {"b", 0})
-        :ets.insert(table, {"d", 1})
-        :ets.insert(table, {"f", 2})
-        :ets.insert(table, {"h", 3})
-        :ets.insert(table, {"\xff", 4})
+        :ets.insert(table, {"b", 0, @v0})
+        :ets.insert(table, {"d", 1, @v0})
+        :ets.insert(table, {"f", 2, @v0})
+        :ets.insert(table, {"h", 3, @v0})
+        :ets.insert(table, {"\xff", 4, @v0})
 
         assert ShardRouter.lookup_shard(table, "a") == 0
         # "b" is START of tag 1's range
@@ -183,202 +224,15 @@ defmodule Bedrock.DataPlane.ShardRouterTest do
     end
   end
 
-  describe "lookup_shards_for_range/3 - range to tags" do
-    setup do
-      table = :ets.new(:range_test, [:ordered_set, :public])
-      # 4 shards with [min, max) ranges:
-      # Tag 0: ["", "d"), Tag 1: ["d", "h"), Tag 2: ["h", "m"), Tag 3: ["m", \xff)
-      :ets.insert(table, {"d", 0})
-      :ets.insert(table, {"h", 1})
-      :ets.insert(table, {"m", 2})
-      :ets.insert(table, {"\xff", 3})
-
-      on_exit(fn ->
-        try do
-          :ets.delete(table)
-        rescue
-          ArgumentError -> :ok
-        end
-      end)
-
-      {:ok, table: table}
-    end
-
-    test "range within single shard returns one tag", %{table: table} do
-      # ["a", "c") is entirely within tag 0's range ["", "d")
-      assert ShardRouter.lookup_shards_for_range(table, "a", "c") == [0]
-    end
-
-    test "range spanning two shards returns both tags", %{table: table} do
-      # ["c", "f") spans tag 0 ["", "d") and tag 1 ["d", "h")
-      tags = ShardRouter.lookup_shards_for_range(table, "c", "f")
-      assert Enum.sort(tags) == [0, 1]
-    end
-
-    test "range spanning all shards returns all tags", %{table: table} do
-      # ["", \xff) spans all shards
-      tags = ShardRouter.lookup_shards_for_range(table, "", "\xff")
-      assert Enum.sort(tags) == [0, 1, 2, 3]
-    end
-
-    test "range at exact boundary", %{table: table} do
-      # ["d", "h") exactly matches tag 1's range
-      # With [min, max): "d" is the START of tag 1, "h" is the END (exclusive)
-      tags = ShardRouter.lookup_shards_for_range(table, "d", "h")
-      assert tags == [1]
-    end
-
-    test "empty range returns single shard", %{table: table} do
-      # ["e", "e") is empty but we still return the shard containing "e"
-      tags = ShardRouter.lookup_shards_for_range(table, "e", "e")
-      # "e" is in tag 1's range ["d", "h")
-      assert tags == [1]
-    end
-
-    test "range in last shard", %{table: table} do
-      # ["z", \xff) is entirely in tag 3's range ["m", \xff)
-      tags = ShardRouter.lookup_shards_for_range(table, "z", "\xff")
-      assert tags == [3]
-    end
-
-    test "range crossing multiple boundaries", %{table: table} do
-      # ["c", "i") spans tags 0, 1, and 2
-      # Tag 0: ["", "d"), Tag 1: ["d", "h"), Tag 2: ["h", "m")
-      tags = ShardRouter.lookup_shards_for_range(table, "c", "i")
-      assert Enum.sort(tags) == [0, 1, 2]
-    end
-  end
-
-  describe "get_logs_for_key/4 - full routing" do
-    setup do
-      table = :ets.new(:routing_test, [:ordered_set, :public])
-      :ets.insert(table, {"m", 0})
-      :ets.insert(table, {"\xff", 1})
-
-      # Log index to log_id mapping
-      log_map = %{0 => "log-a", 1 => "log-b", 2 => "log-c"}
-
-      on_exit(fn ->
-        try do
-          :ets.delete(table)
-        rescue
-          ArgumentError -> :ok
-        end
-      end)
-
-      {:ok, table: table, log_map: log_map}
-    end
-
-    test "routes key to correct logs", %{table: table, log_map: log_map} do
-      # Key "apple" -> tag 0 -> some logs
-      logs = ShardRouter.get_logs_for_key(table, "apple", log_map, 2)
-
-      assert length(logs) == 2
-      assert Enum.all?(logs, &is_binary/1)
-      assert Enum.all?(logs, &(&1 in Map.values(log_map)))
-    end
-
-    test "different shards may route to different logs", %{table: table, log_map: log_map} do
-      logs_shard_0 = ShardRouter.get_logs_for_key(table, "apple", log_map, 2)
-      logs_shard_1 = ShardRouter.get_logs_for_key(table, "zebra", log_map, 2)
-
-      # They might be the same or different depending on golden ratio
-      # Just verify they're valid
-      assert length(logs_shard_0) == 2
-      assert length(logs_shard_1) == 2
-    end
-  end
-
-  describe "lazy log_indices caching" do
-    setup do
-      table = :ets.new(:caching_test, [:ordered_set, :public])
-      :ets.insert(table, {"m", 0})
-      :ets.insert(table, {"\xff", 1})
-
-      log_map = %{0 => "log-a", 1 => "log-b", 2 => "log-c"}
-
-      on_exit(fn ->
-        try do
-          :ets.delete(table)
-        rescue
-          ArgumentError -> :ok
-        end
-      end)
-
-      {:ok, table: table, log_map: log_map}
-    end
-
-    test "get_logs_for_key caches log_indices in ETS", %{table: table, log_map: log_map} do
-      # Initial entry is just {end_key, tag}
-      assert :ets.lookup(table, "m") == [{"m", 0}]
-
-      # First call computes and caches
-      _logs = ShardRouter.get_logs_for_key(table, "apple", log_map, 2)
-
-      # Entry should now be {end_key, {tag, log_indices}}
-      [{_end_key, cached_value}] = :ets.lookup(table, "m")
-      assert is_tuple(cached_value)
-      {tag, log_indices} = cached_value
-      assert tag == 0
-      assert is_list(log_indices)
-      assert length(log_indices) == 2
-    end
-
-    test "subsequent calls use cached log_indices", %{table: table, log_map: log_map} do
-      # First call - computes
-      logs1 = ShardRouter.get_logs_for_key(table, "apple", log_map, 2)
-
-      # Verify it's cached
-      [{_, {0, cached_indices}}] = :ets.lookup(table, "m")
-
-      # Second call - uses cache
-      logs2 = ShardRouter.get_logs_for_key(table, "apple", log_map, 2)
-
-      # Results should be identical
-      assert logs1 == logs2
-
-      # Cache should be unchanged
-      [{_, {0, ^cached_indices}}] = :ets.lookup(table, "m")
-    end
-
-    test "lookup_shard handles cached format", %{table: table, log_map: log_map} do
-      # Trigger caching
-      _logs = ShardRouter.get_logs_for_key(table, "apple", log_map, 2)
-
-      # lookup_shard should still return just the tag
-      tag = ShardRouter.lookup_shard(table, "apple")
-      assert tag == 0
-    end
-
-    test "lookup_shards_for_range handles cached format", %{table: table, log_map: log_map} do
-      # Trigger caching for both shards
-      _logs1 = ShardRouter.get_logs_for_key(table, "apple", log_map, 2)
-      _logs2 = ShardRouter.get_logs_for_key(table, "zebra", log_map, 2)
-
-      # Range lookup should still work
-      tags = ShardRouter.lookup_shards_for_range(table, "a", "z")
-      assert Enum.sort(tags) == [0, 1]
-    end
-
-    test "works with pre-cached entries", %{table: table, log_map: log_map} do
-      # Manually insert cached format
-      :ets.insert(table, {"m", {0, [1, 2]}})
-
-      # Should use cached indices
-      logs = ShardRouter.get_logs_for_key(table, "apple", log_map, 2)
-      assert logs == ["log-b", "log-c"]
-    end
-  end
-
   describe "lookup_shards_with_ranges/3 - range to tags with boundaries" do
     setup do
       table = :ets.new(:ranges_with_bounds, [:ordered_set, :public])
       # 4 shards with [min, max) ranges:
       # Tag 0: ["", "d"), Tag 1: ["d", "h"), Tag 2: ["h", "m"), Tag 3: ["m", \xff)
-      :ets.insert(table, {"d", 0})
-      :ets.insert(table, {"h", 1})
-      :ets.insert(table, {"m", 2})
-      :ets.insert(table, {"\xff", 3})
+      :ets.insert(table, {"d", 0, @v0})
+      :ets.insert(table, {"h", 1, @v0})
+      :ets.insert(table, {"m", 2, @v0})
+      :ets.insert(table, {"\xff", 3, @v0})
 
       on_exit(fn ->
         try do

--- a/test/support/data_plane/finalization_test_support.ex
+++ b/test/support/data_plane/finalization_test_support.ex
@@ -136,7 +136,7 @@ defmodule Bedrock.Test.DataPlane.FinalizationTestSupport do
 
     # Populate shard_keys from shard_layout: %{end_key => {tag, start_key}}
     Enum.each(shard_layout, fn {end_key, {tag, _start_key}} ->
-      :ets.insert(table, {end_key, tag})
+      :ets.insert(table, {end_key, tag, nil})
     end)
 
     log_map =


### PR DESCRIPTION
## Why

The commit proxy's shard table — the ETS ordered_set every batch consults to route mutations to logs — is written by concurrent processes with no ordering between them: per-batch finalization tasks apply resolver windows during resolution, and (since the previous PR in this stack) the server applies the same windows from its mailbox. Plain overwrites made this a last-writer-wins-by-*arrival* race with a permanent failure mode: a descheduled task waking up late could write an old tag over a newer one, and because the resolver had already been acked past that version, nothing would ever re-send the correction. Physical deletes had the mirror-image problem — a late old `set` could resurrect a boundary a newer `clear` had removed.

## What

Shard rows are now `{end_key, tag, version}`, and every write goes through an atomic compare-by-version upsert: try `insert_new`, otherwise `select_replace` guarded on the stored version being no newer. Clears write a `:deleted` tombstone instead of removing the row, so the version to lose against survives. All router navigation — point lookups, range walks, the last-boundary fallback — skips tombstones. Two deliberate choices:

- **Equal versions overwrite.** A transaction's mutations apply in order, so within one version the later mutation must win — that's exactly recovery's clear-everything-then-rewrite pattern. Every writer replays the identical sequence for a given version, so equal-version interleavings still converge on that sequence's final mutation.
- **Snapshot rows carry a `nil` version.** They describe pre-epoch state, so any committed version beats them (atoms sort below binaries in Erlang term order).

The router's lazy log-index cache (`get_logs_for_key`) is deleted: it rewrote rows in place during *reads* — one more unversioned writer in the race — and it had no production callers; the golden-ratio index computation it cached is a few integer operations. `lookup_shards_for_range` (also production-dead) goes with it.

## How

Each row is now a tiny last-writer-wins register keyed by commit version, which is the standard way to make unordered replicated writes converge when the version order is authoritative — and here it is: versions come from the sequencer, and the resolver window protocol guarantees every writer sees a contiguous suffix of entries from its acked floor. The cold audit adversarially replayed the original counterexample (converges: the late old write fails the version guard) and hunted new ones — equal-version divergent sequences (unreachable: the confirms list is canonical per version), fresh-key insert races (ETS serializes `insert_new`; rows are never physically deleted so the loser's `select_replace` always finds a row), and out-of-range tombstoning in `clear_range` (exact key reconstruction, cannot happen).

Tombstones accumulate only until the next recovery rebuilds the table from a fresh snapshot. An all-tombstones table (transiently reachable between a rewrite's clear and its sets, under a concurrent reader) now raises a distinct error rather than masquerading as an empty table.

Ticket: bedrock-q67.24 (blocks bedrock-q67.21). Stacked on #155.