### PR TITLE
bedrock-q67.9 (2/4): commit proxies serve client routing (GetKeyServerLocations analogue)

### DIFF
--- a/lib/bedrock/data_plane/commit_proxy.ex
+++ b/lib/bedrock/data_plane/commit_proxy.ex
@@ -47,6 +47,24 @@ defmodule Bedrock.DataPlane.CommitProxy do
     do: call(commit_proxy, {:recover_from, lock_token, sequencer, resolver_layout, routing_snapshot}, :infinity)
 
   @doc """
+  Fetches the client-facing routing projection: shard boundaries plus
+  materializer refs.
+
+  This is FDB's `GetKeyServerLocations`, answered from the proxy's live
+  routing view - at least as fresh as the proxy's most recently applied
+  commit, unversioned by design. Locations are unverified hints; staleness
+  costs the caller a retry, never a wrong answer.
+
+  A locked proxy replies `{:error, :locked}`: FDB parks location requests
+  until its state is valid, Bedrock refuses and lets the client's retry
+  loop be the parking lot.
+  """
+  @spec fetch_routing(commit_proxy_ref :: ref(), opts :: [timeout_in_ms: Bedrock.timeout_in_ms()]) ::
+          {:ok, RoutingData.client_projection()}
+          | {:error, :locked | :timeout | :unavailable}
+  def fetch_routing(commit_proxy, opts \\ []), do: call(commit_proxy, :fetch_routing, opts[:timeout_in_ms] || 5_000)
+
+  @doc """
   Submits a transaction for commit.
 
   By default the commit is bounded to the user keyspace: any mutation keyed

--- a/lib/bedrock/data_plane/commit_proxy/routing_data.ex
+++ b/lib/bedrock/data_plane/commit_proxy/routing_data.ex
@@ -67,6 +67,27 @@ defmodule Bedrock.DataPlane.CommitProxy.RoutingData do
 
   defstruct [:shards, :log_map, :log_services, :replication_factor, materializers: %{}]
 
+  @typedoc """
+  The client-facing slice of the routing view: shard boundaries plus
+  materializer refs. Log wiring stays proxy-internal.
+  """
+  @type client_projection :: %{
+          shard_layout: %{Bedrock.key() => {tag :: term(), start_key :: Bedrock.key()}},
+          materializers: %{Bedrock.range_tag() => materializer_ref()}
+        }
+
+  @doc """
+  Projects the client-facing slice of the routing view.
+
+  Served to clients by the commit proxy (FDB's `GetKeyServerLocations`
+  answered from `keyInfo`). Locations are unverified hints: a stale
+  projection costs the client a retry, never a wrong answer.
+  """
+  @spec client_projection(t()) :: client_projection()
+  def client_projection(%__MODULE__{shards: shards, materializers: materializers}) do
+    %{shard_layout: Map.new(:gb_trees.to_list(shards)), materializers: materializers}
+  end
+
   @doc """
   Builds routing data from a plain snapshot.
   """

--- a/lib/bedrock/data_plane/commit_proxy/server.ex
+++ b/lib/bedrock/data_plane/commit_proxy/server.ex
@@ -144,7 +144,8 @@ defmodule Bedrock.DataPlane.CommitProxy.Server do
           {:recover_from, binary(), pid(), ResolverLayout.t(), RoutingData.snapshot()}
           | {:commit, Bedrock.epoch(), Bedrock.transaction()}
           | {:commit, Bedrock.epoch(), Bedrock.transaction(), :user | :system}
-          | {:apply_metadata_and_route, pos_integer(), Bedrock.version(), term()},
+          | {:apply_metadata_and_route, pos_integer(), Bedrock.version(), term()}
+          | :fetch_routing,
           GenServer.from(),
           State.t()
         ) ::
@@ -206,6 +207,16 @@ defmodule Bedrock.DataPlane.CommitProxy.Server do
 
   def handle_call({:apply_metadata_and_route, _seq, _cv, _window}, _from, %{mode: :locked} = t),
     do: reply(t, {:error, :locked})
+
+  # Client routing requests (FDB GetKeyServerLocations): answered from the
+  # live routing view. Replying resumes the batch cadence - a routing fetch
+  # must not swallow an open batch's pending timeout.
+  def handle_call(:fetch_routing, from, %{mode: :running} = t) do
+    GenServer.reply(from, {:ok, RoutingData.client_projection(t.routing_data)})
+    noreply_resuming_cadence(t)
+  end
+
+  def handle_call(:fetch_routing, _from, %{mode: :locked} = t), do: reply(t, {:error, :locked})
 
   defp accept_commit(transaction, commit_mode, from, t) do
     case start_batch_if_needed(t) do

--- a/test/bedrock/data_plane/commit_proxy/metadata_distribution_integration_test.exs
+++ b/test/bedrock/data_plane/commit_proxy/metadata_distribution_integration_test.exs
@@ -15,6 +15,7 @@ defmodule Bedrock.DataPlane.CommitProxy.MetadataDistributionIntegrationTest do
 
   import Bedrock.Test.TelemetryTestHelper
 
+  alias Bedrock.DataPlane.CommitProxy
   alias Bedrock.DataPlane.CommitProxy.ResolverLayout
   alias Bedrock.DataPlane.CommitProxy.Server, as: CommitProxyServer
   alias Bedrock.DataPlane.Resolver.MetadataAccumulator
@@ -82,6 +83,7 @@ defmodule Bedrock.DataPlane.CommitProxy.MetadataDistributionIntegrationTest do
       shard_layout: %{<<0xFF, 0xFF>> => {0, <<>>}},
       log_map: %{0 => "log_1"},
       log_services: %{"log_1" => log},
+      materializers: %{0 => {"wkr_sys", "n1@host"}},
       replication_factor: 1
     }
 
@@ -221,6 +223,61 @@ defmodule Bedrock.DataPlane.CommitProxy.MetadataDistributionIntegrationTest do
     assert MetadataAccumulator.entries(:sys.get_state(resolver).metadata_window) == []
     # Windows are exact and always served: the ack advances with every batch
     # even when the window is empty - but nothing polluted the stream.
+  end
+
+  describe "fetch_routing/2 - the GetKeyServerLocations analogue" do
+    test "a locked proxy refuses routing requests until recover_from seeds it", %{epoch: epoch} do
+      locked_proxy =
+        start_supervised!(
+          CommitProxyServer.child_spec(
+            cluster: TestCluster,
+            director: self(),
+            epoch: epoch,
+            instance: 1,
+            max_latency_in_ms: 1,
+            max_per_batch: 10,
+            empty_transaction_timeout_ms: 60_000,
+            lock_token: :crypto.strong_rand_bytes(32),
+            sequencer: self(),
+            resolver_layout: ResolverLayout.from_layout(%{resolvers: []})
+          ),
+          id: :locked_proxy
+        )
+
+      assert {:error, :locked} = CommitProxy.fetch_routing(locked_proxy)
+    end
+
+    test "an unlocked proxy serves the seeded projection", %{proxy: proxy} do
+      assert {:ok, projection} = CommitProxy.fetch_routing(proxy)
+
+      assert projection == %{
+               shard_layout: %{<<0xFF, 0xFF>> => {0, <<>>}},
+               materializers: %{0 => {"wkr_sys", "n1@host"}}
+             }
+    end
+
+    test "committed shard and materializer mutations reach the served projection", %{proxy: proxy, epoch: epoch} do
+      mutations = [
+        {:set, SystemKeys.shard_key("m"), Values.encode_shard_key_entry(7, "")},
+        {:set, SystemKeys.materializer_key(7), Values.encode_materializer_ref("wkr_new", "n2@host")}
+      ]
+
+      version = commit!(proxy, epoch, mutations, "routing_key")
+      wait_until(fn -> proxy_applied_version(proxy) == version end)
+
+      assert {:ok, projection} = CommitProxy.fetch_routing(proxy)
+      assert projection.shard_layout["m"] == {7, ""}
+      assert projection.materializers[7] == {"wkr_new", "n2@host"}
+
+      # The projection is exactly the client slice - no log wiring leaks.
+      assert projection |> Map.keys() |> Enum.sort() == [:materializers, :shard_layout]
+    end
+
+    test "commits still flow while routing is being served", %{proxy: proxy, epoch: epoch} do
+      assert {:ok, _} = CommitProxy.fetch_routing(proxy)
+      assert commit!(proxy, epoch, [{:set, "after_fetch", "v"}], "after_fetch")
+      assert {:ok, _} = CommitProxy.fetch_routing(proxy)
+    end
   end
 
   test "routing families update the routing view; unknown system keys are ignored", %{proxy: proxy, epoch: epoch} do

--- a/test/bedrock/data_plane/commit_proxy/routing_data_test.exs
+++ b/test/bedrock/data_plane/commit_proxy/routing_data_test.exs
@@ -62,6 +62,25 @@ defmodule Bedrock.DataPlane.CommitProxy.RoutingDataTest do
     end
   end
 
+  describe "client_projection/1" do
+    test "exposes shard boundaries and materializer refs; log wiring stays proxy-internal" do
+      snapshot = %{
+        shard_layout: %{"m" => {1, ""}, <<0xFF, 0xFF>> => {0, "m"}},
+        log_map: %{0 => "log-a"},
+        log_services: %{"log-a" => {:log_a, :node1}},
+        materializers: %{0 => {"wkr_sys", "n1@host"}, 1 => {"wkr_a", "n1@host"}},
+        replication_factor: 1
+      }
+
+      projection = snapshot |> RoutingData.from_snapshot() |> RoutingData.client_projection()
+
+      assert projection == %{
+               shard_layout: %{"m" => {1, ""}, <<0xFF, 0xFF>> => {0, "m"}},
+               materializers: %{0 => {"wkr_sys", "n1@host"}, 1 => {"wkr_a", "n1@host"}}
+             }
+    end
+  end
+
   describe "new_empty/0" do
     test "creates empty routing data with all fields initialized" do
       routing_data = RoutingData.new_empty()


### PR DESCRIPTION
Second layer of the q67.9 stack, on top of #172.

**Why**: the proxy's RoutingData is the only live shard topology in the system (seeded at unlock, advanced by every committed metadata window — FDB's keyInfo). Clients need to read it instead of the recovery-frozen TSL fields.

**What**: `CommitProxy.fetch_routing/2` returns the client-facing projection — shard boundaries + materializer refs, log wiring stays proxy-internal. Locked proxies refuse (`{:error, :locked}`, the validState gate; the client retry loop is the parking lot). The reply is unversioned by design: locations are unverified hints, staleness costs a retry, never a wrong answer.

**How**: `RoutingData.client_projection/1` + one server clause that replies from the live view and resumes the batch cadence (a fetch must not swallow an open batch's pending timeout). Integration tests ride the real sequencer/resolver/proxy pipeline.

Full suite green, credo --strict + dialyzer clean.