### PR TITLE
Serialize metadata application; route from immutable snapshots

### DIFF
--- a/lib/bedrock/data_plane/commit_proxy/finalization.ex
+++ b/lib/bedrock/data_plane/commit_proxy/finalization.ex
@@ -41,6 +41,20 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization do
 
   @type metadata_mutations :: [Bedrock.Internal.TransactionBuilder.Tx.mutation()]
 
+  @typedoc """
+  Applies a batch's resolver metadata window - plus, in sharded mode, the
+  batch's own globally-committed metadata (`{committed}`) - to the commit
+  proxy's routing state, serialized in commit-version order, and returns the
+  routing snapshot the batch must push with. `nil` deferred means the window
+  already carries the batch's own metadata (single-resolver mode).
+  """
+  @type metadata_apply_fn() :: (last_commit_version :: Bedrock.version(),
+                                commit_version :: Bedrock.version(),
+                                Resolver.metadata_window(),
+                                {committed :: metadata_mutations()}
+                                | nil ->
+                                  {:ok, RoutingData.t()} | {:error, term()})
+
   @type resolver_fn() :: (Resolver.ref(),
                           Bedrock.epoch(),
                           Bedrock.version(),
@@ -115,11 +129,7 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization do
       :transactions,
       :transaction_count,
       :commit_version,
-      :last_commit_version,
-      :shard_table,
-      :log_map,
-      :log_services,
-      :replication_factor
+      :last_commit_version
     ]
     defstruct [
       :transactions,
@@ -127,10 +137,7 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization do
       :commit_version,
       :last_commit_version,
       :known_committed_version,
-      :shard_table,
-      :log_map,
-      :replication_factor,
-      log_services: %{},
+      routing_data: nil,
       transactions_by_log: %{},
       replied_indices: MapSet.new(),
       aborted_count: 0,
@@ -147,10 +154,7 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization do
             commit_version: Bedrock.version(),
             last_commit_version: Bedrock.version(),
             known_committed_version: Bedrock.version() | nil,
-            shard_table: :ets.table(),
-            log_map: %{non_neg_integer() => Log.id()},
-            log_services: %{Log.id() => {atom(), node()} | pid()},
-            replication_factor: pos_integer(),
+            routing_data: RoutingData.t() | nil,
             transactions_by_log: %{Log.id() => Transaction.encoded()},
             replied_indices: MapSet.t(non_neg_integer()),
             aborted_count: non_neg_integer(),
@@ -219,12 +223,10 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization do
             epoch: Bedrock.epoch(),
             sequencer: pid(),
             resolver_layout: ResolverLayout.t(),
-            routing_data: RoutingData.t(),
             resolver_fn: resolver_fn(),
             metadata_ack: Resolver.metadata_ack(),
-            metadata_merge_fn: (Resolver.metadata_window() -> :ok),
+            metadata_apply_fn: metadata_apply_fn(),
             metadata_confirms: [{Bedrock.version(), metadata_mutations()}],
-            metadata_deferred_fn: (Bedrock.version(), metadata_mutations() -> :ok),
             batch_log_push_fn: log_push_batch_fn(),
             abort_reply_fn: abort_reply_fn(),
             success_reply_fn: success_reply_fn(),
@@ -242,11 +244,12 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization do
     epoch = Keyword.get(opts, :epoch) || raise "Missing epoch in finalization opts"
     sequencer = Keyword.get(opts, :sequencer) || raise "Missing sequencer in finalization opts"
     resolver_layout = Keyword.get(opts, :resolver_layout) || raise "Missing resolver_layout in finalization opts"
-    routing_data = Keyword.get(opts, :routing_data) || raise "Missing routing_data in finalization opts"
+
+    if Keyword.get(opts, :metadata_apply_fn) == nil, do: raise("Missing metadata_apply_fn in finalization opts")
 
     fn ->
       batch
-      |> create_finalization_plan(routing_data)
+      |> create_finalization_plan()
       |> resolve_conflicts(epoch, resolver_layout, opts)
       |> prepare_for_logging()
       |> push_to_logs(opts)
@@ -270,27 +273,17 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization do
   # Pipeline Initialization
   # ============================================================================
 
-  @spec create_finalization_plan(Batch.t(), RoutingData.t()) :: FinalizationPlan.t()
-  def create_finalization_plan(batch, routing_data) do
-    # Routing data is passed in from the commit proxy server
-    # Table is created once on recovery and kept up-to-date as metadata changes
-    %RoutingData{
-      shard_table: shard_table,
-      log_map: log_map,
-      log_services: log_services,
-      replication_factor: replication_factor
-    } = routing_data
-
+  @spec create_finalization_plan(Batch.t()) :: FinalizationPlan.t()
+  def create_finalization_plan(batch) do
+    # Routing data arrives after resolution: the commit proxy server applies
+    # this batch's committed metadata in commit-version order and returns the
+    # snapshot the batch routes with (see apply_committed_metadata/4).
     %FinalizationPlan{
       transactions: Map.new(batch.buffer, &{elem(&1, 0), &1}),
       transaction_count: Batch.transaction_count(batch),
       commit_version: batch.commit_version,
       last_commit_version: batch.last_commit_version,
       known_committed_version: batch.known_committed_version,
-      shard_table: shard_table,
-      log_map: log_map,
-      log_services: log_services,
-      replication_factor: replication_factor,
       stage: :ready_for_resolution
     }
   end
@@ -324,7 +317,7 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization do
            opts
          ) do
       {:ok, _aborted, metadata_window} ->
-        plan = apply_metadata_window(plan, metadata_window, [], opts)
+        plan = apply_committed_metadata(plan, metadata_window, nil, opts)
         split_and_notify_aborts_with_set(plan, MapSet.new(), opts)
 
       {:error, reason} ->
@@ -361,7 +354,7 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization do
          ) do
       {:ok, aborted, metadata_window} ->
         aborted_set = MapSet.new(aborted)
-        plan = apply_metadata_window(plan, metadata_window, [], opts)
+        plan = apply_committed_metadata(plan, metadata_window, nil, opts)
         split_and_notify_aborts_with_set(plan, aborted_set, opts)
 
       {:error, reason} ->
@@ -429,8 +422,8 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization do
            opts
          ) do
       {:ok, aborted_set, metadata_window} ->
-        local_entries = deferred_metadata_entries(plan, metadata_per_tx, aborted_set, has_metadata?, opts)
-        plan = apply_metadata_window(plan, metadata_window, local_entries, opts)
+        deferred = deferred_metadata(metadata_per_tx, aborted_set, has_metadata?)
+        plan = apply_committed_metadata(plan, metadata_window, deferred, opts)
         split_and_notify_aborts_with_set(plan, aborted_set, opts)
 
       {:error, reason} ->
@@ -438,40 +431,32 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization do
     end
   end
 
-  # Filters this batch's metadata by the merged GLOBAL abort set, reports it
-  # through metadata_deferred_fn (so the proxy server re-sends it as a
-  # confirmation on subsequent calls - even when empty, so resolvers release
-  # the hold), and returns it as entries for same-batch routing application.
-  @spec deferred_metadata_entries(
-          FinalizationPlan.t(),
-          [metadata_mutations()],
-          MapSet.t(non_neg_integer()),
-          boolean(),
-          keyword()
-        ) :: [MetadataAccumulator.entry()]
-  defp deferred_metadata_entries(_plan, _metadata_per_tx, _aborted_set, false, _opts), do: []
-
-  defp deferred_metadata_entries(plan, metadata_per_tx, aborted_set, true, opts) do
-    committed_metadata = MetadataAccumulator.committed_mutations(metadata_per_tx, aborted_set)
-
-    metadata_deferred_fn = Keyword.get(opts, :metadata_deferred_fn, fn _version, _mutations -> :ok end)
-    metadata_deferred_fn.(plan.commit_version, committed_metadata)
-
-    if committed_metadata == [], do: [], else: [{plan.commit_version, committed_metadata}]
-  end
-
-  # `local_entries` are this batch's own committed metadata (sharded mode) -
-  # applied to the batch's routing data for same-batch visibility, but NOT to
-  # the structured metadata state, which is fed strictly by resolver windows
-  # (keeping ack semantics intact). Single-resolver callers pass [] - their
+  # Filters this batch's metadata by the merged GLOBAL abort set. The result
+  # rides the apply call to the proxy server, which records it for re-sending
+  # as a confirmation on subsequent resolver calls - even when empty, so
+  # resolvers release the hold. Single-resolver callers pass nil: their
   # batch's metadata arrives inside the window itself.
-  @spec apply_metadata_window(
+  @spec deferred_metadata([metadata_mutations()], MapSet.t(non_neg_integer()), boolean()) ::
+          {committed :: metadata_mutations()} | nil
+  defp deferred_metadata(_metadata_per_tx, _aborted_set, false), do: nil
+
+  defp deferred_metadata(metadata_per_tx, aborted_set, true),
+    do: {MetadataAccumulator.committed_mutations(metadata_per_tx, aborted_set)}
+
+  # The commit proxy server applies committed metadata one batch at a time in
+  # commit-version order and returns the routing snapshot this batch pushes
+  # with - which therefore includes the batch's OWN committed metadata (a
+  # shard split in this batch routes this batch's log push). Concurrent
+  # batches route from their own immutable snapshots and cannot observe each
+  # other mid-application. This is FDB's postResolution ordering: apply
+  # metadata, then assign mutations to logs, one batch at a time.
+  @spec apply_committed_metadata(
           FinalizationPlan.t(),
           Resolver.metadata_window(),
-          [MetadataAccumulator.entry()],
+          {committed :: metadata_mutations()} | nil,
           keyword()
         ) :: FinalizationPlan.t()
-  defp apply_metadata_window(plan, metadata_window, local_entries, opts) do
+  defp apply_committed_metadata(plan, metadata_window, deferred, opts) do
     entries =
       case metadata_window do
         nil -> []
@@ -480,31 +465,15 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization do
 
     trace_metadata_updates_received(plan.commit_version, entries)
 
-    # Hand the window to the caller's merge function so the commit proxy can
-    # fold it (in version order, gap-checked) into its structured metadata
-    # state. Applied at resolution time (like the routing data below): the
-    # resolver has already accumulated these mutations, regardless of how the
-    # rest of the batch fares.
-    metadata_merge_fn = Keyword.get(opts, :metadata_merge_fn, fn _window -> :ok end)
-    if metadata_window != nil, do: metadata_merge_fn.(metadata_window)
+    metadata_apply_fn = Keyword.fetch!(opts, :metadata_apply_fn)
 
-    routing_data = %RoutingData{
-      shard_table: plan.shard_table,
-      log_map: plan.log_map,
-      log_services: plan.log_services,
-      replication_factor: plan.replication_factor
-    }
+    case metadata_apply_fn.(plan.last_commit_version, plan.commit_version, metadata_window, deferred) do
+      {:ok, %RoutingData{} = routing_data} ->
+        %{plan | stage: :conflicts_resolved, metadata_updates: entries, routing_data: routing_data}
 
-    # Window entries precede this batch's own (higher-version) local entries.
-    updated_routing_data = RoutingData.apply_mutations(routing_data, entries ++ local_entries)
-
-    %{
-      plan
-      | stage: :conflicts_resolved,
-        metadata_updates: entries,
-        log_map: updated_routing_data.log_map,
-        log_services: updated_routing_data.log_services
-    }
+      {:error, reason} ->
+        %{plan | error: reason, stage: :failed}
+    end
   end
 
   # Sharded calls carry no metadata_per_tx (accumulation is deferred; see
@@ -711,7 +680,7 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization do
   def prepare_for_logging(%FinalizationPlan{stage: :failed} = plan), do: plan
 
   def prepare_for_logging(%FinalizationPlan{stage: :aborts_notified} = plan) do
-    log_ids = plan.log_map |> Map.values() |> Enum.uniq()
+    log_ids = plan.routing_data.log_map |> Map.values() |> Enum.uniq()
 
     case build_transactions_for_logs(plan, log_ids) do
       {:ok, transactions_by_log} ->
@@ -834,10 +803,10 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization do
   @spec distribute_mutation_to_logs_via_shard_router(term(), FinalizationPlan.t(), %{Log.id() => [term()]}) ::
           {:cont, {:ok, %{Log.id() => [term()]}}} | {:halt, {:error, term()}}
   defp distribute_mutation_to_logs_via_shard_router(mutation, plan, mutations_acc) do
-    %{shard_table: shard_table, log_map: log_map, replication_factor: m} = plan
+    %{shards: shards, log_map: log_map, replication_factor: m} = plan.routing_data
 
     # Split mutation by shards (handles cross-shard clear_range with clamping)
-    tagged_mutations = split_mutation_by_shards(mutation, shard_table)
+    tagged_mutations = split_mutation_by_shards(mutation, shards)
 
     if tagged_mutations == [] do
       key_or_range = mutation_to_key_or_range(mutation)
@@ -906,11 +875,11 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization do
 
   # Split mutation by shards (handles cross-shard clear_range)
   # Returns list of {mutation, tag} tuples
-  @spec split_mutation_by_shards(term(), :ets.table()) :: [{term(), non_neg_integer()}]
-  defp split_mutation_by_shards({:clear_range, start_key, end_key}, shard_table) do
-    shards = ShardRouter.lookup_shards_with_ranges(shard_table, start_key, end_key)
+  @spec split_mutation_by_shards(term(), RoutingData.shard_tree()) :: [{term(), non_neg_integer()}]
+  defp split_mutation_by_shards({:clear_range, start_key, end_key}, shards) do
+    overlapping = ShardRouter.lookup_shards_with_ranges(shards, start_key, end_key)
 
-    Enum.map(shards, fn {tag, shard_start, shard_end} ->
+    Enum.map(overlapping, fn {tag, shard_start, shard_end} ->
       # Clamp range to shard boundaries
       clamped_start = max_binary(start_key, shard_start)
       clamped_end = min_binary(end_key, shard_end)
@@ -919,16 +888,16 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization do
   end
 
   # Single-key mutations don't split
-  defp split_mutation_by_shards({:set, key, _value} = mutation, shard_table) do
-    [{mutation, ShardRouter.lookup_shard(shard_table, key)}]
+  defp split_mutation_by_shards({:set, key, _value} = mutation, shards) do
+    [{mutation, ShardRouter.lookup_shard(shards, key)}]
   end
 
-  defp split_mutation_by_shards({:clear, key} = mutation, shard_table) do
-    [{mutation, ShardRouter.lookup_shard(shard_table, key)}]
+  defp split_mutation_by_shards({:clear, key} = mutation, shards) do
+    [{mutation, ShardRouter.lookup_shard(shards, key)}]
   end
 
-  defp split_mutation_by_shards({:atomic, _op, key, _value} = mutation, shard_table) do
-    [{mutation, ShardRouter.lookup_shard(shard_table, key)}]
+  defp split_mutation_by_shards({:atomic, _op, key, _value} = mutation, shards) do
+    [{mutation, ShardRouter.lookup_shard(shards, key)}]
   end
 
   # Binary comparison helpers for clamping ranges
@@ -950,7 +919,7 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization do
 
     opts_with_log_services =
       opts
-      |> Keyword.put(:log_services, plan.log_services)
+      |> Keyword.put(:log_services, plan.routing_data.log_services)
       |> Keyword.put(:known_committed_version, plan.known_committed_version)
 
     case batch_log_push_fn.(

--- a/lib/bedrock/data_plane/commit_proxy/routing_data.ex
+++ b/lib/bedrock/data_plane/commit_proxy/routing_data.ex
@@ -1,27 +1,34 @@
 defmodule Bedrock.DataPlane.CommitProxy.RoutingData do
   @moduledoc """
-  Manages routing data for the commit proxy.
+  Immutable routing state for the commit proxy.
 
   Encapsulates all information needed to route mutations to logs:
-  - `shard_table` - ETS ordered_set for key → tag ceiling search
+  - `shards` - a `:gb_trees` map of `end_key => {tag, start_key}` for key → tag
+    ceiling search (`end_key` is the shard's exclusive upper bound)
   - `log_map` - Map of index → log_id for golden ratio routing
   - `log_services` - Map of log_id → pid or {otp_name, node} for contacting logs
   - `replication_factor` - Number of logs per mutation
+
+  The value is a plain immutable term: the commit proxy server is its only
+  writer, applying committed metadata one batch at a time in commit-version
+  order, and every finalization task routes from the snapshot the server
+  handed it for its batch. Concurrent batches can never observe - or race -
+  each other's updates, which is what lets these be ordinary data structures
+  with no versions, locks, or shared tables.
 
   ## Lifecycle
 
   - `new_empty/0` - Creates empty routing data for dynamic population
   - `from_snapshot/1` - Builds routing data from a plain snapshot at unlock
-  - `cleanup/1` - Deletes the ETS table when the commit proxy terminates
 
   ## Shard Updates
 
-  - `insert_shard/3` - Adds or updates a shard entry
+  - `insert_shard/4` - Adds or updates a shard entry
   - `delete_shard/2` - Removes a shard entry
 
   ## Log Updates
 
-  - `insert_log/2` - Adds a log to log_map at next index
+  - `insert_log/2` - Adds a log to log_map at next index (idempotent by id)
   - `remove_log/2` - Removes a log and reindexes
   - `put_log_service/3` - Adds or updates a log service reference
   - `delete_log_service/2` - Removes a log service reference
@@ -32,8 +39,10 @@ defmodule Bedrock.DataPlane.CommitProxy.RoutingData do
   alias Bedrock.SystemKeys
   alias Bedrock.SystemKeys.Values
 
+  @type shard_tree :: :gb_trees.tree(Bedrock.key(), {tag :: term(), start_key :: Bedrock.key()})
+
   @type t :: %__MODULE__{
-          shard_table: :ets.table(),
+          shards: shard_tree(),
           log_map: %{non_neg_integer() => Log.id()},
           log_services: %{Log.id() => {atom(), node()} | pid()},
           replication_factor: pos_integer()
@@ -41,8 +50,7 @@ defmodule Bedrock.DataPlane.CommitProxy.RoutingData do
 
   @typedoc """
   A plain-data description of routing state, safe to send between processes
-  and nodes. `from_snapshot/1` turns it into runnable routing data whose ETS
-  table is created by — and therefore owned by and local to — the receiver.
+  and nodes. `from_snapshot/1` turns it into runnable routing data.
   """
   @type snapshot :: %{
           shard_layout: %{Bedrock.key() => {tag :: term(), start_key :: Bedrock.key()}},
@@ -51,11 +59,10 @@ defmodule Bedrock.DataPlane.CommitProxy.RoutingData do
           replication_factor: pos_integer()
         }
 
-  defstruct [:shard_table, :log_map, :log_services, :replication_factor]
+  defstruct [:shards, :log_map, :log_services, :replication_factor]
 
   @doc """
-  Builds routing data from a plain snapshot, creating the ETS shard table in
-  the calling process.
+  Builds routing data from a plain snapshot.
   """
   @spec from_snapshot(snapshot()) :: t()
   def from_snapshot(%{
@@ -64,14 +71,13 @@ defmodule Bedrock.DataPlane.CommitProxy.RoutingData do
         log_services: log_services,
         replication_factor: replication_factor
       }) do
-    shard_table = :ets.new(:shard_keys, [:ordered_set, :public])
-
-    Enum.each(shard_layout, fn {end_key, {tag, _start_key}} ->
-      :ets.insert(shard_table, {end_key, tag})
-    end)
+    shards =
+      Enum.reduce(shard_layout, :gb_trees.empty(), fn {end_key, {tag, start_key}}, tree ->
+        :gb_trees.enter(end_key, {tag, start_key}, tree)
+      end)
 
     %__MODULE__{
-      shard_table: shard_table,
+      shards: shards,
       log_map: log_map,
       log_services: log_services,
       replication_factor: replication_factor
@@ -81,13 +87,13 @@ defmodule Bedrock.DataPlane.CommitProxy.RoutingData do
   @doc """
   Creates empty routing data for dynamic population via metadata.
 
-  Starts with an empty shard table, no logs, and replication factor of 1.
-  All fields are populated incrementally as metadata mutations arrive.
+  Starts with no shards, no logs, and replication factor of 1. All fields
+  are populated incrementally as metadata mutations arrive.
   """
   @spec new_empty() :: t()
   def new_empty do
     %__MODULE__{
-      shard_table: :ets.new(:shard_keys, [:ordered_set, :public]),
+      shards: :gb_trees.empty(),
       log_map: %{},
       log_services: %{},
       replication_factor: 1
@@ -95,37 +101,23 @@ defmodule Bedrock.DataPlane.CommitProxy.RoutingData do
   end
 
   @doc """
-  Cleans up routing data by deleting the ETS table.
-
-  Safe to call with nil or if the table has already been deleted.
-  """
-  @spec cleanup(t() | nil) :: true
-  def cleanup(nil), do: true
-
-  def cleanup(%__MODULE__{shard_table: table}) do
-    :ets.delete(table)
-  rescue
-    ArgumentError -> true
-  end
-
-  @doc """
-  Inserts or updates a shard entry in the routing table.
+  Inserts or updates a shard entry.
 
   Called from apply_mutations/2 when processing shard_key mutations.
   """
-  @spec insert_shard(t(), binary(), term()) :: true
-  def insert_shard(%__MODULE__{shard_table: table}, end_key, tag) do
-    :ets.insert(table, {end_key, tag})
+  @spec insert_shard(t(), binary(), term(), Bedrock.key()) :: t()
+  def insert_shard(%__MODULE__{shards: shards} = routing_data, end_key, tag, start_key) do
+    %{routing_data | shards: :gb_trees.enter(end_key, {tag, start_key}, shards)}
   end
 
   @doc """
-  Deletes a shard entry from the routing table.
+  Deletes a shard entry.
 
   Called from apply_mutations/2 when processing shard_key clear mutations.
   """
-  @spec delete_shard(t(), binary()) :: true
-  def delete_shard(%__MODULE__{shard_table: table}, end_key) do
-    :ets.delete(table, end_key)
+  @spec delete_shard(t(), binary()) :: t()
+  def delete_shard(%__MODULE__{shards: shards} = routing_data, end_key) do
+    %{routing_data | shards: :gb_trees.delete_any(end_key, shards)}
   end
 
   @doc """
@@ -189,7 +181,7 @@ defmodule Bedrock.DataPlane.CommitProxy.RoutingData do
   Applies metadata mutations to update routing data.
 
   Handles shard_key and layout_log mutations:
-  - shard_key: Updates ETS shard_table
+  - shard_key: Updates the shard tree
   - layout_log: Updates both log_map and log_services
 
   ## Parameters
@@ -201,7 +193,7 @@ defmodule Bedrock.DataPlane.CommitProxy.RoutingData do
 
   Updated routing data with applied mutations.
   """
-  @spec apply_mutations(t(), [{term(), [term()]}]) :: t()
+  @spec apply_mutations(t(), [{Bedrock.version(), [term()]}]) :: t()
   def apply_mutations(%__MODULE__{} = routing_data, updates) do
     Enum.reduce(updates, routing_data, fn {_version, mutations}, acc ->
       Enum.reduce(mutations, acc, &apply_mutation/2)
@@ -214,11 +206,9 @@ defmodule Bedrock.DataPlane.CommitProxy.RoutingData do
         # Undecodable values are ignored; the routing table keeps its last
         # good entry rather than crashing the commit proxy.
         case Values.decode_shard_key_entry(value) do
-          {:ok, {tag, _start_key}} -> insert_shard(routing_data, end_key, tag)
-          {:error, _} -> :ignored
+          {:ok, {tag, start_key}} -> insert_shard(routing_data, end_key, tag, start_key)
+          {:error, _} -> routing_data
         end
-
-        routing_data
 
       {:layout_log, log_id} ->
         # The value (log descriptor tags) is not needed for routing; service
@@ -234,7 +224,6 @@ defmodule Bedrock.DataPlane.CommitProxy.RoutingData do
     case SystemKeys.parse_key(key) do
       {:shard_key, end_key} ->
         delete_shard(routing_data, end_key)
-        routing_data
 
       {:layout_log, log_id} ->
         routing_data
@@ -257,14 +246,17 @@ defmodule Bedrock.DataPlane.CommitProxy.RoutingData do
 
   defp apply_mutation(_mutation, routing_data), do: routing_data
 
-  defp clear_shards_in_range(%__MODULE__{shard_table: table} = routing_data, start_key, end_key) do
-    for {shard_end_key, _tag} <- :ets.tab2list(table),
-        full_key = SystemKeys.shard_key(shard_end_key),
-        full_key >= start_key and full_key < end_key do
-      :ets.delete(table, shard_end_key)
-    end
+  defp clear_shards_in_range(%__MODULE__{shards: shards} = routing_data, start_key, end_key) do
+    cleared =
+      shards
+      |> :gb_trees.keys()
+      |> Enum.filter(fn shard_end_key ->
+        full_key = SystemKeys.shard_key(shard_end_key)
+        full_key >= start_key and full_key < end_key
+      end)
+      |> Enum.reduce(shards, &:gb_trees.delete_any/2)
 
-    routing_data
+    %{routing_data | shards: cleared}
   end
 
   defp clear_logs_in_range(%__MODULE__{log_map: log_map} = routing_data, start_key, end_key) do

--- a/lib/bedrock/data_plane/commit_proxy/server.ex
+++ b/lib/bedrock/data_plane/commit_proxy/server.ex
@@ -137,7 +137,6 @@ defmodule Bedrock.DataPlane.CommitProxy.Server do
   @spec terminate(term(), State.t()) :: :ok
   def terminate(_reason, %State{} = t) do
     abort_current_batch(t)
-    RoutingData.cleanup(t.routing_data)
     :ok
   end
 
@@ -145,7 +144,8 @@ defmodule Bedrock.DataPlane.CommitProxy.Server do
   @spec handle_call(
           {:recover_from, binary(), pid(), ResolverLayout.t(), RoutingData.snapshot()}
           | {:commit, Bedrock.epoch(), Bedrock.transaction()}
-          | {:commit, Bedrock.epoch(), Bedrock.transaction(), :user | :system},
+          | {:commit, Bedrock.epoch(), Bedrock.transaction(), :user | :system}
+          | {:apply_metadata_and_route, pos_integer(), Bedrock.version(), term(), term()},
           GenServer.from(),
           State.t()
         ) ::
@@ -156,7 +156,6 @@ defmodule Bedrock.DataPlane.CommitProxy.Server do
         %{mode: :locked} = t
       ) do
     if lock_token == t.lock_token do
-      RoutingData.cleanup(t.routing_data)
       routing_data = RoutingData.from_snapshot(routing_snapshot)
 
       reply(
@@ -186,6 +185,36 @@ defmodule Bedrock.DataPlane.CommitProxy.Server do
   def handle_call({:commit, _epoch, _transaction, _commit_mode}, _from, %{mode: :locked} = t),
     do: reply(t, {:error, :locked})
 
+  # A finalization task asks for its batch's committed metadata to be applied
+  # and for the routing snapshot to push with. Requests are served strictly in
+  # batch-sequence order - a request whose predecessor has not yet been
+  # applied waits - so every batch routes with exactly the metadata at or
+  # below its own commit version, its own included. This is FDB's
+  # postResolution ordering (apply metadata, then assign mutations to logs,
+  # one batch at a time), keyed like FDB's latestLocalCommitBatchLogging on a
+  # PROXY-LOCAL sequence: global sequencer versions interleave across
+  # proxies, so chaining on them would park forever whenever another proxy
+  # took the intervening version. The snapshot handed back is immutable, so
+  # the log push itself proceeds in parallel with later batches' applies.
+  def handle_call(
+        {:apply_metadata_and_route, seq, commit_version, window, deferred},
+        from,
+        %{mode: :running, routed_seq: prev_seq} = t
+      )
+      when seq == prev_seq + 1 do
+    t = apply_and_route(t, seq, commit_version, window, deferred)
+    GenServer.reply(from, {:ok, t.routing_data})
+    noreply_resuming_cadence(drain_pending_applies(t))
+  end
+
+  def handle_call({:apply_metadata_and_route, seq, commit_version, window, deferred}, from, %{mode: :running} = t) do
+    pending = Map.put(t.pending_applies, seq, {from, commit_version, window, deferred})
+    noreply_resuming_cadence(%{t | pending_applies: pending})
+  end
+
+  def handle_call({:apply_metadata_and_route, _seq, _cv, _window, _deferred}, _from, %{mode: :locked} = t),
+    do: reply(t, {:error, :locked})
+
   defp accept_commit(transaction, from, t) do
     case start_batch_if_needed(t) do
       {:error, reason} ->
@@ -203,7 +232,7 @@ defmodule Bedrock.DataPlane.CommitProxy.Server do
 
           {t, batch} ->
             # Finalize asynchronously and reset for next batch
-            finalize_batch_async(batch, t)
+            t = finalize_batch_async(batch, t)
 
             maybe_set_empty_transaction_timeout(t)
         end
@@ -266,8 +295,6 @@ defmodule Bedrock.DataPlane.CommitProxy.Server do
   @impl true
   @spec handle_info(
           :timeout
-          | {:metadata_updates, {Bedrock.version() | nil, Bedrock.version(), [term()]}}
-          | {:metadata_deferred, Bedrock.version(), [term()]}
           | {:finalization_failed, term()}
           | {:DOWN, reference(), :process, pid(), term()},
           State.t()
@@ -281,11 +308,11 @@ defmodule Bedrock.DataPlane.CommitProxy.Server do
     case single_transaction_batch(t, empty_transaction) do
       {:ok, batch} ->
         # Send empty batch asynchronously
-        finalize_batch_async(batch, t)
+        t = finalize_batch_async(batch, t)
 
         maybe_set_empty_transaction_timeout(t)
 
-      {:error, :sequencer_unavailable} ->
+      {:error, _sequencer_unavailable} ->
         exit({:sequencer_unavailable, :timeout_empty_transaction})
     end
   end
@@ -296,22 +323,9 @@ defmodule Bedrock.DataPlane.CommitProxy.Server do
 
   def handle_info(:timeout, %{batch: batch} = t) do
     # Timeout reached - finalize current batch asynchronously
-    finalize_batch_async(batch, t)
+    t = finalize_batch_async(batch, t)
 
     maybe_set_empty_transaction_timeout(%{t | batch: nil})
-  end
-
-  def handle_info({:metadata_updates, window}, t) do
-    noreply_resuming_cadence(apply_metadata_window(t, window))
-  end
-
-  # A sharded finalization task reports its batch's committed metadata
-  # (already filtered by the merged GLOBAL abort set). It is re-sent to the
-  # resolvers as a confirmation on every subsequent call until their windows
-  # ack past its version (see apply_metadata_window/2). Tasks race to this
-  # mailbox, so insert in version order.
-  def handle_info({:metadata_deferred, version, mutations}, t) do
-    noreply_resuming_cadence(add_deferred_metadata(t, version, mutations))
   end
 
   def handle_info({:DOWN, _ref, :process, director_pid, _reason}, %{director: director_pid} = t) do
@@ -329,15 +343,18 @@ defmodule Bedrock.DataPlane.CommitProxy.Server do
     {:noreply, t}
   end
 
+  # Spawns finalization for a batch and assigns it the next proxy-local batch
+  # sequence; returns the updated state. Batches are created and spawned one
+  # at a time in this process, so sequence order is commit-version order.
   defp finalize_batch_async(batch, state) do
     trace_meta = trace_metadata()
     server_pid = self()
+    seq = state.batch_seq + 1
 
     %{
       epoch: epoch,
       sequencer: sequencer,
       resolver_layout: resolver_layout,
-      routing_data: routing_data,
       metadata: %{version: applied_metadata_version},
       deferred_metadata: deferred_metadata
     } = state
@@ -349,17 +366,22 @@ defmodule Bedrock.DataPlane.CommitProxy.Server do
              epoch: epoch,
              sequencer: sequencer,
              resolver_layout: resolver_layout,
-             routing_data: routing_data,
              # Stable proxy identity (this server, not the per-batch task) plus
              # the metadata version this proxy has confirmed applying - the
              # resolver keys its progress and differential windows off this.
              metadata_ack: {server_pid, applied_metadata_version},
-             metadata_merge_fn: fn window -> send(server_pid, {:metadata_updates, window}) end,
              # Deferred-metadata confirmations for sharded resolvers: committed
              # metadata from earlier batches, re-sent until acked via windows.
              metadata_confirms: deferred_metadata,
-             metadata_deferred_fn: fn version, mutations ->
-               send(server_pid, {:metadata_deferred, version, mutations})
+             # Serialized apply-and-route: the server folds this batch's
+             # committed metadata into its state in commit-version order and
+             # returns the immutable routing snapshot the batch pushes with.
+             metadata_apply_fn: fn _prev_version, commit_version, window, deferred ->
+               GenServer.call(
+                 server_pid,
+                 {:apply_metadata_and_route, seq, commit_version, window, deferred},
+                 :infinity
+               )
              end
            ) do
         {:ok, _n_aborts, _n_oks} ->
@@ -369,22 +391,53 @@ defmodule Bedrock.DataPlane.CommitProxy.Server do
           send(server_pid, {:finalization_failed, reason})
       end
     end)
+
+    %{state | batch_seq: seq}
+  end
+
+  # Applies one batch's committed metadata - its resolver window plus, in
+  # sharded mode, its own globally-committed metadata - and advances the
+  # chain. Windows fold into structured metadata AND routing in one step;
+  # deferred metadata folds into routing only (the ack must not advance past
+  # what the resolvers' windows have confirmed) and is recorded for
+  # re-sending as confirmations until a window covers it.
+  defp apply_and_route(t, seq, commit_version, window, deferred) do
+    t
+    |> apply_metadata_window(window)
+    |> apply_deferred_metadata(commit_version, deferred)
+    |> Map.put(:routed_seq, seq)
+  end
+
+  defp drain_pending_applies(t) do
+    case Map.pop(t.pending_applies, t.routed_seq + 1) do
+      {nil, _pending} ->
+        t
+
+      {{from, commit_version, window, deferred}, pending} ->
+        t = apply_and_route(%{t | pending_applies: pending}, t.routed_seq + 1, commit_version, window, deferred)
+        GenServer.reply(from, {:ok, t.routing_data})
+        drain_pending_applies(t)
+    end
+  end
+
+  defp apply_deferred_metadata(t, _commit_version, nil), do: t
+
+  defp apply_deferred_metadata(t, commit_version, {committed}) do
+    t = add_deferred_metadata(t, commit_version, committed)
+
+    if committed == [] do
+      t
+    else
+      %{t | routing_data: RoutingData.apply_mutations(t.routing_data, [{commit_version, committed}])}
+    end
   end
 
   # Folds a resolver metadata window into the proxy's structured metadata AND
-  # its routing data, in one step. Applied in the server process so windows
-  # from concurrent finalization tasks are serialized. Windows can arrive out
-  # of commit-version order (the tasks race to this mailbox), but every window
-  # covers (from, to] starting at a version this proxy had already confirmed
-  # applying, so a late-arriving earlier window is a subset of what has been
-  # applied - entries at or below the applied version are dropped before
-  # application, which keeps the non-idempotent parts of routing data (log
-  # index assignment) exact under overlapping windows.
-  #
-  # Advancing routing data here, atomically with the ack version, is what
-  # lets finalize_batch_async snapshot the pair consistently: a batch whose
-  # ack promises the resolver will not re-send version N's entries always
-  # holds routing data that already includes them (bedrock-q67.24).
+  # its routing data, in one step. Requests are served in commit-version chain
+  # order, but windows still overlap (each covers (from, to] starting at the
+  # version this proxy had confirmed when the batch spawned), so entries at or
+  # below the applied version are dropped before application - which keeps the
+  # non-idempotent parts of routing data (log index assignment) exact.
   #
   # A window whose from_version exceeds what this proxy has applied means the
   # resolver pruned history this proxy never saw (only possible after this
@@ -393,8 +446,10 @@ defmodule Bedrock.DataPlane.CommitProxy.Server do
   # recovery rebuilds proxies with full state.
   @spec apply_metadata_window(
           State.t(),
-          {Bedrock.version() | nil, Bedrock.version(), [term()]}
+          {Bedrock.version() | nil, Bedrock.version(), [term()]} | nil
         ) :: State.t() | no_return()
+  defp apply_metadata_window(t, nil), do: t
+
   defp apply_metadata_window(t, {from_version, to_version, entries}) do
     applied_version = t.metadata.version
 
@@ -452,7 +507,6 @@ defmodule Bedrock.DataPlane.CommitProxy.Server do
     do: noreply(t, timeout: t.empty_transaction_timeout_ms)
 
   defp noreply_resuming_cadence(%{mode: :running} = t), do: noreply(t, timeout: 0)
-  defp noreply_resuming_cadence(t), do: noreply(t)
 
   @spec abort_current_batch(State.t()) :: :ok
   defp abort_current_batch(%{batch: nil}), do: :ok

--- a/lib/bedrock/data_plane/commit_proxy/state.ex
+++ b/lib/bedrock/data_plane/commit_proxy/state.ex
@@ -22,7 +22,10 @@ defmodule Bedrock.DataPlane.CommitProxy.State do
           lock_token: binary(),
           routing_data: RoutingData.t() | nil,
           metadata: Metadata.t(),
-          deferred_metadata: [{Bedrock.version(), [term()]}]
+          deferred_metadata: [{Bedrock.version(), [term()]}],
+          batch_seq: non_neg_integer(),
+          routed_seq: non_neg_integer(),
+          pending_applies: %{pos_integer() => {GenServer.from(), Bedrock.version(), term(), term()}}
         }
   defstruct cluster: nil,
             director: nil,
@@ -40,5 +43,19 @@ defmodule Bedrock.DataPlane.CommitProxy.State do
             # Committed metadata from sharded batches (version-ascending),
             # re-sent as confirmations on every resolver call until the
             # resolvers' windows show it was folded in (ack >= version).
-            deferred_metadata: []
+            deferred_metadata: [],
+            # Proxy-local batch sequence, assigned when a batch's finalization
+            # is spawned (batches are created and spawned one at a time in the
+            # server, so sequence order IS commit-version order). Apply
+            # requests are served strictly in this order - FDB's
+            # latestLocalCommitBatchLogging, a per-proxy counter, deliberately
+            # NOT the global sequencer versions, which interleave across
+            # proxies.
+            batch_seq: 0,
+            # The sequence of the last batch whose metadata was applied and
+            # routing snapshot handed out.
+            routed_seq: 0,
+            # Apply requests that arrived ahead of their predecessor, keyed by
+            # their own sequence number.
+            pending_applies: %{}
 end

--- a/lib/bedrock/data_plane/shard_router.ex
+++ b/lib/bedrock/data_plane/shard_router.ex
@@ -4,11 +4,14 @@ defmodule Bedrock.DataPlane.ShardRouter do
 
   ## Shard Lookup
 
-  Uses an ETS ordered_set table for O(log n) ceiling search. Each entry is `{end_key, tag}`
-  where `end_key` is the exclusive upper bound for that shard.
+  Operates on an immutable `:gb_trees` shard map of `end_key => {tag, start_key}`
+  entries, where `end_key` is the shard's exclusive upper bound (see
+  `Bedrock.DataPlane.CommitProxy.RoutingData`). Because the map is a plain
+  immutable value, lookups always see one self-consistent snapshot - there is
+  no shared table for concurrent writers to race on.
 
   To find the shard for a key:
-  1. Find the first entry where `end_key >= key`
+  1. Find the first entry where `end_key > key`
   2. Return that entry's tag
 
   ## Log Selection
@@ -19,6 +22,8 @@ defmodule Bedrock.DataPlane.ShardRouter do
 
   The mapping is deterministic and stable as long as the log list order is preserved.
   """
+
+  alias Bedrock.DataPlane.CommitProxy.RoutingData
 
   # Golden ratio constant (2^64 / phi) for good distribution
   @golden 0x9E3779B97F4A7C15
@@ -72,17 +77,13 @@ defmodule Bedrock.DataPlane.ShardRouter do
   end
 
   @doc ~S"""
-  Looks up the shard tag for a key using ETS ceiling search.
-
-  The ETS table must be an ordered_set with entries in one of two formats:
-  - `{end_key, tag}` - uncached format
-  - `{end_key, {tag, log_indices}}` - cached format (after `get_logs_for_key/4` call)
+  Looks up the shard tag for a key using ceiling search.
 
   Shard ranges are `[min, max)` - start inclusive, end exclusive.
 
   ## Parameters
 
-    - `table` - ETS table reference
+    - `shards` - shard map (`end_key => {tag, start_key}` gb_tree)
     - `key` - The key to look up
 
   ## Returns
@@ -91,125 +92,43 @@ defmodule Bedrock.DataPlane.ShardRouter do
 
   ## Examples
 
-      # Table has: {"m", 0}, {"\xff", 1}
-      # Shard 0 covers ["", "m"), Shard 1 covers ["m", "\xff")
-      iex> lookup_shard(table, "apple")
+      # Shards: 0 covers ["", "m"), 1 covers ["m", "\xff")
+      iex> lookup_shard(shards, "apple")
       0
-      iex> lookup_shard(table, "m")
+      iex> lookup_shard(shards, "m")
       1  # "m" is the START of shard 1, not end of shard 0
-      iex> lookup_shard(table, "zebra")
+      iex> lookup_shard(shards, "zebra")
       1
 
   """
-  @spec lookup_shard(:ets.table(), binary()) :: non_neg_integer()
-  def lookup_shard(table, key) when is_binary(key) do
+  @spec lookup_shard(RoutingData.shard_tree(), binary()) :: non_neg_integer()
+  def lookup_shard(shards, key) when is_binary(key) do
     # Find first end_key > key (strictly greater)
     # With [min, max) ranges, end_key is exclusive, so we want end_key > key
-    case :ets.next(table, key) do
-      :"$end_of_table" ->
-        # Key is beyond all boundaries - fall back to last entry
-        lookup_last(table)
+    case ceiling_entry(shards, key) do
+      :none ->
+        # Key is beyond all boundaries - fall back to the last entry
+        if :gb_trees.is_empty(shards) do
+          raise "Empty shard map"
+        else
+          {_end_key, {tag, _start_key}} = :gb_trees.largest(shards)
+          tag
+        end
 
-      next_key ->
-        # Found the shard whose end_key > key, meaning key is in this shard's range
-        extract_tag(:ets.lookup_element(table, next_key, 2))
+      {_end_key, {tag, _start_key}} ->
+        tag
     end
-  end
-
-  defp lookup_last(table) do
-    case :ets.last(table) do
-      :"$end_of_table" -> raise "Empty shard_keys table"
-      last_key -> extract_tag(:ets.lookup_element(table, last_key, 2))
-    end
-  end
-
-  # Extract tag from either cached or uncached format
-  # Tags can be integers or strings depending on test setup
-  defp extract_tag({tag, _log_indices}), do: tag
-  defp extract_tag(tag), do: tag
-
-  @doc ~S"""
-  Looks up all shard tags that overlap with a key range.
-
-  Used for range mutations (clear_range) that may span multiple shards.
-  Returns a list of tags for all shards that intersect the range [start_key, end_key).
-
-  ## Parameters
-
-    - `table` - ETS table reference with `{end_key, tag}` entries
-    - `start_key` - Start of the range (inclusive)
-    - `end_key` - End of the range (exclusive)
-
-  ## Returns
-
-  List of shard tags that the range intersects with.
-
-  ## Examples
-
-      # Table has: {"d", 0}, {"h", 1}, {"m", 2}, {"\xff", 3}
-      iex> lookup_shards_for_range(table, "a", "c")
-      [0]
-      iex> lookup_shards_for_range(table, "c", "f")
-      [0, 1]
-
-  """
-  @spec lookup_shards_for_range(:ets.table(), binary(), binary()) :: [non_neg_integer()]
-  def lookup_shards_for_range(table, start_key, end_key) when is_binary(start_key) and is_binary(end_key) do
-    # Find the first shard that contains start_key
-    first_tag = lookup_shard(table, start_key)
-
-    # If start_key == end_key (empty range), just return the start shard
-    if start_key >= end_key do
-      [first_tag]
-    else
-      # Collect all shards from first_tag until we find one that contains end_key
-      collect_shards_in_range(table, start_key, end_key, first_tag)
-    end
-  end
-
-  # Collect all shard tags that overlap with the range [start_key, end_key)
-  @spec collect_shards_in_range(:ets.table(), binary(), binary(), non_neg_integer()) ::
-          [non_neg_integer()]
-  defp collect_shards_in_range(table, start_key, end_key, _first_tag) do
-    # Get all entries from the table
-    entries = :ets.tab2list(table)
-
-    # Sort by end_key
-    sorted = Enum.sort_by(entries, fn {ek, _tag_or_cached} -> ek end)
-
-    # Find shards that overlap with [start_key, end_key)
-    # With [min, max) semantics:
-    # - A shard with end_key E covers [prev_end, E)
-    # - Shard overlaps [start_key, end_key) if: shard_end_key > start_key
-    sorted
-    |> Enum.filter(fn {shard_end_key, _tag_or_cached} ->
-      # Shard must extend past start_key (strictly greater because end is exclusive)
-      shard_end_key > start_key
-    end)
-    |> Enum.reduce_while([], fn {shard_end_key, tag_or_cached}, acc ->
-      tag = extract_tag(tag_or_cached)
-      acc = [tag | acc]
-
-      # If this shard's end_key >= end_key, we've covered the whole range
-      if shard_end_key >= end_key do
-        {:halt, acc}
-      else
-        {:cont, acc}
-      end
-    end)
-    |> Enum.reverse()
   end
 
   @doc ~S"""
   Returns shards overlapping a key range, with their boundaries.
 
-  Unlike `lookup_shards_for_range/3` which returns only tags, this function
-  returns `{tag, shard_start, shard_end}` tuples to enable clamping range
+  Returns `{tag, shard_start, shard_end}` tuples to enable clamping range
   mutations to shard boundaries.
 
   ## Parameters
 
-    - `table` - ETS table reference with `{end_key, tag}` entries
+    - `shards` - shard map (`end_key => {tag, start_key}` gb_tree)
     - `start_key` - Start of the range (inclusive)
     - `end_key` - End of the range (exclusive)
 
@@ -221,108 +140,58 @@ defmodule Bedrock.DataPlane.ShardRouter do
 
   ## Examples
 
-      # Table has: {"d", 0}, {"h", 1}, {"m", 2}, {"\xff", 3}
       # Shards: 0 = ["", "d"), 1 = ["d", "h"), 2 = ["h", "m"), 3 = ["m", "\xff")
-      iex> lookup_shards_with_ranges(table, "a", "c")
+      iex> lookup_shards_with_ranges(shards, "a", "c")
       [{0, "", "d"}]
-      iex> lookup_shards_with_ranges(table, "c", "j")
+      iex> lookup_shards_with_ranges(shards, "c", "j")
       [{0, "", "d"}, {1, "d", "h"}, {2, "h", "m"}]
 
   """
-  @spec lookup_shards_with_ranges(:ets.table(), binary(), binary()) ::
+  @spec lookup_shards_with_ranges(RoutingData.shard_tree(), binary(), binary()) ::
           [{non_neg_integer(), binary(), binary()}]
-  def lookup_shards_with_ranges(table, start_key, end_key) when is_binary(start_key) and is_binary(end_key) do
-    # Find first end_key > start_key (the shard containing start_key)
-    case :ets.next(table, start_key) do
-      :"$end_of_table" ->
-        # start_key is at or beyond every shard's exclusive upper bound:
-        # the range intersects no shard.
-        []
-
-      first_end ->
-        # Find the start boundary of the first shard (previous key in table, or "" if first)
-        first_start = find_shard_start(table, first_end)
-        collect_shards_with_ranges(table, first_end, end_key, first_start, [])
-    end
+  def lookup_shards_with_ranges(shards, start_key, end_key) when is_binary(start_key) and is_binary(end_key) do
+    start_key
+    |> :gb_trees.iterator_from(shards)
+    |> collect_overlapping(start_key, end_key, [])
   end
 
-  # Find the start of a shard (the previous end_key in the table, or "" if first)
-  defp find_shard_start(table, shard_end) do
-    case :ets.prev(table, shard_end) do
-      :"$end_of_table" -> ""
-      prev_key -> prev_key
-    end
-  end
+  defp collect_overlapping(iter, start_key, end_key, acc) do
+    case :gb_trees.next(iter) do
+      :none ->
+        Enum.reverse(acc)
 
-  defp collect_shards_with_ranges(_table, :"$end_of_table", _end_key, _prev_end, acc) do
-    Enum.reverse(acc)
-  end
+      # The iterator starts at keys >= start_key; a shard ending exactly AT
+      # start_key does not overlap (its end is exclusive) - skip it.
+      {shard_end, _value, next_iter} when shard_end <= start_key ->
+        collect_overlapping(next_iter, start_key, end_key, acc)
 
-  defp collect_shards_with_ranges(table, shard_end, end_key, shard_start, acc) when shard_end >= end_key do
-    # Last shard - includes the end_key
-    tag = extract_tag(:ets.lookup_element(table, shard_end, 2))
-    Enum.reverse([{tag, shard_start, shard_end} | acc])
-  end
+      {shard_end, {tag, shard_start}, next_iter} ->
+        acc = [{tag, shard_start, shard_end} | acc]
 
-  defp collect_shards_with_ranges(table, shard_end, end_key, shard_start, acc) do
-    tag = extract_tag(:ets.lookup_element(table, shard_end, 2))
-    next_end = :ets.next(table, shard_end)
-    # Current shard_end becomes the start of the next shard
-    collect_shards_with_ranges(table, next_end, end_key, shard_end, [{tag, shard_start, shard_end} | acc])
-  end
-
-  @doc """
-  Routes a key to its logs using shard lookup and golden ratio log selection.
-
-  Uses lazy caching: first call computes log_indices and caches in ETS,
-  subsequent calls use the cached value. The ETS entry format changes from
-  `{end_key, tag}` to `{end_key, {tag, log_indices}}` after first access.
-
-  ## Parameters
-
-    - `shard_table` - ETS table with `{end_key, tag}` or `{end_key, {tag, log_indices}}` entries
-    - `key` - The key to route
-    - `log_map` - Map from log index to log_id (`%{0 => "log-a", 1 => "log-b", ...}`)
-    - `replication_factor` - How many logs to return
-
-  ## Returns
-
-  List of log_ids that should store data for this key.
-
-  """
-  @spec get_logs_for_key(:ets.table(), binary(), %{non_neg_integer() => binary()}, non_neg_integer()) ::
-          [binary()]
-  def get_logs_for_key(shard_table, key, log_map, replication_factor) do
-    n = map_size(log_map)
-    end_key = find_end_key(shard_table, key)
-
-    log_indices =
-      case :ets.lookup(shard_table, end_key) do
-        [{_, {_tag, cached_indices}}] ->
-          # Already cached - use it
-          cached_indices
-
-        [{_, tag}] when is_integer(tag) ->
-          # Not cached - compute, cache, return
-          indices = get_log_indices(tag, n, replication_factor)
-          :ets.insert(shard_table, {end_key, {tag, indices}})
-          indices
-      end
-
-    Enum.map(log_indices, &Map.fetch!(log_map, &1))
-  end
-
-  # Find the end_key for the shard containing key
-  defp find_end_key(table, key) do
-    case :ets.next(table, key) do
-      :"$end_of_table" ->
-        case :ets.last(table) do
-          :"$end_of_table" -> raise "Empty shard_keys table"
-          last_key -> last_key
+        if shard_end >= end_key do
+          Enum.reverse(acc)
+        else
+          collect_overlapping(next_iter, start_key, end_key, acc)
         end
+    end
+  end
 
-      next_key ->
-        next_key
+  # First entry with end_key strictly greater than key. iterator_from yields
+  # keys >= key, so at most the first entry needs skipping.
+  defp ceiling_entry(shards, key) do
+    iter = :gb_trees.iterator_from(key, shards)
+
+    case :gb_trees.next(iter) do
+      :none -> :none
+      {end_key, value, _next_iter} when end_key > key -> {end_key, value}
+      {_equal_key, _value, next_iter} -> next_entry(next_iter)
+    end
+  end
+
+  defp next_entry(iter) do
+    case :gb_trees.next(iter) do
+      :none -> :none
+      {end_key, value, _next_iter} -> {end_key, value}
     end
   end
 end

--- a/test/bedrock/control_plane/director/recovery/persistence_phase_test.exs
+++ b/test/bedrock/control_plane/director/recovery/persistence_phase_test.exs
@@ -264,19 +264,22 @@ defmodule Bedrock.ControlPlane.Director.Recovery.PersistencePhaseTest do
       assert metadata.shard_metadata |> Map.keys() |> Enum.sort() == ["0", "1"]
     end
 
-    test "shrinking shard layout leaves exactly 2 entries visible to RoutingData ETS" do
+    test "shrinking shard layout leaves exactly 2 entries visible to RoutingData" do
       mutations = captured_system_mutations(base_recovery_attempt())
 
-      routing_data = RoutingData.new_empty()
-      RoutingData.insert_shard(routing_data, <<0x40>>, 2)
-      RoutingData.insert_shard(routing_data, <<0x80>>, 3)
-      RoutingData.insert_shard(routing_data, <<0xFF, 0xFF>>, 4)
+      routing_data =
+        RoutingData.new_empty()
+        |> RoutingData.insert_shard(<<0x40>>, 2, <<>>)
+        |> RoutingData.insert_shard(<<0x80>>, 3, <<0x40>>)
+        |> RoutingData.insert_shard(<<0xFF, 0xFF>>, 4, <<0x80>>)
 
-      updated = RoutingData.apply_mutations(routing_data, [{1, mutations}])
+      updated =
+        RoutingData.apply_mutations(routing_data, [{Bedrock.DataPlane.Version.from_integer(1), mutations}])
 
-      assert :ets.tab2list(updated.shard_table) == [{<<0xFF>>, 1}, {<<0xFF, 0xFF>>, 0}]
-
-      RoutingData.cleanup(routing_data)
+      assert :gb_trees.to_list(updated.shards) == [
+               {<<0xFF>>, {1, <<>>}},
+               {<<0xFF, 0xFF>>, {0, <<0xFF>>}}
+             ]
     end
 
     test "cleared prefix ranges do not cover any other system-key family" do

--- a/test/bedrock/data_plane/commit_proxy/finalization/core_test.exs
+++ b/test/bedrock/data_plane/commit_proxy/finalization/core_test.exs
@@ -83,7 +83,7 @@ defmodule Bedrock.DataPlane.CommitProxy.FinalizationCoreTest do
           epoch: 1,
           sequencer: :test_sequencer,
           resolver_layout: ResolverLayout.from_layout(transaction_system_layout),
-          routing_data: routing_data
+          metadata_apply_fn: Support.metadata_apply_fn(routing_data)
         )
 
       assert result == {:error, {:resolver_unavailable, :unavailable}}
@@ -133,7 +133,7 @@ defmodule Bedrock.DataPlane.CommitProxy.FinalizationCoreTest do
                  resolver_fn: mock_resolver_fn,
                  batch_log_push_fn: mock_successful_log_push(),
                  sequencer_notify_fn: mock_sequencer_notify(),
-                 routing_data: routing_data
+                 metadata_apply_fn: Support.metadata_apply_fn(routing_data)
                )
 
       expected_version = Version.from_integer(100)
@@ -161,7 +161,7 @@ defmodule Bedrock.DataPlane.CommitProxy.FinalizationCoreTest do
                    assert sequencer == :test_sequencer
                    :ok
                  end,
-                 routing_data: routing_data
+                 metadata_apply_fn: Support.metadata_apply_fn(routing_data)
                )
     end
 
@@ -205,7 +205,7 @@ defmodule Bedrock.DataPlane.CommitProxy.FinalizationCoreTest do
                    assert sequencer == :test_sequencer
                    :ok
                  end,
-                 routing_data: routing_data
+                 metadata_apply_fn: Support.metadata_apply_fn(routing_data)
                )
 
       # Both should be aborted
@@ -236,7 +236,7 @@ defmodule Bedrock.DataPlane.CommitProxy.FinalizationCoreTest do
                  resolver_layout: ResolverLayout.from_layout(transaction_system_layout),
                  resolver_fn: mock_resolver_fn,
                  batch_log_push_fn: mock_log_push_fn,
-                 routing_data: routing_data
+                 metadata_apply_fn: Support.metadata_apply_fn(routing_data)
                )
 
       # Transaction should be aborted due to log failure
@@ -266,7 +266,7 @@ defmodule Bedrock.DataPlane.CommitProxy.FinalizationCoreTest do
                  resolver_layout: ResolverLayout.from_layout(transaction_system_layout),
                  resolver_fn: mock_resolver_fn,
                  batch_log_push_fn: mock_log_push_fn,
-                 routing_data: routing_data
+                 metadata_apply_fn: Support.metadata_apply_fn(routing_data)
                )
 
       # Transaction should be aborted due to insufficient acknowledgments
@@ -317,7 +317,7 @@ defmodule Bedrock.DataPlane.CommitProxy.FinalizationCoreTest do
                    assert sequencer == :test_sequencer
                    :ok
                  end,
-                 routing_data: routing_data
+                 metadata_apply_fn: Support.metadata_apply_fn(routing_data)
                )
 
       # Verify both resolver and log push received correct versions
@@ -371,7 +371,7 @@ defmodule Bedrock.DataPlane.CommitProxy.FinalizationCoreTest do
                  resolver_layout: ResolverLayout.from_layout(transaction_system_layout),
                  resolver_fn: mock_resolver_fn,
                  abort_reply_fn: custom_abort_fn,
-                 routing_data: routing_data
+                 metadata_apply_fn: Support.metadata_apply_fn(routing_data)
                )
 
       assert_receive {:custom_abort_called, 1}

--- a/test/bedrock/data_plane/commit_proxy/finalization/data_transformation_test.exs
+++ b/test/bedrock/data_plane/commit_proxy/finalization/data_transformation_test.exs
@@ -29,11 +29,8 @@ defmodule Bedrock.DataPlane.CommitProxy.FinalizationDataTransformationTest do
   end
 
   # Build routing data for tests
+  # Default shard layout covering entire keyspace with a single shard (tag 0)
   defp build_routing_data(logs) do
-    table = :ets.new(:test_shard_keys, [:ordered_set, :public])
-    # Default shard layout covering entire keyspace with a single shard (tag 0)
-    :ets.insert(table, {<<0xFF, 0xFF>>, 0})
-
     log_map =
       logs
       |> Map.keys()
@@ -41,13 +38,12 @@ defmodule Bedrock.DataPlane.CommitProxy.FinalizationDataTransformationTest do
       |> Enum.with_index()
       |> Map.new(fn {log_id, index} -> {index, log_id} end)
 
-    replication_factor = max(1, map_size(logs))
-
-    %RoutingData{shard_table: table, log_map: log_map, replication_factor: replication_factor}
-  end
-
-  defp default_routing_data do
-    build_routing_data(%{})
+    RoutingData.from_snapshot(%{
+      shard_layout: %{<<0xFF, 0xFF>> => {0, <<>>}},
+      log_map: log_map,
+      log_services: %{},
+      replication_factor: max(1, map_size(logs))
+    })
   end
 
   defp create_ordered_transactions(count) do
@@ -118,7 +114,7 @@ defmodule Bedrock.DataPlane.CommitProxy.FinalizationDataTransformationTest do
       routing_data = build_routing_data(layout.logs)
 
       assert %{stage: :ready_for_resolution, transactions: transactions} =
-               Finalization.create_finalization_plan(batch, routing_data)
+               Finalization.create_finalization_plan(batch)
 
       assert map_size(transactions) == 2
 
@@ -149,7 +145,7 @@ defmodule Bedrock.DataPlane.CommitProxy.FinalizationDataTransformationTest do
       batch = create_batch([], 200)
 
       assert %{transactions: transactions, stage: :ready_for_resolution} =
-               Finalization.create_finalization_plan(batch, default_routing_data())
+               Finalization.create_finalization_plan(batch)
 
       assert map_size(transactions) == 0
     end
@@ -164,7 +160,7 @@ defmodule Bedrock.DataPlane.CommitProxy.FinalizationDataTransformationTest do
       batch = create_batch([{fn _ -> :ok end, Transaction.encode(transaction_map)}], 200)
 
       assert %{transactions: transactions} =
-               Finalization.create_finalization_plan(batch, default_routing_data())
+               Finalization.create_finalization_plan(batch)
 
       assert map_size(transactions) == 1
       {_idx, _reply_fn, binary} = Map.fetch!(transactions, 0)
@@ -189,7 +185,7 @@ defmodule Bedrock.DataPlane.CommitProxy.FinalizationDataTransformationTest do
       batch = create_batch([{fn _ -> :ok end, Transaction.encode(transaction_map)}], 200)
 
       assert %{transactions: transactions} =
-               Finalization.create_finalization_plan(batch, default_routing_data())
+               Finalization.create_finalization_plan(batch)
 
       assert map_size(transactions) == 1
       {_idx, _reply_fn, binary} = Map.fetch!(transactions, 0)
@@ -220,7 +216,7 @@ defmodule Bedrock.DataPlane.CommitProxy.FinalizationDataTransformationTest do
       batch = create_batch([{fn _ -> :ok end, Transaction.encode(transaction_map)}], 200)
 
       assert %{transactions: transactions} =
-               Finalization.create_finalization_plan(batch, default_routing_data())
+               Finalization.create_finalization_plan(batch)
 
       assert map_size(transactions) == 1
       {_idx, _reply_fn, binary} = Map.fetch!(transactions, 0)
@@ -245,7 +241,7 @@ defmodule Bedrock.DataPlane.CommitProxy.FinalizationDataTransformationTest do
       batch = create_batch(transactions, 100)
 
       assert %{transactions: transactions} =
-               Finalization.create_finalization_plan(batch, default_routing_data())
+               Finalization.create_finalization_plan(batch)
 
       # Verify transactions map contains all transactions
       assert map_size(transactions) == 4
@@ -298,7 +294,7 @@ defmodule Bedrock.DataPlane.CommitProxy.FinalizationDataTransformationTest do
       batch = create_batch(transactions, 100)
 
       assert %{transactions: transactions} =
-               Finalization.create_finalization_plan(batch, default_routing_data())
+               Finalization.create_finalization_plan(batch)
 
       # For each transaction index, verify the corresponding transaction data
       Enum.each(0..2, fn idx ->

--- a/test/bedrock/data_plane/commit_proxy/finalization/log_push_test.exs
+++ b/test/bedrock/data_plane/commit_proxy/finalization/log_push_test.exs
@@ -83,7 +83,7 @@ defmodule Bedrock.DataPlane.CommitProxy.FinalizationLogPushTest do
                  resolver_layout: ResolverLayout.from_layout(transaction_system_layout),
                  resolver_fn: resolver_fn,
                  sequencer_notify_fn: sequencer_notify_fn,
-                 routing_data: routing_data
+                 metadata_apply_fn: Support.metadata_apply_fn(routing_data)
                )
 
       assert_receive {:reply1, {:ok, _, _}}
@@ -125,7 +125,7 @@ defmodule Bedrock.DataPlane.CommitProxy.FinalizationLogPushTest do
                  resolver_layout: ResolverLayout.from_layout(layout),
                  resolver_fn: resolver_fn,
                  sequencer_notify_fn: sequencer_notify_fn,
-                 routing_data: routing_data
+                 metadata_apply_fn: Support.metadata_apply_fn(routing_data)
                )
 
       assert_receive {:range_reply, {:ok, _, _}}
@@ -164,7 +164,7 @@ defmodule Bedrock.DataPlane.CommitProxy.FinalizationLogPushTest do
                  resolver_layout: ResolverLayout.from_layout(layout),
                  resolver_fn: resolver_fn,
                  sequencer_notify_fn: sequencer_notify_fn,
-                 routing_data: routing_data
+                 metadata_apply_fn: Support.metadata_apply_fn(routing_data)
                )
 
       assert_receive {:reply, {:ok, _, _}}
@@ -227,7 +227,7 @@ defmodule Bedrock.DataPlane.CommitProxy.FinalizationLogPushTest do
                  resolver_layout: ResolverLayout.from_layout(layout),
                  resolver_fn: resolver_fn,
                  sequencer_notify_fn: sequencer_notify_fn,
-                 routing_data: routing_data
+                 metadata_apply_fn: Support.metadata_apply_fn(routing_data)
                )
 
       # Verify correct replies - transaction 1 should be aborted, others succeed
@@ -604,7 +604,7 @@ defmodule Bedrock.DataPlane.CommitProxy.FinalizationLogPushTest do
                  sequencer: layout.sequencer,
                  resolver_layout: ResolverLayout.from_layout(layout),
                  resolver_fn: resolver_fn,
-                 routing_data: routing_data
+                 metadata_apply_fn: Support.metadata_apply_fn(routing_data)
                )
 
       # Both transactions should be aborted due to log failure

--- a/test/bedrock/data_plane/commit_proxy/finalization/metadata_test.exs
+++ b/test/bedrock/data_plane/commit_proxy/finalization/metadata_test.exs
@@ -112,7 +112,7 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization.MetadataTest do
                  sequencer: :test_sequencer,
                  resolver_layout: ResolverLayout.from_layout(transaction_system_layout),
                  resolver_fn: mock_resolver_fn,
-                 routing_data: routing_data,
+                 metadata_apply_fn: Support.metadata_apply_fn(routing_data),
                  batch_log_push_fn: fn _last_version, _tx_by_log, _commit_version, _opts -> :ok end,
                  sequencer_notify_fn: fn _sequencer, _epoch, _commit_version, _opts -> :ok end
                )
@@ -157,7 +157,7 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization.MetadataTest do
                  sequencer: :test_sequencer,
                  resolver_layout: ResolverLayout.from_layout(transaction_system_layout),
                  resolver_fn: mock_resolver_fn,
-                 routing_data: routing_data,
+                 metadata_apply_fn: Support.metadata_apply_fn(routing_data),
                  batch_log_push_fn: fn _last_version, _tx_by_log, _commit_version, _opts -> :ok end,
                  sequencer_notify_fn: fn _sequencer, _epoch, _commit_version, _opts -> :ok end
                )
@@ -206,7 +206,7 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization.MetadataTest do
                  sequencer: :test_sequencer,
                  resolver_layout: ResolverLayout.from_layout(transaction_system_layout),
                  resolver_fn: mock_resolver_fn,
-                 routing_data: routing_data,
+                 metadata_apply_fn: Support.metadata_apply_fn(routing_data),
                  batch_log_push_fn: fn _last_version, _tx_by_log, _commit_version, _opts -> :ok end,
                  sequencer_notify_fn: fn _sequencer, _epoch, _commit_version, _opts -> :ok end
                )
@@ -240,7 +240,7 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization.MetadataTest do
                  sequencer: :test_sequencer,
                  resolver_layout: ResolverLayout.from_layout(transaction_system_layout),
                  resolver_fn: mock_resolver_fn,
-                 routing_data: routing_data,
+                 metadata_apply_fn: Support.metadata_apply_fn(routing_data),
                  batch_log_push_fn: fn _last_version, _tx_by_log, _commit_version, _opts -> :ok end,
                  sequencer_notify_fn: fn _sequencer, _epoch, _commit_version, _opts -> :ok end
                )
@@ -274,7 +274,7 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization.MetadataTest do
                  sequencer: :test_sequencer,
                  resolver_layout: ResolverLayout.from_layout(transaction_system_layout),
                  resolver_fn: mock_resolver_fn,
-                 routing_data: routing_data,
+                 metadata_apply_fn: Support.metadata_apply_fn(routing_data),
                  batch_log_push_fn: fn _last_version, _tx_by_log, _commit_version, _opts -> :ok end,
                  sequencer_notify_fn: fn _sequencer, _epoch, _commit_version, _opts -> :ok end
                )
@@ -335,7 +335,7 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization.MetadataTest do
                  sequencer: :test_sequencer,
                  resolver_layout: ResolverLayout.from_layout(transaction_system_layout),
                  resolver_fn: mock_resolver_fn,
-                 routing_data: routing_data,
+                 metadata_apply_fn: Support.metadata_apply_fn(routing_data),
                  batch_log_push_fn: fn _last_version, _tx_by_log, _commit_version, _opts -> :ok end,
                  sequencer_notify_fn: fn _sequencer, _epoch, _commit_version, _opts -> :ok end
                )
@@ -387,7 +387,7 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization.MetadataTest do
                  sequencer: :test_sequencer,
                  resolver_layout: ResolverLayout.from_layout(transaction_system_layout),
                  resolver_fn: mock_resolver_fn,
-                 routing_data: routing_data,
+                 metadata_apply_fn: Support.metadata_apply_fn(routing_data),
                  batch_log_push_fn: fn _last_version, _tx_by_log, _commit_version, _opts -> :ok end,
                  sequencer_notify_fn: fn _sequencer, _epoch, _commit_version, _opts -> :ok end
                )
@@ -445,7 +445,7 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization.MetadataTest do
                  sequencer: :test_sequencer,
                  resolver_layout: ResolverLayout.from_layout(transaction_system_layout),
                  resolver_fn: mock_resolver_fn,
-                 routing_data: routing_data,
+                 metadata_apply_fn: Support.metadata_apply_fn(routing_data),
                  batch_log_push_fn: fn _last_version, _tx_by_log, _commit_version, _opts -> :ok end,
                  sequencer_notify_fn: fn _sequencer, _epoch, _commit_version, _opts -> :ok end
                )

--- a/test/bedrock/data_plane/commit_proxy/finalization/resolver_retry_test.exs
+++ b/test/bedrock/data_plane/commit_proxy/finalization/resolver_retry_test.exs
@@ -97,7 +97,7 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization.ResolverRetryTest do
                  batch_log_push_fn: fn _last_version, _tx_by_log, _commit_version, _opts -> :ok end,
                  sequencer_notify_fn: fn _sequencer, _epoch, _commit_version, _opts -> :ok end,
                  max_attempts: 3,
-                 routing_data: routing_data
+                 metadata_apply_fn: Support.metadata_apply_fn(routing_data)
                )
 
       # Verify retry happened
@@ -138,7 +138,7 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization.ResolverRetryTest do
                  batch_log_push_fn: fn _last_version, _tx_by_log, _commit_version, _opts -> :ok end,
                  sequencer_notify_fn: fn _sequencer, _epoch, _commit_version, _opts -> :ok end,
                  max_attempts: 3,
-                 routing_data: routing_data
+                 metadata_apply_fn: Support.metadata_apply_fn(routing_data)
                )
 
       assert_receive {:resolver_attempt, 1}
@@ -178,7 +178,7 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization.ResolverRetryTest do
                  batch_log_push_fn: fn _last_version, _tx_by_log, _commit_version, _opts -> :ok end,
                  sequencer_notify_fn: fn _sequencer, _epoch, _commit_version, _opts -> :ok end,
                  max_attempts: 3,
-                 routing_data: routing_data
+                 metadata_apply_fn: Support.metadata_apply_fn(routing_data)
                )
 
       assert_receive {:resolver_attempt, 1}
@@ -221,7 +221,7 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization.ResolverRetryTest do
                  resolver_layout: ResolverLayout.from_layout(transaction_system_layout),
                  resolver_fn: mock_resolver_fn,
                  max_attempts: 3,
-                 routing_data: routing_data
+                 metadata_apply_fn: Support.metadata_apply_fn(routing_data)
                )
 
       # Should have attempted exactly 3 times
@@ -260,7 +260,7 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization.ResolverRetryTest do
                  resolver_layout: ResolverLayout.from_layout(transaction_system_layout),
                  resolver_fn: mock_resolver_fn,
                  max_attempts: 2,
-                 routing_data: routing_data
+                 metadata_apply_fn: Support.metadata_apply_fn(routing_data)
                )
 
       assert_receive {:resolver_attempt, 1}
@@ -294,7 +294,7 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization.ResolverRetryTest do
                  resolver_layout: ResolverLayout.from_layout(transaction_system_layout),
                  resolver_fn: mock_resolver_fn,
                  max_attempts: 3,
-                 routing_data: routing_data
+                 metadata_apply_fn: Support.metadata_apply_fn(routing_data)
                )
 
       assert_receive {:resolver_attempt, 1}
@@ -337,7 +337,7 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization.ResolverRetryTest do
                  resolver_layout: ResolverLayout.from_layout(transaction_system_layout),
                  resolver_fn: mock_resolver_fn,
                  max_attempts: 3,
-                 routing_data: routing_data
+                 metadata_apply_fn: Support.metadata_apply_fn(routing_data)
                )
 
       # Should fail immediately - only 1 attempt
@@ -371,7 +371,7 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization.ResolverRetryTest do
                  resolver_layout: ResolverLayout.from_layout(transaction_system_layout),
                  resolver_fn: mock_resolver_fn,
                  max_attempts: 3,
-                 routing_data: routing_data
+                 metadata_apply_fn: Support.metadata_apply_fn(routing_data)
                )
 
       # Should fail immediately
@@ -435,7 +435,7 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization.ResolverRetryTest do
                  sequencer_notify_fn: fn _sequencer, _epoch, _commit_version, _opts -> :ok end,
                  timeout_fn: custom_timeout_fn,
                  max_attempts: 5,
-                 routing_data: routing_data
+                 metadata_apply_fn: Support.metadata_apply_fn(routing_data)
                )
 
       # Verify timeouts were passed correctly
@@ -500,7 +500,7 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization.ResolverRetryTest do
                  batch_log_push_fn: fn _last_version, _tx_by_log, _commit_version, _opts -> :ok end,
                  sequencer_notify_fn: fn _sequencer, _epoch, _commit_version, _opts -> :ok end,
                  max_attempts: 3,
-                 routing_data: routing_data
+                 metadata_apply_fn: Support.metadata_apply_fn(routing_data)
                )
 
       # Both attempts should see 2 transactions
@@ -562,7 +562,7 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization.ResolverRetryTest do
                    resolver_layout: ResolverLayout.from_layout(transaction_system_layout),
                    resolver_fn: mock_resolver_fn,
                    max_attempts: 3,
-                   routing_data: routing_data
+                   metadata_apply_fn: Support.metadata_apply_fn(routing_data)
                  )
       end)
 

--- a/test/bedrock/data_plane/commit_proxy/finalization/sharded_resolution_and_edge_cases_test.exs
+++ b/test/bedrock/data_plane/commit_proxy/finalization/sharded_resolution_and_edge_cases_test.exs
@@ -75,7 +75,7 @@ defmodule Bedrock.DataPlane.CommitProxy.FinalizationShardedResolutionAndEdgeCase
         epoch: 1,
         sequencer: :test_sequencer,
         resolver_layout: resolver_layout,
-        routing_data: routing_data,
+        metadata_apply_fn: Support.metadata_apply_fn(routing_data),
         batch_log_push_fn: fn _last, _by_log, _commit, _opts -> :ok end,
         sequencer_notify_fn: fn :test_sequencer, _epoch, _commit, _opts -> :ok end
       ],
@@ -214,17 +214,20 @@ defmodule Bedrock.DataPlane.CommitProxy.FinalizationShardedResolutionAndEdgeCase
         :resolver_b, _epoch, _last, _commit, _txns, _metadata, _opts -> {:ok, [1], nil}
       end
 
-      metadata_deferred_fn = fn version, mutations -> send(test_pid, {:deferred, version, mutations}) end
+      metadata_apply_fn = fn _prev, version, _window, deferred ->
+        send(test_pid, {:deferred, version, deferred})
+        {:ok, routing_data()}
+      end
 
       opts =
         base_opts(sharded_layout(), routing_data(),
           resolver_fn: resolver_fn,
-          metadata_deferred_fn: metadata_deferred_fn
+          metadata_apply_fn: metadata_apply_fn
         )
 
       assert {:ok, 1, 1} = Finalization.finalize_batch(batch, opts)
 
-      assert_receive {:deferred, @commit_version, [{:set, <<0xFF, "/committed">>, "meta"}]}
+      assert_receive {:deferred, @commit_version, {[{:set, <<0xFF, "/committed">>, "meta"}]}}
     end
 
     test "merged metadata windows claim the weakest coverage on both ends and withhold unsettled entries" do
@@ -245,9 +248,12 @@ defmodule Bedrock.DataPlane.CommitProxy.FinalizationShardedResolutionAndEdgeCase
           {:ok, [], {v.(90), v.(96), [entry_95]}}
       end
 
-      metadata_merge_fn = fn window -> send(test_pid, {:merged_window, window}) end
+      metadata_apply_fn = fn _prev, _version, window, _deferred ->
+        send(test_pid, {:merged_window, window})
+        {:ok, routing_data()}
+      end
 
-      opts = base_opts(sharded_layout(), routing_data(), resolver_fn: resolver_fn, metadata_merge_fn: metadata_merge_fn)
+      opts = base_opts(sharded_layout(), routing_data(), resolver_fn: resolver_fn, metadata_apply_fn: metadata_apply_fn)
 
       assert {:ok, 0, 0} = Finalization.finalize_batch(empty_batch(), opts)
 

--- a/test/bedrock/data_plane/commit_proxy/metadata_window_application_test.exs
+++ b/test/bedrock/data_plane/commit_proxy/metadata_window_application_test.exs
@@ -1,14 +1,22 @@
 defmodule Bedrock.DataPlane.CommitProxy.MetadataWindowApplicationTest do
   @moduledoc """
-  Pins the commit proxy server's application of resolver metadata windows
-  (bedrock-q67.16).
+  Pins the commit proxy server's serialized apply-and-route step
+  (bedrock-q67.16, bedrock-q67.24).
 
-  Windows arrive from per-batch finalization tasks and can therefore reach the
-  server mailbox out of commit-version order. The protocol makes that safe by
-  construction: every window covers `(from_version, to_version]` starting at
-  the version this proxy last CONFIRMED applying, so concurrent in-flight
-  windows overlap and a late-arriving earlier window is a subset of what has
-  already been applied - the per-entry version guard skips it.
+  Each finalization task asks the server to apply its batch's committed
+  metadata - the resolver window plus, in sharded mode, the batch's own
+  globally-committed metadata - and hand back the immutable routing snapshot
+  the batch pushes with. Requests are served strictly in proxy-local
+  batch-sequence order: a request whose predecessor has not applied yet
+  waits, so every batch routes with exactly the metadata at or below its own
+  commit version. This mirrors FDB's postResolution ordering (apply
+  metadata, then assign mutations to logs, one batch at a time), keyed like
+  FDB's latestLocalCommitBatchLogging on a per-proxy counter - global
+  sequencer versions interleave across proxies.
+
+  Windows still overlap (each covers `(from, to]` from the version the proxy
+  had confirmed when the batch spawned), so entries at or below the applied
+  version are dropped before application.
 
   The one unrecoverable case is a coverage gap (`from_version` beyond what the
   proxy has applied): the resolver has pruned history this proxy never saw, so
@@ -27,15 +35,16 @@ defmodule Bedrock.DataPlane.CommitProxy.MetadataWindowApplicationTest do
 
   defp v(n), do: Version.from_integer(n)
 
-  defp state(metadata) do
+  defp state(opts \\ []) do
     %State{
       cluster: __MODULE__,
       director: self(),
       epoch: 1,
       empty_transaction_timeout_ms: 1_000,
       mode: :running,
-      metadata: metadata,
-      routing_data: RoutingData.new_empty()
+      metadata: Keyword.get(opts, :metadata, Metadata.new()),
+      routing_data: RoutingData.new_empty(),
+      routed_seq: Keyword.get(opts, :routed_seq, 0)
     }
   end
 
@@ -43,94 +52,142 @@ defmodule Bedrock.DataPlane.CommitProxy.MetadataWindowApplicationTest do
 
   defp log_set(log_id), do: {:set, SystemKeys.layout_log(log_id), Values.encode_tag_list([1])}
 
-  defp apply_window(state, window) do
-    {:noreply, updated, _timeout} = Server.handle_info({:metadata_updates, window}, state)
-    updated
+  defp request(state, seq, commit_version, window, deferred \\ nil) do
+    from = {self(), make_ref()}
+    result = Server.handle_call({:apply_metadata_and_route, seq, commit_version, window, deferred}, from, state)
+    {result, elem(from, 1)}
   end
 
-  test "overlapping windows apply idempotently; a late-arriving earlier window is a no-op" do
-    e1 = {v(1), [shard_set("a", 1)]}
-    e2 = {v(2), [shard_set("a", 2)]}
+  defp apply_in_order(state, seq, commit_version, window, deferred \\ nil) do
+    {{:noreply, updated, _timeout}, ref} = request(state, seq, commit_version, window, deferred)
+    assert_receive {^ref, {:ok, routing_data}}
+    {updated, routing_data}
+  end
 
-    # Batch 2's window (same ack, superset) wins the race to the mailbox.
-    updated = apply_window(state(Metadata.new()), {nil, v(2), [e1, e2]})
-    assert %Metadata{shards: %{"a" => 2}, version: version} = updated.metadata
-    assert version == v(2)
+  test "an in-order request applies the window and returns the routing snapshot in one step" do
+    window = {nil, v(1), [{v(1), [shard_set("a", 7), log_set("log_a")]}]}
 
-    # Batch 1's window arrives late: subset of what is applied - no effect.
-    updated = apply_window(updated, {nil, v(1), [e1]})
-    assert %Metadata{shards: %{"a" => 2}, version: version} = updated.metadata
-    assert version == v(2)
+    {updated, routing_data} = apply_in_order(state(), 1, v(1), window)
+
+    assert updated.metadata.version == v(1)
+    assert updated.routed_seq == 1
+    assert routing_data.log_map == %{0 => "log_a"}
+    assert :gb_trees.lookup("a", routing_data.shards) == {:value, {7, ""}}
+    assert updated.routing_data == routing_data
+  end
+
+  test "an out-of-order request waits for its predecessor, then both reply in chain order" do
+    w1 = {nil, v(1), [{v(1), [log_set("log_a")]}]}
+    w2 = {v(1), v(2), [{v(2), [log_set("log_b")]}]}
+
+    # Batch 2's request arrives first: no reply, request held.
+    {{:noreply, held, _timeout}, ref2} = request(state(), 2, v(2), w2)
+    refute_receive {^ref2, _}, 10
+
+    # Batch 1's request arrives: applies, then batch 2 drains behind it.
+    {{:noreply, updated, _timeout}, ref1} = request(held, 1, v(1), w1)
+
+    assert_receive {^ref1, {:ok, routing1}}
+    assert_receive {^ref2, {:ok, routing2}}
+    assert routing1.log_map == %{0 => "log_a"}
+    assert routing2.log_map == %{0 => "log_a", 1 => "log_b"}
+    assert updated.routed_seq == 2
+    assert updated.pending_applies == %{}
+  end
+
+  test "a batch's own deferred metadata routes its batch but does not advance the ack" do
+    window = {nil, v(1), []}
+    deferred = {[shard_set("a", 3), log_set("log_a")]}
+
+    {updated, routing_data} = apply_in_order(state(), 1, v(2), window, deferred)
+
+    # Routing includes the batch's own committed metadata (same-batch
+    # visibility for its log push)...
+    assert routing_data.log_map == %{0 => "log_a"}
+    assert :gb_trees.lookup("a", routing_data.shards) == {:value, {3, ""}}
+
+    # ...but the ack only advances to what resolver windows confirmed, and
+    # the deferred entry is recorded for re-sending as a confirmation.
+    assert updated.metadata.version == v(1)
+    assert [{deferred_version, _mutations}] = updated.deferred_metadata
+    assert deferred_version == v(2)
+  end
+
+  test "a later window covering a deferred version stops re-sending it" do
+    deferred = {[log_set("log_a")]}
+    {updated, _routing} = apply_in_order(state(), 1, v(2), {nil, v(1), []}, deferred)
+
+    # A window whose to_version covers the deferred version proves every
+    # resolver folded the confirmation in.
+    {updated, _routing} = apply_in_order(updated, 2, v(3), {v(1), v(3), [{v(2), [log_set("log_a")]}]})
+
+    assert updated.deferred_metadata == []
+    assert updated.metadata.version == v(3)
+  end
+
+  test "overlapping windows apply idempotently: entries at or below the applied version are dropped" do
+    e1 = {v(1), [log_set("log_a")]}
+    e2 = {v(2), [log_set("log_b")]}
+
+    {updated, _routing} = apply_in_order(state(), 1, v(1), {nil, v(1), [e1]})
+    {updated, routing} = apply_in_order(updated, 2, v(2), {nil, v(2), [e1, e2]})
+
+    assert routing.log_map == %{0 => "log_a", 1 => "log_b"}
+    assert updated.metadata.version == v(2)
   end
 
   test "applied version advances to the window's to_version, not just the last entry's version" do
     # The window covers through v(3) even though the last mutation is at v(1);
     # acking v(3) lets the resolver prune fully.
-    updated = apply_window(state(Metadata.new()), {nil, v(3), [{v(1), [shard_set("a", 1)]}]})
+    {updated, _routing} = apply_in_order(state(), 1, v(3), {nil, v(3), [{v(1), [shard_set("a", 1)]}]})
+
     assert %Metadata{shards: %{"a" => 1}, version: version} = updated.metadata
     assert version == v(3)
   end
 
   test "a window whose from_version exceeds the applied version is a coverage gap: fail fast" do
-    initial = apply_window(state(Metadata.new()), {nil, v(1), [{v(1), [shard_set("a", 1)]}]})
+    {initial, _routing} = apply_in_order(state(), 1, v(1), {nil, v(1), [{v(1), [shard_set("a", 1)]}]})
+
+    from = {self(), make_ref()}
 
     assert {:metadata_coverage_gap, _} =
-             catch_exit(Server.handle_info({:metadata_updates, {v(5), v(6), [{v(6), [shard_set("a", 6)]}]}}, initial))
+             catch_exit(
+               Server.handle_call(
+                 {:apply_metadata_and_route, 2, v(6), {v(5), v(6), [{v(6), [shard_set("a", 6)]}]}, nil},
+                 from,
+                 initial
+               )
+             )
   end
 
   test "a gap is detected even when the window carries no entries" do
+    from = {self(), make_ref()}
+
     assert {:metadata_coverage_gap, _} =
-             catch_exit(Server.handle_info({:metadata_updates, {v(5), v(6), []}}, state(Metadata.new())))
+             catch_exit(Server.handle_call({:apply_metadata_and_route, 1, v(6), {v(5), v(6), []}, nil}, from, state()))
   end
 
-  test "window entries update routing data in the same step that advances the ack" do
-    # A batch snapshots (routing_data, metadata.version) together at spawn.
-    # The resolver keys its differential windows off the version, so routing
-    # state must advance atomically with it - otherwise a batch could hold an
-    # ack that promises entries its routing data never saw (bedrock-q67.24).
-    updated = apply_window(state(Metadata.new()), {nil, v(1), [{v(1), [shard_set("a", 7), log_set("log_a")]}]})
+  test "a nil window advances the chain without touching metadata" do
+    {updated, routing} = apply_in_order(state(), 1, v(1), nil)
 
-    assert updated.metadata.version == v(1)
-    assert updated.routing_data.log_map == %{0 => "log_a"}
-    assert :ets.lookup(updated.routing_data.shard_table, "a") == [{"a", 7}]
+    assert updated.routed_seq == 1
+    assert updated.metadata.version == nil
+    assert routing.log_map == %{}
   end
 
-  test "a re-delivered window does not duplicate log entries" do
-    window = {nil, v(1), [{v(1), [log_set("log_a")]}]}
+  test "the chain is keyed on the proxy-local sequence, not sequencer version numbering" do
+    # With multiple proxies the global sequencer interleaves versions across
+    # them, so this proxy's consecutive batches have non-adjacent versions.
+    # The chain must still link: sequence 1 then 2, whatever the versions.
+    {updated, _routing} = apply_in_order(state(), 1, v(100), {nil, v(100), []})
+    {updated, routing} = apply_in_order(updated, 2, v(250), {v(100), v(250), [{v(250), [log_set("log_a")]}]})
 
-    updated = apply_window(state(Metadata.new()), window)
-    updated = apply_window(updated, window)
-
-    assert updated.routing_data.log_map == %{0 => "log_a"}
+    assert updated.routed_seq == 2
+    assert routing.log_map == %{0 => "log_a"}
   end
 
-  test "an overlapping superset window applies only entries newer than the applied version" do
-    e1 = {v(1), [log_set("log_a")]}
-    e2 = {v(2), [log_set("log_b")]}
-
-    updated = apply_window(state(Metadata.new()), {nil, v(1), [e1]})
-    updated = apply_window(updated, {nil, v(2), [e1, e2]})
-
-    assert updated.routing_data.log_map == %{0 => "log_a", 1 => "log_b"}
-  end
-
-  test "re-setting the same layout_log key at a newer version does not duplicate the log" do
-    # A mid-epoch writer may legitimately re-set a layout_log key (e.g. a tag
-    # change). The log keeps its index; only genuinely new logs append.
-    updated = apply_window(state(Metadata.new()), {nil, v(1), [{v(1), [log_set("log_a")]}]})
-    updated = apply_window(updated, {v(1), v(2), [{v(2), [log_set("log_a"), log_set("log_b")]}]})
-
-    assert updated.routing_data.log_map == %{0 => "log_a", 1 => "log_b"}
-  end
-
-  test "a stale routing-data replacement message can no longer clobber window-applied state" do
-    # Finalization tasks used to send {:routing_data_update, struct} after log
-    # push; racing tasks made the last writer win, silently dropping log-map
-    # changes. The message is retired - if one arrives, it is ignored.
-    updated = apply_window(state(Metadata.new()), {nil, v(1), [{v(1), [log_set("log_a")]}]})
-
-    assert {:noreply, after_stale} = Server.handle_info({:routing_data_update, RoutingData.new_empty()}, updated)
-
-    assert after_stale.routing_data.log_map == %{0 => "log_a"}
+  test "requests are rejected while locked" do
+    locked = %{state() | mode: :locked}
+    {{:reply, {:error, :locked}, _state}, _ref} = request(locked, 1, v(1), nil)
   end
 end

--- a/test/bedrock/data_plane/commit_proxy/routing_data_test.exs
+++ b/test/bedrock/data_plane/commit_proxy/routing_data_test.exs
@@ -2,11 +2,18 @@ defmodule Bedrock.DataPlane.CommitProxy.RoutingDataTest do
   use ExUnit.Case, async: true
 
   alias Bedrock.DataPlane.CommitProxy.RoutingData
+  alias Bedrock.DataPlane.ShardRouter
+  alias Bedrock.DataPlane.Version
   alias Bedrock.SystemKeys
   alias Bedrock.SystemKeys.Values
 
+  defp v(n), do: Version.from_integer(n)
+
+  # Shard boundaries as a plain sorted list of {end_key, {tag, start_key}}.
+  defp shard_list(%RoutingData{shards: shards}), do: :gb_trees.to_list(shards)
+
   describe "from_snapshot/1" do
-    test "builds fully-populated routing data owned by the calling process" do
+    test "builds fully-populated routing data" do
       snapshot = %{
         shard_layout: %{"m" => {1, ""}, <<0xFF, 0xFF>> => {0, "m"}},
         log_map: %{0 => "log-a", 1 => "log-b"},
@@ -16,13 +23,10 @@ defmodule Bedrock.DataPlane.CommitProxy.RoutingDataTest do
 
       routing_data = RoutingData.from_snapshot(snapshot)
 
-      assert :ets.info(routing_data.shard_table, :owner) == self()
-      assert :ets.tab2list(routing_data.shard_table) == [{"m", 1}, {<<0xFF, 0xFF>>, 0}]
+      assert shard_list(routing_data) == [{"m", {1, ""}}, {<<0xFF, 0xFF>>, {0, "m"}}]
       assert routing_data.log_map == %{0 => "log-a", 1 => "log-b"}
       assert routing_data.log_services == %{"log-a" => {:log_a, :node1}, "log-b" => {:log_b, :node2}}
       assert routing_data.replication_factor == 2
-
-      RoutingData.cleanup(routing_data)
     end
 
     test "builds empty routing data from an empty snapshot" do
@@ -30,10 +34,22 @@ defmodule Bedrock.DataPlane.CommitProxy.RoutingDataTest do
 
       routing_data = RoutingData.from_snapshot(snapshot)
 
-      assert :ets.tab2list(routing_data.shard_table) == []
+      assert shard_list(routing_data) == []
       assert routing_data.replication_factor == 1
+    end
 
-      RoutingData.cleanup(routing_data)
+    test "is a plain immutable value: derived copies do not affect the original" do
+      original =
+        RoutingData.from_snapshot(%{
+          shard_layout: %{"m" => {1, ""}},
+          log_map: %{},
+          log_services: %{},
+          replication_factor: 1
+        })
+
+      _derived = RoutingData.insert_shard(original, "z", 2, "m")
+
+      assert shard_list(original) == [{"m", {1, ""}}]
     end
   end
 
@@ -42,372 +58,232 @@ defmodule Bedrock.DataPlane.CommitProxy.RoutingDataTest do
       routing_data = RoutingData.new_empty()
 
       assert %RoutingData{} = routing_data
-      assert is_reference(routing_data.shard_table)
+      assert shard_list(routing_data) == []
       assert routing_data.log_map == %{}
       assert routing_data.log_services == %{}
       assert routing_data.replication_factor == 1
     end
+  end
 
-    test "creates empty ETS ordered_set table" do
-      routing_data = RoutingData.new_empty()
+  describe "insert_shard/4 and delete_shard/2" do
+    test "inserts and overwrites shard entries" do
+      routing_data =
+        RoutingData.new_empty()
+        |> RoutingData.insert_shard("m", 1, "")
+        |> RoutingData.insert_shard(<<0xFF, 0xFF>>, 2, "m")
+        |> RoutingData.insert_shard("m", 7, "")
 
-      # Table should be empty
-      assert :ets.tab2list(routing_data.shard_table) == []
+      assert shard_list(routing_data) == [{"m", {7, ""}}, {<<0xFF, 0xFF>>, {2, "m"}}]
+    end
 
-      # Table should be ordered_set (verify by type info)
-      info = :ets.info(routing_data.shard_table)
-      assert info[:type] == :ordered_set
+    test "deletes a shard entry; deleting an absent key is a no-op" do
+      routing_data =
+        RoutingData.new_empty()
+        |> RoutingData.insert_shard("m", 1, "")
+        |> RoutingData.delete_shard("m")
+        |> RoutingData.delete_shard("never_there")
 
-      RoutingData.cleanup(routing_data)
+      assert shard_list(routing_data) == []
     end
   end
 
   describe "insert_log/2" do
     test "adds log to empty log_map at index 0" do
-      routing_data = RoutingData.new_empty()
-
-      updated = RoutingData.insert_log(routing_data, "log-1")
+      updated = RoutingData.insert_log(RoutingData.new_empty(), "log-1")
 
       assert updated.log_map == %{0 => "log-1"}
-
-      RoutingData.cleanup(routing_data)
     end
 
     test "adds logs at sequential indices" do
-      routing_data = RoutingData.new_empty()
-
       updated =
-        routing_data
+        RoutingData.new_empty()
         |> RoutingData.insert_log("log-a")
         |> RoutingData.insert_log("log-b")
         |> RoutingData.insert_log("log-c")
 
       assert updated.log_map == %{0 => "log-a", 1 => "log-b", 2 => "log-c"}
+    end
 
-      RoutingData.cleanup(routing_data)
+    test "is idempotent by log id: a re-inserted log keeps its index" do
+      updated =
+        RoutingData.new_empty()
+        |> RoutingData.insert_log("log-a")
+        |> RoutingData.insert_log("log-b")
+        |> RoutingData.insert_log("log-a")
+
+      assert updated.log_map == %{0 => "log-a", 1 => "log-b"}
     end
 
     test "does not modify other fields" do
       routing_data = RoutingData.new_empty()
-      original_table = routing_data.shard_table
 
       updated = RoutingData.insert_log(routing_data, "log-1")
 
-      assert updated.shard_table == original_table
+      assert updated.shards == routing_data.shards
       assert updated.log_services == %{}
       assert updated.replication_factor == 1
-
-      RoutingData.cleanup(routing_data)
     end
   end
 
   describe "remove_log/2" do
-    test "removes log from log_map" do
-      routing_data =
+    test "removes log from log_map and reindexes to contiguous indices" do
+      updated =
         RoutingData.new_empty()
         |> RoutingData.insert_log("log-a")
         |> RoutingData.insert_log("log-b")
         |> RoutingData.insert_log("log-c")
+        |> RoutingData.remove_log("log-b")
 
-      updated = RoutingData.remove_log(routing_data, "log-b")
-
-      # Should reindex to maintain contiguous indices
       assert updated.log_map == %{0 => "log-a", 1 => "log-c"}
-
-      RoutingData.cleanup(routing_data)
-    end
-
-    test "removes last log" do
-      routing_data =
-        RoutingData.new_empty()
-        |> RoutingData.insert_log("log-a")
-        |> RoutingData.insert_log("log-b")
-
-      updated = RoutingData.remove_log(routing_data, "log-b")
-
-      assert updated.log_map == %{0 => "log-a"}
-
-      RoutingData.cleanup(routing_data)
     end
 
     test "removes first log and reindexes" do
-      routing_data =
+      updated =
         RoutingData.new_empty()
         |> RoutingData.insert_log("log-a")
         |> RoutingData.insert_log("log-b")
         |> RoutingData.insert_log("log-c")
-
-      updated = RoutingData.remove_log(routing_data, "log-a")
+        |> RoutingData.remove_log("log-a")
 
       assert updated.log_map == %{0 => "log-b", 1 => "log-c"}
-
-      RoutingData.cleanup(routing_data)
     end
 
-    test "no-op if log not found" do
-      routing_data = RoutingData.insert_log(RoutingData.new_empty(), "log-a")
-
-      updated = RoutingData.remove_log(routing_data, "nonexistent")
+    test "no-op if log not found, including on an empty map" do
+      updated =
+        RoutingData.new_empty()
+        |> RoutingData.insert_log("log-a")
+        |> RoutingData.remove_log("nonexistent")
 
       assert updated.log_map == %{0 => "log-a"}
-
-      RoutingData.cleanup(routing_data)
-    end
-
-    test "handles removing from empty log_map" do
-      routing_data = RoutingData.new_empty()
-
-      updated = RoutingData.remove_log(routing_data, "nonexistent")
-
-      assert updated.log_map == %{}
-
-      RoutingData.cleanup(routing_data)
+      assert RoutingData.remove_log(RoutingData.new_empty(), "nonexistent").log_map == %{}
     end
   end
 
-  describe "put_log_service/3" do
-    test "adds service ref to log_services" do
-      routing_data = RoutingData.new_empty()
-
-      updated = RoutingData.put_log_service(routing_data, "log-1", {:log_1, :node@host})
-
-      assert updated.log_services == %{"log-1" => {:log_1, :node@host}}
-
-      RoutingData.cleanup(routing_data)
-    end
-
-    test "adds multiple service refs" do
-      routing_data = RoutingData.new_empty()
-
-      updated =
-        routing_data
-        |> RoutingData.put_log_service("log-1", {:log_1, :n1@host})
-        |> RoutingData.put_log_service("log-2", {:log_2, :n2@host})
-
-      assert updated.log_services == %{
-               "log-1" => {:log_1, :n1@host},
-               "log-2" => {:log_2, :n2@host}
-             }
-
-      RoutingData.cleanup(routing_data)
-    end
-
-    test "overwrites existing service ref" do
-      routing_data = RoutingData.put_log_service(RoutingData.new_empty(), "log-1", {:old_ref, :old_node})
-
-      updated = RoutingData.put_log_service(routing_data, "log-1", {:new_ref, :new_node})
-
-      assert updated.log_services == %{"log-1" => {:new_ref, :new_node}}
-
-      RoutingData.cleanup(routing_data)
-    end
-
-    test "does not modify other fields" do
-      routing_data = RoutingData.insert_log(RoutingData.new_empty(), "log-1")
-
-      updated = RoutingData.put_log_service(routing_data, "log-1", {:log_1, :node@host})
-
-      assert updated.log_map == %{0 => "log-1"}
-      assert updated.replication_factor == 1
-
-      RoutingData.cleanup(routing_data)
-    end
-  end
-
-  describe "delete_log_service/2" do
-    test "removes service ref from log_services" do
+  describe "put_log_service/3 and delete_log_service/2" do
+    test "adds, overwrites, and removes service refs" do
       routing_data =
         RoutingData.new_empty()
         |> RoutingData.put_log_service("log-1", {:log_1, :n1@host})
         |> RoutingData.put_log_service("log-2", {:log_2, :n2@host})
+        |> RoutingData.put_log_service("log-1", {:log_1b, :n3@host})
 
-      updated = RoutingData.delete_log_service(routing_data, "log-1")
+      assert routing_data.log_services == %{"log-1" => {:log_1b, :n3@host}, "log-2" => {:log_2, :n2@host}}
 
-      assert updated.log_services == %{"log-2" => {:log_2, :n2@host}}
+      assert RoutingData.delete_log_service(routing_data, "log-1").log_services ==
+               %{"log-2" => {:log_2, :n2@host}}
 
-      RoutingData.cleanup(routing_data)
-    end
-
-    test "no-op if log not found" do
-      routing_data = RoutingData.put_log_service(RoutingData.new_empty(), "log-1", {:log_1, :node@host})
-
-      updated = RoutingData.delete_log_service(routing_data, "nonexistent")
-
-      assert updated.log_services == %{"log-1" => {:log_1, :node@host}}
-
-      RoutingData.cleanup(routing_data)
-    end
-
-    test "handles deleting from empty log_services" do
-      routing_data = RoutingData.new_empty()
-
-      updated = RoutingData.delete_log_service(routing_data, "nonexistent")
-
-      assert updated.log_services == %{}
-
-      RoutingData.cleanup(routing_data)
+      assert RoutingData.delete_log_service(routing_data, "nonexistent").log_services ==
+               routing_data.log_services
     end
   end
 
   describe "set_replication_factor/2" do
-    test "updates replication factor" do
-      routing_data = RoutingData.new_empty()
+    test "updates replication factor without touching other fields" do
+      routing_data = RoutingData.insert_log(RoutingData.new_empty(), "log-1")
 
       updated = RoutingData.set_replication_factor(routing_data, 3)
 
       assert updated.replication_factor == 3
-
-      RoutingData.cleanup(routing_data)
-    end
-
-    test "does not modify other fields" do
-      routing_data =
-        RoutingData.new_empty()
-        |> RoutingData.insert_log("log-1")
-        |> RoutingData.put_log_service("log-1", {:log_1, :node@host})
-
-      updated = RoutingData.set_replication_factor(routing_data, 5)
-
       assert updated.log_map == %{0 => "log-1"}
-      assert updated.log_services == %{"log-1" => {:log_1, :node@host}}
-
-      RoutingData.cleanup(routing_data)
     end
   end
 
   describe "integration: typical usage pattern" do
-    test "builds complete routing data incrementally" do
-      # Start empty
-      routing_data = RoutingData.new_empty()
-
-      # Add logs (as they arrive via metadata)
+    test "builds complete routing data incrementally and routes with it" do
       routing_data =
-        routing_data
+        RoutingData.new_empty()
         |> RoutingData.insert_log("log-1")
         |> RoutingData.insert_log("log-2")
         |> RoutingData.insert_log("log-3")
-
-      # Add service refs (how to reach each log)
-      routing_data =
-        routing_data
         |> RoutingData.put_log_service("log-1", {:log_1, :n1@host})
         |> RoutingData.put_log_service("log-2", {:log_2, :n2@host})
         |> RoutingData.put_log_service("log-3", {:log_3, :n3@host})
-
-      # Add shard entries (via existing insert_shard/3)
-      RoutingData.insert_shard(routing_data, "m", 0)
-      RoutingData.insert_shard(routing_data, "z", 1)
-      RoutingData.insert_shard(routing_data, <<0xFF, 0xFF>>, 2)
-
-      # Set replication factor
-      routing_data = RoutingData.set_replication_factor(routing_data, 3)
-
-      # Verify complete state
-      assert routing_data.log_map == %{0 => "log-1", 1 => "log-2", 2 => "log-3"}
-
-      assert routing_data.log_services == %{
-               "log-1" => {:log_1, :n1@host},
-               "log-2" => {:log_2, :n2@host},
-               "log-3" => {:log_3, :n3@host}
-             }
+        |> RoutingData.insert_shard("m", 0, "")
+        |> RoutingData.insert_shard("z", 1, "m")
+        |> RoutingData.insert_shard(<<0xFF, 0xFF>>, 2, "z")
+        |> RoutingData.set_replication_factor(3)
 
       assert routing_data.replication_factor == 3
 
-      assert :ets.tab2list(routing_data.shard_table) == [
-               {"m", 0},
-               {"z", 1},
-               {<<0xFF, 0xFF>>, 2}
+      assert shard_list(routing_data) == [
+               {"m", {0, ""}},
+               {"z", {1, "m"}},
+               {<<0xFF, 0xFF>>, {2, "z"}}
              ]
 
-      RoutingData.cleanup(routing_data)
+      assert ShardRouter.lookup_shard(routing_data.shards, "apple") == 0
+      assert ShardRouter.lookup_shard(routing_data.shards, "pear") == 1
+      assert ShardRouter.lookup_shard(routing_data.shards, <<0xFF, "/system/x">>) == 2
     end
   end
 
   describe "apply_mutations/2" do
     test "handles shard_key set mutation" do
-      routing_data = RoutingData.new_empty()
-      key = SystemKeys.shard_key("m")
-      value = Values.encode_shard_key_entry(42, "")
-      updates = [{100, [{:set, key, value}]}]
+      updates = [{v(100), [{:set, SystemKeys.shard_key("m"), Values.encode_shard_key_entry(42, "")}]}]
 
-      updated = RoutingData.apply_mutations(routing_data, updates)
+      updated = RoutingData.apply_mutations(RoutingData.new_empty(), updates)
 
-      assert :ets.lookup(updated.shard_table, "m") == [{"m", 42}]
-
-      RoutingData.cleanup(routing_data)
+      assert shard_list(updated) == [{"m", {42, ""}}]
     end
 
     test "handles multiple shard_key mutations" do
-      routing_data = RoutingData.new_empty()
-
       updates = [
-        {100,
+        {v(100),
          [
            {:set, SystemKeys.shard_key("a"), Values.encode_shard_key_entry(1, "")},
-           {:set, SystemKeys.shard_key("m"), Values.encode_shard_key_entry(2, "")},
-           {:set, SystemKeys.shard_key("z"), Values.encode_shard_key_entry(3, "")}
+           {:set, SystemKeys.shard_key("m"), Values.encode_shard_key_entry(2, "a")},
+           {:set, SystemKeys.shard_key("z"), Values.encode_shard_key_entry(3, "m")}
          ]}
       ]
 
-      updated = RoutingData.apply_mutations(routing_data, updates)
+      updated = RoutingData.apply_mutations(RoutingData.new_empty(), updates)
 
-      assert :ets.lookup(updated.shard_table, "a") == [{"a", 1}]
-      assert :ets.lookup(updated.shard_table, "m") == [{"m", 2}]
-      assert :ets.lookup(updated.shard_table, "z") == [{"z", 3}]
-
-      RoutingData.cleanup(routing_data)
+      assert shard_list(updated) == [{"a", {1, ""}}, {"m", {2, "a"}}, {"z", {3, "m"}}]
     end
 
-    test "handles layout_log set mutation - updates log_map" do
-      routing_data = RoutingData.new_empty()
-      key = SystemKeys.layout_log("log-123")
-      # layout_log stores log descriptor (tags) as erlang term
-      log_descriptor = [0, 1]
-      value = Values.encode_tag_list(log_descriptor)
-      updates = [{100, [{:set, key, value}]}]
+    test "skips a shard_key set whose value does not decode, keeping the last good entry" do
+      routing_data = RoutingData.insert_shard(RoutingData.new_empty(), "m", 42, "")
+
+      updates = [{v(100), [{:set, SystemKeys.shard_key("m"), <<0xEE, 0xEE, 0xEE>>}]}]
 
       updated = RoutingData.apply_mutations(routing_data, updates)
 
-      # Should add to log_map at next index
-      assert updated.log_map == %{0 => "log-123"}
-      # log_services are NOT populated from persisted data - they're runtime state
-      assert updated.log_services == %{}
-
-      RoutingData.cleanup(routing_data)
+      assert shard_list(updated) == [{"m", {42, ""}}]
     end
 
-    test "handles multiple layout_log mutations" do
-      routing_data = RoutingData.new_empty()
+    test "handles layout_log set mutation - updates log_map only" do
+      updates = [{v(100), [{:set, SystemKeys.layout_log("log-1"), Values.encode_tag_list([0])}]}]
 
-      updates = [
-        {100,
-         [
-           {:set, SystemKeys.layout_log("log-1"), Values.encode_tag_list([0])},
-           {:set, SystemKeys.layout_log("log-2"), Values.encode_tag_list([1])}
-         ]}
-      ]
+      updated = RoutingData.apply_mutations(RoutingData.new_empty(), updates)
 
-      updated = RoutingData.apply_mutations(routing_data, updates)
-
-      assert updated.log_map == %{0 => "log-1", 1 => "log-2"}
+      assert updated.log_map == %{0 => "log-1"}
       # log_services are NOT populated from persisted data
       assert updated.log_services == %{}
+    end
 
-      RoutingData.cleanup(routing_data)
+    test "a re-set layout_log key keeps its index" do
+      updates = [
+        {v(100), [{:set, SystemKeys.layout_log("log-1"), Values.encode_tag_list([0])}]},
+        {v(101),
+         [
+           {:set, SystemKeys.layout_log("log-1"), Values.encode_tag_list([1])},
+           {:set, SystemKeys.layout_log("log-2"), Values.encode_tag_list([2])}
+         ]}
+      ]
+
+      updated = RoutingData.apply_mutations(RoutingData.new_empty(), updates)
+
+      assert updated.log_map == %{0 => "log-1", 1 => "log-2"}
     end
 
     test "handles shard_key clear mutation" do
-      routing_data = RoutingData.new_empty()
-      RoutingData.insert_shard(routing_data, "m", 42)
+      routing_data = RoutingData.insert_shard(RoutingData.new_empty(), "m", 42, "")
 
-      key = SystemKeys.shard_key("m")
-      updates = [{100, [{:clear, key}]}]
+      updates = [{v(100), [{:clear, SystemKeys.shard_key("m")}]}]
 
       updated = RoutingData.apply_mutations(routing_data, updates)
 
-      assert :ets.lookup(updated.shard_table, "m") == []
-
-      RoutingData.cleanup(routing_data)
+      assert shard_list(updated) == []
     end
 
     test "handles layout_log clear mutation" do
@@ -416,108 +292,76 @@ defmodule Bedrock.DataPlane.CommitProxy.RoutingDataTest do
         |> RoutingData.insert_log("log-123")
         |> RoutingData.put_log_service("log-123", {:my_log, :node@host})
 
-      key = SystemKeys.layout_log("log-123")
-      updates = [{100, [{:clear, key}]}]
+      updates = [{v(100), [{:clear, SystemKeys.layout_log("log-123")}]}]
 
       updated = RoutingData.apply_mutations(routing_data, updates)
 
-      # Should remove from log_services
       assert updated.log_services == %{}
-      # log_map removal and reindex
       assert updated.log_map == %{}
-
-      RoutingData.cleanup(routing_data)
     end
 
-    test "applies updates from multiple versions in order" do
-      routing_data = RoutingData.new_empty()
-
+    test "applies updates from multiple versions in order; later version wins" do
       updates = [
-        {100, [{:set, SystemKeys.shard_key("a"), Values.encode_shard_key_entry(1, "")}]},
-        {101, [{:set, SystemKeys.shard_key("b"), Values.encode_shard_key_entry(2, "")}]},
-        {102, [{:set, SystemKeys.shard_key("a"), Values.encode_shard_key_entry(99, "")}]}
+        {v(100), [{:set, SystemKeys.shard_key("a"), Values.encode_shard_key_entry(1, "")}]},
+        {v(101), [{:set, SystemKeys.shard_key("b"), Values.encode_shard_key_entry(2, "a")}]},
+        {v(102), [{:set, SystemKeys.shard_key("a"), Values.encode_shard_key_entry(99, "")}]}
       ]
 
-      updated = RoutingData.apply_mutations(routing_data, updates)
+      updated = RoutingData.apply_mutations(RoutingData.new_empty(), updates)
 
-      # Later version (102) overwrites earlier (100)
-      assert :ets.lookup(updated.shard_table, "a") == [{"a", 99}]
-      assert :ets.lookup(updated.shard_table, "b") == [{"b", 2}]
-
-      RoutingData.cleanup(routing_data)
+      assert shard_list(updated) == [{"a", {99, ""}}, {"b", {2, "a"}}]
     end
 
-    test "ignores unknown key types" do
-      routing_data = RoutingData.new_empty()
+    test "ignores unknown system keys and non-system keys" do
+      updates = [
+        {v(100),
+         [
+           {:set, "\xff/system/unknown/foo", "bar"},
+           {:set, "user/data", "value"}
+         ]}
+      ]
 
-      # Unknown system key
-      updates = [{100, [{:set, "\xff/system/unknown/foo", "bar"}]}]
-
-      updated = RoutingData.apply_mutations(routing_data, updates)
-
-      # Should not crash, routing_data unchanged
-      assert updated.log_map == %{}
-      assert updated.log_services == %{}
-      assert :ets.tab2list(updated.shard_table) == []
-
-      RoutingData.cleanup(routing_data)
-    end
-
-    test "ignores non-system keys" do
-      routing_data = RoutingData.new_empty()
-
-      updates = [{100, [{:set, "user/data", "value"}]}]
-
-      updated = RoutingData.apply_mutations(routing_data, updates)
+      updated = RoutingData.apply_mutations(RoutingData.new_empty(), updates)
 
       assert updated.log_map == %{}
-      assert :ets.tab2list(updated.shard_table) == []
-
-      RoutingData.cleanup(routing_data)
+      assert shard_list(updated) == []
     end
 
     test "ignores unsupported mutation types" do
       routing_data = RoutingData.new_empty()
 
-      # atomic ops are not routing-relevant
-      updates = [{100, [{:atomic, :add, "key", <<1>>}]}]
+      updates = [{v(100), [{:atomic, :add, "key", <<1>>}]}]
 
-      updated = RoutingData.apply_mutations(routing_data, updates)
-
-      assert updated == routing_data
-
-      RoutingData.cleanup(routing_data)
+      assert RoutingData.apply_mutations(routing_data, updates) == routing_data
     end
 
     test "clear_range removes shard entries whose full key falls in range" do
-      routing_data = RoutingData.new_empty()
-      RoutingData.insert_shard(routing_data, "a", 1)
-      RoutingData.insert_shard(routing_data, "m", 2)
-      RoutingData.insert_shard(routing_data, "z", 3)
+      routing_data =
+        RoutingData.new_empty()
+        |> RoutingData.insert_shard("a", 1, "")
+        |> RoutingData.insert_shard("m", 2, "a")
+        |> RoutingData.insert_shard("z", 3, "m")
 
       # Clear [shard_key("a"), shard_key("z")) - end is exclusive, so "z" survives
-      updates = [{100, [{:clear_range, SystemKeys.shard_key("a"), SystemKeys.shard_key("z")}]}]
+      updates = [{v(100), [{:clear_range, SystemKeys.shard_key("a"), SystemKeys.shard_key("z")}]}]
 
       updated = RoutingData.apply_mutations(routing_data, updates)
 
-      assert :ets.tab2list(updated.shard_table) == [{"z", 3}]
-
-      RoutingData.cleanup(routing_data)
+      assert shard_list(updated) == [{"z", {3, "m"}}]
     end
 
     test "clear_range over the shard_keys prefix removes all shard entries" do
-      routing_data = RoutingData.new_empty()
-      RoutingData.insert_shard(routing_data, "m", 1)
-      RoutingData.insert_shard(routing_data, <<0xFF, 0xFF>>, 2)
+      routing_data =
+        RoutingData.new_empty()
+        |> RoutingData.insert_shard("m", 1, "")
+        |> RoutingData.insert_shard(<<0xFF, 0xFF>>, 2, "m")
 
       {start_key, end_key} = Bedrock.KeyRange.from_prefix(SystemKeys.shard_keys_prefix())
-      updates = [{100, [{:clear_range, start_key, end_key}]}]
+      updates = [{v(100), [{:clear_range, start_key, end_key}]}]
 
       updated = RoutingData.apply_mutations(routing_data, updates)
 
-      assert :ets.tab2list(updated.shard_table) == []
-
-      RoutingData.cleanup(routing_data)
+      assert shard_list(updated) == []
     end
 
     test "clear_range removes layout_log entries in range, reindexing log_map and dropping services" do
@@ -530,41 +374,39 @@ defmodule Bedrock.DataPlane.CommitProxy.RoutingDataTest do
         |> RoutingData.put_log_service("log-b", {:log_b, :n2@host})
 
       # Clear [layout_log("log-a"), layout_log("log-c")) - "log-c" survives
-      updates = [{100, [{:clear_range, SystemKeys.layout_log("log-a"), SystemKeys.layout_log("log-c")}]}]
+      updates = [{v(100), [{:clear_range, SystemKeys.layout_log("log-a"), SystemKeys.layout_log("log-c")}]}]
 
       updated = RoutingData.apply_mutations(routing_data, updates)
 
       assert updated.log_map == %{0 => "log-c"}
       assert updated.log_services == %{}
-
-      RoutingData.cleanup(routing_data)
     end
 
     test "clear_range outside routing families leaves routing data unchanged" do
-      routing_data = RoutingData.new_empty()
-      RoutingData.insert_shard(routing_data, "m", 1)
-      routing_data = RoutingData.insert_log(routing_data, "log-1")
+      routing_data =
+        RoutingData.new_empty()
+        |> RoutingData.insert_shard("m", 1, "")
+        |> RoutingData.insert_log("log-1")
 
-      updates = [{100, [{:clear_range, "user/a", "user/z"}]}]
+      updates = [{v(100), [{:clear_range, "user/a", "user/z"}]}]
 
       updated = RoutingData.apply_mutations(routing_data, updates)
 
-      assert :ets.tab2list(updated.shard_table) == [{"m", 1}]
+      assert shard_list(updated) == [{"m", {1, ""}}]
       assert updated.log_map == %{0 => "log-1"}
-
-      RoutingData.cleanup(routing_data)
     end
 
     test "recovery-style rewrite: clear_range then sets shrinks 3 shards to 2" do
-      routing_data = RoutingData.new_empty()
-      RoutingData.insert_shard(routing_data, "g", 1)
-      RoutingData.insert_shard(routing_data, "p", 2)
-      RoutingData.insert_shard(routing_data, <<0xFF, 0xFF>>, 3)
+      routing_data =
+        RoutingData.new_empty()
+        |> RoutingData.insert_shard("g", 1, "")
+        |> RoutingData.insert_shard("p", 2, "g")
+        |> RoutingData.insert_shard(<<0xFF, 0xFF>>, 3, "p")
 
       {start_key, end_key} = Bedrock.KeyRange.from_prefix(SystemKeys.shard_keys_prefix())
 
       updates = [
-        {100,
+        {v(100),
          [
            {:clear_range, start_key, end_key},
            {:set, SystemKeys.shard_key("m"), Values.encode_shard_key_entry(10, "")},
@@ -574,34 +416,25 @@ defmodule Bedrock.DataPlane.CommitProxy.RoutingDataTest do
 
       updated = RoutingData.apply_mutations(routing_data, updates)
 
-      assert :ets.tab2list(updated.shard_table) == [{"m", 10}, {<<0xFF, 0xFF>>, 11}]
-
-      RoutingData.cleanup(routing_data)
+      assert shard_list(updated) == [{"m", {10, ""}}, {<<0xFF, 0xFF>>, {11, "m"}}]
     end
 
     test "handles mixed shard_key and layout_log mutations" do
-      routing_data = RoutingData.new_empty()
-
       updates = [
-        {100,
+        {v(100),
          [
            {:set, SystemKeys.shard_key("m"), Values.encode_shard_key_entry(1, "")},
            {:set, SystemKeys.layout_log("log-1"), Values.encode_tag_list([0])},
-           {:set, SystemKeys.shard_key("z"), Values.encode_shard_key_entry(2, "")},
+           {:set, SystemKeys.shard_key("z"), Values.encode_shard_key_entry(2, "m")},
            {:set, SystemKeys.layout_log("log-2"), Values.encode_tag_list([1])}
          ]}
       ]
 
-      updated = RoutingData.apply_mutations(routing_data, updates)
+      updated = RoutingData.apply_mutations(RoutingData.new_empty(), updates)
 
-      # Shard entries
-      assert :ets.lookup(updated.shard_table, "m") == [{"m", 1}]
-      assert :ets.lookup(updated.shard_table, "z") == [{"z", 2}]
-      # Log entries - only log_map populated, not log_services
+      assert shard_list(updated) == [{"m", {1, ""}}, {"z", {2, "m"}}]
       assert updated.log_map == %{0 => "log-1", 1 => "log-2"}
       assert updated.log_services == %{}
-
-      RoutingData.cleanup(routing_data)
     end
   end
 end

--- a/test/bedrock/data_plane/commit_proxy/sequencer_notification_test.exs
+++ b/test/bedrock/data_plane/commit_proxy/sequencer_notification_test.exs
@@ -64,7 +64,10 @@ defmodule Bedrock.DataPlane.CommitProxy.SequencerNotificationTest do
       opts = create_finalization_opts()
 
       assert {:ok, 0, 0} =
-               Finalization.finalize_batch(batch, opts ++ [routing_data: routing_data, sequencer: layout.sequencer])
+               Finalization.finalize_batch(
+                 batch,
+                 opts ++ [metadata_apply_fn: Support.metadata_apply_fn(routing_data), sequencer: layout.sequencer]
+               )
 
       assert_receive {:sequencer_notified, 100}, 100
 
@@ -80,7 +83,10 @@ defmodule Bedrock.DataPlane.CommitProxy.SequencerNotificationTest do
       opts = create_finalization_opts()
 
       assert {:error, :unavailable} =
-               Finalization.finalize_batch(batch, opts ++ [routing_data: routing_data, sequencer: layout.sequencer])
+               Finalization.finalize_batch(
+                 batch,
+                 opts ++ [metadata_apply_fn: Support.metadata_apply_fn(routing_data), sequencer: layout.sequencer]
+               )
     end
   end
 end

--- a/test/bedrock/data_plane/commit_proxy/server_test.exs
+++ b/test/bedrock/data_plane/commit_proxy/server_test.exs
@@ -1314,11 +1314,10 @@ defmodule Bedrock.DataPlane.CommitProxy.ServerTest do
 
       %{routing_data: routing_data} = :sys.get_state(commit_proxy)
 
-      # The table must be created by (and die with) the proxy itself: a table
-      # reference built in another process is invalid after that process dies,
-      # and is never valid on another node.
-      assert :ets.info(routing_data.shard_table, :owner) == commit_proxy
-      assert :ets.tab2list(routing_data.shard_table) == [{<<0xFF, 0xFF>>, 0}]
+      # Routing data is a plain immutable value: nothing about it is tied to
+      # the process that built it, so a snapshot can cross processes and
+      # nodes safely (the crash class that motivated bedrock-q67.20.1).
+      assert :gb_trees.to_list(routing_data.shards) == [{<<0xFF, 0xFF>>, {0, ""}}]
       assert routing_data.log_map == %{0 => "log-1"}
       assert routing_data.log_services == %{"log-1" => {:log_1, :node1}}
     end

--- a/test/bedrock/data_plane/shard_router_test.exs
+++ b/test/bedrock/data_plane/shard_router_test.exs
@@ -1,6 +1,7 @@
 defmodule Bedrock.DataPlane.ShardRouterTest do
   use ExUnit.Case, async: true
 
+  alias Bedrock.DataPlane.CommitProxy.RoutingData
   alias Bedrock.DataPlane.ShardRouter
 
   describe "get_log_indices/3 - golden ratio log selection" do
@@ -92,362 +93,153 @@ defmodule Bedrock.DataPlane.ShardRouterTest do
     end
   end
 
-  describe "lookup_shard/2 - ETS ceiling search" do
-    setup do
-      # Create ETS table with shard_keys
-      table = :ets.new(:test_shard_keys, [:ordered_set, :public])
+  # Shards: %{end_key => {tag, start_key}}
+  defp shards(shard_layout) do
+    RoutingData.from_snapshot(%{
+      shard_layout: shard_layout,
+      log_map: %{},
+      log_services: %{},
+      replication_factor: 1
+    }).shards
+  end
 
+  describe "lookup_shard/2 - ceiling search" do
+    setup do
       # Shard ranges are [min, max) - start inclusive, end exclusive
       # Tag 0 covers ["", "m"), tag 1 covers ["m", \xff)
-      :ets.insert(table, {"m", 0})
-      :ets.insert(table, {"\xff", 1})
-
-      on_exit(fn ->
-        try do
-          :ets.delete(table)
-        rescue
-          ArgumentError -> :ok
-        end
-      end)
-
-      {:ok, table: table}
+      {:ok, shards: shards(%{"m" => {0, ""}, "\xff" => {1, "m"}})}
     end
 
-    test "finds correct shard for key before first boundary", %{table: table} do
-      assert ShardRouter.lookup_shard(table, "a") == 0
-      assert ShardRouter.lookup_shard(table, "hello") == 0
-      assert ShardRouter.lookup_shard(table, "") == 0
-      assert ShardRouter.lookup_shard(table, "lzzz") == 0
+    test "finds correct shard for key before first boundary", %{shards: shards} do
+      assert ShardRouter.lookup_shard(shards, "a") == 0
+      assert ShardRouter.lookup_shard(shards, "hello") == 0
+      assert ShardRouter.lookup_shard(shards, "") == 0
+      assert ShardRouter.lookup_shard(shards, "lzzz") == 0
     end
 
-    test "finds correct shard for key at boundary", %{table: table} do
+    test "finds correct shard for key at boundary", %{shards: shards} do
       # With [min, max) semantics: "m" is the START of tag 1's range, not end of tag 0
-      # Tag 0 covers ["", "m"), tag 1 covers ["m", \xff)
-      assert ShardRouter.lookup_shard(table, "m") == 1
+      assert ShardRouter.lookup_shard(shards, "m") == 1
     end
 
-    test "finds correct shard for key after first boundary", %{table: table} do
-      assert ShardRouter.lookup_shard(table, "n") == 1
-      assert ShardRouter.lookup_shard(table, "zebra") == 1
-      assert ShardRouter.lookup_shard(table, "\xfe") == 1
+    test "finds correct shard for key after first boundary", %{shards: shards} do
+      assert ShardRouter.lookup_shard(shards, "n") == 1
+      assert ShardRouter.lookup_shard(shards, "zebra") == 1
+      assert ShardRouter.lookup_shard(shards, "\xfe") == 1
     end
 
-    test "handles system keys (metadata shard)", %{table: table} do
-      # System keys start with \xff, which is >= "m", so they go to tag 1
-      # But in real setup, there would be a shard_key entry for system keys
-      assert ShardRouter.lookup_shard(table, "\xff/system/foo") == 1
+    test "keys beyond every boundary fall back to the last shard", %{shards: shards} do
+      assert ShardRouter.lookup_shard(shards, "\xff/system/foo") == 1
+    end
+
+    test "raises on an empty shard map" do
+      assert_raise RuntimeError, "Empty shard map", fn ->
+        ShardRouter.lookup_shard(shards(%{}), "a")
+      end
     end
   end
 
   describe "lookup_shard/2 - edge cases" do
     test "single shard covering entire keyspace" do
-      table = :ets.new(:single_shard, [:ordered_set, :public])
+      single = shards(%{"\xff" => {0, ""}})
 
-      try do
-        # Single shard covers ["", \xff)
-        :ets.insert(table, {"\xff", 0})
-
-        assert ShardRouter.lookup_shard(table, "") == 0
-        assert ShardRouter.lookup_shard(table, "any_key") == 0
-        assert ShardRouter.lookup_shard(table, "\xfe") == 0
-      after
-        :ets.delete(table)
-      end
+      assert ShardRouter.lookup_shard(single, "") == 0
+      assert ShardRouter.lookup_shard(single, "any_key") == 0
+      assert ShardRouter.lookup_shard(single, "\xfe") == 0
     end
 
     test "many shards" do
-      table = :ets.new(:many_shards, [:ordered_set, :public])
+      # Tag 0: ["", "b"), Tag 1: ["b", "d"), Tag 2: ["d", "f"),
+      # Tag 3: ["f", "h"), Tag 4: ["h", \xff)
+      many =
+        shards(%{
+          "b" => {0, ""},
+          "d" => {1, "b"},
+          "f" => {2, "d"},
+          "h" => {3, "f"},
+          "\xff" => {4, "h"}
+        })
 
-      try do
-        # 5 shards with [min, max) ranges:
-        # Tag 0: ["", "b"), Tag 1: ["b", "d"), Tag 2: ["d", "f"),
-        # Tag 3: ["f", "h"), Tag 4: ["h", \xff)
-        :ets.insert(table, {"b", 0})
-        :ets.insert(table, {"d", 1})
-        :ets.insert(table, {"f", 2})
-        :ets.insert(table, {"h", 3})
-        :ets.insert(table, {"\xff", 4})
-
-        assert ShardRouter.lookup_shard(table, "a") == 0
-        # "b" is START of tag 1's range
-        assert ShardRouter.lookup_shard(table, "b") == 1
-        assert ShardRouter.lookup_shard(table, "c") == 1
-        # "d" is START of tag 2's range
-        assert ShardRouter.lookup_shard(table, "d") == 2
-        assert ShardRouter.lookup_shard(table, "e") == 2
-        assert ShardRouter.lookup_shard(table, "g") == 3
-        assert ShardRouter.lookup_shard(table, "z") == 4
-      after
-        :ets.delete(table)
-      end
-    end
-  end
-
-  describe "lookup_shards_for_range/3 - range to tags" do
-    setup do
-      table = :ets.new(:range_test, [:ordered_set, :public])
-      # 4 shards with [min, max) ranges:
-      # Tag 0: ["", "d"), Tag 1: ["d", "h"), Tag 2: ["h", "m"), Tag 3: ["m", \xff)
-      :ets.insert(table, {"d", 0})
-      :ets.insert(table, {"h", 1})
-      :ets.insert(table, {"m", 2})
-      :ets.insert(table, {"\xff", 3})
-
-      on_exit(fn ->
-        try do
-          :ets.delete(table)
-        rescue
-          ArgumentError -> :ok
-        end
-      end)
-
-      {:ok, table: table}
-    end
-
-    test "range within single shard returns one tag", %{table: table} do
-      # ["a", "c") is entirely within tag 0's range ["", "d")
-      assert ShardRouter.lookup_shards_for_range(table, "a", "c") == [0]
-    end
-
-    test "range spanning two shards returns both tags", %{table: table} do
-      # ["c", "f") spans tag 0 ["", "d") and tag 1 ["d", "h")
-      tags = ShardRouter.lookup_shards_for_range(table, "c", "f")
-      assert Enum.sort(tags) == [0, 1]
-    end
-
-    test "range spanning all shards returns all tags", %{table: table} do
-      # ["", \xff) spans all shards
-      tags = ShardRouter.lookup_shards_for_range(table, "", "\xff")
-      assert Enum.sort(tags) == [0, 1, 2, 3]
-    end
-
-    test "range at exact boundary", %{table: table} do
-      # ["d", "h") exactly matches tag 1's range
-      # With [min, max): "d" is the START of tag 1, "h" is the END (exclusive)
-      tags = ShardRouter.lookup_shards_for_range(table, "d", "h")
-      assert tags == [1]
-    end
-
-    test "empty range returns single shard", %{table: table} do
-      # ["e", "e") is empty but we still return the shard containing "e"
-      tags = ShardRouter.lookup_shards_for_range(table, "e", "e")
-      # "e" is in tag 1's range ["d", "h")
-      assert tags == [1]
-    end
-
-    test "range in last shard", %{table: table} do
-      # ["z", \xff) is entirely in tag 3's range ["m", \xff)
-      tags = ShardRouter.lookup_shards_for_range(table, "z", "\xff")
-      assert tags == [3]
-    end
-
-    test "range crossing multiple boundaries", %{table: table} do
-      # ["c", "i") spans tags 0, 1, and 2
-      # Tag 0: ["", "d"), Tag 1: ["d", "h"), Tag 2: ["h", "m")
-      tags = ShardRouter.lookup_shards_for_range(table, "c", "i")
-      assert Enum.sort(tags) == [0, 1, 2]
-    end
-  end
-
-  describe "get_logs_for_key/4 - full routing" do
-    setup do
-      table = :ets.new(:routing_test, [:ordered_set, :public])
-      :ets.insert(table, {"m", 0})
-      :ets.insert(table, {"\xff", 1})
-
-      # Log index to log_id mapping
-      log_map = %{0 => "log-a", 1 => "log-b", 2 => "log-c"}
-
-      on_exit(fn ->
-        try do
-          :ets.delete(table)
-        rescue
-          ArgumentError -> :ok
-        end
-      end)
-
-      {:ok, table: table, log_map: log_map}
-    end
-
-    test "routes key to correct logs", %{table: table, log_map: log_map} do
-      # Key "apple" -> tag 0 -> some logs
-      logs = ShardRouter.get_logs_for_key(table, "apple", log_map, 2)
-
-      assert length(logs) == 2
-      assert Enum.all?(logs, &is_binary/1)
-      assert Enum.all?(logs, &(&1 in Map.values(log_map)))
-    end
-
-    test "different shards may route to different logs", %{table: table, log_map: log_map} do
-      logs_shard_0 = ShardRouter.get_logs_for_key(table, "apple", log_map, 2)
-      logs_shard_1 = ShardRouter.get_logs_for_key(table, "zebra", log_map, 2)
-
-      # They might be the same or different depending on golden ratio
-      # Just verify they're valid
-      assert length(logs_shard_0) == 2
-      assert length(logs_shard_1) == 2
-    end
-  end
-
-  describe "lazy log_indices caching" do
-    setup do
-      table = :ets.new(:caching_test, [:ordered_set, :public])
-      :ets.insert(table, {"m", 0})
-      :ets.insert(table, {"\xff", 1})
-
-      log_map = %{0 => "log-a", 1 => "log-b", 2 => "log-c"}
-
-      on_exit(fn ->
-        try do
-          :ets.delete(table)
-        rescue
-          ArgumentError -> :ok
-        end
-      end)
-
-      {:ok, table: table, log_map: log_map}
-    end
-
-    test "get_logs_for_key caches log_indices in ETS", %{table: table, log_map: log_map} do
-      # Initial entry is just {end_key, tag}
-      assert :ets.lookup(table, "m") == [{"m", 0}]
-
-      # First call computes and caches
-      _logs = ShardRouter.get_logs_for_key(table, "apple", log_map, 2)
-
-      # Entry should now be {end_key, {tag, log_indices}}
-      [{_end_key, cached_value}] = :ets.lookup(table, "m")
-      assert is_tuple(cached_value)
-      {tag, log_indices} = cached_value
-      assert tag == 0
-      assert is_list(log_indices)
-      assert length(log_indices) == 2
-    end
-
-    test "subsequent calls use cached log_indices", %{table: table, log_map: log_map} do
-      # First call - computes
-      logs1 = ShardRouter.get_logs_for_key(table, "apple", log_map, 2)
-
-      # Verify it's cached
-      [{_, {0, cached_indices}}] = :ets.lookup(table, "m")
-
-      # Second call - uses cache
-      logs2 = ShardRouter.get_logs_for_key(table, "apple", log_map, 2)
-
-      # Results should be identical
-      assert logs1 == logs2
-
-      # Cache should be unchanged
-      [{_, {0, ^cached_indices}}] = :ets.lookup(table, "m")
-    end
-
-    test "lookup_shard handles cached format", %{table: table, log_map: log_map} do
-      # Trigger caching
-      _logs = ShardRouter.get_logs_for_key(table, "apple", log_map, 2)
-
-      # lookup_shard should still return just the tag
-      tag = ShardRouter.lookup_shard(table, "apple")
-      assert tag == 0
-    end
-
-    test "lookup_shards_for_range handles cached format", %{table: table, log_map: log_map} do
-      # Trigger caching for both shards
-      _logs1 = ShardRouter.get_logs_for_key(table, "apple", log_map, 2)
-      _logs2 = ShardRouter.get_logs_for_key(table, "zebra", log_map, 2)
-
-      # Range lookup should still work
-      tags = ShardRouter.lookup_shards_for_range(table, "a", "z")
-      assert Enum.sort(tags) == [0, 1]
-    end
-
-    test "works with pre-cached entries", %{table: table, log_map: log_map} do
-      # Manually insert cached format
-      :ets.insert(table, {"m", {0, [1, 2]}})
-
-      # Should use cached indices
-      logs = ShardRouter.get_logs_for_key(table, "apple", log_map, 2)
-      assert logs == ["log-b", "log-c"]
+      assert ShardRouter.lookup_shard(many, "a") == 0
+      # "b" is START of tag 1's range
+      assert ShardRouter.lookup_shard(many, "b") == 1
+      assert ShardRouter.lookup_shard(many, "c") == 1
+      # "d" is START of tag 2's range
+      assert ShardRouter.lookup_shard(many, "d") == 2
+      assert ShardRouter.lookup_shard(many, "e") == 2
+      assert ShardRouter.lookup_shard(many, "g") == 3
+      assert ShardRouter.lookup_shard(many, "z") == 4
     end
   end
 
   describe "lookup_shards_with_ranges/3 - range to tags with boundaries" do
     setup do
-      table = :ets.new(:ranges_with_bounds, [:ordered_set, :public])
-      # 4 shards with [min, max) ranges:
       # Tag 0: ["", "d"), Tag 1: ["d", "h"), Tag 2: ["h", "m"), Tag 3: ["m", \xff)
-      :ets.insert(table, {"d", 0})
-      :ets.insert(table, {"h", 1})
-      :ets.insert(table, {"m", 2})
-      :ets.insert(table, {"\xff", 3})
-
-      on_exit(fn ->
-        try do
-          :ets.delete(table)
-        rescue
-          ArgumentError -> :ok
-        end
-      end)
-
-      {:ok, table: table}
+      {:ok,
+       shards:
+         shards(%{
+           "d" => {0, ""},
+           "h" => {1, "d"},
+           "m" => {2, "h"},
+           "\xff" => {3, "m"}
+         })}
     end
 
-    test "returns shard boundaries for single shard range", %{table: table} do
+    test "returns shard boundaries for single shard range", %{shards: shards} do
       # ["a", "c") is entirely within tag 0's range ["", "d")
-      result = ShardRouter.lookup_shards_with_ranges(table, "a", "c")
-      assert result == [{0, "", "d"}]
+      assert ShardRouter.lookup_shards_with_ranges(shards, "a", "c") == [{0, "", "d"}]
     end
 
-    test "returns boundaries for range spanning two shards", %{table: table} do
+    test "returns boundaries for range spanning two shards", %{shards: shards} do
       # ["c", "f") spans tag 0 ["", "d") and tag 1 ["d", "h")
-      result = ShardRouter.lookup_shards_with_ranges(table, "c", "f")
-      assert result == [{0, "", "d"}, {1, "d", "h"}]
+      assert ShardRouter.lookup_shards_with_ranges(shards, "c", "f") == [{0, "", "d"}, {1, "d", "h"}]
     end
 
-    test "returns boundaries for range spanning all shards", %{table: table} do
-      # ["", \xff) spans all shards
-      result = ShardRouter.lookup_shards_with_ranges(table, "", "\xff")
-      assert result == [{0, "", "d"}, {1, "d", "h"}, {2, "h", "m"}, {3, "m", "\xff"}]
+    test "returns boundaries for range spanning all shards", %{shards: shards} do
+      assert ShardRouter.lookup_shards_with_ranges(shards, "", "\xff") ==
+               [{0, "", "d"}, {1, "d", "h"}, {2, "h", "m"}, {3, "m", "\xff"}]
     end
 
-    test "returns boundaries at exact shard boundary", %{table: table} do
-      # ["d", "h") exactly matches tag 1's range
-      result = ShardRouter.lookup_shards_with_ranges(table, "d", "h")
-      assert result == [{1, "d", "h"}]
+    test "returns boundaries at exact shard boundary", %{shards: shards} do
+      # ["d", "h") exactly matches tag 1's range; a shard ending AT the range
+      # start (exclusive end) does not overlap.
+      assert ShardRouter.lookup_shards_with_ranges(shards, "d", "h") == [{1, "d", "h"}]
     end
 
-    test "returns boundaries for range in last shard", %{table: table} do
-      # ["z", \xff) is entirely in tag 3's range ["m", \xff)
-      result = ShardRouter.lookup_shards_with_ranges(table, "z", "\xff")
-      assert result == [{3, "m", "\xff"}]
+    test "returns boundaries for range in last shard", %{shards: shards} do
+      assert ShardRouter.lookup_shards_with_ranges(shards, "z", "\xff") == [{3, "m", "\xff"}]
     end
 
-    test "returns boundaries for range crossing multiple boundaries", %{table: table} do
-      # ["c", "i") spans tags 0, 1, and 2
-      result = ShardRouter.lookup_shards_with_ranges(table, "c", "i")
-      assert result == [{0, "", "d"}, {1, "d", "h"}, {2, "h", "m"}]
+    test "returns boundaries for range crossing multiple boundaries", %{shards: shards} do
+      assert ShardRouter.lookup_shards_with_ranges(shards, "c", "i") ==
+               [{0, "", "d"}, {1, "d", "h"}, {2, "h", "m"}]
     end
 
-    test "returns [] for range entirely beyond shard coverage", %{table: table} do
+    test "an empty range returns the shard containing its point" do
+      # Intent pin: split_mutation_by_shards treats an empty tagged list as a
+      # coverage error, so an empty clear_range must still resolve to its
+      # containing shard (the clamped result is a harmless no-op).
+      shards = shards(%{"h" => {1, "d"}, "\xff" => {2, "h"}})
+
+      assert ShardRouter.lookup_shards_with_ranges(shards, "e", "e") == [{1, "d", "h"}]
+    end
+
+    test "returns [] for range entirely beyond shard coverage", %{shards: shards} do
       # Last shard end_key is "\xff" (exclusive); ranges starting at or beyond
-      # it intersect no shard. Regression: this used to raise ArgumentError via
-      # :ets.prev(table, :"$end_of_table").
-      assert ShardRouter.lookup_shards_with_ranges(table, "\xff", "\xff\x00") == []
-      assert ShardRouter.lookup_shards_with_ranges(table, <<0xFF, 0xFF>>, <<0xFF, 0xFF, 0>>) == []
+      # it intersect no shard.
+      assert ShardRouter.lookup_shards_with_ranges(shards, "\xff", "\xff\x00") == []
+      assert ShardRouter.lookup_shards_with_ranges(shards, <<0xFF, 0xFF>>, <<0xFF, 0xFF, 0>>) == []
     end
 
-    test "enables correct clamping of clear_range", %{table: table} do
+    test "enables correct clamping of clear_range", %{shards: shards} do
       # Test the use case: clamping clear_range "a" to "z" to shard boundaries
-      shards = ShardRouter.lookup_shards_with_ranges(table, "a", "z")
-
-      # Use boundaries to clamp the original range
       clamped =
-        Enum.map(shards, fn {tag, shard_start, shard_end} ->
-          clamped_start = max("a", shard_start)
-          clamped_end = min("z", shard_end)
-          {tag, clamped_start, clamped_end}
+        shards
+        |> ShardRouter.lookup_shards_with_ranges("a", "z")
+        |> Enum.map(fn {tag, shard_start, shard_end} ->
+          {tag, max("a", shard_start), min("z", shard_end)}
         end)
 
-      # Verify clamped ranges
       assert clamped == [
                {0, "a", "d"},
                {1, "d", "h"},

--- a/test/support/data_plane/finalization_test_support.ex
+++ b/test/support/data_plane/finalization_test_support.ex
@@ -125,19 +125,12 @@ defmodule Bedrock.Test.DataPlane.FinalizationTestSupport do
 
   @doc """
   Builds routing data from a transaction system layout.
-  Used by finalize_batch opts.
+  Used to seed metadata_apply_fn/1 for finalize_batch opts.
   """
   def build_routing_data(transaction_system_layout) do
     logs = Map.get(transaction_system_layout, :logs, %{})
     services = Map.get(transaction_system_layout, :services, %{})
     shard_layout = Map.get(transaction_system_layout, :shard_layout, default_shard_layout())
-
-    table = :ets.new(:test_shard_keys, [:ordered_set, :public])
-
-    # Populate shard_keys from shard_layout: %{end_key => {tag, start_key}}
-    Enum.each(shard_layout, fn {end_key, {tag, _start_key}} ->
-      :ets.insert(table, {end_key, tag})
-    end)
 
     log_map =
       logs
@@ -166,12 +159,36 @@ defmodule Bedrock.Test.DataPlane.FinalizationTestSupport do
 
     replication_factor = max(1, map_size(logs))
 
-    %RoutingData{
-      shard_table: table,
+    RoutingData.from_snapshot(%{
+      shard_layout: shard_layout,
       log_map: log_map,
       log_services: log_services,
       replication_factor: replication_factor
-    }
+    })
+  end
+
+  @doc """
+  A stand-in for the commit proxy server's serialized apply-and-route step:
+  applies the batch's window entries and own committed metadata to the given
+  routing data and returns the snapshot the batch should push with.
+  """
+  def metadata_apply_fn(%RoutingData{} = routing_data) do
+    fn _prev_version, commit_version, window, deferred ->
+      entries =
+        case window do
+          nil -> []
+          {_from, _to, entries} -> entries
+        end
+
+      own =
+        case deferred do
+          nil -> []
+          {[]} -> []
+          {committed} -> [{commit_version, committed}]
+        end
+
+      {:ok, RoutingData.apply_mutations(routing_data, entries ++ own)}
+    end
   end
 
   # Default shard layout covering entire keyspace with a single shard (tag 0)


### PR DESCRIPTION
## Why

The commit proxy's shard-routing state was a shared ETS table written by concurrent finalization tasks and the server, with no ordering between them. Closing that race was headed toward versioned rows, tombstones, and compare-and-swap upserts — machinery to *tolerate* disorder. FoundationDB never needs any of it: `postResolution` applies each batch's committed metadata one batch at a time in order — first the mutations other proxies committed (relayed by resolvers), then the batch's own — and only then assigns the batch's mutations to logs. `keyInfo` has a single writer, and a batch that restructures the system routes itself with its own new map, which is exactly what the first commit of a fresh epoch needs.

## What

The same shape, translated to BEAM idioms:

- **Routing data is a plain immutable value** — shard boundaries live in a `:gb_trees` map instead of an ETS table. No table lifecycle, no ownership, no cleanup; a snapshot crosses processes and nodes safely, which permanently retires the crash class that started this arc (an ETS reference shipped to another node).
- **The server serializes metadata application per batch.** After resolution, a finalization task makes one call: apply my batch's committed metadata — the resolver window plus, in sharded mode, the batch's own globally-committed mutations — and hand back the snapshot I push with. Requests are served strictly in a **proxy-local batch sequence** (FDB's `latestLocalCommitBatchLogging`); a request arriving ahead of its predecessor waits. The sequence is deliberately not the global sequencer versions: those interleave across proxies, so chaining on them would park forever the moment a second proxy takes an intervening version.
- **The parallel part stays parallel — more so than FDB.** Because the snapshot is immutable, mutation splitting and log pushes run outside the serialized section (FDB must keep tag assignment inside its gate; `keyInfo` is mutable in place), and Shale's log servers already reorder out-of-order pushes by version chain, so pushes need no gate either.

Deleted along the way: the shared `:public` table and its lifecycle, in-task window application, the `{:metadata_updates}`/`{:metadata_deferred}` side-messages and their callback options, and the router's lazy in-row log-index cache — all folded into the one apply-and-route call. Net −400 lines.

## How

Failure handling needs no new machinery: every path where a batch dies before its apply call either reports `finalization_failed` (server stops, director recovers) or crashes the task, which is linked to the server. A successor parked behind a dead predecessor therefore never outlives the proxy. The window protocol is unchanged as a transport — differential `(from, to]` windows off the proxy's ack, gap fail-fast, deferred confirms in sharded mode — only its application point collapsed into one serialized step, where the version filter keeps overlapping windows idempotent.

Cold-audited adversarially (deadlock/livelock hunts across every failure interleaving, anchor races, ack-vs-snapshot consistency, GenServer reply discipline) and verified line-by-line against `CommitProxyServer.actor.cpp` and Shale's push reordering. The audit's one blocker — the chain was originally keyed on global sequencer versions, deadlocking under a multi-proxy configuration — is fixed by the proxy-local sequence above and pinned by a test that chains batches with non-adjacent versions.

Ticket: bedrock-q67.24 (blocks bedrock-q67.21). Stacked on #155; replaces the withdrawn #157.