### PR TITLE
Converged verdicts replace the hold/confirm metadata protocol

### DIFF
--- a/lib/bedrock/data_plane/commit_proxy/finalization.ex
+++ b/lib/bedrock/data_plane/commit_proxy/finalization.ex
@@ -43,16 +43,12 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization do
   @type metadata_mutations :: [Bedrock.Internal.TransactionBuilder.Tx.mutation()]
 
   @typedoc """
-  Applies a batch's resolver metadata window - plus, in sharded mode, the
-  batch's own globally-committed metadata (`{committed}`) - to the commit
-  proxy's routing state, serialized in commit-version order, and returns the
-  routing snapshot the batch must push with. `nil` deferred means the window
-  already carries the batch's own metadata (single-resolver mode).
+  Applies a batch's committed metadata window to the commit proxy's routing
+  state, serialized in commit-version order, and returns the routing snapshot
+  the batch must push with. The window's entries are plain
+  `{version, [mutation]}` - verdicts have already been resolved.
   """
-  @type metadata_apply_fn() :: (commit_version :: Bedrock.version(),
-                                Resolver.metadata_window(),
-                                {committed :: metadata_mutations()}
-                                | nil ->
+  @type metadata_apply_fn() :: (commit_version :: Bedrock.version(), Resolver.metadata_window() ->
                                   {:ok, RoutingData.t()} | {:error, term()})
 
   @type resolver_fn() :: (Resolver.ref(),
@@ -196,11 +192,10 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization do
   batch-sequence order, and returns the immutable routing snapshot the batch
   pushes with.
 
-  With SHARDED resolvers accumulation is deferred: no resolver knows the merged global
-  abort set at resolution time, so metadata-carrying batch versions are held
-  (`metadata_hold`); the batch's globally-committed metadata rides the apply
-  call, and the server re-sends it as `metadata_confirms` on subsequent calls
-  until resolver windows confirm it was folded in (see
+  With SHARDED resolvers no resolver knows the merged global abort set - and
+  none needs to: every resolver receives every transaction's metadata and
+  records it with its LOCAL verdict; the window merge ANDs the verdicts
+  positionally into the exact global verdict (see
   `Bedrock.DataPlane.Resolver`).
 
   ## Parameters
@@ -228,7 +223,6 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization do
             resolver_fn: resolver_fn(),
             metadata_ack: Resolver.metadata_ack(),
             metadata_apply_fn: metadata_apply_fn(),
-            metadata_confirms: [{Bedrock.version(), metadata_mutations()}],
             batch_log_push_fn: log_push_batch_fn(),
             abort_reply_fn: abort_reply_fn(),
             success_reply_fn: success_reply_fn(),
@@ -406,7 +400,7 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization do
            opts
          ) do
       {:ok, _aborted, metadata_window} ->
-        plan = apply_committed_metadata(plan, metadata_window, nil, opts)
+        plan = apply_committed_metadata(plan, metadata_window, opts)
         split_and_notify_aborts_with_set(plan, MapSet.new(), opts)
 
       {:error, reason} ->
@@ -443,7 +437,7 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization do
          ) do
       {:ok, aborted, metadata_window} ->
         aborted_set = MapSet.new(aborted)
-        plan = apply_committed_metadata(plan, metadata_window, nil, opts)
+        plan = apply_committed_metadata(plan, metadata_window, opts)
         split_and_notify_aborts_with_set(plan, aborted_set, opts)
 
       {:error, reason} ->
@@ -453,17 +447,16 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization do
 
   # Sharded multi-resolver path
   #
-  # Each resolver only sees its own shard's conflicts, so no resolver can know
-  # the GLOBAL abort set at resolution time - metadata accumulation is
-  # deferred (bedrock-q67.17). No metadata_per_tx is sent; instead the call
-  # carries `metadata_hold: true` when this batch has metadata (each resolver
-  # marks the version as held, capping its windows below it) plus
-  # `metadata_confirms` - committed metadata from earlier batches, filtered by
-  # the merged global abort set, which the proxy re-sends on every call until
-  # the resolvers' windows confirm it was folded in. The batch's own committed
-  # metadata rides the `metadata_apply_fn` call: the server records it for
-  # confirmation on subsequent calls and folds it into the routing snapshot
-  # this batch pushes with (same-batch visibility, as in single-resolver mode).
+  # Each resolver only sees its own shard's conflict ranges, so no resolver
+  # can know the GLOBAL abort set - and none needs to. Every resolver
+  # receives every transaction's metadata mutations and records them with
+  # its LOCAL verdict; the merge below ANDs the verdicts positionally across
+  # all resolvers' windows. A conflict anywhere vetoes; a resolver holding
+  # none of a transaction's ranges contributes a trivially-true verdict - so
+  # the AND is exactly the global verdict (FDB's stateMutations relay /
+  # applyMetadataEffect). Windows cover through this batch's own version, so
+  # the batch's own committed metadata arrives inside the merged window, the
+  # same as single-resolver mode.
   def resolve_conflicts(
         %FinalizationPlan{stage: :ready_for_resolution} = plan,
         epoch,
@@ -499,11 +492,9 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization do
         {txn_map, metadata_list}
       end
 
-    has_metadata? = Enum.any?(metadata_per_tx, &(&1 != []))
-    opts = Keyword.put(opts, :metadata_hold, has_metadata?)
-
     case call_all_resolvers_with_map(
            resolver_transaction_map,
+           metadata_per_tx,
            epoch,
            plan.last_commit_version,
            plan.commit_version,
@@ -511,26 +502,13 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization do
            opts
          ) do
       {:ok, aborted_set, metadata_window} ->
-        deferred = deferred_metadata(metadata_per_tx, aborted_set, has_metadata?)
-        plan = apply_committed_metadata(plan, metadata_window, deferred, opts)
+        plan = apply_committed_metadata(plan, metadata_window, opts)
         split_and_notify_aborts_with_set(plan, aborted_set, opts)
 
       {:error, reason} ->
         %{plan | error: reason, stage: :failed}
     end
   end
-
-  # Filters this batch's metadata by the merged GLOBAL abort set. The result
-  # rides the apply call to the proxy server, which records it for re-sending
-  # as a confirmation on subsequent resolver calls - even when empty, so
-  # resolvers release the hold. Single-resolver callers pass nil: their
-  # batch's metadata arrives inside the window itself.
-  @spec deferred_metadata([metadata_mutations()], MapSet.t(non_neg_integer()), boolean()) ::
-          {committed :: metadata_mutations()} | nil
-  defp deferred_metadata(_metadata_per_tx, _aborted_set, false), do: nil
-
-  defp deferred_metadata(metadata_per_tx, aborted_set, true),
-    do: {MetadataAccumulator.committed_mutations(metadata_per_tx, aborted_set)}
 
   # The commit proxy server applies committed metadata one batch at a time in
   # commit-version order and returns the routing snapshot this batch pushes
@@ -539,15 +517,18 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization do
   # batches route from their own immutable snapshots and cannot observe each
   # other mid-application. This is FDB's postResolution ordering: apply
   # metadata, then assign mutations to logs, one batch at a time.
-  @spec apply_committed_metadata(
-          FinalizationPlan.t(),
-          Resolver.metadata_window(),
-          {committed :: metadata_mutations()} | nil,
-          keyword()
-        ) :: FinalizationPlan.t()
-  defp apply_committed_metadata(plan, metadata_window, deferred, opts) do
+  #
+  # The window arrives verdict-carrying (each entry holds {mutations,
+  # local_verdict} pairs, already ANDed across resolvers in sharded mode);
+  # committed_window/1 keeps only unanimously-committed mutations so the
+  # server sees the plain {version, [mutation]} shape.
+  @spec apply_committed_metadata(FinalizationPlan.t(), Resolver.metadata_window(), keyword()) ::
+          FinalizationPlan.t()
+  defp apply_committed_metadata(plan, metadata_window, opts) do
+    committed = committed_window(metadata_window)
+
     entries =
-      case metadata_window do
+      case committed do
         nil -> []
         {_from, _to, entries} -> entries
       end
@@ -556,7 +537,7 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization do
 
     metadata_apply_fn = Keyword.fetch!(opts, :metadata_apply_fn)
 
-    case metadata_apply_fn.(plan.commit_version, metadata_window, deferred) do
+    case metadata_apply_fn.(plan.commit_version, committed) do
       {:ok, %RoutingData{} = routing_data} ->
         %{plan | stage: :conflicts_resolved, metadata_updates: entries, routing_data: routing_data}
 
@@ -565,17 +546,50 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization do
     end
   end
 
-  # Sharded calls carry no metadata_per_tx (accumulation is deferred; see
-  # resolve_conflicts above), so resolvers are called with [].
+  # Drops vetoed transactions from a verdict-carrying window and flattens the
+  # survivors, yielding plain {version, [mutation]} entries. Entries whose
+  # transactions were all vetoed disappear; the window bounds are unchanged
+  # (the ack advances on coverage, not content).
+  @spec committed_window(Resolver.metadata_window()) ::
+          {Bedrock.version() | nil, Bedrock.version(), [{Bedrock.version(), metadata_mutations()}]} | nil
+  defp committed_window(nil), do: nil
+
+  defp committed_window({from, to, entries}) do
+    committed =
+      entries
+      |> Enum.map(fn {version, transaction_metadata} ->
+        mutations =
+          transaction_metadata
+          |> Enum.filter(fn {_mutations, committed?} -> committed? end)
+          |> Enum.flat_map(fn {mutations, true} -> mutations end)
+
+        {version, mutations}
+      end)
+      |> Enum.reject(fn {_version, mutations} -> mutations == [] end)
+
+    {from, to, committed}
+  end
+
+  # Every resolver receives the full metadata_per_tx so each can record
+  # verdict-carrying entries (see resolve_conflicts above).
   @spec call_all_resolvers_with_map(
           %{Resolver.ref() => [Transaction.encoded()]},
+          [metadata_mutations()],
           Bedrock.epoch(),
           Bedrock.version(),
           Bedrock.version(),
           [{start_key :: Bedrock.key(), Resolver.ref()}],
           keyword()
         ) :: {:ok, MapSet.t(non_neg_integer()), Resolver.metadata_window()} | {:error, term()}
-  defp call_all_resolvers_with_map(resolver_transaction_map, epoch, last_version, commit_version, resolvers, opts) do
+  defp call_all_resolvers_with_map(
+         resolver_transaction_map,
+         metadata_per_tx,
+         epoch,
+         last_version,
+         commit_version,
+         resolvers,
+         opts
+       ) do
     async_stream_fn = Keyword.get(opts, :async_stream_fn, &Task.async_stream/3)
     timeout = Keyword.get(opts, :timeout, 5_000)
 
@@ -584,7 +598,7 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization do
       fn {_start_key, ref} ->
         # Every resolver must have transactions after task processing
         filtered_transactions = Map.fetch!(resolver_transaction_map, ref)
-        call_resolver_with_retry(ref, epoch, last_version, commit_version, filtered_transactions, [], opts)
+        call_resolver_with_retry(ref, epoch, last_version, commit_version, filtered_transactions, metadata_per_tx, opts)
       end,
       timeout: timeout
     )
@@ -600,18 +614,16 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization do
     end)
   end
 
-  # Sharded resolvers each maintain independent (largely duplicate) metadata
-  # accumulators, so their windows are merged conservatively: the WEAKEST
-  # coverage claims on both ends - max from_version (a gap at any resolver is
-  # still detected) and MIN to_version (the ack derived from the merged window
-  # must not exceed what every resolver has actually served; their settled
-  # floors can differ transiently under deferred confirmation). Entries at the
-  # same version are identical by construction (one entry per batch version,
-  # broadcast to all resolvers), so they are deduplicated by version, and
-  # entries beyond the merged to_version are truncated - they will be
-  # re-served once every resolver has settled past them. A resolver returns
-  # nil only when its settled floor has reached its last_version, so nil
-  # replies never mask a lower settled floor here.
+  # Sharded resolvers each maintain independent metadata accumulators whose
+  # entries carry LOCAL verdicts, so merging is where the global verdict is
+  # born: coverage claims are the WEAKEST of both windows - max from_version
+  # (a gap at any resolver is still detected) and min to_version - and
+  # entries at the same version are combined by ANDing verdicts positionally
+  # (every resolver recorded the same transactions in the same order from
+  # the same broadcast metadata_per_tx; a length mismatch means the windows
+  # diverged and the batch must fail rather than guess). Entries present in
+  # only one window lie at or below the other's from (already applied at the
+  # proxy and filtered there) - their solo verdicts are moot.
   @spec merge_metadata_windows(Resolver.metadata_window(), Resolver.metadata_window()) :: Resolver.metadata_window()
   defp merge_metadata_windows(nil, window), do: window
   defp merge_metadata_windows(window, nil), do: window
@@ -622,11 +634,25 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization do
 
     entries =
       (entries_a ++ entries_b)
+      |> Enum.group_by(&elem(&1, 0), &elem(&1, 1))
       |> Enum.sort_by(&elem(&1, 0))
-      |> Enum.dedup_by(&elem(&1, 0))
+      |> Enum.map(fn {version, metadata_lists} -> {version, and_verdicts(version, metadata_lists)} end)
       |> Enum.take_while(fn {version, _} -> version <= to end)
 
     {from, to, entries}
+  end
+
+  defp and_verdicts(_version, [transaction_metadata]), do: transaction_metadata
+
+  defp and_verdicts(version, [first | _rest] = metadata_lists) do
+    if !Enum.all?(metadata_lists, &(length(&1) == length(first))) do
+      raise "resolver metadata windows diverged at version #{inspect(version)}"
+    end
+
+    Enum.zip_with(metadata_lists, fn pairs ->
+      {mutations, _} = hd(pairs)
+      {mutations, Enum.all?(pairs, fn {_mutations, committed?} -> committed? end)}
+    end)
   end
 
   @spec call_resolver_with_retry(
@@ -658,18 +684,11 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization do
     # to a timeout is simply re-sent by the resolver - no window is ever skipped.
     metadata_ack = Keyword.get(opts, :metadata_ack, {self(), nil})
 
-    # Deferred-metadata directives (sharded mode; see resolve_conflicts).
-    # Retried calls re-carry them: holds and confirms are idempotent.
-    metadata_hold = Keyword.get(opts, :metadata_hold, false)
-    metadata_confirms = Keyword.get(opts, :metadata_confirms, [])
-
     timeout_in_ms = timeout_fn.(attempts_used)
 
     case resolver_fn.(ref, epoch, last_version, commit_version, filtered_transactions, metadata_per_tx,
            timeout: timeout_in_ms,
-           metadata_ack: metadata_ack,
-           metadata_hold: metadata_hold,
-           metadata_confirms: metadata_confirms
+           metadata_ack: metadata_ack
          ) do
       {:ok, _, _} = success ->
         success

--- a/lib/bedrock/data_plane/commit_proxy/server.ex
+++ b/lib/bedrock/data_plane/commit_proxy/server.ex
@@ -145,7 +145,7 @@ defmodule Bedrock.DataPlane.CommitProxy.Server do
           {:recover_from, binary(), pid(), ResolverLayout.t(), RoutingData.snapshot()}
           | {:commit, Bedrock.epoch(), Bedrock.transaction()}
           | {:commit, Bedrock.epoch(), Bedrock.transaction(), :user | :system}
-          | {:apply_metadata_and_route, pos_integer(), Bedrock.version(), term(), term()},
+          | {:apply_metadata_and_route, pos_integer(), Bedrock.version(), term()},
           GenServer.from(),
           State.t()
         ) ::
@@ -193,22 +193,22 @@ defmodule Bedrock.DataPlane.CommitProxy.Server do
   # took the intervening version. The snapshot handed back is immutable, so
   # the log push itself proceeds in parallel with later batches' applies.
   def handle_call(
-        {:apply_metadata_and_route, seq, commit_version, window, deferred},
+        {:apply_metadata_and_route, seq, commit_version, window},
         from,
         %{mode: :running, routed_seq: prev_seq} = t
       )
       when seq == prev_seq + 1 do
-    t = apply_and_route(t, seq, commit_version, window, deferred)
+    t = apply_and_route(t, seq, commit_version, window)
     GenServer.reply(from, {:ok, t.routing_data})
     noreply_resuming_cadence(drain_pending_applies(t))
   end
 
-  def handle_call({:apply_metadata_and_route, seq, commit_version, window, deferred}, from, %{mode: :running} = t) do
-    pending = Map.put(t.pending_applies, seq, {from, commit_version, window, deferred})
+  def handle_call({:apply_metadata_and_route, seq, commit_version, window}, from, %{mode: :running} = t) do
+    pending = Map.put(t.pending_applies, seq, {from, commit_version, window})
     noreply_resuming_cadence(%{t | pending_applies: pending})
   end
 
-  def handle_call({:apply_metadata_and_route, _seq, _cv, _window, _deferred}, _from, %{mode: :locked} = t),
+  def handle_call({:apply_metadata_and_route, _seq, _cv, _window}, _from, %{mode: :locked} = t),
     do: reply(t, {:error, :locked})
 
   defp accept_commit(transaction, commit_mode, from, t) do
@@ -298,8 +298,7 @@ defmodule Bedrock.DataPlane.CommitProxy.Server do
       epoch: epoch,
       sequencer: sequencer,
       resolver_layout: resolver_layout,
-      metadata: %{version: applied_metadata_version},
-      deferred_metadata: deferred_metadata
+      metadata: %{version: applied_metadata_version}
     } = state
 
     Task.start_link(fn ->
@@ -313,18 +312,11 @@ defmodule Bedrock.DataPlane.CommitProxy.Server do
              # the metadata version this proxy has confirmed applying - the
              # resolver keys its progress and differential windows off this.
              metadata_ack: {server_pid, applied_metadata_version},
-             # Deferred-metadata confirmations for sharded resolvers: committed
-             # metadata from earlier batches, re-sent until acked via windows.
-             metadata_confirms: deferred_metadata,
              # Serialized apply-and-route: the server folds this batch's
              # committed metadata into its state in commit-version order and
              # returns the immutable routing snapshot the batch pushes with.
-             metadata_apply_fn: fn commit_version, window, deferred ->
-               GenServer.call(
-                 server_pid,
-                 {:apply_metadata_and_route, seq, commit_version, window, deferred},
-                 :infinity
-               )
+             metadata_apply_fn: fn commit_version, window ->
+               GenServer.call(server_pid, {:apply_metadata_and_route, seq, commit_version, window}, :infinity)
              end
            ) do
         {:ok, _n_aborts, _n_oks} ->
@@ -338,16 +330,12 @@ defmodule Bedrock.DataPlane.CommitProxy.Server do
     %{state | batch_seq: seq}
   end
 
-  # Applies one batch's committed metadata - its resolver window plus, in
-  # sharded mode, its own globally-committed metadata - and advances the
-  # chain. Windows fold into structured metadata AND routing in one step;
-  # deferred metadata folds into routing only (the ack must not advance past
-  # what the resolvers' windows have confirmed) and is recorded for
-  # re-sending as confirmations until a window covers it.
-  defp apply_and_route(t, seq, commit_version, window, deferred) do
+  # Applies one batch's committed metadata window - which covers through the
+  # batch's own version, its own committed metadata included - into
+  # structured metadata AND routing in one step, and advances the chain.
+  defp apply_and_route(t, seq, _commit_version, window) do
     t
     |> apply_metadata_window(window)
-    |> apply_deferred_metadata(commit_version, deferred)
     |> Map.put(:routed_seq, seq)
   end
 
@@ -356,22 +344,10 @@ defmodule Bedrock.DataPlane.CommitProxy.Server do
       {nil, _pending} ->
         t
 
-      {{from, commit_version, window, deferred}, pending} ->
-        t = apply_and_route(%{t | pending_applies: pending}, t.routed_seq + 1, commit_version, window, deferred)
+      {{from, commit_version, window}, pending} ->
+        t = apply_and_route(%{t | pending_applies: pending}, t.routed_seq + 1, commit_version, window)
         GenServer.reply(from, {:ok, t.routing_data})
         drain_pending_applies(t)
-    end
-  end
-
-  defp apply_deferred_metadata(t, _commit_version, nil), do: t
-
-  defp apply_deferred_metadata(t, commit_version, {committed}) do
-    t = add_deferred_metadata(t, commit_version, committed)
-
-    if committed == [] do
-      t
-    else
-      %{t | routing_data: RoutingData.apply_mutations(t.routing_data, [{commit_version, committed}])}
     end
   end
 
@@ -416,18 +392,7 @@ defmodule Bedrock.DataPlane.CommitProxy.Server do
     # windows keep this monotone.
     version = if metadata.version == nil or to_version > metadata.version, do: to_version, else: metadata.version
 
-    # A window covering a deferred version proves every resolver folded that
-    # confirmation in (in sharded mode the merged to_version is the MINIMUM
-    # settled version across resolvers) - stop re-sending it.
-    deferred_metadata = Enum.drop_while(t.deferred_metadata, fn {v, _mutations} -> v <= version end)
-
-    %{t | metadata: %{metadata | version: version}, routing_data: routing_data, deferred_metadata: deferred_metadata}
-  end
-
-  @spec add_deferred_metadata(State.t(), Bedrock.version(), [term()]) :: State.t()
-  defp add_deferred_metadata(t, version, mutations) do
-    {earlier, later} = Enum.split_while(t.deferred_metadata, fn {v, _} -> v < version end)
-    %{t | deferred_metadata: earlier ++ [{version, mutations} | later]}
+    %{t | metadata: %{metadata | version: version}, routing_data: routing_data}
   end
 
   @spec reply_fn(GenServer.from()) :: Batch.reply_fn()

--- a/lib/bedrock/data_plane/commit_proxy/state.ex
+++ b/lib/bedrock/data_plane/commit_proxy/state.ex
@@ -22,10 +22,9 @@ defmodule Bedrock.DataPlane.CommitProxy.State do
           lock_token: binary(),
           routing_data: RoutingData.t() | nil,
           metadata: Metadata.t(),
-          deferred_metadata: [{Bedrock.version(), [term()]}],
           batch_seq: non_neg_integer(),
           routed_seq: non_neg_integer(),
-          pending_applies: %{pos_integer() => {GenServer.from(), Bedrock.version(), term(), term()}}
+          pending_applies: %{pos_integer() => {GenServer.from(), Bedrock.version(), term()}}
         }
   defstruct cluster: nil,
             director: nil,
@@ -40,10 +39,6 @@ defmodule Bedrock.DataPlane.CommitProxy.State do
             lock_token: nil,
             routing_data: nil,
             metadata: %Metadata{},
-            # Committed metadata from sharded batches (version-ascending),
-            # re-sent as confirmations on every resolver call until the
-            # resolvers' windows show it was folded in (ack >= version).
-            deferred_metadata: [],
             # Proxy-local batch sequence, assigned when a batch's finalization
             # is spawned (batches are created and spawned one at a time in the
             # server, so sequence order IS commit-version order). Apply

--- a/lib/bedrock/data_plane/resolver.ex
+++ b/lib/bedrock/data_plane/resolver.ex
@@ -24,21 +24,21 @@ defmodule Bedrock.DataPlane.Resolver do
   next call and concurrent in-flight windows overlap (out-of-order arrival at
   the proxy is lossless).
 
-  ## Deferred Metadata (sharded resolvers)
+  ## Converged verdicts (sharded resolvers)
 
-  With sharded resolvers each resolver only sees its own shard's conflicts,
-  so a locally-committed transaction can still be aborted globally (by
-  another shard's resolver). Metadata accumulation is therefore DEFERRED in
-  sharded mode: the proxy sends no `metadata_per_tx`, instead passing
-  `metadata_hold: true` when the batch carries metadata (the resolver marks
-  the batch version as held) and `metadata_confirms` - `{version, mutations}`
-  pairs for earlier held batches, already filtered by the proxy's merged
-  GLOBAL abort set - which the resolver folds into its window at the original
-  commit versions. Windows never extend past the oldest still-held version,
-  so no proxy can ack past metadata that has yet to be confirmed - version
-  order is preserved even when confirmations arrive out of order. Held
-  versions a proxy never confirms (it died mid-batch) expire with the version
-  retention horizon.
+  With sharded resolvers each resolver only sees its own shard's conflict
+  ranges, so a locally-committed transaction can still be aborted globally
+  (by another shard's resolver). Metadata therefore travels with its LOCAL
+  verdict: every resolver receives every batch's `metadata_per_tx`, records
+  each metadata-carrying transaction's mutations together with its own
+  verdict, and window entries carry `{mutations, committed?}` pairs. The
+  proxy ANDs the verdicts positionally across all resolvers' windows - a
+  conflict anywhere vetoes; a resolver holding none of a transaction's
+  ranges contributes a trivially-true verdict - so the AND is exactly the
+  global verdict, and no resolver ever needs to know it. This is
+  FoundationDB's stateMutations relay (each resolver records local
+  `committed`; the consuming proxy ANDs across resolvers in
+  applyMetadataEffect).
   """
 
   alias Bedrock.DataPlane.Resolver.MetadataAccumulator
@@ -66,15 +66,6 @@ defmodule Bedrock.DataPlane.Resolver do
            entries :: [MetadataAccumulator.entry()]}
           | nil
 
-  @typedoc """
-  Deferred-metadata directives for sharded mode: whether this batch's
-  metadata must be held pending global-abort confirmation, plus confirmations
-  (globally-filtered committed mutations at their original commit versions)
-  for earlier held batches.
-  """
-  @type metadata_directives ::
-          {hold? :: boolean(), confirms :: [{Bedrock.version(), metadata_mutations()}]}
-
   @spec resolve_transactions(
           ref(),
           epoch :: Bedrock.epoch(),
@@ -84,9 +75,7 @@ defmodule Bedrock.DataPlane.Resolver do
           metadata_per_tx :: [metadata_mutations()],
           opts :: [
             timeout: Bedrock.timeout_in_ms(),
-            metadata_ack: metadata_ack(),
-            metadata_hold: boolean(),
-            metadata_confirms: [{Bedrock.version(), metadata_mutations()}]
+            metadata_ack: metadata_ack()
           ]
         ) ::
           {:ok, aborted :: [transaction_index :: non_neg_integer()], metadata_window()}
@@ -95,7 +84,6 @@ defmodule Bedrock.DataPlane.Resolver do
   def resolve_transactions(ref, epoch, last_version, commit_version, transaction_summaries, metadata_per_tx, opts \\ []) do
     timeout = opts[:timeout] || :infinity
     metadata_ack = opts[:metadata_ack] || {self(), nil}
-    metadata_directives = {opts[:metadata_hold] || false, opts[:metadata_confirms] || []}
 
     :telemetry.span(
       [:bedrock, :data_plane, :resolver, :call, :resolve_transactions],
@@ -111,7 +99,7 @@ defmodule Bedrock.DataPlane.Resolver do
         ref
         |> GenServer.call(
           {:resolve_transactions, epoch, {last_version, commit_version}, transaction_summaries, metadata_per_tx,
-           metadata_ack, metadata_directives},
+           metadata_ack},
           timeout
         )
         |> case do

--- a/lib/bedrock/data_plane/resolver/metadata_accumulator.ex
+++ b/lib/bedrock/data_plane/resolver/metadata_accumulator.ex
@@ -11,7 +11,14 @@ defmodule Bedrock.DataPlane.Resolver.MetadataAccumulator do
 
   @type mutation :: Bedrock.Internal.TransactionBuilder.Tx.mutation()
 
-  @type entry :: {version :: Bedrock.version(), mutations :: [mutation()]}
+  @typedoc """
+  One metadata-carrying transaction's mutations with this resolver's LOCAL
+  verdict. The commit proxy ANDs verdicts positionally across all resolvers'
+  windows to obtain the global verdict.
+  """
+  @type transaction_metadata :: {mutations :: [mutation()], committed? :: boolean()}
+
+  @type entry :: {version :: Bedrock.version(), [transaction_metadata()]}
 
   @type t :: %__MODULE__{
           reversed_entries: [entry()]
@@ -35,79 +42,30 @@ defmodule Bedrock.DataPlane.Resolver.MetadataAccumulator do
 
   ## Examples
 
-      iex> acc = new() |> append(v(1), [{:set, <<0xFF, "a">>, "1"}])
+      iex> acc = new() |> append(v(1), [{[{:set, <<0xFF, "a">>, "1"}], true}])
       iex> entries(acc)
-      [{<<0, 0, 0, 0, 0, 0, 0, 1>>, [{:set, <<0xFF, "a">>, "1"}]}]
+      [{<<0, 0, 0, 0, 0, 0, 0, 1>>, [{[{:set, <<0xFF, "a">>, "1"}], true}]}]
   """
   @spec entries(t()) :: [entry()]
   def entries(%__MODULE__{reversed_entries: reversed}), do: Enum.reverse(reversed)
 
   @doc """
-  Appends mutations at a given version to the accumulator.
+  Appends a version's transaction metadata (with local verdicts) to the
+  accumulator.
 
-  Mutations are stored in version order. If mutations is empty, this is a no-op.
-
-  ## Parameters
-    - `accumulator` - The accumulator to append to
-    - `version` - The commit version for these mutations
-    - `mutations` - List of metadata mutations to append
+  Entries are stored in version order. If the list is empty, this is a no-op.
 
   ## Examples
 
-      iex> acc = new() |> append(v(1), [{:set, <<0xFF, "key">>, "value"}])
+      iex> acc = new() |> append(v(1), [{[{:set, <<0xFF, "key">>, "value"}], true}])
       iex> length(entries(acc))
       1
   """
-  @spec append(t(), Bedrock.version(), [mutation()]) :: t()
+  @spec append(t(), Bedrock.version(), [transaction_metadata()]) :: t()
   def append(accumulator, _version, []), do: accumulator
 
-  def append(%__MODULE__{reversed_entries: reversed} = accumulator, version, mutations) do
-    %{accumulator | reversed_entries: [{version, mutations} | reversed]}
-  end
-
-  @doc """
-  Flattens per-transaction metadata mutations, keeping only transactions that
-  survived the abort set (indices are batch positions), in transaction order.
-
-  Shared by immediate accumulation (resolver, local abort set) and deferred
-  confirmation (commit proxy, merged global abort set) so both sides agree on
-  which mutations a batch committed.
-
-  ## Examples
-
-      iex> committed_mutations([[{:set, <<0xFF, "a">>, "1"}], [{:set, <<0xFF, "b">>, "2"}]], MapSet.new([1]))
-      [{:set, <<0xFF, "a">>, "1"}]
-  """
-  @spec committed_mutations([[mutation()]], MapSet.t(non_neg_integer())) :: [mutation()]
-  def committed_mutations(metadata_per_tx, aborted_set) do
-    metadata_per_tx
-    |> Enum.with_index()
-    |> Enum.reject(fn {_mutations, idx} -> MapSet.member?(aborted_set, idx) end)
-    |> Enum.flat_map(fn {mutations, _idx} -> mutations end)
-  end
-
-  @doc """
-  Inserts mutations at a given version, maintaining version order even when
-  the version is older than existing entries.
-
-  Used for deferred (confirmed-later) metadata in sharded-resolver mode, where
-  confirmations for different versions can arrive out of order. If mutations
-  is empty, this is a no-op.
-
-  ## Examples
-
-      iex> acc = new()
-      iex>   |> append(v(2), [{:set, <<0xFF, "b">>, "2"}])
-      iex>   |> insert_sorted(v(1), [{:set, <<0xFF, "a">>, "1"}])
-      iex> Enum.map(entries(acc), &elem(&1, 0))
-      [<<0, 0, 0, 0, 0, 0, 0, 1>>, <<0, 0, 0, 0, 0, 0, 0, 2>>]
-  """
-  @spec insert_sorted(t(), Bedrock.version(), [mutation()]) :: t()
-  def insert_sorted(accumulator, _version, []), do: accumulator
-
-  def insert_sorted(%__MODULE__{reversed_entries: reversed} = accumulator, version, mutations) do
-    {newer, older} = Enum.split_while(reversed, fn {v, _} -> v > version end)
-    %{accumulator | reversed_entries: newer ++ [{version, mutations} | older]}
+  def append(%__MODULE__{reversed_entries: reversed} = accumulator, version, transaction_metadata) do
+    %{accumulator | reversed_entries: [{version, transaction_metadata} | reversed]}
   end
 
   @doc """
@@ -123,10 +81,10 @@ defmodule Bedrock.DataPlane.Resolver.MetadataAccumulator do
   ## Examples
 
       iex> acc = new()
-      iex>   |> append(v(1), [{:set, <<0xFF, "a">>, "1"}])
-      iex>   |> append(v(2), [{:set, <<0xFF, "b">>, "2"}])
+      iex>   |> append(v(1), [{[{:set, <<0xFF, "a">>, "1"}], true}])
+      iex>   |> append(v(2), [{[{:set, <<0xFF, "b">>, "2"}], true}])
       iex> mutations_since(acc, v(1))
-      [{<<0, 0, 0, 0, 0, 0, 0, 2>>, [{:set, <<0xFF, "b">>, "2"}]}]
+      [{<<0, 0, 0, 0, 0, 0, 0, 2>>, [{[{:set, <<0xFF, "b">>, "2"}], true}]}]
   """
   @spec mutations_since(t(), Bedrock.version() | nil) :: [entry()]
   def mutations_since(%__MODULE__{reversed_entries: reversed}, nil), do: Enum.reverse(reversed)
@@ -159,8 +117,8 @@ defmodule Bedrock.DataPlane.Resolver.MetadataAccumulator do
   ## Examples
 
       iex> acc = new()
-      iex>   |> append(v(1), [{:set, <<0xFF, "a">>, "1"}])
-      iex>   |> append(v(2), [{:set, <<0xFF, "b">>, "2"}])
+      iex>   |> append(v(1), [{[{:set, <<0xFF, "a">>, "1"}], true}])
+      iex>   |> append(v(2), [{[{:set, <<0xFF, "b">>, "2"}], true}])
       iex>   |> prune_through(v(1))
       iex> length(entries(acc))
       1

--- a/lib/bedrock/data_plane/resolver/server.ex
+++ b/lib/bedrock/data_plane/resolver/server.ex
@@ -106,7 +106,7 @@ defmodule Bedrock.DataPlane.Resolver.Server do
 
   @impl true
   def handle_call(
-        {:resolve_transactions, epoch, {_last_version, _next_version}, _transactions, _metadata, _ack, _directives},
+        {:resolve_transactions, epoch, {_last_version, _next_version}, _transactions, _metadata, _ack},
         _from,
         t
       )
@@ -116,8 +116,7 @@ defmodule Bedrock.DataPlane.Resolver.Server do
 
   @impl true
   def handle_call(
-        {:resolve_transactions, epoch, {last_version, next_version}, transactions, metadata_per_tx, metadata_ack,
-         metadata_directives},
+        {:resolve_transactions, epoch, {last_version, next_version}, transactions, metadata_per_tx, metadata_ack},
         from,
         t
       )
@@ -129,9 +128,7 @@ defmodule Bedrock.DataPlane.Resolver.Server do
     |> case do
       :ok ->
         noreply(t,
-          continue:
-            {:process_ready,
-             {next_version, transactions, metadata_per_tx, metadata_ack, metadata_directives, reply_fn(from)}}
+          continue: {:process_ready, {next_version, transactions, metadata_per_tx, metadata_ack, reply_fn(from)}}
         )
 
       {:error, reason} ->
@@ -142,8 +139,7 @@ defmodule Bedrock.DataPlane.Resolver.Server do
 
   @impl true
   def handle_call(
-        {:resolve_transactions, epoch, {last_version, next_version}, transactions, metadata_per_tx, metadata_ack,
-         metadata_directives},
+        {:resolve_transactions, epoch, {last_version, next_version}, transactions, metadata_per_tx, metadata_ack},
         from,
         t
       )
@@ -154,7 +150,7 @@ defmodule Bedrock.DataPlane.Resolver.Server do
     |> Validation.check_transactions()
     |> case do
       :ok ->
-        data = {next_version, transactions, metadata_per_tx, metadata_ack, metadata_directives}
+        data = {next_version, transactions, metadata_per_tx, metadata_ack}
 
         {new_waiting, _timeout} =
           WaitingList.insert(
@@ -177,25 +173,21 @@ defmodule Bedrock.DataPlane.Resolver.Server do
 
   @impl true
   def handle_call(
-        {:resolve_transactions, epoch, {last_version, next_version}, _transactions, _metadata, metadata_ack,
-         {_hold?, confirms}},
+        {:resolve_transactions, epoch, {last_version, next_version}, _transactions, _metadata, metadata_ack},
         _from,
         t
       )
       when t.mode == :running and epoch == t.epoch and is_binary(last_version) and last_version < t.last_version do
     # A retry of an already-processed batch (its reply was lost): REPLAY the
     # recorded verdict - recomputing or fabricating one could tell clients
-    # "aborted" for transactions the system committed. Any hold was recorded
-    # on first processing (re-holding a confirmed version would wedge it),
-    # but the retry's confirms may be new; apply them (idempotent). The
-    # metadata window is recomputed - it is differential by the caller's ack,
-    # so recomputation is the correct, idempotent choice. A verdict pruned
-    # past the retention horizon (or never recorded) has no truthful answer:
-    # fail explicitly and let the proxy fail fast into recovery.
+    # "aborted" for transactions the system committed. The metadata window is
+    # recomputed - it is differential by the caller's ack, so recomputation
+    # is the correct, idempotent choice. A verdict pruned past the retention
+    # horizon (or never recorded) has no truthful answer: fail explicitly and
+    # let the proxy fail fast into recovery.
     case Map.fetch(t.recent_replies, next_version) do
       {:ok, aborted_indices} ->
-        {t, confirmed_any?} = apply_metadata_confirms(t, confirms)
-        {metadata_window, t} = get_metadata_window_for_proxy(t, metadata_ack, confirmed_any?)
+        {metadata_window, t} = get_metadata_window_for_proxy(t, metadata_ack)
         reply(t, {:ok, aborted_indices, metadata_window})
 
       :error ->
@@ -224,10 +216,7 @@ defmodule Bedrock.DataPlane.Resolver.Server do
   end
 
   @impl true
-  def handle_continue(
-        {:process_ready, {next_version, transactions, metadata_per_tx, metadata_ack, {hold?, confirms}, reply_fn}},
-        t
-      ) do
+  def handle_continue({:process_ready, {next_version, transactions, metadata_per_tx, metadata_ack, reply_fn}}, t) do
     emit_processing(transactions, next_version)
 
     {conflicts, aborted} = resolve(t.conflicts, transactions, next_version)
@@ -241,22 +230,13 @@ defmodule Bedrock.DataPlane.Resolver.Server do
 
     emit_completed(transactions, aborted, next_version)
 
-    # Fold in confirmed deferred metadata, then either hold this batch
-    # (sharded mode - accumulation deferred until the proxy confirms against
-    # the merged GLOBAL abort set; any metadata_per_tx is ignored so immediate
-    # and deferred accumulation can never double-apply) or accumulate
-    # immediately (single-resolver mode - the local abort set IS global).
-    {t, confirmed_any?} = apply_metadata_confirms(t, confirms)
-
-    t =
-      if hold? do
-        %{t | held_metadata_versions: MapSet.put(t.held_metadata_versions, next_version)}
-      else
-        accumulate_committed_metadata(t, next_version, metadata_per_tx, aborted)
-      end
+    # Record each metadata-carrying transaction's mutations with this
+    # resolver's LOCAL verdict; the proxy ANDs verdicts across all resolvers'
+    # windows to reach the global verdict (FDB's stateMutations relay).
+    t = accumulate_metadata_verdicts(t, next_version, metadata_per_tx, aborted)
 
     # Get the differential window for this proxy and record its confirmed progress
-    {metadata_window, t} = get_metadata_window_for_proxy(t, metadata_ack, confirmed_any?)
+    {metadata_window, t} = get_metadata_window_for_proxy(t, metadata_ack)
 
     reply_fn.({:ok, aborted, metadata_window})
     emit_reply_sent(transactions, aborted, next_version)
@@ -265,11 +245,11 @@ defmodule Bedrock.DataPlane.Resolver.Server do
       {updated_waiting, nil} ->
         noreply(%{t | waiting: updated_waiting}, continue: :next_timeout)
 
-      {updated_waiting, {_deadline, reply_fn, {waiting_next_version, transactions, metadata, ack, directives}}} ->
+      {updated_waiting, {_deadline, reply_fn, {waiting_next_version, transactions, metadata, ack}}} ->
         emit_waiting_resolved(transactions, [], waiting_next_version)
 
         noreply(%{t | waiting: updated_waiting},
-          continue: {:process_ready, {waiting_next_version, transactions, metadata, ack, directives, reply_fn}}
+          continue: {:process_ready, {waiting_next_version, transactions, metadata, ack, reply_fn}}
         )
     end
   end
@@ -316,80 +296,40 @@ defmodule Bedrock.DataPlane.Resolver.Server do
   # Metadata accumulation and distribution helpers
   # ===========================================================================
 
-  # Accumulates metadata mutations from committed (non-aborted) transactions
-  @spec accumulate_committed_metadata(State.t(), Bedrock.version(), [[tuple()]], [non_neg_integer()]) :: State.t()
-  defp accumulate_committed_metadata(t, commit_version, metadata_per_tx, aborted) do
+  # Records each metadata-carrying transaction's mutations with this
+  # resolver's LOCAL verdict, in transaction order. Verdict-false entries are
+  # recorded too: at the proxy's merge, absence must never be mistaken for a
+  # veto, so a veto is always explicit.
+  @spec accumulate_metadata_verdicts(State.t(), Bedrock.version(), [[tuple()]], [non_neg_integer()]) :: State.t()
+  defp accumulate_metadata_verdicts(t, commit_version, metadata_per_tx, aborted) do
+    aborted_set = MapSet.new(aborted)
+
     metadata_per_tx
-    |> MetadataAccumulator.committed_mutations(MapSet.new(aborted))
+    |> Enum.with_index()
+    |> Enum.filter(fn {mutations, _idx} -> mutations != [] end)
+    |> Enum.map(fn {mutations, idx} -> {mutations, not MapSet.member?(aborted_set, idx)} end)
     |> case do
       [] -> t
-      mutations -> %{t | metadata_window: MetadataAccumulator.append(t.metadata_window, commit_version, mutations)}
-    end
-  end
-
-  # Folds confirmed deferred metadata (already filtered by the proxy's merged
-  # GLOBAL abort set) into the window at the original commit versions.
-  # Confirmations for different held versions can arrive out of order, so the
-  # insert is sorted; the settled-version cap below guarantees no proxy has
-  # been served (or acked) past any still-held version, so a late insert is
-  # never behind anyone's ack. Idempotent: only still-held versions apply, so
-  # a retried call re-carrying confirms is a no-op. Returns whether any hold
-  # was released (derived from the held-set delta).
-  @spec apply_metadata_confirms(State.t(), [{Bedrock.version(), [tuple()]}]) ::
-          {State.t(), confirmed_any? :: boolean()}
-  defp apply_metadata_confirms(t, confirms) do
-    updated =
-      Enum.reduce(confirms, t, fn {version, mutations}, t ->
-        if MapSet.member?(t.held_metadata_versions, version) do
-          %{
-            t
-            | metadata_window: MetadataAccumulator.insert_sorted(t.metadata_window, version, mutations),
-              held_metadata_versions: MapSet.delete(t.held_metadata_versions, version)
-          }
-        else
-          t
-        end
-      end)
-
-    {updated, updated.held_metadata_versions != t.held_metadata_versions}
-  end
-
-  # The highest version whose metadata is fully settled: everything at or
-  # below it is either accumulated or known metadata-free. Held (deferred,
-  # unconfirmed) versions cap it - windows must never let a proxy ack past
-  # metadata that could still be confirmed later.
-  @spec settled_version(State.t()) :: Bedrock.version()
-  defp settled_version(%{held_metadata_versions: held, last_version: last_version}) do
-    case Enum.min(held, fn -> nil end) do
-      nil -> last_version
-      oldest_held -> Version.subtract(oldest_held, 1)
+      entries -> %{t | metadata_window: MetadataAccumulator.append(t.metadata_window, commit_version, entries)}
     end
   end
 
   # Builds the differential metadata window for a proxy and records its
   # confirmed progress.
   #
-  # The window covers (from, settled] where `from` is the version the proxy
-  # has CONFIRMED applying (its ack) and `settled` is last_version except when
-  # deferred metadata is still held (see settled_version/1). Progress advances
-  # only via acks, so a reply lost to a call timeout is simply re-sent on the
-  # proxy's next call, and windows to concurrently in-flight batches overlap -
-  # out-of-order arrival at the proxy is lossless (its per-entry version guard
-  # skips already-applied entries).
+  # The window covers (from, last_version] where `from` is the version the
+  # proxy has CONFIRMED applying (its ack). Progress advances only via acks,
+  # so a reply lost to a call timeout is simply re-sent on the proxy's next
+  # call, and windows to concurrently in-flight batches overlap -
+  # out-of-order arrival at the proxy is lossless (the proxy filters entries
+  # at or below its applied version).
   #
-  # If pruning (or a held-version expiry) has discarded coverage the proxy
-  # never confirmed, the window's from_version is the pruned floor - above the
-  # proxy's applied version - which the proxy detects as an unrecoverable
-  # coverage gap.
-  #
-  # A window is nil only when there is nothing to report AND settled has
-  # reached last_version: while metadata is held (or when this call released a
-  # hold), even an empty window is returned so the merged to_version at the
-  # proxy honestly reflects this resolver's settled floor and confirmed holds
-  # advance the proxy's ack (letting it stop re-sending confirmations).
-  @spec get_metadata_window_for_proxy(State.t(), Resolver.metadata_ack(), confirmed_any? :: boolean()) ::
+  # If pruning has discarded coverage the proxy never confirmed, the window's
+  # from_version is the pruned floor - above the proxy's applied version -
+  # which the proxy detects as an unrecoverable coverage gap.
+  @spec get_metadata_window_for_proxy(State.t(), Resolver.metadata_ack()) ::
           {Resolver.metadata_window(), State.t()}
-  defp get_metadata_window_for_proxy(t, {proxy_id, acked}, confirmed_any?) do
+  defp get_metadata_window_for_proxy(t, {proxy_id, acked}) do
     t =
       t
       |> record_proxy_progress(proxy_id, acked)
@@ -406,27 +346,13 @@ defmodule Bedrock.DataPlane.Resolver.Server do
     floor = t.metadata_pruned_through
     gap? = floor != nil and (acked == nil or acked < floor)
     from = if gap?, do: floor, else: acked
-    settled = settled_version(t)
 
-    # Entries above the settled floor (confirmed while an older version is
-    # still held) are withheld until everything below them settles.
-    entries =
-      t.metadata_window
-      |> MetadataAccumulator.mutations_since(from)
-      |> withhold_unsettled(settled, t.last_version)
+    entries = MetadataAccumulator.mutations_since(t.metadata_window, from)
 
-    window =
-      if entries == [] and not gap? and not confirmed_any? and settled == t.last_version,
-        do: nil,
-        else: {from, settled, entries}
+    window = if entries == [] and not gap?, do: nil, else: {from, t.last_version, entries}
 
     {window, t}
   end
-
-  # Fast path: with no held versions, settled == last_version and no entry can
-  # exceed it.
-  defp withhold_unsettled(entries, settled, last_version) when settled == last_version, do: entries
-  defp withhold_unsettled(entries, settled, _), do: Enum.take_while(entries, fn {version, _} -> version <= settled end)
 
   @spec record_proxy_progress(State.t(), pid(), Bedrock.version() | nil) :: State.t()
   defp record_proxy_progress(t, proxy_id, acked) do
@@ -443,21 +369,10 @@ defmodule Bedrock.DataPlane.Resolver.Server do
   defp max_ack(prev, nil), do: prev
   defp max_ack(prev, acked), do: max(prev, acked)
 
-  # Expires state older than the version retention horizon:
-  #
-  # - Proxies not seen within the horizon are dropped so a dead (or
-  #   pathologically stalled) proxy neither leaks a progress entry nor blocks
-  #   window pruning forever. A live proxy calls at least once per empty-batch
-  #   interval, far inside the horizon.
-  # - Held (deferred, unconfirmed) metadata versions older than the horizon
-  #   are dropped so an unconfirmed hold cannot cap window distribution
-  #   forever. A hold this old is an invariant breach - its proxy stopped
-  #   confirming (it died mid-batch, or is stalled beyond any healthy cadence)
-  #   and the metadata MAY have committed - so the expired version is folded
-  #   into metadata_pruned_through: every proxy acked below it (necessarily
-  #   all of them, since holds cap acks) takes the coverage-gap fail-fast exit
-  #   into director-driven recovery, which rebuilds metadata from durable
-  #   state, rather than silently missing possibly-committed metadata.
+  # Expires proxies not seen within the version retention horizon, so a dead
+  # (or pathologically stalled) proxy neither leaks a progress entry nor
+  # blocks window pruning forever. A live proxy calls at least once per
+  # empty-batch interval, far inside the horizon.
   @spec expire_stale(State.t()) :: State.t()
   defp expire_stale(t) do
     case retention_cutoff(t) do
@@ -465,14 +380,7 @@ defmodule Bedrock.DataPlane.Resolver.Server do
         t
 
       cutoff ->
-        {expired_holds, live_holds} = MapSet.split_with(t.held_metadata_versions, &(&1 < cutoff))
-
-        %{
-          t
-          | proxy_progress: Map.filter(t.proxy_progress, fn {_pid, {_acked, seen}} -> seen >= cutoff end),
-            held_metadata_versions: live_holds,
-            metadata_pruned_through: max_ack(t.metadata_pruned_through, Enum.max(expired_holds, fn -> nil end))
-        }
+        %{t | proxy_progress: Map.filter(t.proxy_progress, fn {_pid, {_acked, seen}} -> seen >= cutoff end)}
     end
   end
 

--- a/lib/bedrock/data_plane/resolver/state.ex
+++ b/lib/bedrock/data_plane/resolver/state.ex
@@ -52,7 +52,6 @@ defmodule Bedrock.DataPlane.Resolver.State do
           },
           metadata_window: MetadataAccumulator.t(),
           metadata_pruned_through: Bedrock.version() | nil,
-          held_metadata_versions: MapSet.t(Bedrock.version()),
           recent_replies: %{Bedrock.version() => [non_neg_integer()]}
         }
   defstruct conflicts: nil,
@@ -68,7 +67,6 @@ defmodule Bedrock.DataPlane.Resolver.State do
             proxy_progress: %{},
             metadata_window: nil,
             metadata_pruned_through: nil,
-            held_metadata_versions: MapSet.new(),
             # Abort sets of processed batches, keyed by their commit version
             # and pruned with the conflict retention horizon: a retried batch
             # (lost reply) REPLAYS its original verdict - FDB's

--- a/test/bedrock/data_plane/commit_proxy/finalization/metadata_test.exs
+++ b/test/bedrock/data_plane/commit_proxy/finalization/metadata_test.exs
@@ -190,7 +190,7 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization.MetadataTest do
       commit_version = Version.from_integer(100)
 
       metadata_window =
-        {nil, commit_version, [{commit_version, [{:set, <<0xFF, "system_key">>, "system_value"}]}]}
+        {nil, commit_version, [{commit_version, [{[{:set, <<0xFF, "system_key">>, "system_value"}], true}]}]}
 
       mock_resolver_fn = fn _resolver, _epoch, _last_version, _commit_version, _summaries, _metadata_per_tx, _opts ->
         {:ok, [], metadata_window}

--- a/test/bedrock/data_plane/commit_proxy/finalization/sharded_resolution_and_edge_cases_test.exs
+++ b/test/bedrock/data_plane/commit_proxy/finalization/sharded_resolution_and_edge_cases_test.exs
@@ -160,98 +160,51 @@ defmodule Bedrock.DataPlane.CommitProxy.FinalizationShardedResolutionAndEdgeCase
       assert_receive {:tx1, {:error, :aborted}}
     end
 
-    test "defers metadata: resolvers get no metadata_per_tx, a hold flag, and re-sent confirmations" do
+    test "every resolver receives every transaction's metadata mutations" do
       test_pid = self()
-      confirms = [{Version.from_integer(90), [{:set, <<0xFF, "k">>, "v"}]}]
 
       metadata_tx =
         Transaction.encode(%{
-          mutations: [{:set, "apple", "v0"}, {:set, <<0xFF, "/system/key">>, "meta"}],
+          mutations: [{:set, "apple", "v"}, {:set, <<0xFF, "/system/key">>, "meta"}],
           write_conflicts: [{"apple", "apple" <> <<0>>}],
           read_conflicts: nil
         })
 
       batch = batch_with([{reply_fn(test_pid, :tx0), metadata_tx}])
 
-      resolver_fn = fn ref, _epoch, _last, _commit, _txns, metadata_per_tx, opts ->
-        send(test_pid, {:resolver_called, ref, metadata_per_tx, opts[:metadata_hold], opts[:metadata_confirms]})
+      resolver_fn = fn ref, _epoch, _last, _commit, _txns, metadata_per_tx, _opts ->
+        send(test_pid, {:metadata_at, ref, metadata_per_tx})
         {:ok, [], nil}
       end
 
-      opts =
-        base_opts(sharded_layout(), routing_data(),
-          resolver_fn: resolver_fn,
-          metadata_confirms: confirms
-        )
+      opts = base_opts(sharded_layout(), routing_data(), resolver_fn: resolver_fn)
 
       assert {:ok, 0, 1} = Finalization.finalize_batch(batch, opts)
 
-      # No speculative metadata reaches any resolver; both get the hold flag
-      # (this batch carries metadata) and the proxy's pending confirmations.
-      assert_receive {:resolver_called, :resolver_a, [], true, ^confirms}
-      assert_receive {:resolver_called, :resolver_b, [], true, ^confirms}
+      # Both resolvers see the same broadcast metadata, so each can record
+      # verdict-carrying entries; the merge ANDs them into the global verdict.
+      expected = [[{:set, <<0xFF, "/system/key">>, "meta"}]]
+      assert_receive {:metadata_at, :resolver_a, ^expected}
+      assert_receive {:metadata_at, :resolver_b, ^expected}
     end
 
-    test "the metadata apply call carries committed metadata filtered by the MERGED global abort set" do
-      test_pid = self()
-
-      metadata_tx = fn key, meta_key ->
-        Transaction.encode(%{
-          mutations: [{:set, key, "v"}, {:set, meta_key, "meta"}],
-          write_conflicts: [{key, key <> <<0>>}],
-          read_conflicts: nil
-        })
-      end
-
-      # tx0 survives; tx1 is aborted by resolver_b ONLY - resolver_a saw no
-      # conflict for it, but its metadata must still be excluded globally.
-      batch =
-        batch_with([
-          {reply_fn(test_pid, :tx0), metadata_tx.("apple", <<0xFF, "/committed">>)},
-          {reply_fn(test_pid, :tx1), metadata_tx.("zebra", <<0xFF, "/aborted">>)}
-        ])
-
-      resolver_fn = fn
-        :resolver_a, _epoch, _last, _commit, _txns, _metadata, _opts -> {:ok, [], nil}
-        :resolver_b, _epoch, _last, _commit, _txns, _metadata, _opts -> {:ok, [1], nil}
-      end
-
-      metadata_apply_fn = fn version, _window, deferred ->
-        send(test_pid, {:deferred, version, deferred})
-        {:ok, routing_data()}
-      end
-
-      opts =
-        base_opts(sharded_layout(), routing_data(),
-          resolver_fn: resolver_fn,
-          metadata_apply_fn: metadata_apply_fn
-        )
-
-      assert {:ok, 1, 1} = Finalization.finalize_batch(batch, opts)
-
-      assert_receive {:deferred, @commit_version, {[{:set, <<0xFF, "/committed">>, "meta"}]}}
-    end
-
-    test "merged metadata windows claim the weakest coverage on both ends and withhold unsettled entries" do
+    test "the metadata apply call receives only unanimously-committed mutations" do
       test_pid = self()
       v = &Version.from_integer/1
-      entry_95 = {v.(95), [{:set, <<0xFF, "a">>, "1"}]}
-      entry_98 = {v.(98), [{:set, <<0xFF, "b">>, "2"}]}
+      meta = [{:set, <<0xFF, "a">>, "1"}]
 
-      # resolver_a has settled through v(99); resolver_b only through v(96)
-      # (it still holds deferred metadata). The merged window must not let the
-      # proxy ack past v(96) nor apply the entry at v(98) out of order, and
-      # the duplicate entry at v(95) (both resolvers carry it) collapses.
+      # Both resolvers relay the same entry at v(95): resolver_a's slice saw
+      # no conflict (committed), resolver_b's did (vetoed). The AND vetoes.
       resolver_fn = fn
         :resolver_a, _epoch, _last, _commit, _txns, _metadata, _opts ->
-          {:ok, [], {v.(90), v.(99), [entry_95, entry_98]}}
+          {:ok, [], {v.(90), v.(96), [{v.(95), [{meta, true}]}]}}
 
         :resolver_b, _epoch, _last, _commit, _txns, _metadata, _opts ->
-          {:ok, [], {v.(90), v.(96), [entry_95]}}
+          {:ok, [], {v.(90), v.(96), [{v.(95), [{meta, false}]}]}}
       end
 
-      metadata_apply_fn = fn _version, window, _deferred ->
-        send(test_pid, {:merged_window, window})
+      metadata_apply_fn = fn _version, window ->
+        send(test_pid, {:committed_window, window})
         {:ok, routing_data()}
       end
 
@@ -261,7 +214,40 @@ defmodule Bedrock.DataPlane.CommitProxy.FinalizationShardedResolutionAndEdgeCase
 
       from90 = v.(90)
       to96 = v.(96)
-      assert_receive {:merged_window, {^from90, ^to96, [^entry_95]}}
+      assert_receive {:committed_window, {^from90, ^to96, []}}
+    end
+
+    test "merged windows claim the weakest coverage and AND verdicts per transaction" do
+      test_pid = self()
+      v = &Version.from_integer/1
+      meta_a = [{:set, <<0xFF, "a">>, "1"}]
+      meta_b = [{:set, <<0xFF, "b">>, "2"}]
+
+      # v(95) carries two metadata transactions; the second is vetoed at
+      # resolver_b only. resolver_a claims coverage through v(99), resolver_b
+      # through v(96): the merged window claims the weakest (min) coverage
+      # and truncates entries beyond it.
+      resolver_fn = fn
+        :resolver_a, _epoch, _last, _commit, _txns, _metadata, _opts ->
+          {:ok, [], {v.(90), v.(99), [{v.(95), [{meta_a, true}, {meta_b, true}]}, {v.(98), [{meta_b, true}]}]}}
+
+        :resolver_b, _epoch, _last, _commit, _txns, _metadata, _opts ->
+          {:ok, [], {v.(90), v.(96), [{v.(95), [{meta_a, true}, {meta_b, false}]}]}}
+      end
+
+      metadata_apply_fn = fn _version, window ->
+        send(test_pid, {:committed_window, window})
+        {:ok, routing_data()}
+      end
+
+      opts = base_opts(sharded_layout(), routing_data(), resolver_fn: resolver_fn, metadata_apply_fn: metadata_apply_fn)
+
+      assert {:ok, 0, 0} = Finalization.finalize_batch(empty_batch(), opts)
+
+      from90 = v.(90)
+      to96 = v.(96)
+      v95 = v.(95)
+      assert_receive {:committed_window, {^from90, ^to96, [{^v95, ^meta_a}]}}
     end
 
     test "fails the batch when a resolver task exits" do

--- a/test/bedrock/data_plane/commit_proxy/metadata_distribution_integration_test.exs
+++ b/test/bedrock/data_plane/commit_proxy/metadata_distribution_integration_test.exs
@@ -176,7 +176,7 @@ defmodule Bedrock.DataPlane.CommitProxy.MetadataDistributionIntegrationTest do
     # 1. The resolver's MetadataAccumulator captured the system-key mutation
     #    at the batch's commit version.
     resolver_entries = MetadataAccumulator.entries(:sys.get_state(resolver).metadata_window)
-    assert {^version, [{:set, ^shard_key, ^encoded_tag}]} = List.keyfind(resolver_entries, version, 0)
+    assert {^version, [{[{:set, ^shard_key, ^encoded_tag}], true}]} = List.keyfind(resolver_entries, version, 0)
 
     # 2. The commit proxy's post-batch state contains the PARSED structured entry.
     wait_until(fn -> proxy_metadata(proxy).shards != %{} end)

--- a/test/bedrock/data_plane/commit_proxy/metadata_window_application_test.exs
+++ b/test/bedrock/data_plane/commit_proxy/metadata_window_application_test.exs
@@ -4,8 +4,8 @@ defmodule Bedrock.DataPlane.CommitProxy.MetadataWindowApplicationTest do
   (bedrock-q67.16, bedrock-q67.24).
 
   Each finalization task asks the server to apply its batch's committed
-  metadata - the resolver window plus, in sharded mode, the batch's own
-  globally-committed metadata - and hand back the immutable routing snapshot
+  metadata window - which covers through the batch's own version, its own
+  committed metadata included - and hand back the immutable routing snapshot
   the batch pushes with. Requests are served strictly in proxy-local
   batch-sequence order: a request whose predecessor has not applied yet
   waits, so every batch routes with exactly the metadata at or below its own
@@ -52,14 +52,14 @@ defmodule Bedrock.DataPlane.CommitProxy.MetadataWindowApplicationTest do
 
   defp log_set(log_id), do: {:set, SystemKeys.layout_log(log_id), Values.encode_tag_list([1])}
 
-  defp request(state, seq, commit_version, window, deferred \\ nil) do
+  defp request(state, seq, commit_version, window) do
     from = {self(), make_ref()}
-    result = Server.handle_call({:apply_metadata_and_route, seq, commit_version, window, deferred}, from, state)
+    result = Server.handle_call({:apply_metadata_and_route, seq, commit_version, window}, from, state)
     {result, elem(from, 1)}
   end
 
-  defp apply_in_order(state, seq, commit_version, window, deferred \\ nil) do
-    {{:noreply, updated, _timeout}, ref} = request(state, seq, commit_version, window, deferred)
+  defp apply_in_order(state, seq, commit_version, window) do
+    {{:noreply, updated, _timeout}, ref} = request(state, seq, commit_version, window)
     assert_receive {^ref, {:ok, routing_data}}
     {updated, routing_data}
   end
@@ -95,34 +95,17 @@ defmodule Bedrock.DataPlane.CommitProxy.MetadataWindowApplicationTest do
     assert updated.pending_applies == %{}
   end
 
-  test "a batch's own deferred metadata routes its batch but does not advance the ack" do
-    window = {nil, v(1), []}
-    deferred = {[shard_set("a", 3), log_set("log_a")]}
+  test "a batch's own committed metadata arrives in its window and routes its own push" do
+    # The window covers through the batch's own commit version (verdicts
+    # already resolved at the merge), so applying it gives the batch
+    # same-batch visibility and honestly advances the ack to its version.
+    window = {nil, v(2), [{v(2), [shard_set("a", 3), log_set("log_a")]}]}
 
-    {updated, routing_data} = apply_in_order(state(), 1, v(2), window, deferred)
+    {updated, routing_data} = apply_in_order(state(), 1, v(2), window)
 
-    # Routing includes the batch's own committed metadata (same-batch
-    # visibility for its log push)...
     assert routing_data.log_map == %{0 => "log_a"}
     assert :gb_trees.lookup("a", routing_data.shards) == {:value, {3, ""}}
-
-    # ...but the ack only advances to what resolver windows confirmed, and
-    # the deferred entry is recorded for re-sending as a confirmation.
-    assert updated.metadata.version == v(1)
-    assert [{deferred_version, _mutations}] = updated.deferred_metadata
-    assert deferred_version == v(2)
-  end
-
-  test "a later window covering a deferred version stops re-sending it" do
-    deferred = {[log_set("log_a")]}
-    {updated, _routing} = apply_in_order(state(), 1, v(2), {nil, v(1), []}, deferred)
-
-    # A window whose to_version covers the deferred version proves every
-    # resolver folded the confirmation in.
-    {updated, _routing} = apply_in_order(updated, 2, v(3), {v(1), v(3), [{v(2), [log_set("log_a")]}]})
-
-    assert updated.deferred_metadata == []
-    assert updated.metadata.version == v(3)
+    assert updated.metadata.version == v(2)
   end
 
   test "overlapping windows apply idempotently: entries at or below the applied version are dropped" do
@@ -153,7 +136,7 @@ defmodule Bedrock.DataPlane.CommitProxy.MetadataWindowApplicationTest do
     assert {:metadata_coverage_gap, _} =
              catch_exit(
                Server.handle_call(
-                 {:apply_metadata_and_route, 2, v(6), {v(5), v(6), [{v(6), [shard_set("a", 6)]}]}, nil},
+                 {:apply_metadata_and_route, 2, v(6), {v(5), v(6), [{v(6), [shard_set("a", 6)]}]}},
                  from,
                  initial
                )
@@ -164,7 +147,7 @@ defmodule Bedrock.DataPlane.CommitProxy.MetadataWindowApplicationTest do
     from = {self(), make_ref()}
 
     assert {:metadata_coverage_gap, _} =
-             catch_exit(Server.handle_call({:apply_metadata_and_route, 1, v(6), {v(5), v(6), []}, nil}, from, state()))
+             catch_exit(Server.handle_call({:apply_metadata_and_route, 1, v(6), {v(5), v(6), []}}, from, state()))
   end
 
   test "a nil window advances the chain without touching metadata" do

--- a/test/bedrock/data_plane/commit_proxy/server_test.exs
+++ b/test/bedrock/data_plane/commit_proxy/server_test.exs
@@ -30,7 +30,7 @@ defmodule Bedrock.DataPlane.CommitProxy.ServerTest do
 
     def handle_call(
           {:resolve_transactions, _epoch, {_last_version, _next_version}, _transactions, _metadata_per_tx,
-           {_proxy_id, _acked_version}, {_metadata_hold?, _metadata_confirms}},
+           {_proxy_id, _acked_version}},
           _from,
           state
         ) do

--- a/test/bedrock/data_plane/commit_proxy/sharded_metadata_distribution_integration_test.exs
+++ b/test/bedrock/data_plane/commit_proxy/sharded_metadata_distribution_integration_test.exs
@@ -224,7 +224,7 @@ defmodule Bedrock.DataPlane.CommitProxy.ShardedMetadataDistributionIntegrationTe
     # version (ordering is preserved by version, not by confirmation arrival).
     for resolver <- [resolver_a, resolver_b] do
       entries = MetadataAccumulator.entries(:sys.get_state(resolver).metadata_window)
-      assert {^version, [^metadata_mutation]} = List.keyfind(entries, version, 0)
+      assert {^version, [{[^metadata_mutation], true}]} = List.keyfind(entries, version, 0)
     end
   end
 
@@ -272,8 +272,8 @@ defmodule Bedrock.DataPlane.CommitProxy.ShardedMetadataDistributionIntegrationTe
     entries = MetadataAccumulator.entries(:sys.get_state(resolver_a).metadata_window)
     metadata_entries = for {v, muts} <- entries, v in [v1, v3], do: {v, muts}
     assert [{^v1, [tag1_mutation]}, {^v3, [tag3_mutation]}] = metadata_entries
-    assert tag1_mutation == set_tag.(1)
-    assert tag3_mutation == set_tag.(3)
+    assert tag1_mutation == {[set_tag.(1)], true}
+    assert tag3_mutation == {[set_tag.(3)], true}
 
     refute set_tag.(2) in resolver_metadata_mutations(resolver_a)
   end

--- a/test/bedrock/data_plane/resolver/metadata_window_distribution_test.exs
+++ b/test/bedrock/data_plane/resolver/metadata_window_distribution_test.exs
@@ -21,6 +21,11 @@ defmodule Bedrock.DataPlane.Resolver.MetadataWindowDistributionTest do
   - once a proxy confirms, the window is pruned through the minimum confirmed
     ack, and steady-state replies are `nil` - O(new updates) per batch.
 
+  Window entries carry `{mutations, local_verdict}` pairs per
+  metadata-carrying transaction: each resolver records its own verdict and
+  the commit proxy ANDs verdicts across all resolvers' windows to reach the
+  global one (bedrock-q67.22, FDB's stateMutations relay).
+
   Proxies not seen within the resolver's version retention are expired from
   `proxy_progress` (bounding it to ~live proxies and unblocking pruning). A
   returning laggard whose ack predates the pruned floor receives a window with
@@ -100,14 +105,14 @@ defmodule Bedrock.DataPlane.Resolver.MetadataWindowDistributionTest do
   } do
     resolver = start_resolver()
 
-    assert {:ok, [], {nil, to1, [{to1_entry, [^m1]}]}} =
+    assert {:ok, [], {nil, to1, [{to1_entry, [{[^m1], true}]}]}} =
              resolve_from_fresh_task(resolver, v(0), v(1), "k1", [m1], {proxy, nil})
 
     assert to1 == v(1)
     assert to1_entry == v(1)
 
     # Proxy confirmed v(1): only the new update rides the next reply.
-    assert {:ok, [], {from2, to2, [{entry_v2, [^m2]}]}} =
+    assert {:ok, [], {from2, to2, [{entry_v2, [{[^m2], true}]}]}} =
              resolve_from_fresh_task(resolver, v(1), v(2), "k2", [m2], {proxy, v(1)})
 
     assert {from2, to2, entry_v2} == {v(1), v(2), v(2)}
@@ -123,13 +128,14 @@ defmodule Bedrock.DataPlane.Resolver.MetadataWindowDistributionTest do
   } do
     resolver = start_resolver()
 
-    assert {:ok, [], {nil, _, [{_, [^m1]}]}} = resolve_from_fresh_task(resolver, v(0), v(1), "k1", [m1], {proxy, nil})
+    assert {:ok, [], {nil, _, [{_, [{[^m1], true}]}]}} =
+             resolve_from_fresh_task(resolver, v(0), v(1), "k1", [m1], {proxy, nil})
 
     # The proxy never applied the first window (call timed out; reply lost).
     # Its next call carries the same ack - the resolver re-sends everything
     # since the confirmed version, so the second window is a superset of the
     # first and out-of-order arrival at the proxy is equally harmless.
-    assert {:ok, [], {nil, to2, [{e1, [^m1]}, {e2, [^m2]}]}} =
+    assert {:ok, [], {nil, to2, [{e1, [{[^m1], true}]}, {e2, [{[^m2], true}]}]}} =
              resolve_from_fresh_task(resolver, v(1), v(2), "k2", [m2], {proxy, nil})
 
     assert {to2, e1, e2} == {v(2), v(1), v(2)}
@@ -157,7 +163,7 @@ defmodule Bedrock.DataPlane.Resolver.MetadataWindowDistributionTest do
 
     # Entries at or below the confirmed version (and older than the retention
     # horizon) are pruned.
-    assert [{entry_version, [^m3]}] = MetadataAccumulator.entries(state.metadata_window)
+    assert [{entry_version, [{[^m3], true}]}] = MetadataAccumulator.entries(state.metadata_window)
     assert entry_version == v(2500)
   end
 
@@ -168,8 +174,11 @@ defmodule Bedrock.DataPlane.Resolver.MetadataWindowDistributionTest do
   } do
     resolver = start_resolver()
 
-    assert {:ok, [], {nil, _, [{_, [^m1]}]}} = resolve_from_fresh_task(resolver, v(0), v(1), "k1", [m1], {proxy, nil})
-    assert {:ok, [], {_, _, [{_, [^m2]}]}} = resolve_from_fresh_task(resolver, v(1), v(2), "k2", [m2], {proxy, v(1)})
+    assert {:ok, [], {nil, _, [{_, [{[^m1], true}]}]}} =
+             resolve_from_fresh_task(resolver, v(0), v(1), "k1", [m1], {proxy, nil})
+
+    assert {:ok, [], {_, _, [{_, [{[^m2], true}]}]}} =
+             resolve_from_fresh_task(resolver, v(1), v(2), "k2", [m2], {proxy, v(1)})
 
     # Proxy confirmed through v(2); window pruned through v(2).
     assert {:ok, [], nil} = resolve_from_fresh_task(resolver, v(2), v(3), "k3", [], {proxy, v(2)})
@@ -194,7 +203,7 @@ defmodule Bedrock.DataPlane.Resolver.MetadataWindowDistributionTest do
     proxy_a = spawn_link(fn -> Process.sleep(:infinity) end)
     proxy_b = spawn_link(fn -> Process.sleep(:infinity) end)
 
-    assert {:ok, [], {nil, _, [{_, [^m1]}]}} =
+    assert {:ok, [], {nil, _, [{_, [{[^m1], true}]}]}} =
              resolve_from_fresh_task(resolver, v(0), v(1000), "k1", [m1], {proxy_a, nil})
 
     # proxy_a confirms v(1000) while the entry is still inside the horizon
@@ -202,7 +211,7 @@ defmodule Bedrock.DataPlane.Resolver.MetadataWindowDistributionTest do
     assert {:ok, [], nil} = resolve_from_fresh_task(resolver, v(1000), v(1500), "k2", [], {proxy_a, v(1000)})
 
     # proxy_b's first-ever call: full window, not a gap.
-    assert {:ok, [], {nil, to, [{entry_version, [^m1]}]}} =
+    assert {:ok, [], {nil, to, [{entry_version, [{[^m1], true}]}]}} =
              resolve_from_fresh_task(resolver, v(1500), v(1600), "k3", [], {proxy_b, nil})
 
     assert {to, entry_version} == {v(1600), v(1000)}
@@ -218,7 +227,7 @@ defmodule Bedrock.DataPlane.Resolver.MetadataWindowDistributionTest do
     proxy_a = spawn_link(fn -> Process.sleep(:infinity) end)
     proxy_b = spawn_link(fn -> Process.sleep(:infinity) end)
 
-    assert {:ok, [], {nil, to_b, [{_, [^m1]}]}} =
+    assert {:ok, [], {nil, to_b, [{_, [{[^m1], true}]}]}} =
              resolve_from_fresh_task(resolver, v(0), v(1), "k1", [m1], {proxy_b, nil})
 
     assert to_b == v(1)
@@ -228,7 +237,7 @@ defmodule Bedrock.DataPlane.Resolver.MetadataWindowDistributionTest do
 
     # proxy_a first calls late: its window covers (nil, v(1500)] with the same
     # single entry, so it acks v(1500) - far beyond the entry's version.
-    assert {:ok, [], {nil, to_a, [{_, [^m1]}]}} =
+    assert {:ok, [], {nil, to_a, [{_, [{[^m1], true}]}]}} =
              resolve_from_fresh_task(resolver, v(2), v(1500), "k3", [], {proxy_a, nil})
 
     assert to_a == v(1500)
@@ -245,131 +254,6 @@ defmodule Bedrock.DataPlane.Resolver.MetadataWindowDistributionTest do
     # discarded, so it missed NOTHING - it must get a plain (empty)
     # differential, not a gap-marked window that would force a full recovery.
     assert {:ok, [], nil} = resolve_from_fresh_task(resolver, v(3100), v(3200), "k5", [], {proxy_b, v(1)})
-  end
-
-  describe "deferred metadata (sharded mode, bedrock-q67.17)" do
-    test "a held batch caps the window; the confirmation releases it at the original commit version", %{
-      proxy: proxy,
-      m1: m1
-    } do
-      resolver = start_resolver()
-
-      # Sharded batch carrying metadata: no metadata_per_tx, hold the version.
-      # While a hold is outstanding the window is returned (never nil) so the
-      # settled cap reaches the proxy's merge, but it never extends to (or
-      # past) the held version.
-      assert {:ok, [], {nil, to0, []}} =
-               resolve_from_fresh_task(resolver, v(0), v(1), "k1", [], {proxy, nil}, metadata_hold: true)
-
-      assert to0 == v(0)
-
-      assert {:ok, [], {nil, to0b, []}} = resolve_from_fresh_task(resolver, v(1), v(2), "k2", [], {proxy, nil})
-      assert to0b == v(0)
-
-      # The confirmation (already filtered by the proxy's merged global abort
-      # set) folds in at the ORIGINAL commit version and rides the reply.
-      assert {:ok, [], {nil, to, [{entry_version, [^m1]}]}} =
-               resolve_from_fresh_task(resolver, v(2), v(3), "k3", [], {proxy, nil}, metadata_confirms: [{v(1), [m1]}])
-
-      assert {to, entry_version} == {v(3), v(1)}
-      assert :sys.get_state(resolver).held_metadata_versions == MapSet.new()
-    end
-
-    test "a confirmation of an all-aborted batch clears the hold and advances the window with no entries", %{
-      proxy: proxy
-    } do
-      resolver = start_resolver()
-
-      assert {:ok, [], {nil, _, []}} =
-               resolve_from_fresh_task(resolver, v(0), v(1), "k1", [], {proxy, nil}, metadata_hold: true)
-
-      # Every metadata-carrying transaction in the batch was globally aborted:
-      # the confirmation carries no mutations, but the reply still carries a
-      # window so the proxy's ack advances and it stops re-sending.
-      assert {:ok, [], {nil, to, []}} =
-               resolve_from_fresh_task(resolver, v(1), v(2), "k2", [], {proxy, nil}, metadata_confirms: [{v(1), []}])
-
-      assert to == v(2)
-      assert MetadataAccumulator.entries(:sys.get_state(resolver).metadata_window) == []
-    end
-
-    test "re-sent confirmations are idempotent", %{proxy: proxy, m1: m1} do
-      resolver = start_resolver()
-
-      assert {:ok, [], {nil, _, []}} =
-               resolve_from_fresh_task(resolver, v(0), v(1), "k1", [], {proxy, nil}, metadata_hold: true)
-
-      assert {:ok, [], {nil, _, [{_, [^m1]}]}} =
-               resolve_from_fresh_task(resolver, v(1), v(2), "k2", [], {proxy, nil}, metadata_confirms: [{v(1), [m1]}])
-
-      # The proxy re-sends until its ack covers v(1); no duplicate entry.
-      assert {:ok, [], _} =
-               resolve_from_fresh_task(resolver, v(2), v(3), "k3", [], {proxy, nil}, metadata_confirms: [{v(1), [m1]}])
-
-      assert [{entry_version, [^m1]}] = MetadataAccumulator.entries(:sys.get_state(resolver).metadata_window)
-      assert entry_version == v(1)
-    end
-
-    test "out-of-order confirmations from different proxies keep entries in version order and withheld until settled",
-         %{m1: m1, m2: m2} do
-      resolver = start_resolver()
-      proxy_a = spawn_link(fn -> Process.sleep(:infinity) end)
-      proxy_b = spawn_link(fn -> Process.sleep(:infinity) end)
-
-      # proxy_a holds v(1); proxy_b holds v(2).
-      assert {:ok, [], {nil, _, []}} =
-               resolve_from_fresh_task(resolver, v(0), v(1), "k1", [], {proxy_a, nil}, metadata_hold: true)
-
-      assert {:ok, [], {nil, _, []}} =
-               resolve_from_fresh_task(resolver, v(1), v(2), "k2", [], {proxy_b, nil}, metadata_hold: true)
-
-      # proxy_b confirms v(2) FIRST - but v(1) is still held, so the entry at
-      # v(2) is withheld (no proxy may apply or ack past unsettled metadata).
-      assert {:ok, [], {nil, to_b, []}} =
-               resolve_from_fresh_task(resolver, v(2), v(3), "k3", [], {proxy_b, nil},
-                 metadata_confirms: [{v(2), [m2]}]
-               )
-
-      assert to_b == v(0)
-
-      # proxy_a confirms v(1): everything settles and both entries are served
-      # in ORIGINAL version order.
-      assert {:ok, [], {nil, to, [{e1, [^m1]}, {e2, [^m2]}]}} =
-               resolve_from_fresh_task(resolver, v(3), v(4), "k4", [], {proxy_a, nil},
-                 metadata_confirms: [{v(1), [m1]}]
-               )
-
-      assert {to, e1, e2} == {v(4), v(1), v(2)}
-    end
-
-    test "held versions never confirmed (dead proxy) expire into a coverage gap, not silent loss", %{
-      proxy: proxy,
-      m1: m1
-    } do
-      # 1ms retention = 1000 versions.
-      resolver = start_resolver(version_retention_ms: 1)
-
-      assert {:ok, [], {nil, _, []}} =
-               resolve_from_fresh_task(resolver, v(0), v(1), "k1", [], {proxy, nil}, metadata_hold: true)
-
-      # The submitting proxy never confirms v(1) (it died mid-batch, or
-      # stalled beyond any healthy cadence). Once the held version falls out
-      # of the retention horizon it expires - but the metadata MAY have
-      # committed, so the expired version poisons the pruned floor: proxies
-      # acked below it (necessarily all of them - holds cap acks) receive a
-      # gap-marked window (from_version above their applied version) and take
-      # the fail-fast exit into recovery rather than silently missing it.
-      assert {:ok, [], {from, to, []}} = resolve_from_fresh_task(resolver, v(1), v(2500), "k2", [], {proxy, nil})
-      assert {from, to} == {v(1), v(2500)}
-      assert :sys.get_state(resolver).held_metadata_versions == MapSet.new()
-
-      # A proxy acked at or above the poisoned floor is served normally
-      # (single-mode accumulation here just proves the cap is gone).
-      assert {:ok, [], {_, to, [{entry_version, [^m1]}]}} =
-               resolve_from_fresh_task(resolver, v(2500), v(2600), "k3", [m1], {proxy, v(2500)})
-
-      assert {to, entry_version} == {v(2600), v(2600)}
-    end
   end
 
   test "proxies not seen within version retention expire; a returning laggard gets a gap-marked window", %{
@@ -392,12 +276,12 @@ defmodule Bedrock.DataPlane.Resolver.MetadataWindowDistributionTest do
 
     state = :sys.get_state(resolver)
     refute Map.has_key?(state.proxy_progress, proxy_b)
-    assert [{entry_version, [^m3]}] = MetadataAccumulator.entries(state.metadata_window)
+    assert [{entry_version, [{[^m3], true}]}] = MetadataAccumulator.entries(state.metadata_window)
     assert entry_version == v(5000)
 
     # proxy_b returns with an ack below the pruned floor: the window's
     # from_version exceeds what proxy_b applied - the proxy-side gap signal.
-    assert {:ok, [], {from, to, [{_, [^m3]}]}} =
+    assert {:ok, [], {from, to, [{_, [{[^m3], true}]}]}} =
              resolve_from_fresh_task(resolver, v(5000), v(5001), "k5", [], {proxy_b, nil})
 
     assert {from, to} == {v(3), v(5001)}

--- a/test/bedrock/data_plane/resolver/server_test.exs
+++ b/test/bedrock/data_plane/resolver/server_test.exs
@@ -313,7 +313,7 @@ defmodule Bedrock.DataPlane.Resolver.ServerTest do
       wait_until(fn -> map_size(:sys.get_state(server).waiting) == 1 end)
       state = :sys.get_state(server)
 
-      assert [{deadline, _reply_fn, {^future_version, [^test_transaction], [[]], _proxy_pid, _metadata_directives}}] =
+      assert [{deadline, _reply_fn, {^future_version, [^test_transaction], [[]], _proxy_pid}}] =
                Map.get(state.waiting, next_version)
 
       assert is_integer(deadline)

--- a/test/support/data_plane/finalization_test_support.ex
+++ b/test/support/data_plane/finalization_test_support.ex
@@ -35,26 +35,6 @@ defmodule Bedrock.Test.DataPlane.FinalizationTestSupport do
   end
 
   # Fake resolver for testing conflict resolution without self-calls
-  defmodule FakeResolver do
-    @moduledoc false
-    use GenServer
-
-    def start_link(opts \\ []) do
-      GenServer.start_link(__MODULE__, :ok, opts)
-    end
-
-    def init(:ok), do: {:ok, %{}}
-
-    def handle_call(
-          {:resolve_transactions, _epoch, {_last_version, _commit_version}, _transaction_summaries, _metadata_per_tx,
-           {_proxy_id, _acked_version}, {_metadata_hold?, _metadata_confirms}},
-          _from,
-          state
-        ) do
-      # Return no conflicts and no metadata window for simple test scenarios
-      {:reply, {:ok, [], nil}, state}
-    end
-  end
 
   @doc """
   Creates a fake sequencer that handles synchronous report_successful_commit calls.
@@ -62,14 +42,6 @@ defmodule Bedrock.Test.DataPlane.FinalizationTestSupport do
   """
   def create_fake_sequencer do
     ExUnit.Callbacks.start_supervised!(FakeSequencer)
-  end
-
-  @doc """
-  Creates a fake resolver that handles resolve_transactions calls without conflicts.
-  Uses start_supervised! for proper test lifecycle management.
-  """
-  def create_fake_resolver do
-    ExUnit.Callbacks.start_supervised!(FakeResolver)
   end
 
   @doc """
@@ -169,25 +141,19 @@ defmodule Bedrock.Test.DataPlane.FinalizationTestSupport do
 
   @doc """
   A stand-in for the commit proxy server's serialized apply-and-route step:
-  applies the batch's window entries and own committed metadata to the given
-  routing data and returns the snapshot the batch should push with.
+  applies the batch's committed window entries to the given routing data and
+  returns the snapshot the batch should push with. The window arrives with
+  verdicts already resolved (plain `{version, [mutation]}` entries).
   """
   def metadata_apply_fn(%RoutingData{} = routing_data) do
-    fn commit_version, window, deferred ->
+    fn _commit_version, window ->
       entries =
         case window do
           nil -> []
           {_from, _to, entries} -> entries
         end
 
-      own =
-        case deferred do
-          nil -> []
-          {[]} -> []
-          {committed} -> [{commit_version, committed}]
-        end
-
-      {:ok, RoutingData.apply_mutations(routing_data, entries ++ own)}
+      {:ok, RoutingData.apply_mutations(routing_data, entries)}
     end
   end
 


### PR DESCRIPTION
## Why

Sharded resolvers each see only their own shard's conflict ranges, so none knows the global abort set — and committed system metadata must never be distributed for a globally-aborted transaction. The existing answer was a protocol layer: metadata-carrying versions held at every resolver, windows capped at a settled floor, the proxy re-sending globally-filtered confirmations until windows acknowledged them, holds expiring into a poisoned pruning floor. It worked, and the integration branch review named it the single largest deletion available: "every month the hold/confirm layer lives, it accretes callers."

FDB proves no resolver needs the global verdict, because the *proxy* computes it. Every resolver records a state transaction's mutations with its **local** verdict; the consuming proxy ANDs the flags across all resolvers (`applyMetadataEffect`). A conflict anywhere vetoes; a resolver holding none of a transaction's ranges contributes a trivially-true verdict; the AND of partial verdicts is exactly the global verdict. The FDB source audit also refuted the constraint recorded earlier on the ticket — state transactions carry unrestricted mixed user/system conflict ranges; nothing requires system-only conflicts.

## What

Each batch's `metadata_per_tx` is now broadcast to every resolver (conflict ranges stay sharded — broadcasting them would add nothing). Accumulator entries become `{mutations, local_verdict}` pairs — vetoes recorded explicitly, never inferred from absence. The proxy's existing window merge ANDs verdicts positionally across resolvers, raising on structural divergence (a check FDB doesn't even have), and drops vetoed mutations before the serialized apply, so everything downstream sees the same plain entries as before. Windows cover through the batch's own version, so its own committed metadata arrives inside its own merged window — the entire deferred/own-entry special case on the proxy disappears and the ack honestly advances to the batch's commit version, exactly FDB's per-proxy `lastVersion`.

Deleted wholesale: holds, settled-version caps, withheld entries, hold expiry, sorted confirmation inserts, the confirm re-send loop, the `{hold?, confirms}` protocol directives, and the proxy's deferred-metadata state. Net −300 lines.

## How

The cold audit adversarially verified: the abort-set union (client verdicts) and window-verdict AND are logical complements of the same per-resolver bits and can never disagree; window alignment holds across every divergence scenario (laggard expiry, retention pruning, replay interleaving) with no false-positive of the divergence raise on healthy traffic; phantom metadata under post-resolution proxy death is contained identically to FDB — every batch pushes to every log, Shale's version chaining blocks later durability behind the un-pushed version, and the epoch dies. The decisive correctness pin survives from before the rewrite, unchanged: "metadata from a transaction aborted by only ONE shard's resolver is never distributed," running against real resolvers.

Ticket: bedrock-q67.22. Stacked on #164. FDB references: Resolver.actor.cpp stateMutations recording, CommitProxyServer.actor.cpp applyMetadataEffect, ResolverInterface.h (whose comment is literally this entry type: "[version][transaction#] -> (committed, [mutation#])").