### PR TITLE
bedrock-q67.9 (1/4): materializer refs ride the keyspace (serverList/ analogue)

### DIFF
--- a/.github/workflows/elixir_ci.yaml
+++ b/.github/workflows/elixir_ci.yaml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ "main", "develop" ]
   pull_request:
-    branches: [ "main", "develop", "feature/q67-phase-b-prereqs", "q67**", "rag**" ]
+    branches: [ "main", "develop", "feature/q67-phase-b-prereqs", "q67**", "feature/q67**", "rag**" ]
   workflow_dispatch:
   schedule:
     - cron: "0 7 * * 1"

--- a/lib/bedrock/control_plane/config/transaction_system_layout.ex
+++ b/lib/bedrock/control_plane/config/transaction_system_layout.ex
@@ -58,4 +58,34 @@ defmodule Bedrock.ControlPlane.Config.TransactionSystemLayout do
 
   @spec random_id() :: id()
   def random_id, do: :rand.uniform(1_000_000)
+
+  @doc """
+  Inverts `shard_materializers` through `services` into the string-encoded
+  refs the `materializers/` keyspace family carries: `%{tag => {worker_id,
+  node}}`. Both the persistence phase (the family's writer) and the routing
+  snapshot (the recover_from seed) derive from this, so the seed and the
+  keyspace cannot disagree.
+
+  A pid without a matching materializer service record is skipped - the
+  family only names workers the layout actually references.
+  """
+  @spec materializer_refs(t()) :: %{Bedrock.range_tag() => {String.t(), String.t()}}
+  def materializer_refs(layout) do
+    services = Map.get(layout, :services, %{})
+
+    layout
+    |> Map.get(:shard_materializers)
+    |> Kernel.||(%{})
+    |> Enum.flat_map(fn
+      {tag, pid} when is_pid(pid) ->
+        case Enum.find(services, &match?({_, %{kind: :materializer, status: {:up, ^pid}}}, &1)) do
+          {worker_id, _descriptor} -> [{tag, {worker_id, Atom.to_string(node(pid))}}]
+          nil -> []
+        end
+
+      _ ->
+        []
+    end)
+    |> Map.new()
+  end
 end

--- a/lib/bedrock/control_plane/director/recovery/persistence_phase.ex
+++ b/lib/bedrock/control_plane/director/recovery/persistence_phase.ex
@@ -189,8 +189,10 @@ defmodule Bedrock.ControlPlane.Director.Recovery.PersistencePhase do
   end
 
   # Every key written here has a named reader: layout/logs/ keys feed each
-  # proxy's RoutingData log wiring through resolver windows, and shard_keys/
-  # feeds both RoutingData and the next recovery's materializer bootstrap.
+  # proxy's RoutingData log wiring through resolver windows, shard_keys/
+  # feeds both RoutingData and the next recovery's materializer bootstrap,
+  # and materializers/ refs feed the client-facing routing projection
+  # (FDB's serverList analogue - runtime hints, never recovery input).
   # Nothing else is written - a system key without a reader is inventory,
   # not communication (config and policy travel via the object-storage
   # cluster bootstrap, which the coordinator actually reads; services are
@@ -205,7 +207,26 @@ defmodule Bedrock.ControlPlane.Director.Recovery.PersistencePhase do
         Tx.set(tx, SystemKeys.layout_log(log_id), Values.encode_tag_list(log_descriptor))
       end)
 
-    build_shard_keys(tx, transaction_system_layout.shard_layout)
+    tx = build_shard_keys(tx, transaction_system_layout.shard_layout)
+    build_materializer_keys(tx, transaction_system_layout)
+  end
+
+  # Creates materializer_key(tag) -> {worker_id, node} entries (strings; the
+  # reader derives the callable ref). Gated like shard_keys: an empty ref map
+  # means shard management is not active, so existing entries are untouched.
+  @spec build_materializer_keys(Tx.t(), TransactionSystemLayout.t()) :: Tx.t()
+  defp build_materializer_keys(tx, transaction_system_layout) do
+    case TransactionSystemLayout.materializer_refs(transaction_system_layout) do
+      refs when map_size(refs) == 0 ->
+        tx
+
+      refs ->
+        tx = clear_prefix(tx, SystemKeys.materializers_prefix())
+
+        Enum.reduce(refs, tx, fn {tag, {worker_id, node}}, tx ->
+          Tx.set(tx, SystemKeys.materializer_key(tag), Values.encode_materializer_ref(worker_id, node))
+        end)
+    end
   end
 
   # Rewritten-every-recovery keyed families are cleared before their entries

--- a/lib/bedrock/control_plane/director/recovery/persistence_phase.ex
+++ b/lib/bedrock/control_plane/director/recovery/persistence_phase.ex
@@ -212,18 +212,26 @@ defmodule Bedrock.ControlPlane.Director.Recovery.PersistencePhase do
   end
 
   # Creates materializer_key(tag) -> {worker_id, node} entries (strings; the
-  # reader derives the callable ref). Gated like shard_keys: an empty ref map
-  # means shard management is not active, so existing entries are untouched.
+  # reader derives the callable ref). Gated like shard_keys, on the same
+  # INPUT: shard_materializers absent/empty means shard management is not
+  # active, so existing entries are untouched. When active, the prefix is
+  # cleared even if no pid inverts to a service record - the keyspace and
+  # the unlock seed must agree, and the seed derives from the same refs.
   @spec build_materializer_keys(Tx.t(), TransactionSystemLayout.t()) :: Tx.t()
   defp build_materializer_keys(tx, transaction_system_layout) do
-    case TransactionSystemLayout.materializer_refs(transaction_system_layout) do
-      refs when map_size(refs) == 0 ->
+    case Map.get(transaction_system_layout, :shard_materializers) do
+      nil ->
         tx
 
-      refs ->
+      materializers when map_size(materializers) == 0 ->
+        tx
+
+      _active ->
         tx = clear_prefix(tx, SystemKeys.materializers_prefix())
 
-        Enum.reduce(refs, tx, fn {tag, {worker_id, node}}, tx ->
+        transaction_system_layout
+        |> TransactionSystemLayout.materializer_refs()
+        |> Enum.reduce(tx, fn {tag, {worker_id, node}}, tx ->
           Tx.set(tx, SystemKeys.materializer_key(tag), Values.encode_materializer_ref(worker_id, node))
         end)
     end

--- a/lib/bedrock/control_plane/director/recovery/topology_phase.ex
+++ b/lib/bedrock/control_plane/director/recovery/topology_phase.ex
@@ -249,7 +249,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery.TopologyPhase do
   # turns it into its own RoutingData (`RoutingData.from_snapshot/1`); proxies
   # may live on other nodes, so nothing process- or node-local goes in here.
   @spec build_routing_snapshot(TransactionSystemLayout.t()) :: CommitProxy.RoutingData.snapshot()
-  defp build_routing_snapshot(%{logs: logs, services: services, shard_layout: shard_layout}) do
+  defp build_routing_snapshot(%{logs: logs, services: services, shard_layout: shard_layout} = layout) do
     # Build log_map: index -> log_id
     log_map =
       logs
@@ -279,6 +279,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery.TopologyPhase do
       shard_layout: shard_layout || %{},
       log_map: log_map,
       log_services: log_services,
+      materializers: TransactionSystemLayout.materializer_refs(layout),
       replication_factor: max(1, map_size(logs))
     }
   end

--- a/lib/bedrock/data_plane/commit_proxy/routing_data.ex
+++ b/lib/bedrock/data_plane/commit_proxy/routing_data.ex
@@ -7,6 +7,9 @@ defmodule Bedrock.DataPlane.CommitProxy.RoutingData do
     ceiling search (`end_key` is the shard's exclusive upper bound)
   - `log_map` - Map of index → log_id for golden ratio routing
   - `log_services` - Map of log_id → pid or {otp_name, node} for contacting logs
+  - `materializers` - Map of tag → `{worker_id, node}` (strings, as committed
+    to the `materializers/` keyspace family) for the client-facing routing
+    projection; clients derive the callable ref
   - `replication_factor` - Number of logs per mutation
 
   The value is a plain immutable term: the commit proxy server is its only
@@ -39,10 +42,14 @@ defmodule Bedrock.DataPlane.CommitProxy.RoutingData do
 
   @type shard_tree :: :gb_trees.tree(Bedrock.key(), {tag :: term(), start_key :: Bedrock.key()})
 
+  @typedoc "A materializer ref as committed to the keyspace: worker id and node, both strings."
+  @type materializer_ref :: {worker_id :: String.t(), node :: String.t()}
+
   @type t :: %__MODULE__{
           shards: shard_tree(),
           log_map: %{non_neg_integer() => Log.id()},
           log_services: %{Log.id() => {atom(), node()} | pid()},
+          materializers: %{Bedrock.range_tag() => materializer_ref()},
           replication_factor: pos_integer()
         }
 
@@ -51,24 +58,27 @@ defmodule Bedrock.DataPlane.CommitProxy.RoutingData do
   and nodes. `from_snapshot/1` turns it into runnable routing data.
   """
   @type snapshot :: %{
+          optional(:materializers) => %{Bedrock.range_tag() => materializer_ref()},
           shard_layout: %{Bedrock.key() => {tag :: term(), start_key :: Bedrock.key()}},
           log_map: %{non_neg_integer() => Log.id()},
           log_services: %{Log.id() => {atom(), node()} | pid()},
           replication_factor: pos_integer()
         }
 
-  defstruct [:shards, :log_map, :log_services, :replication_factor]
+  defstruct [:shards, :log_map, :log_services, :replication_factor, materializers: %{}]
 
   @doc """
   Builds routing data from a plain snapshot.
   """
   @spec from_snapshot(snapshot()) :: t()
-  def from_snapshot(%{
-        shard_layout: shard_layout,
-        log_map: log_map,
-        log_services: log_services,
-        replication_factor: replication_factor
-      }) do
+  def from_snapshot(
+        %{
+          shard_layout: shard_layout,
+          log_map: log_map,
+          log_services: log_services,
+          replication_factor: replication_factor
+        } = snapshot
+      ) do
     shards =
       Enum.reduce(shard_layout, :gb_trees.empty(), fn {end_key, {tag, start_key}}, tree ->
         :gb_trees.enter(end_key, {tag, start_key}, tree)
@@ -78,6 +88,7 @@ defmodule Bedrock.DataPlane.CommitProxy.RoutingData do
       shards: shards,
       log_map: log_map,
       log_services: log_services,
+      materializers: Map.get(snapshot, :materializers, %{}),
       replication_factor: replication_factor
     }
   end
@@ -94,6 +105,7 @@ defmodule Bedrock.DataPlane.CommitProxy.RoutingData do
       shards: :gb_trees.empty(),
       log_map: %{},
       log_services: %{},
+      materializers: %{},
       replication_factor: 1
     }
   end
@@ -193,9 +205,20 @@ defmodule Bedrock.DataPlane.CommitProxy.RoutingData do
         end
 
       {:layout_log, log_id} ->
-        # The value (log descriptor tags) is not needed for routing; service
-        # refs are populated at runtime by the director, not from persisted data.
+        # The value (log descriptor tags) is not needed for routing; LOG
+        # service refs are populated at runtime by the director, not from
+        # persisted data (this epoch's log wiring is runtime state - the
+        # ServerDBInfo analogue). Materializer refs below deliberately DO
+        # ride persisted data: they are client-facing hints, FDB serverList
+        # style, and the Distributor mutates them mid-epoch (bedrock-q67.21).
         insert_log(routing_data, log_id)
+
+      {:materializer_key, tag} ->
+        # Undecodable values are ignored, keeping the last good ref.
+        case Values.decode_materializer_ref(value) do
+          {:ok, ref} -> %{routing_data | materializers: Map.put(routing_data.materializers, tag, ref)}
+          {:error, _} -> routing_data
+        end
 
       _ ->
         routing_data
@@ -212,6 +235,9 @@ defmodule Bedrock.DataPlane.CommitProxy.RoutingData do
         |> remove_log(log_id)
         |> delete_log_service(log_id)
 
+      {:materializer_key, tag} ->
+        %{routing_data | materializers: Map.delete(routing_data.materializers, tag)}
+
       _ ->
         routing_data
     end
@@ -224,6 +250,7 @@ defmodule Bedrock.DataPlane.CommitProxy.RoutingData do
     routing_data
     |> clear_shards_in_range(start_key, end_key)
     |> clear_logs_in_range(start_key, end_key)
+    |> clear_materializers_in_range(start_key, end_key)
   end
 
   defp apply_mutation(_mutation, routing_data), do: routing_data
@@ -239,6 +266,16 @@ defmodule Bedrock.DataPlane.CommitProxy.RoutingData do
       |> Enum.reduce(shards, &:gb_trees.delete_any/2)
 
     %{routing_data | shards: cleared}
+  end
+
+  defp clear_materializers_in_range(%__MODULE__{materializers: materializers} = routing_data, start_key, end_key) do
+    kept =
+      Map.reject(materializers, fn {tag, _ref} ->
+        full_key = SystemKeys.materializer_key(tag)
+        full_key >= start_key and full_key < end_key
+      end)
+
+    %{routing_data | materializers: kept}
   end
 
   defp clear_logs_in_range(%__MODULE__{log_map: log_map} = routing_data, start_key, end_key) do

--- a/lib/bedrock/system_keys.ex
+++ b/lib/bedrock/system_keys.ex
@@ -5,10 +5,14 @@ defmodule Bedrock.SystemKeys do
   Every key defined here has a named reader: `shard_keys/<end_key>` feeds each
   commit proxy's routing view (through resolver metadata windows) and the next
   recovery's materializer bootstrap; `layout/logs/<log_id>` keys feed the
-  routing view's log wiring (the tag-list value is not consumed by routing).
-  A system key without a reader is inventory, not communication - families
-  return here when their readers do (config authority with bedrock-q67.25,
-  the structured proxy view with bedrock-q67.9).
+  routing view's log wiring (the tag-list value is not consumed by routing);
+  `materializers/<tag>` refs feed the client-facing routing projection served
+  by commit proxies (FDB's `serverList/` analogue - interfaces ride the
+  keyspace). Materializer refs are runtime hints for clients, never recovery
+  input: bootstrap rebuilds assignment from `shard_keys/` plus live foreman
+  discovery. A system key without a reader is inventory, not communication -
+  families return here when their readers do (config authority with
+  bedrock-q67.25).
   """
 
   @system_prefix "\xff/system"
@@ -29,14 +33,34 @@ defmodule Bedrock.SystemKeys do
   @spec layout_logs_prefix() :: Bedrock.key()
   def layout_logs_prefix, do: "#{@system_prefix}/layout/logs/"
 
+  @doc "Materializer ref entry: `materializers/<tag>` -> `{worker_id, node}` strings"
+  @spec materializer_key(Bedrock.range_tag()) :: Bedrock.key()
+  def materializer_key(tag) when is_integer(tag), do: "#{@system_prefix}/materializers/#{tag}"
+
+  @doc "Prefix covering every materializer ref entry"
+  @spec materializers_prefix() :: Bedrock.key()
+  def materializers_prefix, do: "#{@system_prefix}/materializers/"
+
   @doc """
   Parses a system key into its family. Unknown system keys parse as
   `:unknown` (forward compatibility); non-system keys as `:error`.
   """
   @spec parse_key(Bedrock.key()) ::
-          {:layout_log, String.t()} | {:shard_key, Bedrock.key()} | :unknown | :error
+          {:layout_log, String.t()}
+          | {:shard_key, Bedrock.key()}
+          | {:materializer_key, Bedrock.range_tag()}
+          | :unknown
+          | :error
   def parse_key(<<@system_prefix, "/layout/logs/", rest::binary>>), do: {:layout_log, rest}
   def parse_key(<<@system_prefix, "/shard_keys/", rest::binary>>), do: {:shard_key, rest}
+
+  def parse_key(<<@system_prefix, "/materializers/", rest::binary>>) do
+    case Integer.parse(rest) do
+      {tag, ""} -> {:materializer_key, tag}
+      _ -> :unknown
+    end
+  end
+
   def parse_key(<<@system_prefix, _rest::binary>>), do: :unknown
   def parse_key(_key), do: :error
 end

--- a/lib/bedrock/system_keys/values.ex
+++ b/lib/bedrock/system_keys/values.ex
@@ -8,8 +8,10 @@ defmodule Bedrock.SystemKeys.Values do
   bytes must never create atoms.
 
   The surface is exactly the families with readers - `shard_keys/` entries
-  (the routing boundary map) and `layout/logs/` tag lists. Families return
-  here when their readers do.
+  (the routing boundary map), `layout/logs/` tag lists, and `materializers/`
+  refs (worker id and node as strings; consumers derive the callable
+  `{otp_name, node}` ref, so the no-atoms rule holds through decode).
+  Families return here when their readers do.
   """
 
   alias Bedrock.Encoding.Tuple, as: TupleEncoding
@@ -38,6 +40,18 @@ defmodule Bedrock.SystemKeys.Values do
   def encode_shard_key_entry(tag, start_key) when is_integer(tag) and is_binary(start_key),
     do: TupleEncoding.pack({tag, start_key})
 
+  @doc """
+  Encodes a materializer ref: `{worker_id, node}`, both strings.
+
+  Refs are string-encoded on purpose - never atoms or pids - so decoding
+  durable bytes never creates atoms. The worker's OTP name is derivable
+  from the id (`cluster.otp_name_for_worker/1`); conversion to a callable
+  ref happens at the consumer.
+  """
+  @spec encode_materializer_ref(String.t(), String.t()) :: binary()
+  def encode_materializer_ref(worker_id, node) when is_binary(worker_id) and is_binary(node),
+    do: TupleEncoding.pack({worker_id, node})
+
   @doc "Decodes a list of integer range tags."
   @spec decode_tag_list(binary()) :: {:ok, [Bedrock.range_tag()]} | decode_error()
   def decode_tag_list(binary), do: safe_unpack(binary, &(is_list(&1) and Enum.all?(&1, fn t -> is_integer(t) end)))
@@ -47,6 +61,11 @@ defmodule Bedrock.SystemKeys.Values do
   def decode_shard_key_entry(binary),
     do: safe_unpack(binary, &match?({tag, start_key} when is_integer(tag) and is_binary(start_key), &1))
 
+  @doc "Decodes a materializer ref to `{:ok, {worker_id, node}}` (strings)."
+  @spec decode_materializer_ref(binary()) :: {:ok, {String.t(), String.t()}} | decode_error()
+  def decode_materializer_ref(binary),
+    do: safe_unpack(binary, &match?({worker_id, node} when is_binary(worker_id) and is_binary(node), &1))
+
   @doc """
   Decodes a value given its parsed system key (from
   `Bedrock.SystemKeys.parse_key/1`).
@@ -54,6 +73,7 @@ defmodule Bedrock.SystemKeys.Values do
   @spec decode_for(term(), binary()) :: {:ok, term()} | decode_error()
   def decode_for({:shard_key, _end_key}, value), do: decode_shard_key_entry(value)
   def decode_for({:layout_log, _log_id}, value), do: decode_tag_list(value)
+  def decode_for({:materializer_key, _tag}, value), do: decode_materializer_ref(value)
   def decode_for(_unknown, _value), do: {:error, :unknown_family}
 
   defp safe_unpack(binary, valid?) when is_binary(binary) do

--- a/test/bedrock/control_plane/director/recovery/persistence_phase_test.exs
+++ b/test/bedrock/control_plane/director/recovery/persistence_phase_test.exs
@@ -13,6 +13,9 @@ defmodule Bedrock.ControlPlane.Director.Recovery.PersistencePhaseTest do
 
   # Shared test data setup
   defp mock_transaction_system_layout do
+    mat_sys = spawn(fn -> Process.sleep(:infinity) end)
+    mat_user = spawn(fn -> Process.sleep(:infinity) end)
+
     %{
       id: "test_layout_id",
       epoch: 1,
@@ -23,12 +26,16 @@ defmodule Bedrock.ControlPlane.Director.Recovery.PersistencePhaseTest do
       resolvers: [{<<0>>, self()}],
       logs: %{"log_1" => [1, 2]},
       services: %{
-        "log_1" => %{status: {:up, self()}, kind: :log, last_seen: {:log_1, :node1}}
+        "log_1" => %{status: {:up, self()}, kind: :log, last_seen: {:log_1, :node1}},
+        "wkr_sys" => %{status: {:up, mat_sys}, kind: :materializer, last_seen: {:wkr_sys_name, node()}},
+        "wkr_user" => %{status: {:up, mat_user}, kind: :materializer, last_seen: {:wkr_user_name, node()}}
       },
       shard_layout: %{
         <<0xFF>> => {1, <<>>},
         <<0xFF, 0xFF>> => {0, <<0xFF>>}
-      }
+      },
+      metadata_materializer: mat_sys,
+      shard_materializers: %{0 => mat_sys, 1 => mat_user}
     }
   end
 
@@ -48,8 +55,8 @@ defmodule Bedrock.ControlPlane.Director.Recovery.PersistencePhaseTest do
 
   describe "execute/2" do
     test "succeeds with existing transaction system layout and transitions to completed" do
-      expected_layout = mock_transaction_system_layout()
       recovery_attempt = base_recovery_attempt()
+      expected_layout = recovery_attempt.transaction_system_layout
 
       context = Map.put(recovery_context(), :commit_transaction_fn, fn _, _, _ -> {:ok, 1, 0} end)
 
@@ -106,6 +113,47 @@ defmodule Bedrock.ControlPlane.Director.Recovery.PersistencePhaseTest do
       assert decoded[{:shard_key, <<0xFF, 0xFF>>}] == {0, <<0xFF>>}
 
       assert decoded[{:layout_log, "log_1"}] == [1, 2]
+
+      # Materializer refs: worker id + node as strings (FDB serverList
+      # analogue), derived by inverting shard_materializers through services.
+      node_string = Atom.to_string(node())
+      assert decoded[{:materializer_key, 0}] == {"wkr_sys", node_string}
+      assert decoded[{:materializer_key, 1}] == {"wkr_user", node_string}
+    end
+
+    test "materializer family is skipped entirely when shard_materializers is absent" do
+      layout = Map.drop(mock_transaction_system_layout(), [:shard_materializers, :metadata_materializer])
+
+      recovery_attempt = Map.put(base_recovery_attempt(), :transaction_system_layout, layout)
+      mutations = captured_system_mutations(recovery_attempt)
+
+      prefix = SystemKeys.materializers_prefix()
+      {clear_start, clear_end} = KeyRange.from_prefix(prefix)
+
+      refute Enum.any?(mutations, fn
+               {:set, key, _} -> String.starts_with?(key, prefix)
+               {:clear_range, ^clear_start, ^clear_end} -> true
+               _ -> false
+             end)
+    end
+
+    test "a materializer pid without a service record is skipped, not invented" do
+      layout = mock_transaction_system_layout()
+      orphan = spawn(fn -> Process.sleep(:infinity) end)
+      layout = put_in(layout, [:shard_materializers, 9], orphan)
+
+      recovery_attempt = Map.put(base_recovery_attempt(), :transaction_system_layout, layout)
+      mutations = captured_system_mutations(recovery_attempt)
+
+      refute Enum.any?(mutations, fn
+               {:set, key, _} -> key == SystemKeys.materializer_key(9)
+               _ -> false
+             end)
+
+      assert Enum.any?(mutations, fn
+               {:set, key, _} -> key == SystemKeys.materializer_key(0)
+               _ -> false
+             end)
     end
 
     test "commits the system transaction in system mode by default" do
@@ -183,7 +231,8 @@ defmodule Bedrock.ControlPlane.Director.Recovery.PersistencePhaseTest do
 
       for prefix <- [
             SystemKeys.shard_keys_prefix(),
-            SystemKeys.layout_logs_prefix()
+            SystemKeys.layout_logs_prefix(),
+            SystemKeys.materializers_prefix()
           ] do
         {clear_start, clear_end} = KeyRange.from_prefix(prefix)
 

--- a/test/bedrock/control_plane/director/recovery/persistence_phase_test.exs
+++ b/test/bedrock/control_plane/director/recovery/persistence_phase_test.exs
@@ -137,6 +137,26 @@ defmodule Bedrock.ControlPlane.Director.Recovery.PersistencePhaseTest do
              end)
     end
 
+    test "active shard management with zero matching service records still clears the family" do
+      # Keyspace and seed must agree: the seed would be empty, so the
+      # keyspace must end empty too - the clear fires even with no sets.
+      layout = mock_transaction_system_layout()
+      layout = Map.update!(layout, :services, &Map.drop(&1, ["wkr_sys", "wkr_user"]))
+
+      recovery_attempt = Map.put(base_recovery_attempt(), :transaction_system_layout, layout)
+      mutations = captured_system_mutations(recovery_attempt)
+
+      prefix = SystemKeys.materializers_prefix()
+      {clear_start, clear_end} = KeyRange.from_prefix(prefix)
+
+      assert Enum.any?(mutations, &match?({:clear_range, ^clear_start, ^clear_end}, &1))
+
+      refute Enum.any?(mutations, fn
+               {:set, key, _} -> String.starts_with?(key, prefix)
+               _ -> false
+             end)
+    end
+
     test "a materializer pid without a service record is skipped, not invented" do
       layout = mock_transaction_system_layout()
       orphan = spawn(fn -> Process.sleep(:infinity) end)

--- a/test/bedrock/control_plane/director/recovery/topology_phase_test.exs
+++ b/test/bedrock/control_plane/director/recovery/topology_phase_test.exs
@@ -87,6 +87,38 @@ defmodule Bedrock.ControlPlane.Director.Recovery.TopologyPhaseTest do
       refute snapshot |> Map.values() |> Enum.any?(&is_reference/1)
     end
 
+    test "routing snapshot carries string-encoded materializer refs (the q67.23 seed)" do
+      test_pid = self()
+      mat_sys = spawn(fn -> Process.sleep(:infinity) end)
+
+      recovery_attempt =
+        base_recovery_attempt()
+        |> with_logs(%{"log_1" => [1, 2]})
+        |> with_transaction_services(%{
+          "log_1" => %{status: {:up, self()}, kind: :log, last_seen: {:log_1, :node1}},
+          "wkr_sys" => %{status: {:up, mat_sys}, kind: :materializer, last_seen: {:wkr_sys_name, node()}}
+        })
+        |> Map.put(:shard_materializers, %{0 => mat_sys})
+
+      context =
+        recovery_context()
+        |> with_lock_token("test_token")
+        |> Map.put(:unlock_commit_proxy_fn, fn _proxy, _token, _sequencer, _resolver_layout, snapshot ->
+          send(test_pid, {:routing_snapshot, snapshot})
+          :ok
+        end)
+
+      {_result, _next_phase} = TopologyPhase.execute(recovery_attempt, context)
+
+      assert_received {:routing_snapshot, snapshot}
+
+      # Refs are the same plain strings the persistence phase commits to the
+      # materializers/ family - the seed and the keyspace cannot disagree
+      # because both are derived from the same layout.
+      node_string = Atom.to_string(node())
+      assert snapshot.materializers == %{0 => {"wkr_sys", node_string}}
+    end
+
     test "fails when commit proxy unlocking fails" do
       recovery_attempt =
         base_recovery_attempt()

--- a/test/bedrock/data_plane/commit_proxy/routing_data_test.exs
+++ b/test/bedrock/data_plane/commit_proxy/routing_data_test.exs
@@ -38,6 +38,15 @@ defmodule Bedrock.DataPlane.CommitProxy.RoutingDataTest do
       assert routing_data.replication_factor == 1
     end
 
+    test "carries materializer refs when present; defaults to empty when absent" do
+      base = %{shard_layout: %{}, log_map: %{}, log_services: %{}, replication_factor: 1}
+
+      assert RoutingData.from_snapshot(base).materializers == %{}
+
+      with_refs = Map.put(base, :materializers, %{0 => {"wkr_sys", "n1@host"}})
+      assert RoutingData.from_snapshot(with_refs).materializers == %{0 => {"wkr_sys", "n1@host"}}
+    end
+
     test "is a plain immutable value: derived copies do not affect the original" do
       original =
         RoutingData.from_snapshot(%{
@@ -245,6 +254,53 @@ defmodule Bedrock.DataPlane.CommitProxy.RoutingDataTest do
       updated = RoutingData.apply_mutations(RoutingData.new_empty(), updates)
 
       assert updated.log_map == %{0 => "log-1", 1 => "log-2"}
+    end
+
+    test "handles materializer_key set mutation - decoded refs stay strings" do
+      updates = [
+        {v(100), [{:set, SystemKeys.materializer_key(7), Values.encode_materializer_ref("wkr_a", "n1@host")}]}
+      ]
+
+      updated = RoutingData.apply_mutations(RoutingData.new_empty(), updates)
+
+      assert updated.materializers == %{7 => {"wkr_a", "n1@host"}}
+    end
+
+    test "skips a materializer_key set whose value does not decode, keeping the last good entry" do
+      routing_data = %{RoutingData.new_empty() | materializers: %{7 => {"wkr_a", "n1@host"}}}
+
+      updates = [{v(100), [{:set, SystemKeys.materializer_key(7), <<0xEE, 0xEE>>}]}]
+
+      assert RoutingData.apply_mutations(routing_data, updates).materializers == %{7 => {"wkr_a", "n1@host"}}
+    end
+
+    test "handles materializer_key clear mutation" do
+      routing_data = %{RoutingData.new_empty() | materializers: %{7 => {"wkr_a", "n1@host"}}}
+
+      updates = [{v(100), [{:clear, SystemKeys.materializer_key(7)}]}]
+
+      assert RoutingData.apply_mutations(routing_data, updates).materializers == %{}
+    end
+
+    test "clear_range over the materializers prefix drops covered entries only" do
+      routing_data = %{
+        RoutingData.new_empty()
+        | materializers: %{0 => {"wkr_sys", "n1@host"}, 7 => {"wkr_a", "n1@host"}, 12 => {"wkr_b", "n2@host"}}
+      }
+
+      prefix = SystemKeys.materializers_prefix()
+      updates = [{v(100), [{:clear_range, prefix, prefix <> <<0xFF>>}]}]
+
+      assert RoutingData.apply_mutations(routing_data, updates).materializers == %{}
+    end
+
+    test "clear_range over an unrelated family leaves materializers untouched" do
+      routing_data = %{RoutingData.new_empty() | materializers: %{7 => {"wkr_a", "n1@host"}}}
+
+      prefix = SystemKeys.shard_keys_prefix()
+      updates = [{v(100), [{:clear_range, prefix, prefix <> <<0xFF>>}]}]
+
+      assert RoutingData.apply_mutations(routing_data, updates).materializers == %{7 => {"wkr_a", "n1@host"}}
     end
 
     test "handles shard_key clear mutation" do

--- a/test/bedrock/system_keys/values_test.exs
+++ b/test/bedrock/system_keys/values_test.exs
@@ -36,13 +36,37 @@ defmodule Bedrock.SystemKeys.ValuesTest do
     end
   end
 
+  describe "materializer refs" do
+    test "round-trip" do
+      assert {:ok, {"wkr_abc", "node@host"}} =
+               Values.decode_materializer_ref(Values.encode_materializer_ref("wkr_abc", "node@host"))
+    end
+
+    test "encoder rejects non-binary input loudly - refs are encoded as strings, never atoms or pids" do
+      assert_raise FunctionClauseError, fn -> Values.encode_materializer_ref(:worker_name, "node@host") end
+      assert_raise FunctionClauseError, fn -> Values.encode_materializer_ref("wkr_abc", :node@host) end
+      assert_raise FunctionClauseError, fn -> Values.encode_materializer_ref(self(), "node@host") end
+    end
+
+    test "decoder never raises on garbage or wrong shapes, and never creates atoms" do
+      assert {:error, :invalid_encoding} = Values.decode_materializer_ref(<<0xEE, 0xEE>>)
+      assert {:error, :invalid_type} = Values.decode_materializer_ref(Values.encode_tag_list([1]))
+      assert {:error, :invalid_type} = Values.decode_materializer_ref(Values.encode_shard_key_entry(1, "m"))
+      assert {:error, :invalid_encoding} = Values.decode_materializer_ref(:not_binary)
+    end
+  end
+
   describe "decode_for/2 - the writer/reader contract" do
     test "dispatches by parsed key family" do
       shard_value = Values.encode_shard_key_entry(3, "a")
       log_value = Values.encode_tag_list([0, 1])
+      ref_value = Values.encode_materializer_ref("wkr_abc", "node@host")
 
       assert {:ok, {3, "a"}} = Values.decode_for(SystemKeys.parse_key(SystemKeys.shard_key("m")), shard_value)
       assert {:ok, [0, 1]} = Values.decode_for(SystemKeys.parse_key(SystemKeys.layout_log("log_1")), log_value)
+
+      assert {:ok, {"wkr_abc", "node@host"}} =
+               Values.decode_for(SystemKeys.parse_key(SystemKeys.materializer_key(7)), ref_value)
     end
 
     test "unknown families decode as errors, never raise" do

--- a/test/bedrock/system_keys_test.exs
+++ b/test/bedrock/system_keys_test.exs
@@ -13,10 +13,23 @@ defmodule Bedrock.SystemKeysTest do
       assert SystemKeys.parse_key(SystemKeys.layout_log("log_1")) == {:layout_log, "log_1"}
     end
 
+    test "materializer_key/1 round-trips through parse_key/1" do
+      assert SystemKeys.parse_key(SystemKeys.materializer_key(0)) == {:materializer_key, 0}
+      assert SystemKeys.parse_key(SystemKeys.materializer_key(42)) == {:materializer_key, 42}
+    end
+
+    test "materializer keys with non-integer tags parse as :unknown" do
+      assert SystemKeys.parse_key(SystemKeys.materializers_prefix() <> "not_a_tag") == :unknown
+      assert SystemKeys.parse_key(SystemKeys.materializers_prefix() <> "12x") == :unknown
+      assert SystemKeys.parse_key(SystemKeys.materializers_prefix()) == :unknown
+    end
+
     test "prefixes cover exactly their families" do
       assert String.starts_with?(SystemKeys.shard_key("x"), SystemKeys.shard_keys_prefix())
       assert String.starts_with?(SystemKeys.layout_log("x"), SystemKeys.layout_logs_prefix())
+      assert String.starts_with?(SystemKeys.materializer_key(3), SystemKeys.materializers_prefix())
       refute String.starts_with?(SystemKeys.layout_log("x"), SystemKeys.shard_keys_prefix())
+      refute String.starts_with?(SystemKeys.materializer_key(3), SystemKeys.shard_keys_prefix())
     end
 
     test "unknown system keys parse as :unknown, non-system keys as :error" do


### PR DESCRIPTION
First layer of the q67.9 stack (design + audit trail on the ticket).

**Why**: clients are moving onto proxy-served routing; RoutingData lacked tag → materializer. FDB solves this with `serverList/` in the keyspace — interfaces ride committed data, decoded into keyInfo. Same move here.

**What**: new `materializers/<tag>` system-key family, written by recovery's system transaction (clear+rewrite, gated like shard_keys), folded into RoutingData through the metadata window pipeline, and seeded via the recover_from snapshot (the q67.23 seed) — seed and keyspace derive from one inversion helper so they cannot disagree.

**How**: string-encoded `{worker_id, node}` values (no atoms/pids in durable bytes; consumers derive the callable ref); `parse_key`/`decode_for` dispatch; set/clear/clear_range application incl. the clear-range helper that keeps shrinking layouts from leaving stale refs.

Full suite green (2,547), credo --strict + dialyzer clean.