### PR TITLE
Validate keyspace bounds in the pipeline, per transaction

### DIFF
--- a/lib/bedrock/data_plane/commit_proxy.ex
+++ b/lib/bedrock/data_plane/commit_proxy.ex
@@ -70,7 +70,7 @@ defmodule Bedrock.DataPlane.CommitProxy do
         ) ::
           {:ok, version :: Bedrock.version(), index :: non_neg_integer()}
           | {:error, :wrong_epoch | :locked | :abort | :timeout | :unavailable}
-          | {:error, {:key_out_of_range | :atomic_on_system_key, Bedrock.key()}}
+          | {:error, {:key_out_of_range, Bedrock.key()}}
           | {:error, :invalid_transaction}
   def commit(commit_proxy, epoch, transaction, opts \\ []) do
     case Keyword.get(opts, :mode, :user) do

--- a/lib/bedrock/data_plane/commit_proxy/batch.ex
+++ b/lib/bedrock/data_plane/commit_proxy/batch.ex
@@ -7,6 +7,13 @@ defmodule Bedrock.DataPlane.CommitProxy.Batch do
 
   @type reply_fn :: ({:ok, Bedrock.version(), index :: non_neg_integer()} | {:error, :abort} -> :ok)
 
+  @typedoc """
+  Who is committing, carried per transaction: it decides the legal write
+  range during pipeline validation (user commits end at the system boundary,
+  system commits at the end of the keyspace).
+  """
+  @type commit_mode :: :user | :system
+
   @type t :: %__MODULE__{
           started_at: Bedrock.timestamp_in_ms(),
           finalized_at: Bedrock.timestamp_in_ms() | nil,
@@ -14,7 +21,7 @@ defmodule Bedrock.DataPlane.CommitProxy.Batch do
           commit_version: Bedrock.version(),
           known_committed_version: Bedrock.version() | nil,
           n_transactions: non_neg_integer(),
-          buffer: [{index :: non_neg_integer(), reply_fn(), Transaction.encoded(), Task.t() | nil}]
+          buffer: [{index :: non_neg_integer(), reply_fn(), Transaction.encoded(), commit_mode()}]
         }
   defstruct started_at: nil,
             finalized_at: nil,
@@ -42,17 +49,18 @@ defmodule Bedrock.DataPlane.CommitProxy.Batch do
   end
 
   @spec transactions_in_order(t()) :: [
-          {index :: non_neg_integer(), reply_fn(), Transaction.encoded(), Task.t() | nil}
+          {index :: non_neg_integer(), reply_fn(), Transaction.encoded(), commit_mode()}
         ]
   def transactions_in_order(t), do: Enum.reverse(t.buffer)
 
   @spec all_callers(t()) :: [reply_fn()]
   def all_callers(t), do: Enum.map(t.buffer, &elem(&1, 1))
 
-  @spec add_transaction(t(), Transaction.encoded(), reply_fn(), Task.t() | nil) :: t()
-  def add_transaction(t, transaction, reply_fn, task) when is_binary(transaction) do
+  @spec add_transaction(t(), Transaction.encoded(), reply_fn(), commit_mode()) :: t()
+  def add_transaction(t, transaction, reply_fn, commit_mode)
+      when is_binary(transaction) and commit_mode in [:user, :system] do
     index = t.n_transactions
-    %{t | buffer: [{index, reply_fn, transaction, task} | t.buffer], n_transactions: index + 1}
+    %{t | buffer: [{index, reply_fn, transaction, commit_mode} | t.buffer], n_transactions: index + 1}
   end
 
   @spec transaction_count(t()) :: non_neg_integer()

--- a/lib/bedrock/data_plane/commit_proxy/batching.ex
+++ b/lib/bedrock/data_plane/commit_proxy/batching.ex
@@ -30,7 +30,7 @@ defmodule Bedrock.DataPlane.CommitProxy.Batching do
         {:ok,
          timestamp()
          |> new_batch(last_commit_version, commit_version, known_committed_version)
-         |> add_transaction(transaction, reply_fn, nil)
+         |> add_transaction(transaction, reply_fn, :user)
          |> set_finalized_at(timestamp())}
 
       {:error, reason} ->
@@ -51,10 +51,10 @@ defmodule Bedrock.DataPlane.CommitProxy.Batching do
 
   def start_batch_if_needed(t), do: t
 
-  @spec add_transaction_to_batch(State.t(), Transaction.encoded(), Batch.reply_fn(), Task.t() | nil) ::
+  @spec add_transaction_to_batch(State.t(), Transaction.encoded(), Batch.reply_fn(), Batch.commit_mode()) ::
           State.t()
-  def add_transaction_to_batch(t, transaction, reply_fn, task) when is_binary(transaction),
-    do: %{t | batch: add_transaction(t.batch, transaction, reply_fn, task)}
+  def add_transaction_to_batch(t, transaction, reply_fn, commit_mode) when is_binary(transaction),
+    do: %{t | batch: add_transaction(t.batch, transaction, reply_fn, commit_mode)}
 
   @spec apply_finalization_policy(State.t()) ::
           {State.t(), batch_to_finalize :: Batch.t()} | {State.t(), nil}

--- a/lib/bedrock/data_plane/commit_proxy/finalization.ex
+++ b/lib/bedrock/data_plane/commit_proxy/finalization.ex
@@ -20,7 +20,8 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization do
       trace_commit_proxy_batch_started: 3,
       trace_commit_proxy_batch_finished: 4,
       trace_commit_proxy_batch_failed: 3,
-      trace_metadata_updates_received: 2
+      trace_metadata_updates_received: 2,
+      trace_ingress_validation_failed: 1
     ]
 
   import Bitwise, only: [<<<: 2]
@@ -147,7 +148,7 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization do
 
     @type t :: %__MODULE__{
             transactions: %{
-              non_neg_integer() => {non_neg_integer(), Batch.reply_fn(), Transaction.encoded(), Task.t() | nil}
+              non_neg_integer() => {non_neg_integer(), Batch.reply_fn(), Transaction.encoded(), Batch.commit_mode()}
             },
             transaction_count: non_neg_integer(),
             commit_version: Bedrock.version(),
@@ -251,6 +252,7 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization do
     fn ->
       batch
       |> create_finalization_plan()
+      |> reject_invalid_transactions()
       |> resolve_conflicts(epoch, resolver_layout, opts)
       |> prepare_for_logging()
       |> push_to_logs(opts)
@@ -288,6 +290,92 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization do
       stage: :ready_for_resolution
     }
   end
+
+  # ============================================================================
+  # Keyspace Validation
+  # ============================================================================
+
+  # Per-transaction keyspace validation, in the pipeline rather than at the
+  # proxy's serialized accept loop (FDB validates tenant access the same way:
+  # per-transaction sendError inside postResolution while the batch
+  # proceeds). Each rejected transaction gets its specific error through its
+  # own reply and is replaced with an empty transaction, so its conflict
+  # ranges never enter resolver history and its mutations never reach a log.
+  #
+  # The legal write range depends on who is committing - the mode rides each
+  # buffer entry: user commits end at the system boundary, system commits at
+  # the end of the keyspace. Keys past the commit's bound belong to no shard
+  # the caller may touch; before validation existed, single-key mutations
+  # were silently routed into the LAST shard and a clear_range past the
+  # boundary failed the whole batch. clear_range ends are exclusive, so an
+  # end AT the bound is legal.
+  #
+  # Atomics are bounded like any other mutation, nothing more - FDB parity.
+  # The metadata views cannot diverge from an atomic because atomics never
+  # enter the metadata stream in the first place: metadata_mutation?/1 admits
+  # only sets and clears, exactly FDB's isMetadataMutation.
+  @spec reject_invalid_transactions(FinalizationPlan.t()) :: FinalizationPlan.t()
+  def reject_invalid_transactions(%FinalizationPlan{transaction_count: 0} = plan), do: plan
+
+  def reject_invalid_transactions(%FinalizationPlan{} = plan) do
+    {transactions, replied, n_rejected} =
+      Enum.reduce(plan.transactions, {plan.transactions, plan.replied_indices, 0}, fn
+        {idx, {idx, reply_fn, transaction, commit_mode}}, {transactions, replied, n_rejected} = acc ->
+          case first_rejected_mutation(transaction, commit_mode) do
+            nil ->
+              acc
+
+            :invalid_transaction ->
+              reply_fn.({:error, :invalid_transaction})
+              blank = {idx, reply_fn, Transaction.empty_transaction(), commit_mode}
+              {Map.put(transactions, idx, blank), MapSet.put(replied, idx), n_rejected + 1}
+
+            {reason, key} ->
+              reply_fn.({:error, {reason, key}})
+              blank = {idx, reply_fn, Transaction.empty_transaction(), commit_mode}
+              {Map.put(transactions, idx, blank), MapSet.put(replied, idx), n_rejected + 1}
+          end
+      end)
+
+    %{plan | transactions: transactions, replied_indices: replied, aborted_count: plan.aborted_count + n_rejected}
+  end
+
+  # Returns nil when valid, {reason, key} for the offending mutation, or
+  # :invalid_transaction when the mutation section decodes but its payload is
+  # corrupt (the decode stream raises lazily; unguarded, that would crash the
+  # finalization task and with it the proxy). No catch-all clause: a mutation
+  # shape this validator does not know is caught by the rescue and rejected
+  # as :invalid_transaction, so a future mutation type fails closed instead
+  # of bypassing the gate.
+  @spec first_rejected_mutation(Transaction.encoded(), Batch.commit_mode()) ::
+          {:key_out_of_range, Bedrock.key()} | :invalid_transaction | nil
+  defp first_rejected_mutation(transaction, commit_mode) do
+    bound = keyspace_bound(commit_mode)
+
+    case Transaction.mutations(transaction) do
+      {:ok, mutations} -> Enum.find_value(mutations, &rejected_mutation(&1, bound))
+      {:error, :section_not_found} -> nil
+      {:error, _} -> :invalid_transaction
+    end
+  rescue
+    error ->
+      trace_ingress_validation_failed(error)
+      :invalid_transaction
+  end
+
+  defp keyspace_bound(:user), do: Bedrock.end_of_user_keyspace()
+  defp keyspace_bound(:system), do: Bedrock.end_of_keyspace()
+
+  defp rejected_mutation({:set, key, _value}, bound), do: key_past_bound(key, bound)
+  defp rejected_mutation({:clear, key}, bound), do: key_past_bound(key, bound)
+
+  defp rejected_mutation({:atomic, _op, key, _value}, bound), do: key_past_bound(key, bound)
+
+  defp rejected_mutation({:clear_range, start_key, end_key}, bound) do
+    key_past_bound(start_key, bound) || if end_key > bound, do: {:key_out_of_range, end_key}
+  end
+
+  defp key_past_bound(key, bound), do: if(key >= bound, do: {:key_out_of_range, key})
 
   # ============================================================================
   # Conflict Resolution
@@ -336,7 +424,7 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization do
     {filtered_transactions, metadata_per_tx} =
       0..(plan.transaction_count - 1)
       |> Enum.map(fn idx ->
-        {_idx, _reply_fn, transaction, _task} = Map.fetch!(plan.transactions, idx)
+        {_idx, _reply_fn, transaction, _commit_mode} = Map.fetch!(plan.transactions, idx)
         conflicts = Transaction.extract_sections!(transaction, [:read_conflicts, :write_conflicts])
         metadata = extract_metadata_mutations(transaction)
         {conflicts, metadata}
@@ -394,7 +482,7 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization do
         {maps, metadata_list} =
           0..(plan.transaction_count - 1)
           |> Enum.map(fn idx ->
-            {_idx, _reply_fn, transaction, _task} = Map.fetch!(plan.transactions, idx)
+            {_idx, _reply_fn, transaction, _commit_mode} = Map.fetch!(plan.transactions, idx)
             task = create_resolver_task_in_finalization(transaction, resolver_layout)
             map = Task.await(task, 5000)
             metadata = extract_metadata_mutations(transaction)
@@ -657,16 +745,21 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization do
     abort_reply_fn =
       Keyword.get(opts, :abort_reply_fn, &reply_to_all_clients_with_aborted_transactions/1)
 
-    # Reply to aborted transactions
-    aborted_set
+    # Rejected transactions were already answered with their specific error;
+    # never let a conflict-abort double-reply them. (Their emptied conflict
+    # sections make resolver aborts impossible today - this guard makes the
+    # invariant structural rather than incidental.)
+    newly_aborted = MapSet.difference(aborted_set, plan.replied_indices)
+
+    newly_aborted
     |> Enum.map(fn idx ->
-      {_idx, reply_fn, _binary, _task} = Map.fetch!(plan.transactions, idx)
+      {_idx, reply_fn, _binary, _commit_mode} = Map.fetch!(plan.transactions, idx)
       reply_fn
     end)
     |> abort_reply_fn.()
 
-    # Track that we've replied to these transactions and count them as aborted
-    %{plan | replied_indices: aborted_set, aborted_count: MapSet.size(aborted_set), stage: :aborts_notified}
+    replied = MapSet.union(plan.replied_indices, newly_aborted)
+    %{plan | replied_indices: replied, aborted_count: MapSet.size(replied), stage: :aborts_notified}
   end
 
   @spec reply_to_all_clients_with_aborted_transactions([Batch.reply_fn()]) :: :ok
@@ -755,13 +848,13 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization do
   end
 
   @spec process_transaction_for_logs(
-          {non_neg_integer(), {non_neg_integer(), Batch.reply_fn(), Transaction.encoded(), Task.t() | nil}},
+          {non_neg_integer(), {non_neg_integer(), Batch.reply_fn(), Transaction.encoded(), Batch.commit_mode()}},
           FinalizationPlan.t(),
           %{Log.id() => [term()]}
         ) ::
           {:cont, {:ok, %{Log.id() => [term()]}}}
           | {:halt, {:error, term()}}
-  defp process_transaction_for_logs({idx, {_idx, _reply_fn, binary, _task}}, plan, acc) do
+  defp process_transaction_for_logs({idx, {_idx, _reply_fn, binary, _commit_mode}}, plan, acc) do
     if MapSet.member?(plan.replied_indices, idx) do
       # Skip transactions that were already replied to (aborted)
       {:cont, {:ok, acc}}
@@ -1131,7 +1224,7 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization do
     successful_entries =
       plan.transactions
       |> Enum.reject(fn {idx, _entry} -> MapSet.member?(plan.replied_indices, idx) end)
-      |> Enum.map(fn {idx, {tx_idx, reply_fn, _binary, _task}} -> {reply_fn, tx_idx, idx} end)
+      |> Enum.map(fn {idx, {tx_idx, reply_fn, _binary, _commit_mode}} -> {reply_fn, tx_idx, idx} end)
 
     successful_indices = Enum.map(successful_entries, fn {_reply_fn, _tx_idx, idx} -> idx end)
 

--- a/lib/bedrock/data_plane/commit_proxy/server.ex
+++ b/lib/bedrock/data_plane/commit_proxy/server.ex
@@ -47,13 +47,7 @@ defmodule Bedrock.DataPlane.CommitProxy.Server do
   import Bedrock.DataPlane.CommitProxy.Finalization, only: [finalize_batch: 2]
 
   import Bedrock.DataPlane.CommitProxy.Telemetry,
-    only: [
-      trace_metadata: 0,
-      trace_metadata: 1,
-      trace_metadata_applied: 2,
-      trace_unknown_key_skipped: 1,
-      trace_ingress_validation_failed: 1
-    ]
+    only: [trace_metadata: 0, trace_metadata: 1, trace_metadata_applied: 2, trace_unknown_key_skipped: 1]
 
   import Bedrock.Internal.GenServer.Replies
 
@@ -178,11 +172,7 @@ defmodule Bedrock.DataPlane.CommitProxy.Server do
 
   def handle_call({:commit, epoch, transaction, commit_mode}, from, %{mode: :running, epoch: epoch} = t)
       when is_binary(transaction) and commit_mode in [:user, :system] do
-    case first_rejected_mutation(transaction, commit_mode) do
-      nil -> accept_commit(transaction, from, t)
-      :invalid_transaction -> reply(t, {:error, :invalid_transaction})
-      {reason, key} -> reply(t, {:error, {reason, key}})
-    end
+    accept_commit(transaction, commit_mode, from, t)
   end
 
   def handle_call({:commit, _epoch, _transaction, _commit_mode}, _from, %{mode: :running} = t),
@@ -221,7 +211,7 @@ defmodule Bedrock.DataPlane.CommitProxy.Server do
   def handle_call({:apply_metadata_and_route, _seq, _cv, _window, _deferred}, _from, %{mode: :locked} = t),
     do: reply(t, {:error, :locked})
 
-  defp accept_commit(transaction, from, t) do
+  defp accept_commit(transaction, commit_mode, from, t) do
     case start_batch_if_needed(t) do
       {:error, reason} ->
         GenServer.reply(from, {:error, :abort})
@@ -229,7 +219,7 @@ defmodule Bedrock.DataPlane.CommitProxy.Server do
 
       updated_t ->
         updated_t
-        |> add_transaction_to_batch(transaction, reply_fn(from), nil)
+        |> add_transaction_to_batch(transaction, reply_fn(from), commit_mode)
         |> apply_finalization_policy()
         |> case do
           {t, nil} ->
@@ -244,61 +234,6 @@ defmodule Bedrock.DataPlane.CommitProxy.Server do
         end
     end
   end
-
-  # The legal write range depends on who is committing: user commits end at
-  # the system boundary, system commits at the end of the keyspace. Keys past
-  # the commit's bound belong to no shard the caller may touch. Before this
-  # check, finalization silently routed such single-key mutations into the
-  # LAST shard (the system shard) via the router's ceiling fallback, and a
-  # clear_range starting past the last boundary failed the whole batch -
-  # after it had consumed a commit version - stopping the proxy into
-  # director recovery. Rejecting at ingress costs the one offending commit.
-  # clear_range ends are exclusive, so an end AT the bound is legal.
-  #
-  # Atomics on system keys are rejected in EVERY mode: the metadata pipeline
-  # (Metadata, RoutingData, and every view fed by the commit stream) replays
-  # only sets and clears, while the materializer would apply the atomic
-  # durably - the two copies of truth would silently diverge.
-  #
-  # Returns nil when valid, {reason, key} for the offending mutation, or
-  # :invalid_transaction when the mutation section decodes but its payload
-  # is corrupt (the decode stream raises lazily; unguarded, that would
-  # crash the proxy here).
-  @spec first_rejected_mutation(Transaction.encoded(), :user | :system) ::
-          {:key_out_of_range | :atomic_on_system_key, Bedrock.key()} | :invalid_transaction | nil
-  defp first_rejected_mutation(transaction, commit_mode) do
-    bound = keyspace_bound(commit_mode)
-
-    case Transaction.mutations(transaction) do
-      {:ok, mutations} -> Enum.find_value(mutations, &rejected_mutation(&1, bound))
-      {:error, :section_not_found} -> nil
-      {:error, _} -> :invalid_transaction
-    end
-  rescue
-    error ->
-      trace_ingress_validation_failed(error)
-      :invalid_transaction
-  end
-
-  defp keyspace_bound(:user), do: Bedrock.end_of_user_keyspace()
-  defp keyspace_bound(:system), do: Bedrock.end_of_keyspace()
-
-  defp rejected_mutation({:set, key, _value}, bound), do: key_past_bound(key, bound)
-  defp rejected_mutation({:clear, key}, bound), do: key_past_bound(key, bound)
-
-  defp rejected_mutation({:atomic, _op, key, _value}, bound) do
-    key_past_bound(key, bound) ||
-      if key >= Bedrock.end_of_user_keyspace(), do: {:atomic_on_system_key, key}
-  end
-
-  # No catch-all clause: a mutation shape this validator does not know is
-  # caught by the rescue above and rejected as :invalid_transaction, so a
-  # future mutation type fails closed instead of bypassing the gate.
-  defp rejected_mutation({:clear_range, start_key, end_key}, bound) do
-    key_past_bound(start_key, bound) || if end_key > bound, do: {:key_out_of_range, end_key}
-  end
-
-  defp key_past_bound(key, bound), do: if(key >= bound, do: {:key_out_of_range, key})
 
   @impl true
   @spec handle_info(

--- a/lib/bedrock/internal/repo.ex
+++ b/lib/bedrock/internal/repo.ex
@@ -339,14 +339,10 @@ defmodule Bedrock.Internal.Repo do
       {:ok, _commit_version} ->
         result
 
-      # A key outside the caller's legal range, an atomic op aimed at a
-      # system key, or an undecodable transaction is a permanent client
-      # error - retrying cannot change the outcome, so surface it instead
-      # of burning the transaction deadline.
+      # A key outside the caller's legal range or an undecodable transaction
+      # is a permanent client error - retrying cannot change the outcome, so
+      # surface it instead of burning the transaction deadline.
       {:error, {:key_out_of_range, _key} = reason} ->
-        throw({__MODULE__, :rollback, reason})
-
-      {:error, {:atomic_on_system_key, _key} = reason} ->
         throw({__MODULE__, :rollback, reason})
 
       {:error, :invalid_transaction = reason} ->

--- a/test/bedrock/data_plane/commit_proxy/batch_test.exs
+++ b/test/bedrock/data_plane/commit_proxy/batch_test.exs
@@ -25,13 +25,11 @@ defmodule Bedrock.DataPlane.CommitProxy.BatchTest do
       batch = Batch.new_batch(1000, <<1::64>>, <<2::64>>)
       transaction = <<1, 2, 3>>
       reply_fn = fn _ -> :ok end
-      task = nil
-
-      batch = Batch.add_transaction(batch, transaction, reply_fn, task)
+      batch = Batch.add_transaction(batch, transaction, reply_fn, :user)
 
       assert batch.n_transactions == 1
       assert length(batch.buffer) == 1
-      assert [{0, ^reply_fn, ^transaction, nil}] = batch.buffer
+      assert [{0, ^reply_fn, ^transaction, :user}] = batch.buffer
     end
 
     test "increments transaction count and index" do
@@ -40,13 +38,13 @@ defmodule Bedrock.DataPlane.CommitProxy.BatchTest do
 
       batch =
         batch
-        |> Batch.add_transaction(<<1>>, reply_fn, nil)
-        |> Batch.add_transaction(<<2>>, reply_fn, nil)
-        |> Batch.add_transaction(<<3>>, reply_fn, nil)
+        |> Batch.add_transaction(<<1>>, reply_fn, :user)
+        |> Batch.add_transaction(<<2>>, reply_fn, :user)
+        |> Batch.add_transaction(<<3>>, reply_fn, :user)
 
       assert batch.n_transactions == 3
       # Buffer is in reverse order (most recent first)
-      assert [{2, _, <<3>>, nil}, {1, _, <<2>>, nil}, {0, _, <<1>>, nil}] = batch.buffer
+      assert [{2, _, <<3>>, :user}, {1, _, <<2>>, :user}, {0, _, <<1>>, :user}] = batch.buffer
     end
   end
 
@@ -57,14 +55,14 @@ defmodule Bedrock.DataPlane.CommitProxy.BatchTest do
 
       batch =
         batch
-        |> Batch.add_transaction(<<1>>, reply_fn, nil)
-        |> Batch.add_transaction(<<2>>, reply_fn, nil)
-        |> Batch.add_transaction(<<3>>, reply_fn, nil)
+        |> Batch.add_transaction(<<1>>, reply_fn, :user)
+        |> Batch.add_transaction(<<2>>, reply_fn, :user)
+        |> Batch.add_transaction(<<3>>, reply_fn, :user)
 
       # Should reverse the buffer to get original insertion order
       transactions = Batch.transactions_in_order(batch)
 
-      assert [{0, _, <<1>>, nil}, {1, _, <<2>>, nil}, {2, _, <<3>>, nil}] = transactions
+      assert [{0, _, <<1>>, :user}, {1, _, <<2>>, :user}, {2, _, <<3>>, :user}] = transactions
     end
   end
 
@@ -77,9 +75,9 @@ defmodule Bedrock.DataPlane.CommitProxy.BatchTest do
 
       batch =
         batch
-        |> Batch.add_transaction(<<1>>, reply_fn_1, nil)
-        |> Batch.add_transaction(<<2>>, reply_fn_2, nil)
-        |> Batch.add_transaction(<<3>>, reply_fn_3, nil)
+        |> Batch.add_transaction(<<1>>, reply_fn_1, :user)
+        |> Batch.add_transaction(<<2>>, reply_fn_2, :user)
+        |> Batch.add_transaction(<<3>>, reply_fn_3, :user)
 
       callers = Batch.all_callers(batch)
 
@@ -94,10 +92,10 @@ defmodule Bedrock.DataPlane.CommitProxy.BatchTest do
 
       assert Batch.transaction_count(batch) == 0
 
-      batch = Batch.add_transaction(batch, <<1>>, fn _ -> :ok end, nil)
+      batch = Batch.add_transaction(batch, <<1>>, fn _ -> :ok end, :user)
       assert Batch.transaction_count(batch) == 1
 
-      batch = Batch.add_transaction(batch, <<2>>, fn _ -> :ok end, nil)
+      batch = Batch.add_transaction(batch, <<2>>, fn _ -> :ok end, :user)
       assert Batch.transaction_count(batch) == 2
     end
   end

--- a/test/bedrock/data_plane/commit_proxy/batching_test.exs
+++ b/test/bedrock/data_plane/commit_proxy/batching_test.exs
@@ -205,17 +205,17 @@ defmodule Bedrock.DataPlane.CommitProxy.BatchingTest do
       transaction = sample_transaction()
       reply_fn = fn _result -> :ok end
 
-      result = Batching.add_transaction_to_batch(state, transaction, reply_fn, nil)
+      result = Batching.add_transaction_to_batch(state, transaction, reply_fn, :user)
 
       assert %State{batch: %Batch{} = batch} = result
       assert batch.n_transactions == 1
       assert length(batch.buffer) == 1
 
-      [{index, stored_reply_fn, stored_tx, stored_task}] = batch.buffer
+      [{index, stored_reply_fn, stored_tx, stored_mode}] = batch.buffer
       assert index == 0
       assert stored_reply_fn == reply_fn
       assert stored_tx == transaction
-      assert stored_task == nil
+      assert stored_mode == :user
     end
 
     test "increments index for each transaction added" do
@@ -233,8 +233,8 @@ defmodule Bedrock.DataPlane.CommitProxy.BatchingTest do
       tx2 = sample_transaction()
       reply_fn = fn _result -> :ok end
 
-      state = Batching.add_transaction_to_batch(state, tx1, reply_fn, nil)
-      state = Batching.add_transaction_to_batch(state, tx2, reply_fn, nil)
+      state = Batching.add_transaction_to_batch(state, tx1, reply_fn, :user)
+      state = Batching.add_transaction_to_batch(state, tx2, reply_fn, :user)
 
       assert state.batch.n_transactions == 2
 
@@ -244,7 +244,7 @@ defmodule Bedrock.DataPlane.CommitProxy.BatchingTest do
       assert idx2 == 1
     end
 
-    test "stores task reference when provided" do
+    test "stores the commit mode alongside the transaction" do
       existing_batch = %Batch{
         started_at: 1000,
         last_commit_version: Version.from_integer(10),
@@ -257,15 +257,11 @@ defmodule Bedrock.DataPlane.CommitProxy.BatchingTest do
 
       transaction = sample_transaction()
       reply_fn = fn _result -> :ok end
-      task = Task.async(fn -> :some_result end)
 
-      result = Batching.add_transaction_to_batch(state, transaction, reply_fn, task)
+      result = Batching.add_transaction_to_batch(state, transaction, reply_fn, :system)
 
-      [{_index, _reply_fn, _tx, stored_task}] = result.batch.buffer
-      assert stored_task == task
-
-      # Clean up task
-      Task.await(task)
+      [{_index, _reply_fn, _tx, stored_mode}] = result.batch.buffer
+      assert stored_mode == :system
     end
   end
 
@@ -274,7 +270,7 @@ defmodule Bedrock.DataPlane.CommitProxy.BatchingTest do
       # Create batch at max capacity
       transactions =
         for i <- 0..4 do
-          {i, fn _result -> :ok end, sample_transaction(), nil}
+          {i, fn _result -> :ok end, sample_transaction(), :user}
         end
 
       batch = %Batch{
@@ -304,7 +300,7 @@ defmodule Bedrock.DataPlane.CommitProxy.BatchingTest do
         last_commit_version: Version.from_integer(10),
         commit_version: Version.from_integer(11),
         n_transactions: 1,
-        buffer: [{0, fn _result -> :ok end, sample_transaction(), nil}]
+        buffer: [{0, fn _result -> :ok end, sample_transaction(), :user}]
       }
 
       state = build_state(%{batch: batch, max_latency_in_ms: 100})
@@ -323,7 +319,7 @@ defmodule Bedrock.DataPlane.CommitProxy.BatchingTest do
         last_commit_version: Version.from_integer(10),
         commit_version: Version.from_integer(11),
         n_transactions: 1,
-        buffer: [{0, fn _result -> :ok end, sample_transaction(), nil}]
+        buffer: [{0, fn _result -> :ok end, sample_transaction(), :user}]
       }
 
       state = build_state(%{batch: batch, max_per_batch: 10, max_latency_in_ms: 10_000})
@@ -340,7 +336,7 @@ defmodule Bedrock.DataPlane.CommitProxy.BatchingTest do
 
       transactions =
         for i <- 0..4 do
-          {i, fn _result -> :ok end, sample_transaction(), nil}
+          {i, fn _result -> :ok end, sample_transaction(), :user}
         end
 
       batch = %Batch{
@@ -381,10 +377,10 @@ defmodule Bedrock.DataPlane.CommitProxy.BatchingTest do
       tx = sample_transaction()
       reply_fn = fn _result -> :ok end
 
-      state = Batching.add_transaction_to_batch(state, tx, reply_fn, nil)
+      state = Batching.add_transaction_to_batch(state, tx, reply_fn, :user)
       assert state.batch.n_transactions == 1
 
-      state = Batching.add_transaction_to_batch(state, tx, reply_fn, nil)
+      state = Batching.add_transaction_to_batch(state, tx, reply_fn, :user)
       assert state.batch.n_transactions == 2
 
       # Policy check - not yet ready
@@ -393,7 +389,7 @@ defmodule Bedrock.DataPlane.CommitProxy.BatchingTest do
       assert state.batch
 
       # Add third transaction - should trigger policy
-      state = Batching.add_transaction_to_batch(state, tx, reply_fn, nil)
+      state = Batching.add_transaction_to_batch(state, tx, reply_fn, :user)
       assert state.batch.n_transactions == 3
 
       {state, batch_to_finalize} = Batching.apply_finalization_policy(state)

--- a/test/bedrock/data_plane/commit_proxy/finalization/core_test.exs
+++ b/test/bedrock/data_plane/commit_proxy/finalization/core_test.exs
@@ -26,8 +26,8 @@ defmodule Bedrock.DataPlane.CommitProxy.FinalizationCoreTest do
     buffer =
       transactions
       |> Enum.with_index()
-      |> Enum.map(fn {{reply_fn, tx_binary, task}, index} ->
-        {index, reply_fn, tx_binary, task}
+      |> Enum.map(fn {{reply_fn, tx_binary, commit_mode}, index} ->
+        {index, reply_fn, tx_binary, commit_mode}
       end)
 
     %Batch{
@@ -102,15 +102,13 @@ defmodule Bedrock.DataPlane.CommitProxy.FinalizationCoreTest do
       # Create reply functions and tasks
       reply_fn1 = create_reply_fn(self(), :reply1)
       reply_fn2 = create_reply_fn(self(), :reply2)
-      task1 = Task.async(fn -> %{:test_resolver => tx1_binary} end)
-      task2 = Task.async(fn -> %{:test_resolver => tx2_binary} end)
 
       batch =
         create_batch_with_transactions(100, 99, [
           # index 0 - will be aborted
-          {reply_fn1, tx1_binary, task1},
+          {reply_fn1, tx1_binary, :system},
           # index 1 - success
-          {reply_fn2, tx2_binary, task2}
+          {reply_fn2, tx2_binary, :system}
         ])
 
       # Mock resolver that aborts first transaction (index 0)
@@ -178,13 +176,11 @@ defmodule Bedrock.DataPlane.CommitProxy.FinalizationCoreTest do
       # Create reply functions and tasks
       reply_fn1 = create_reply_fn(self(), :reply1)
       reply_fn2 = create_reply_fn(self(), :reply2)
-      task1 = Task.async(fn -> %{:test_resolver => tx1_binary} end)
-      task2 = Task.async(fn -> %{:test_resolver => tx2_binary} end)
 
       batch =
         create_batch_with_transactions(100, 99, [
-          {reply_fn1, tx1_binary, task1},
-          {reply_fn2, tx2_binary, task2}
+          {reply_fn1, tx1_binary, :system},
+          {reply_fn2, tx2_binary, :system}
         ])
 
       # Mock resolver that aborts both transactions
@@ -342,11 +338,10 @@ defmodule Bedrock.DataPlane.CommitProxy.FinalizationCoreTest do
       transaction_map = create_test_transaction(<<"key">>, <<"value">>)
       binary_transaction = Transaction.encode(transaction_map)
       reply_fn = create_reply_fn(self(), :reply)
-      task = Task.async(fn -> %{:test_resolver => binary_transaction} end)
 
       batch =
         create_batch_with_transactions(100, 99, [
-          {reply_fn, binary_transaction, task}
+          {reply_fn, binary_transaction, :user}
         ])
 
       # Custom abort function that tracks calls

--- a/test/bedrock/data_plane/commit_proxy/finalization/ingress_rejection_test.exs
+++ b/test/bedrock/data_plane/commit_proxy/finalization/ingress_rejection_test.exs
@@ -1,0 +1,243 @@
+defmodule Bedrock.DataPlane.CommitProxy.Finalization.IngressRejectionTest do
+  @moduledoc """
+  Pins per-transaction keyspace validation inside the finalization pipeline
+  (bedrock-q67.28).
+
+  Validation moved off the commit proxy's serialized accept loop into the
+  batch pipeline: invalid transactions are rejected individually - each gets
+  its specific error through its own reply - while the rest of the batch
+  proceeds. This is FDB's shape (validateAndProcessTenantAccess replies
+  per-transaction inside postResolution and the batch continues), improved in
+  one respect: a rejected transaction is replaced with an empty transaction
+  before resolution, so its conflict ranges never pollute resolver history.
+
+  The legal write range depends on the commit's mode, which travels with each
+  transaction in the batch: user commits end at the system boundary, system
+  commits at the end of the keyspace; corrupt mutation payloads fail closed
+  as :invalid_transaction. Atomics are bounded like any other mutation - FDB
+  parity; they never enter the metadata stream (metadata_mutation?/1 admits
+  only sets and clears, exactly FDB's isMetadataMutation), so no view can
+  diverge from one.
+  """
+  use ExUnit.Case, async: true
+
+  alias Bedrock.DataPlane.CommitProxy.Batch
+  alias Bedrock.DataPlane.CommitProxy.Finalization
+  alias Bedrock.DataPlane.CommitProxy.ResolverLayout
+  alias Bedrock.DataPlane.Transaction
+  alias Bedrock.DataPlane.Version
+  alias Bedrock.Test.DataPlane.FinalizationTestSupport, as: Support
+
+  defp encode(mutations, conflict_key) do
+    Transaction.encode(%{
+      mutations: mutations,
+      read_conflicts: nil,
+      write_conflicts: [{conflict_key, conflict_key <> <<0>>}]
+    })
+  end
+
+  # Rewrites the MUTATIONS section with a garbage-opcode payload under a
+  # valid CRC: the section opens cleanly and the lazy decode raises
+  # mid-stream - the failure mode validation must contain.
+  defp corrupt_mutation_payload(<<header::binary-size(8), sections::binary>>),
+    do: header <> corrupt_mutations_section(sections)
+
+  defp corrupt_mutations_section(
+         <<0x01, size::unsigned-big-24, _crc::unsigned-big-32, _payload::binary-size(size), rest::binary>>
+       ) do
+    payload = :binary.copy(<<0xEE>>, max(size, 1))
+    crc = :erlang.crc32(<<0x01, byte_size(payload)::unsigned-big-24, payload::binary>>)
+    <<0x01, byte_size(payload)::unsigned-big-24, crc::unsigned-big-32, payload::binary>> <> rest
+  end
+
+  defp corrupt_mutations_section(
+         <<tag, size::unsigned-big-24, crc::unsigned-big-32, payload::binary-size(size), rest::binary>>
+       ) do
+    <<tag, size::unsigned-big-24, crc::unsigned-big-32, payload::binary>> <> corrupt_mutations_section(rest)
+  end
+
+  defp reply_to_self(name) do
+    test_pid = self()
+    fn result -> send(test_pid, {name, result}) end
+  end
+
+  defp batch_of(entries) do
+    buffer =
+      entries
+      |> Enum.with_index()
+      |> Enum.map(fn {{reply_fn, tx, mode}, idx} -> {idx, reply_fn, tx, mode} end)
+      |> Enum.reverse()
+
+    %Batch{
+      started_at: 0,
+      finalized_at: 0,
+      last_commit_version: Version.from_integer(99),
+      commit_version: Version.from_integer(100),
+      n_transactions: length(entries),
+      buffer: buffer
+    }
+  end
+
+  defp finalize(batch, opts_overrides \\ []) do
+    test_pid = self()
+
+    layout = %{logs: %{"log_1" => [0]}, services: %{"log_1" => %{kind: :log, status: {:up, self()}}}}
+    routing_data = Support.build_routing_data(layout)
+
+    resolver_fn = fn _ref, _epoch, _last, _commit, transactions, _metadata, _opts ->
+      send(test_pid, {:resolved, transactions})
+      {:ok, [], nil}
+    end
+
+    opts =
+      Keyword.merge(
+        [
+          epoch: 1,
+          sequencer: :test_sequencer,
+          resolver_layout: %ResolverLayout.Single{resolver_ref: :test_resolver},
+          metadata_apply_fn: Support.metadata_apply_fn(routing_data),
+          resolver_fn: resolver_fn,
+          batch_log_push_fn: fn _last, by_log, _commit, _opts ->
+            send(test_pid, {:pushed, by_log})
+            :ok
+          end,
+          sequencer_notify_fn: fn _sequencer, _epoch, _commit, _opts -> :ok end
+        ],
+        opts_overrides
+      )
+
+    Finalization.finalize_batch(batch, opts)
+  end
+
+  test "rejects an out-of-range user mutation per-transaction while the batch commits the rest" do
+    bad_key = <<0xFF, "/system/forbidden">>
+
+    batch =
+      batch_of([
+        {reply_to_self(:ok_tx), encode([{:set, "a", "1"}], "a"), :user},
+        {reply_to_self(:bad_tx), encode([{:set, bad_key, "x"}], "b"), :user}
+      ])
+
+    assert {:ok, 1, 1} = finalize(batch)
+
+    assert_receive {:bad_tx, {:error, {:key_out_of_range, ^bad_key}}}
+    assert_receive {:ok_tx, {:ok, _version, _index}}
+  end
+
+  test "the mode travels per transaction: system and user commits mix in one batch" do
+    system_key = <<0xFF, "/system/ok">>
+
+    batch =
+      batch_of([
+        {reply_to_self(:system_tx), encode([{:set, system_key, "v"}], "s"), :system},
+        {reply_to_self(:user_tx), encode([{:set, system_key, "v"}], "u"), :user}
+      ])
+
+    assert {:ok, 1, 1} = finalize(batch)
+
+    assert_receive {:system_tx, {:ok, _version, _index}}
+    assert_receive {:user_tx, {:error, {:key_out_of_range, ^system_key}}}
+  end
+
+  test "a corrupt mutation payload fails closed without failing the batch" do
+    corrupt = corrupt_mutation_payload(encode([{:set, "k", "v"}], "k"))
+
+    batch =
+      batch_of([
+        {reply_to_self(:good_tx), encode([{:set, "a", "1"}], "a"), :user},
+        {reply_to_self(:corrupt_tx), corrupt, :user}
+      ])
+
+    assert {:ok, 1, 1} = finalize(batch)
+
+    assert_receive {:corrupt_tx, {:error, :invalid_transaction}}
+    assert_receive {:good_tx, {:ok, _version, _index}}
+  end
+
+  test "rejected transactions contribute no conflicts to resolution" do
+    bad_key = <<0xFF, "/system/forbidden">>
+
+    batch =
+      batch_of([
+        {reply_to_self(:ok_tx), encode([{:set, "a", "1"}], "a"), :user},
+        {reply_to_self(:bad_tx), encode([{:set, bad_key, "x"}], "poison_range"), :user}
+      ])
+
+    assert {:ok, 1, 1} = finalize(batch)
+
+    empty_sections = Transaction.extract_sections!(Transaction.empty_transaction(), [:read_conflicts, :write_conflicts])
+
+    assert_receive {:resolved, [_ok_sections, rejected_sections]}
+    assert rejected_sections == empty_sections
+  end
+
+  test "rejected transactions are excluded from log pushes" do
+    bad_key = <<0xFF, "/system/forbidden">>
+
+    batch =
+      batch_of([
+        {reply_to_self(:ok_tx), encode([{:set, "a", "1"}], "a"), :user},
+        {reply_to_self(:bad_tx), encode([{:set, bad_key, "x"}], "b"), :user}
+      ])
+
+    assert {:ok, 1, 1} = finalize(batch)
+
+    assert_receive {:pushed, by_log}
+
+    for {_log_id, transaction} <- by_log do
+      mutations = transaction |> Transaction.mutations!() |> Enum.to_list()
+      refute Enum.any?(mutations, fn mutation -> match?({:set, ^bad_key, _}, mutation) end)
+    end
+  end
+
+  test "boundary matrix: the legal write range depends on the commit mode" do
+    eok = Bedrock.end_of_keyspace()
+    boundary = Bedrock.end_of_user_keyspace()
+
+    cases = [
+      # {mode, mutations, expected_error_or_ok}
+      {:user, [{:set, "user/ok", "v"}], :ok},
+      {:user, [{:atomic, :add, "user/counter", <<1::64-little>>}], :ok},
+      {:user, [{:clear_range, "a", boundary}], :ok},
+      {:user, [{:set, <<0xFE, 0xFF, 0xFF, 0xFF>>, "v"}], :ok},
+      {:user, [{:set, boundary, "v"}], {:key_out_of_range, boundary}},
+      {:user, [{:clear, <<0xFF, 0x00>>}], {:key_out_of_range, <<0xFF, 0x00>>}},
+      {:user, [{:clear_range, "a", <<0xFF, 0x00>>}], {:key_out_of_range, <<0xFF, 0x00>>}},
+      {:user, [{:clear_range, boundary, boundary <> <<1>>}], {:key_out_of_range, boundary}},
+      {:user, [{:set, "fine", "v"}, {:set, eok, "v"}], {:key_out_of_range, eok}},
+      {:system, [{:set, <<0xFF, "/system/ok">>, "v"}], :ok},
+      {:system, [{:clear_range, "a", eok}], :ok},
+      {:system, [{:set, <<0xFF, 0xFE, 0xFF, 0xFF>>, "v"}], :ok},
+      {:system, [{:set, eok, "v"}], {:key_out_of_range, eok}},
+      {:system, [{:clear, eok <> <<1>>}], {:key_out_of_range, eok <> <<1>>}},
+      {:system, [{:clear_range, eok, eok <> <<1>>}], {:key_out_of_range, eok}},
+      {:system, [{:clear_range, "a", eok <> <<1>>}], {:key_out_of_range, eok <> <<1>>}},
+      {:system, [{:atomic, :add, eok <> <<1>>, <<1::64-little>>}], {:key_out_of_range, eok <> <<1>>}},
+      {:system, [{:atomic, :add, <<0xFF, "/system/n">>, <<1::64-little>>}, {:set, "a", "v"}], :ok}
+    ]
+
+    for {{mode, mutations, expected}, n} <- Enum.with_index(cases) do
+      name = :"case_#{n}"
+      batch = batch_of([{reply_to_self(name), encode(mutations, "ck#{n}"), mode}])
+
+      case expected do
+        :ok ->
+          assert {:ok, 0, 1} = finalize(batch), "case #{n} should commit"
+          assert_receive {^name, {:ok, _version, _index}}
+
+        error ->
+          assert {:ok, 1, 0} = finalize(batch), "case #{n} should reject"
+          assert_receive {^name, {:error, ^error}}
+      end
+    end
+  end
+
+  test "a batch of only rejected transactions still completes" do
+    bad_key = Bedrock.end_of_keyspace()
+
+    batch = batch_of([{reply_to_self(:bad_tx), encode([{:set, bad_key, "v"}], "a"), :system}])
+
+    assert {:ok, 1, 0} = finalize(batch)
+    assert_receive {:bad_tx, {:error, {:key_out_of_range, ^bad_key}}}
+  end
+end

--- a/test/bedrock/data_plane/commit_proxy/finalization/metadata_test.exs
+++ b/test/bedrock/data_plane/commit_proxy/finalization/metadata_test.exs
@@ -48,8 +48,8 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization.MetadataTest do
     buffer =
       transactions
       |> Enum.with_index()
-      |> Enum.map(fn {{reply_fn, tx_binary, task}, index} ->
-        {index, reply_fn, tx_binary, task}
+      |> Enum.map(fn {{reply_fn, tx_binary, commit_mode}, index} ->
+        {index, reply_fn, tx_binary, commit_mode}
       end)
 
     %Batch{
@@ -92,11 +92,10 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization.MetadataTest do
       tx_map = create_transaction_with_metadata("key1", "value1", "meta_key", "meta_value")
       tx_binary = Transaction.encode(tx_map)
       reply_fn = create_reply_fn(self(), :reply)
-      task = Task.async(fn -> %{:test_resolver => tx_binary} end)
 
       batch =
         create_batch_with_transactions(100, 99, [
-          {reply_fn, tx_binary, task}
+          {reply_fn, tx_binary, :system}
         ])
 
       # Mock resolver that captures metadata_per_tx
@@ -138,11 +137,10 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization.MetadataTest do
       tx_map = create_transaction_without_metadata("key1", "value1")
       tx_binary = Transaction.encode(tx_map)
       reply_fn = create_reply_fn(self(), :reply)
-      task = Task.async(fn -> %{:test_resolver => tx_binary} end)
 
       batch =
         create_batch_with_transactions(100, 99, [
-          {reply_fn, tx_binary, task}
+          {reply_fn, tx_binary, :system}
         ])
 
       mock_resolver_fn = fn _resolver, _epoch, _last_version, _commit_version, _summaries, metadata_per_tx, _opts ->
@@ -182,11 +180,10 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization.MetadataTest do
       tx_map = create_transaction_without_metadata("key1", "value1")
       tx_binary = Transaction.encode(tx_map)
       reply_fn = create_reply_fn(self(), :reply)
-      task = Task.async(fn -> %{:test_resolver => tx_binary} end)
 
       batch =
         create_batch_with_transactions(100, 99, [
-          {reply_fn, tx_binary, task}
+          {reply_fn, tx_binary, :system}
         ])
 
       # Mock resolver returns a metadata window (entries stored in plan.metadata_updates)
@@ -222,11 +219,10 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization.MetadataTest do
       tx_map = create_transaction_without_metadata("key1", "value1")
       tx_binary = Transaction.encode(tx_map)
       reply_fn = create_reply_fn(self(), :reply)
-      task = Task.async(fn -> %{:test_resolver => tx_binary} end)
 
       batch =
         create_batch_with_transactions(100, 99, [
-          {reply_fn, tx_binary, task}
+          {reply_fn, tx_binary, :system}
         ])
 
       mock_resolver_fn = fn _resolver, _epoch, _last_version, _commit_version, _summaries, _metadata_per_tx, _opts ->
@@ -255,11 +251,10 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization.MetadataTest do
       tx_map = create_transaction_without_metadata("key1", "value1")
       tx_binary = Transaction.encode(tx_map)
       reply_fn = create_reply_fn(self(), :reply)
-      task = Task.async(fn -> %{:test_resolver => tx_binary} end)
 
       batch =
         create_batch_with_transactions(100, 99, [
-          {reply_fn, tx_binary, task}
+          {reply_fn, tx_binary, :system}
         ])
 
       # Resolver returns no metadata updates
@@ -302,25 +297,22 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization.MetadataTest do
       tx1_map = create_transaction_with_metadata("key1", "value1", "meta1", "meta_val1")
       tx1_binary = Transaction.encode(tx1_map)
       reply_fn1 = create_reply_fn(self(), :reply1)
-      task1 = Task.async(fn -> %{:test_resolver => tx1_binary} end)
 
       # Transaction 2: no metadata
       tx2_map = create_transaction_without_metadata("key2", "value2")
       tx2_binary = Transaction.encode(tx2_map)
       reply_fn2 = create_reply_fn(self(), :reply2)
-      task2 = Task.async(fn -> %{:test_resolver => tx2_binary} end)
 
       # Transaction 3: has metadata
       tx3_map = create_transaction_with_metadata("key3", "value3", "meta3", "meta_val3")
       tx3_binary = Transaction.encode(tx3_map)
       reply_fn3 = create_reply_fn(self(), :reply3)
-      task3 = Task.async(fn -> %{:test_resolver => tx3_binary} end)
 
       batch =
         create_batch_with_transactions(100, 99, [
-          {reply_fn1, tx1_binary, task1},
-          {reply_fn2, tx2_binary, task2},
-          {reply_fn3, tx3_binary, task3}
+          {reply_fn1, tx1_binary, :system},
+          {reply_fn2, tx2_binary, :system},
+          {reply_fn3, tx3_binary, :system}
         ])
 
       mock_resolver_fn = fn _resolver, _epoch, _last_version, _commit_version, _summaries, metadata_per_tx, _opts ->
@@ -426,11 +418,10 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization.MetadataTest do
 
       tx_binary = Transaction.encode(tx_map)
       reply_fn = create_reply_fn(self(), :reply)
-      task = Task.async(fn -> %{:test_resolver => tx_binary} end)
 
       batch =
         create_batch_with_transactions(100, 99, [
-          {reply_fn, tx_binary, task}
+          {reply_fn, tx_binary, :system}
         ])
 
       mock_resolver_fn = fn _resolver, _epoch, _last_version, _commit_version, _summaries, metadata_per_tx, _opts ->

--- a/test/bedrock/data_plane/commit_proxy/finalization/resolver_retry_test.exs
+++ b/test/bedrock/data_plane/commit_proxy/finalization/resolver_retry_test.exs
@@ -42,8 +42,8 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization.ResolverRetryTest do
     buffer =
       transactions
       |> Enum.with_index()
-      |> Enum.map(fn {{reply_fn, tx_binary, task}, index} ->
-        {index, reply_fn, tx_binary, task}
+      |> Enum.map(fn {{reply_fn, tx_binary, commit_mode}, index} ->
+        {index, reply_fn, tx_binary, commit_mode}
       end)
 
     %Batch{
@@ -481,13 +481,11 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization.ResolverRetryTest do
 
       reply_fn1 = create_reply_fn(self(), :reply1)
       reply_fn2 = create_reply_fn(self(), :reply2)
-      task1 = Task.async(fn -> %{:test_resolver => tx1_binary} end)
-      task2 = Task.async(fn -> %{:test_resolver => tx2_binary} end)
 
       batch =
         create_batch_with_transactions(100, 99, [
-          {reply_fn1, tx1_binary, task1},
-          {reply_fn2, tx2_binary, task2}
+          {reply_fn1, tx1_binary, :system},
+          {reply_fn2, tx2_binary, :system}
         ])
 
       assert {:ok, 0, 2} =

--- a/test/bedrock/data_plane/commit_proxy/finalization/sharded_resolution_and_edge_cases_test.exs
+++ b/test/bedrock/data_plane/commit_proxy/finalization/sharded_resolution_and_edge_cases_test.exs
@@ -36,7 +36,9 @@ defmodule Bedrock.DataPlane.CommitProxy.FinalizationShardedResolutionAndEdgeCase
     buffer =
       transactions
       |> Enum.with_index()
-      |> Enum.map(fn {{reply_fn, binary}, idx} -> {idx, reply_fn, binary, nil} end)
+      # System mode: these batches write \xFF metadata keys, which user-mode
+      # commits are rejected for during pipeline validation.
+      |> Enum.map(fn {{reply_fn, binary}, idx} -> {idx, reply_fn, binary, :system} end)
 
     %Batch{
       commit_version: @commit_version,
@@ -299,10 +301,11 @@ defmodule Bedrock.DataPlane.CommitProxy.FinalizationShardedResolutionAndEdgeCase
   end
 
   describe "keys outside shard coverage" do
-    test "clear_range entirely beyond shard coverage fails the batch with a coverage error and aborts the client" do
-      # Default shard layout covers ["", <<0xFF, 0xFF>>); this range starts at
-      # the exclusive upper bound, so no shard covers it. Regression: this used
-      # to crash the finalization task with ArgumentError from :ets.prev.
+    test "an out-of-bounds clear_range is rejected per-transaction, not fatal to the batch" do
+      # A range starting at the end of the keyspace is out of the commit's
+      # legal write range: pipeline validation rejects just this transaction
+      # with its specific error. (This used to fail the whole batch - and
+      # before that, crash the finalization task.)
       hostile_tx =
         Transaction.encode(%{
           mutations: [{:clear_range, <<0xFF, 0xFF>>, <<0xFF, 0xFF, 0>>}],
@@ -316,8 +319,30 @@ defmodule Bedrock.DataPlane.CommitProxy.FinalizationShardedResolutionAndEdgeCase
 
       opts = base_opts(single_layout(), routing_data(), resolver_fn: resolver_fn)
 
-      assert {:error, {:storage_team_coverage_error, {<<0xFF, 0xFF>>, <<0xFF, 0xFF, 0>>}}} =
-               Finalization.finalize_batch(batch, opts)
+      assert {:ok, 1, 0} = Finalization.finalize_batch(batch, opts)
+
+      assert_receive {:tx0, {:error, {:key_out_of_range, <<0xFF, 0xFF>>}}}
+    end
+
+    test "an in-bounds clear_range no shard covers fails the batch with a coverage error" do
+      # The shard map covers only ["", "m"): the range ["x", "z") is legal to
+      # write but no shard owns it - a map/keyspace divergence the batch must
+      # not paper over.
+      hostile_tx =
+        Transaction.encode(%{
+          mutations: [{:clear_range, "x", "z"}],
+          write_conflicts: [{"x", "z"}],
+          read_conflicts: nil
+        })
+
+      batch = batch_with([{reply_fn(self(), :tx0), hostile_tx}])
+
+      resolver_fn = fn _ref, _epoch, _last, _commit, _txns, _metadata, _opts -> {:ok, [], nil} end
+
+      opts =
+        base_opts(single_layout(), routing_data(%{shard_layout: %{"m" => {0, ""}}}), resolver_fn: resolver_fn)
+
+      assert {:error, {:storage_team_coverage_error, {"x", "z"}}} = Finalization.finalize_batch(batch, opts)
 
       assert_receive {:tx0, {:error, :aborted}}
     end

--- a/test/bedrock/data_plane/commit_proxy/metadata_distribution_integration_test.exs
+++ b/test/bedrock/data_plane/commit_proxy/metadata_distribution_integration_test.exs
@@ -144,6 +144,19 @@ defmodule Bedrock.DataPlane.CommitProxy.MetadataDistributionIntegrationTest do
 
   defp proxy_metadata(proxy), do: :sys.get_state(proxy).metadata
 
+  test "a user-mode commit writing a system key is rejected end-to-end while the proxy keeps serving", %{
+    proxy: proxy,
+    epoch: epoch
+  } do
+    bad_key = <<0xFF, "/system/forbidden">>
+    tx = encode_tx([{:set, bad_key, "x"}], "user_key")
+
+    assert {:error, {:key_out_of_range, ^bad_key}} = GenServer.call(proxy, {:commit, epoch, tx, :user}, 5_000)
+
+    # The rejection was per-transaction: the proxy is alive and commits still flow.
+    assert commit!(proxy, epoch, [{:set, "after_rejection", "v"}], "after_rejection")
+  end
+
   test "system-key mutation flows commit -> resolver accumulator -> parsed proxy metadata", %{
     proxy: proxy,
     resolver: resolver,

--- a/test/bedrock/data_plane/commit_proxy/server_test.exs
+++ b/test/bedrock/data_plane/commit_proxy/server_test.exs
@@ -749,6 +749,7 @@ defmodule Bedrock.DataPlane.CommitProxy.ServerTest do
       # Before recovery, commit should return :locked
       transaction = TransactionTestSupport.new_log_transaction(0, %{"key" => "value"})
       assert {:error, :locked} = GenServer.call(commit_proxy, {:commit, 1, transaction})
+      assert {:error, :locked} = GenServer.call(commit_proxy, {:commit, 1, transaction, :system})
 
       # After recovery with correct token, should transition to running
       assert :ok =
@@ -947,236 +948,6 @@ defmodule Bedrock.DataPlane.CommitProxy.ServerTest do
     end
   end
 
-  describe "keyspace bounds validation at ingress" do
-    # The sequencer here is a bare atom: any transaction that survives
-    # validation would crash the proxy on version assignment, so a clean
-    # {:error, {:key_out_of_range, _}} reply with the proxy still alive
-    # proves rejection happens before the batch is ever started.
-    setup do
-      lock_token = "bounds_test_token"
-      resolver_layout = %ResolverLayout.Single{resolver_ref: :test_resolver}
-
-      opts = [
-        cluster: TestCluster,
-        director: self(),
-        epoch: 1,
-        instance: 0,
-        max_latency_in_ms: 50,
-        max_per_batch: 5,
-        empty_transaction_timeout_ms: 60_000,
-        lock_token: lock_token,
-        sequencer: :fake_sequencer,
-        resolver_layout: resolver_layout
-      ]
-
-      commit_proxy = start_supervised!(Server.child_spec(opts))
-
-      :ok =
-        GenServer.call(
-          commit_proxy,
-          {:recover_from, lock_token, :fake_sequencer, resolver_layout, empty_routing_snapshot()}
-        )
-
-      {:ok, commit_proxy: commit_proxy}
-    end
-
-    defp encode_mutations(mutations) do
-      Transaction.encode(%{
-        mutations: mutations,
-        read_conflicts: [],
-        write_conflicts: [{"k", "k" <> <<0>>}]
-      })
-    end
-
-    # Rewrites the MUTATIONS section with a garbage-opcode payload under a
-    # valid CRC: the section opens cleanly and the lazy decode raises
-    # mid-stream — the failure mode ingress validation must contain.
-    defp corrupt_mutation_payload(<<header::binary-size(8), sections::binary>>),
-      do: header <> corrupt_mutations_section(sections)
-
-    defp corrupt_mutations_section(
-           <<0x01, size::unsigned-big-24, _crc::unsigned-big-32, _payload::binary-size(size), rest::binary>>
-         ) do
-      payload = :binary.copy(<<0xEE>>, max(size, 1))
-      crc = :erlang.crc32(<<0x01, byte_size(payload)::unsigned-big-24, payload::binary>>)
-      <<0x01, byte_size(payload)::unsigned-big-24, crc::unsigned-big-32, payload::binary>> <> rest
-    end
-
-    defp corrupt_mutations_section(
-           <<tag, size::unsigned-big-24, crc::unsigned-big-32, payload::binary-size(size), rest::binary>>
-         ) do
-      <<tag, size::unsigned-big-24, crc::unsigned-big-32, payload::binary>> <> corrupt_mutations_section(rest)
-    end
-
-    test "rejects a set at the end of the keyspace without touching the sequencer", %{commit_proxy: proxy} do
-      eok = Bedrock.end_of_keyspace()
-      tx = encode_mutations([{:set, eok, "v"}])
-
-      assert {:error, {:key_out_of_range, ^eok}} = GenServer.call(proxy, {:commit, 1, tx})
-      assert Process.alive?(proxy)
-    end
-
-    test "rejects a set beyond the end of the keyspace", %{commit_proxy: proxy} do
-      key = Bedrock.end_of_keyspace() <> <<0x01>>
-      tx = encode_mutations([{:set, key, "v"}])
-
-      assert {:error, {:key_out_of_range, ^key}} = GenServer.call(proxy, {:commit, 1, tx})
-    end
-
-    test "rejects a clear at or beyond the end of the keyspace", %{commit_proxy: proxy} do
-      key = Bedrock.end_of_keyspace()
-      tx = encode_mutations([{:clear, key}])
-
-      assert {:error, {:key_out_of_range, ^key}} = GenServer.call(proxy, {:commit, 1, tx})
-    end
-
-    test "rejects a clear_range starting at the end of the keyspace", %{commit_proxy: proxy} do
-      eok = Bedrock.end_of_keyspace()
-      tx = encode_mutations([{:clear_range, eok, eok <> <<0x01>>}])
-
-      assert {:error, {:key_out_of_range, ^eok}} = GenServer.call(proxy, {:commit, 1, tx})
-    end
-
-    test "rejects a clear_range ending beyond the end of the keyspace", %{commit_proxy: proxy} do
-      bad_end = Bedrock.end_of_keyspace() <> <<0x01>>
-      tx = encode_mutations([{:clear_range, "a", bad_end}])
-
-      assert {:error, {:key_out_of_range, ^bad_end}} = GenServer.call(proxy, {:commit, 1, tx})
-    end
-
-    test "rejects when any single mutation in the transaction is out of range", %{commit_proxy: proxy} do
-      key = Bedrock.end_of_keyspace()
-      tx = encode_mutations([{:set, "fine", "v"}, {:set, key, "v"}])
-
-      assert {:error, {:key_out_of_range, ^key}} = GenServer.call(proxy, {:commit, 1, tx})
-    end
-
-    test "rejects an atomic op keyed past the end of the keyspace", %{commit_proxy: proxy} do
-      key = Bedrock.end_of_keyspace() <> <<0x01>>
-      tx = encode_mutations([{:atomic, :add, key, <<1::64-little>>}])
-
-      assert {:error, {:key_out_of_range, ^key}} = GenServer.call(proxy, {:commit, 1, tx})
-    end
-
-    test "accepts a long user key that sorts below the system boundary", %{commit_proxy: proxy} do
-      # <<0xFE, 0xFF, ...>> is longer than the boundary but sorts below it;
-      # it must reach version assignment (killing the proxy at the atom
-      # sequencer), not be rejected at ingress.
-      ref = Process.monitor(proxy)
-      tx = encode_mutations([{:set, <<0xFE, 0xFF, 0xFF, 0xFF>>, "v"}])
-
-      assert {:error, :abort} = GenServer.call(proxy, {:commit, 1, tx})
-      assert_receive {:DOWN, ^ref, :process, _, {:sequencer_unavailable, _}}
-    end
-
-    test "accepts a long system key that sorts below the end of the keyspace", %{commit_proxy: proxy} do
-      # Same length-vs-order check at the system bound: <<0xFF, 0xFE, ...>>
-      # sorts below <<0xFF, 0xFF>> despite being longer.
-      ref = Process.monitor(proxy)
-      tx = encode_mutations([{:set, <<0xFF, 0xFE, 0xFF, 0xFF>>, "v"}])
-
-      assert {:error, :abort} = GenServer.call(proxy, {:commit, 1, tx, :system})
-      assert_receive {:DOWN, ^ref, :process, _, {:sequencer_unavailable, _}}
-    end
-
-    test "rejects a transaction whose mutation payload is corrupt without crashing", %{commit_proxy: proxy} do
-      # A valid mutation-section header over a garbage payload: the lazy
-      # decode raises mid-stream. Ingress must catch it and reject just this
-      # transaction; the proxy stays alive.
-      valid = encode_mutations([{:set, "k", "v"}])
-      corrupt = corrupt_mutation_payload(valid)
-
-      assert {:error, :invalid_transaction} = GenServer.call(proxy, {:commit, 1, corrupt})
-      assert Process.alive?(proxy)
-    end
-
-    test "in-range user mutations pass validation and reach version assignment", %{commit_proxy: proxy} do
-      # Keys below the system boundary and a clear_range ending exactly AT
-      # the boundary (exclusive end) are legal for user commits. The proxy
-      # must die at VERSION ASSIGNMENT (the atom sequencer) - proving these
-      # passed validation - not anywhere inside the validation pass.
-      ref = Process.monitor(proxy)
-
-      tx =
-        encode_mutations([
-          {:set, "user/ok", "v"},
-          {:atomic, :add, "user/counter", <<1::64-little>>},
-          {:clear_range, "a", Bedrock.end_of_user_keyspace()}
-        ])
-
-      assert {:error, :abort} = GenServer.call(proxy, {:commit, 1, tx})
-      assert_receive {:DOWN, ^ref, :process, _, {:sequencer_unavailable, _}}
-    end
-
-    test "rejects a user commit that writes a system key", %{commit_proxy: proxy} do
-      key = <<0xFF, "/system/shard_keys/x">>
-      tx = encode_mutations([{:set, key, "v"}])
-
-      assert {:error, {:key_out_of_range, ^key}} = GenServer.call(proxy, {:commit, 1, tx})
-      assert Process.alive?(proxy)
-    end
-
-    test "rejects a user clear that targets the reserved range below the system prefix", %{commit_proxy: proxy} do
-      # The whole range at and above <<0xFF>> is reserved, not just \xff/system.
-      key = <<0xFF, 0x00>>
-      tx = encode_mutations([{:clear, key}])
-
-      assert {:error, {:key_out_of_range, ^key}} = GenServer.call(proxy, {:commit, 1, tx})
-    end
-
-    test "rejects a user clear_range that crosses into system space", %{commit_proxy: proxy} do
-      bad_end = <<0xFF, 0x00>>
-      tx = encode_mutations([{:clear_range, "a", bad_end}])
-
-      assert {:error, {:key_out_of_range, ^bad_end}} = GenServer.call(proxy, {:commit, 1, tx})
-    end
-
-    test "rejects a user clear_range starting at the system boundary", %{commit_proxy: proxy} do
-      boundary = Bedrock.end_of_user_keyspace()
-      tx = encode_mutations([{:clear_range, boundary, boundary <> <<0x01>>}])
-
-      assert {:error, {:key_out_of_range, ^boundary}} = GenServer.call(proxy, {:commit, 1, tx})
-    end
-
-    test "system-mode commits may write system keys", %{commit_proxy: proxy} do
-      # A system commit's legal range extends to the end of the keyspace: the
-      # set on a system key and the clear_range ending AT the end of the
-      # keyspace must both reach version assignment.
-      ref = Process.monitor(proxy)
-
-      tx =
-        encode_mutations([
-          {:set, <<0xFF, "/system/ok">>, "v"},
-          {:clear_range, "a", Bedrock.end_of_keyspace()}
-        ])
-
-      assert {:error, :abort} = GenServer.call(proxy, {:commit, 1, tx, :system})
-      assert_receive {:DOWN, ^ref, :process, _, {:sequencer_unavailable, _}}
-    end
-
-    test "system mode is still bounded by the end of the keyspace", %{commit_proxy: proxy} do
-      eok = Bedrock.end_of_keyspace()
-      tx = encode_mutations([{:set, eok, "v"}])
-
-      assert {:error, {:key_out_of_range, ^eok}} = GenServer.call(proxy, {:commit, 1, tx, :system})
-      assert Process.alive?(proxy)
-    end
-
-    test "rejects atomics on system keys even in system mode", %{commit_proxy: proxy} do
-      key = <<0xFF, "/system/counter">>
-      tx = encode_mutations([{:atomic, :add, key, <<1::64-little>>}])
-
-      assert {:error, {:atomic_on_system_key, ^key}} = GenServer.call(proxy, {:commit, 1, tx, :system})
-      assert Process.alive?(proxy)
-    end
-
-    test "system-mode commits respect epoch and lock checks", %{commit_proxy: proxy} do
-      tx = encode_mutations([{:set, <<0xFF, "/system/ok">>, "v"}])
-
-      assert {:error, :wrong_epoch} = GenServer.call(proxy, {:commit, 99, tx, :system})
-    end
-  end
-
   describe "epoch validation" do
     test "rejects commit with wrong epoch" do
       director = self()
@@ -1207,6 +978,10 @@ defmodule Bedrock.DataPlane.CommitProxy.ServerTest do
       transaction = TransactionTestSupport.new_log_transaction(0, %{"k" => "v"})
       assert {:error, :wrong_epoch} = GenServer.call(commit_proxy, {:commit, 41, transaction})
       assert {:error, :wrong_epoch} = GenServer.call(commit_proxy, {:commit, 43, transaction})
+
+      # System-mode commits pass the same epoch gate - pipeline validation
+      # never sees a transaction the accept guards refused.
+      assert {:error, :wrong_epoch} = GenServer.call(commit_proxy, {:commit, 41, transaction, :system})
     end
   end
 

--- a/test/bedrock/internal/repo_transact_test.exs
+++ b/test/bedrock/internal/repo_transact_test.exs
@@ -284,30 +284,6 @@ defmodule Bedrock.Internal.RepoTransactTest do
       assert TransactionContext.builder(TestRepo) == nil
     end
 
-    test "surfaces atomic_on_system_key immediately instead of retrying" do
-      # Same permanent-rejection contract as key_out_of_range: an atomic op
-      # aimed at a system key is deterministic, so retrying cannot succeed.
-      key = <<0xFF, "/system/counter">>
-      proxy = start_supervised!({RejectingProxy, {:atomic_on_system_key, key}})
-      attempts = :counters.new(1, [])
-
-      result =
-        Repo.transact(
-          NoCluster,
-          TestRepo,
-          fn ->
-            :counters.add(attempts, 1, 1)
-            Repo.put(TestRepo, "key", "value")
-          end,
-          transaction_system_layout: %{epoch: 1, proxies: [proxy]},
-          retry_limit: 3
-        )
-
-      assert result == {:error, {:atomic_on_system_key, key}}
-      assert :counters.get(attempts, 1) == 1
-      assert TransactionContext.builder(TestRepo) == nil
-    end
-
     test "raises after exhausting the retry limit when commit keeps failing" do
       # A put makes the transaction non-empty; with no commit proxies in the
       # layout, commit fails with :unavailable, a retryable failure.

--- a/test/support/data_plane/finalization_test_support.ex
+++ b/test/support/data_plane/finalization_test_support.ex
@@ -196,11 +196,6 @@ defmodule Bedrock.Test.DataPlane.FinalizationTestSupport do
     %{<<0xFF, 0xFF>> => {0, <<>>}}
   end
 
-  # Helper function to create test resolver task
-  defp create_test_resolver_task(binary) do
-    Task.async(fn -> %{:test_resolver => binary} end)
-  end
-
   @doc """
   Creates a test batch with given parameters.
   """
@@ -225,11 +220,8 @@ defmodule Bedrock.Test.DataPlane.FinalizationTestSupport do
 
     default_binary = Transaction.encode(default_transaction_map)
 
-    # Create a simple task that returns single resolver map (for tests)
-    default_task = create_test_resolver_task(default_binary)
-
     default_transactions = [
-      {0, fn result -> send(self(), {:reply, result}) end, default_binary, default_task}
+      {0, fn result -> send(self(), {:reply, result}) end, default_binary, :user}
     ]
 
     buffer = if Enum.empty?(transactions), do: default_transactions, else: transactions
@@ -237,17 +229,18 @@ defmodule Bedrock.Test.DataPlane.FinalizationTestSupport do
     # Ensure buffer contains indexed transactions
     indexed_buffer =
       case buffer do
-        # If buffer already has indexed format {index, reply_fn, binary, task}, use as-is
-        [{_idx, _reply_fn, _binary, _task} | _] ->
+        # If buffer already has indexed format {index, reply_fn, binary, commit_mode}, use as-is
+        [{_idx, _reply_fn, _binary, _commit_mode} | _] ->
           buffer
 
-        # If buffer has old format {reply_fn, binary}, add indices and tasks
+        # If buffer has {reply_fn, binary} or {reply_fn, binary, mode} entries,
+        # add indices (mode defaults to :user)
         _ ->
           buffer
           |> Enum.with_index()
-          |> Enum.map(fn {{reply_fn, binary}, idx} ->
-            task = create_test_resolver_task(binary)
-            {idx, reply_fn, binary, task}
+          |> Enum.map(fn
+            {{reply_fn, binary}, idx} -> {idx, reply_fn, binary, :user}
+            {{reply_fn, binary, mode}, idx} -> {idx, reply_fn, binary, mode}
           end)
       end
 


### PR DESCRIPTION
## Why

The keyspace/corruption scan ran inside the commit proxy's GenServer accept loop — a full decode of every mutation of every commit on the proxy's one serialized resource, with finalization decoding everything again in the parallel task. The review flagged it as the only place the branch spends computation twice on the serial path.

## What

Validation moves into the finalization pipeline as a per-transaction stage that runs before conflict resolution. An invalid transaction gets its specific error through its own reply — `{:key_out_of_range, key}` or `:invalid_transaction` — while the rest of the batch proceeds. The commit mode now rides each batch entry (repurposing the always-`nil` task slot), so user and system commits mix freely in one batch, each validated against its own bound. What stays at accept: only the byte-free guards (epoch, lock, mode atom, binary-ness).

The former atomics-on-system-keys ban is **dropped for FDB parity**: atomics never enter the metadata stream in either system — `metadata_mutation?/1` admits only sets and clears, exactly FDB's `isMetadataMutation` — so no metadata view can diverge from one. The ban guarded a hazard the structure already precludes, and would have forbidden the legitimate FDB pattern of atomics on non-metadata system keys (backup/DR-style bookkeeping in `\xff\x02`).

## How

This is FDB's own shape: `validateAndProcessTenantAccess` does per-transaction `sendError` inside `postResolution` and the batch continues — FDB's accept-time checks are reserved for byte-pure request properties, versioned-state checks live in the pipeline. One deliberate improvement over FDB: a rejected transaction is replaced with an empty transaction *before* resolution, so its conflict ranges never enter resolver history (FDB lets tenant-failed ranges in, a false-conflict source it simply accepts). The FDB source audit also confirmed what proxy-side bounds enforcement guards against — FDB leaves it to client honesty, where a dishonest client's out-of-range write is silently dropped by every storage server and an out-of-range conflict range crashes the proxy on an assert.

Accepted cost, FDB-sanctioned: a rejected transaction's batch still consumes its (shared) commit version. Behavior upgrade: an out-of-bounds `clear_range` now rejects one transaction instead of failing the whole batch.

Ticket: bedrock-q67.28. Stacked on #162.