### PR TITLE
Resolvers replay retried batches instead of fabricating verdicts

### DIFF
--- a/lib/bedrock/data_plane/resolver/server.ex
+++ b/lib/bedrock/data_plane/resolver/server.ex
@@ -177,20 +177,30 @@ defmodule Bedrock.DataPlane.Resolver.Server do
 
   @impl true
   def handle_call(
-        {:resolve_transactions, epoch, {last_version, _next_version}, transactions, _metadata, metadata_ack,
+        {:resolve_transactions, epoch, {last_version, next_version}, _transactions, _metadata, metadata_ack,
          {_hold?, confirms}},
         _from,
         t
       )
       when t.mode == :running and epoch == t.epoch and is_binary(last_version) and last_version < t.last_version do
-    # All transactions aborted due to stale version - return a differential
-    # metadata window for the proxy. This is a retry of an already-processed
-    # batch, so any hold was recorded then (re-holding a confirmed version
-    # would wedge it) - but its confirms may be new; apply them (idempotent).
-    {t, confirmed_any?} = apply_metadata_confirms(t, confirms)
-    {metadata_window, t} = get_metadata_window_for_proxy(t, metadata_ack, confirmed_any?)
-    aborted_indices = Enum.to_list(0..(length(transactions) - 1)//1)
-    reply(t, {:ok, aborted_indices, metadata_window})
+    # A retry of an already-processed batch (its reply was lost): REPLAY the
+    # recorded verdict - recomputing or fabricating one could tell clients
+    # "aborted" for transactions the system committed. Any hold was recorded
+    # on first processing (re-holding a confirmed version would wedge it),
+    # but the retry's confirms may be new; apply them (idempotent). The
+    # metadata window is recomputed - it is differential by the caller's ack,
+    # so recomputation is the correct, idempotent choice. A verdict pruned
+    # past the retention horizon (or never recorded) has no truthful answer:
+    # fail explicitly and let the proxy fail fast into recovery.
+    case Map.fetch(t.recent_replies, next_version) do
+      {:ok, aborted_indices} ->
+        {t, confirmed_any?} = apply_metadata_confirms(t, confirms)
+        {metadata_window, t} = get_metadata_window_for_proxy(t, metadata_ack, confirmed_any?)
+        reply(t, {:ok, aborted_indices, metadata_window})
+
+      :error ->
+        reply(t, {:error, :version_beyond_retention})
+    end
   end
 
   @impl true
@@ -221,7 +231,14 @@ defmodule Bedrock.DataPlane.Resolver.Server do
     emit_processing(transactions, next_version)
 
     {conflicts, aborted} = resolve(t.conflicts, transactions, next_version)
-    t = %{t | conflicts: conflicts, last_version: next_version}
+
+    t = %{
+      t
+      | conflicts: conflicts,
+        last_version: next_version,
+        recent_replies: Map.put(t.recent_replies, next_version, aborted)
+    }
+
     emit_completed(transactions, aborted, next_version)
 
     # Fold in confirmed deferred metadata, then either hold this batch
@@ -269,8 +286,16 @@ defmodule Bedrock.DataPlane.Resolver.Server do
 
       updated_state =
         if current_version_int >= retention_microseconds do
-          new_conflicts = remove_old_transactions(t.conflicts, Version.subtract(t.last_version, retention_microseconds))
-          %{t | conflicts: new_conflicts, last_sweep_time: Time.monotonic_now_in_ms()}
+          floor = Version.subtract(t.last_version, retention_microseconds)
+          new_conflicts = remove_old_transactions(t.conflicts, floor)
+          recent_replies = Map.reject(t.recent_replies, fn {version, _aborted} -> version < floor end)
+
+          %{
+            t
+            | conflicts: new_conflicts,
+              recent_replies: recent_replies,
+              last_sweep_time: Time.monotonic_now_in_ms()
+          }
         else
           %{t | last_sweep_time: Time.monotonic_now_in_ms()}
         end

--- a/lib/bedrock/data_plane/resolver/state.ex
+++ b/lib/bedrock/data_plane/resolver/state.ex
@@ -52,7 +52,8 @@ defmodule Bedrock.DataPlane.Resolver.State do
           },
           metadata_window: MetadataAccumulator.t(),
           metadata_pruned_through: Bedrock.version() | nil,
-          held_metadata_versions: MapSet.t(Bedrock.version())
+          held_metadata_versions: MapSet.t(Bedrock.version()),
+          recent_replies: %{Bedrock.version() => [non_neg_integer()]}
         }
   defstruct conflicts: nil,
             last_version: nil,
@@ -67,5 +68,11 @@ defmodule Bedrock.DataPlane.Resolver.State do
             proxy_progress: %{},
             metadata_window: nil,
             metadata_pruned_through: nil,
-            held_metadata_versions: MapSet.new()
+            held_metadata_versions: MapSet.new(),
+            # Abort sets of processed batches, keyed by their commit version
+            # and pruned with the conflict retention horizon: a retried batch
+            # (lost reply) REPLAYS its original verdict - FDB's
+            # outstandingBatches. Windows are recomputed per ack, so only the
+            # verdict needs caching.
+            recent_replies: %{}
 end

--- a/test/bedrock/data_plane/resolver/retry_replay_test.exs
+++ b/test/bedrock/data_plane/resolver/retry_replay_test.exs
@@ -1,0 +1,117 @@
+defmodule Bedrock.DataPlane.Resolver.RetryReplayTest do
+  @moduledoc """
+  Pins the resolver's reply replay for retried batches (bedrock-q67.22
+  prerequisite).
+
+  A commit proxy retries a resolve call when the reply is lost (timeout,
+  network). The batch was already processed - conflict history advanced,
+  verdicts recorded - so the retry must REPLAY the original abort set, never
+  recompute or fabricate one. FDB keeps `outstandingBatches` for exactly
+  this; Bedrock caches the abort set per processed version, pruned with the
+  same retention horizon as conflict history, and recomputes only the
+  metadata window (which is differential by the caller's ack, so recomputing
+  is the correct, idempotent choice).
+
+  A retry below the retention floor - or for a version this resolver never
+  processed - has no truthful answer, so it fails explicitly instead of
+  fabricating an all-aborted reply that would tell clients "aborted" for
+  transactions the system may have committed.
+  """
+  use ExUnit.Case, async: true
+
+  alias Bedrock.DataPlane.Resolver
+  alias Bedrock.DataPlane.Resolver.Server, as: ResolverServer
+  alias Bedrock.DataPlane.Transaction
+  alias Bedrock.DataPlane.Version
+
+  defp v(n), do: Version.from_integer(n)
+
+  defp start_resolver(opts \\ []) do
+    start_supervised!(
+      {ResolverServer,
+       [
+         lock_token: :crypto.strong_rand_bytes(32),
+         key_range: {"", <<0xFF, 0xFF>>},
+         epoch: 1,
+         last_version: Version.zero(),
+         director: self(),
+         cluster: __MODULE__
+       ] ++ opts}
+    )
+  end
+
+  defp write_tx(key) do
+    Transaction.encode(%{
+      mutations: [{:set, key, "v"}],
+      read_conflicts: [],
+      write_conflicts: [{key, key <> <<0>>}]
+    })
+  end
+
+  defp read_tx(key, read_version) do
+    Transaction.encode(%{
+      mutations: [{:set, "other", "v"}],
+      read_conflicts: {read_version, [{key, key <> <<0>>}]},
+      write_conflicts: [{"other", "other" <> <<0>>}]
+    })
+  end
+
+  defp resolve(resolver, last_v, next_v, transactions) do
+    parent = self()
+
+    spawn_link(fn ->
+      result =
+        Resolver.resolve_transactions(resolver, 1, last_v, next_v, transactions, [[], []], metadata_ack: {parent, nil})
+
+      send(parent, {:resolved, result})
+    end)
+
+    assert_receive {:resolved, result}, 1_000
+    result
+  end
+
+  test "a retried batch replays the original abort set, not abort-all" do
+    resolver = start_resolver()
+
+    # v1 writes "k"; the v2 batch holds one clean write and one transaction
+    # that read "k" at v0 - the read is stale, so exactly index 1 aborts.
+    assert {:ok, [], _window} = resolve(resolver, v(0), v(1), [write_tx("k")])
+    assert {:ok, [1], _window} = resolve(resolver, v(1), v(2), [write_tx("a"), read_tx("k", v(0))])
+
+    # The reply was lost; the proxy retries the identical batch. The original
+    # verdict must come back - not "all aborted".
+    assert {:ok, [1], _window} = resolve(resolver, v(1), v(2), [write_tx("a"), read_tx("k", v(0))])
+  end
+
+  test "a replayed reply is stable across repeated retries" do
+    resolver = start_resolver()
+
+    assert {:ok, [], _} = resolve(resolver, v(0), v(1), [write_tx("k")])
+    assert {:ok, [], _} = resolve(resolver, v(1), v(2), [write_tx("b")])
+
+    assert {:ok, [], _} = resolve(resolver, v(0), v(1), [write_tx("k")])
+    assert {:ok, [], _} = resolve(resolver, v(0), v(1), [write_tx("k")])
+  end
+
+  test "a retry for a version this resolver never processed fails explicitly" do
+    resolver = start_resolver()
+
+    assert {:ok, [], _} = resolve(resolver, v(0), v(10), [write_tx("k")])
+
+    # (v3, v7) is below last_version but was never a processed batch here: a
+    # truthful replay is impossible, so no verdict may be invented.
+    assert {:error, :version_beyond_retention} = resolve(resolver, v(3), v(7), [write_tx("x")])
+  end
+
+  test "replies below the retention floor are pruned and retries fail explicitly" do
+    # 1ms retention = 1000 versions; sweep on every call.
+    resolver = start_resolver(version_retention_ms: 1, sweep_interval_ms: 0)
+
+    assert {:ok, [], _} = resolve(resolver, v(0), v(1), [write_tx("k")])
+
+    # Advance far past the horizon so the sweep drops the cached reply.
+    assert {:ok, [], _} = resolve(resolver, v(1), v(2_000_000), [write_tx("z")])
+
+    assert {:error, :version_beyond_retention} = resolve(resolver, v(0), v(1), [write_tx("k")])
+  end
+end


### PR DESCRIPTION
## Why

When a commit proxy retried a resolve call whose reply was lost, the resolver answered with a fabricated all-aborted verdict. Clients could hear "aborted" for transactions the system committed — bounded today only by the log chain stalling the un-pushed version into recovery, and fatal to any design where resolver windows carry verdicts (the next PR): the windows would say "committed" while the client heard "aborted."

## What

Each processed batch's abort set is cached by commit version (`recent_replies`), pruned with the same retention sweep that bounds conflict history. A retry replays the recorded verdict; only the metadata window is recomputed, which is the correct, idempotent choice because windows are differential by the caller's ack. A retry below the retention floor — or for a version this resolver never processed — has no truthful answer, so it fails explicitly with `:version_beyond_retention` and the proxy fails fast into recovery.

## How

This is FDB's `outstandingBatches`: cached replies keyed by version, replayed verbatim for duplicate requests, pruned by a proxy-progress watermark. Bedrock caches only the abort set rather than the full reply because its windows are pull-differential rather than FDB's exact push — recomputing them against the caller's current ack is not just safe but more correct than replaying a stale one.

Ticket: bedrock-q67.22 (prerequisite). Stacked on #163.