### PR TITLE
bedrock-q67.9 (3/4): clients read the shard map from commit proxies

### DIFF
--- a/lib/bedrock/cluster/link.ex
+++ b/lib/bedrock/cluster/link.ex
@@ -62,6 +62,32 @@ defmodule Bedrock.Cluster.Link do
   end
 
   @doc """
+  Fetch the node's cached routing projection (shard boundaries plus
+  materializer refs, as served by `Bedrock.DataPlane.CommitProxy.fetch_routing/2`).
+
+  The Link is the node-wide location cache (FDB's `DatabaseContext`
+  locationCache): it only stores. On a miss the caller fetches from a
+  commit proxy and caches the result back with `cache_routing/2`.
+  """
+  @spec fetch_cached_routing(ref(), opts :: [timeout_in_ms: Bedrock.timeout_in_ms()]) ::
+          {:ok, map()} | {:error, :unavailable | :timeout | :unknown}
+  def fetch_cached_routing(link, opts \\ []), do: call(link, :get_routing, opts[:timeout_in_ms] || 1000)
+
+  @doc "Caches a routing projection fetched from a commit proxy."
+  @spec cache_routing(ref(), map()) :: :ok
+  def cache_routing(link, routing), do: cast(link, {:cache_routing, routing})
+
+  @doc """
+  Drops the cached routing projection.
+
+  Called by the client retry loop when a read fails in a routing-shaped way
+  (unroutable key, dead materializer, unavailable) - a dead pid is exactly
+  what a stale snapshot looks like, so the next transaction refetches.
+  """
+  @spec invalidate_routing(ref()) :: :ok
+  def invalidate_routing(link), do: cast(link, :invalidate_routing)
+
+  @doc """
   Fetch the cluster descriptor.
   This includes the coordinator nodes and other cluster configuration.
   """

--- a/lib/bedrock/cluster/link/server.ex
+++ b/lib/bedrock/cluster/link/server.ex
@@ -114,6 +114,25 @@ defmodule Bedrock.Cluster.Link.Server do
     reply(t, {:ok, t.descriptor})
   end
 
+  # The node-wide routing cache (FDB DatabaseContext locationCache): the Link
+  # only stores; callers fetch from a commit proxy on miss and cast the
+  # result back. No TTL - entries live until invalidated or a wiring push
+  # drops them; staleness is backstopped by the client retry loop.
+  @spec handle_call(:get_routing, GenServer.from(), State.t()) ::
+          {:reply, {:ok, map()} | {:error, :unavailable}, State.t()}
+  def handle_call(:get_routing, _, t) do
+    case t.routing do
+      nil -> reply(t, {:error, :unavailable})
+      routing -> reply(t, {:ok, routing})
+    end
+  end
+
+  @doc false
+  @impl true
+  @spec handle_cast({:cache_routing, map()} | :invalidate_routing, State.t()) :: {:noreply, State.t()}
+  def handle_cast({:cache_routing, routing}, t), do: noreply(%{t | routing: routing})
+  def handle_cast(:invalidate_routing, t), do: noreply(%{t | routing: nil})
+
   @doc false
   @impl true
   @spec handle_info({:timeout, :find_a_live_coordinator}, State.t()) ::
@@ -130,8 +149,9 @@ defmodule Bedrock.Cluster.Link.Server do
       foreman -> send(foreman, {:tsl_updated, new_tsl})
     end
 
-    updated_state = %{t | transaction_system_layout: new_tsl}
-    noreply(updated_state)
+    # A wiring push means a recovery happened: drop the routing cache so
+    # new-epoch wiring can never pair with old-epoch routing.
+    noreply(%{t | transaction_system_layout: new_tsl, routing: nil})
   end
 
   @spec handle_info({:DOWN, reference(), :process, term(), term()}, State.t()) ::

--- a/lib/bedrock/cluster/link/state.ex
+++ b/lib/bedrock/cluster/link/state.ex
@@ -14,7 +14,8 @@ defmodule Bedrock.Cluster.Link.State do
           timers: %{atom() => reference()} | nil,
           mode: :passive | :active,
           capabilities: [Bedrock.Cluster.capability()],
-          transaction_system_layout: TransactionSystemLayout.t() | nil
+          transaction_system_layout: TransactionSystemLayout.t() | nil,
+          routing: map() | nil
         }
   defstruct node: nil,
             cluster: nil,
@@ -24,5 +25,6 @@ defmodule Bedrock.Cluster.Link.State do
             timers: nil,
             mode: :active,
             capabilities: [],
-            transaction_system_layout: nil
+            transaction_system_layout: nil,
+            routing: nil
 end

--- a/lib/bedrock/internal/repo.ex
+++ b/lib/bedrock/internal/repo.ex
@@ -3,11 +3,33 @@ defmodule Bedrock.Internal.Repo do
   import Bitwise
 
   alias Bedrock.Cluster.Link
+  alias Bedrock.DataPlane.CommitProxy
   alias Bedrock.Internal.Repo.TransactionContext
   alias Bedrock.Internal.TransactionBuilder
   alias Bedrock.KeySelector
 
   @default_timeout_in_ms 5_000
+
+  # Read failures that never resolve without new information, only with a
+  # retry: version window misses resolve with a fresh read version, and the
+  # rest are routing- or liveness-shaped (FDB's wrong_shard_server model:
+  # they cost the caller a retry, never surface to the user).
+  @retryable_read_failures [
+    :timeout,
+    :unavailable,
+    :version_too_new,
+    :version_too_old,
+    :layout_lookup_failed,
+    :no_servers_to_race,
+    :locked
+  ]
+
+  # Of those, the ones that look like stale routing: an unroutable key, no
+  # servers to race, or a server that stopped answering. A dead pid is
+  # exactly what a stale snapshot looks like, so the retry drops the node's
+  # routing cache and refetches from a proxy. Version window misses are not
+  # routing's fault and keep the cache.
+  @routing_invalidating_failures [:layout_lookup_failed, :no_servers_to_race, :unavailable, :timeout, :locked]
 
   @type transaction :: pid()
   @type key :: term()
@@ -37,7 +59,7 @@ defmodule Bedrock.Internal.Repo do
       {:error, :not_found} ->
         nil
 
-      {:failure, reason} when reason in [:timeout, :unavailable, :version_too_new] ->
+      {:failure, reason} when reason in @retryable_read_failures ->
         throw({__MODULE__, t, :retryable_failure, reason})
 
       {failure_or_error, reason} when failure_or_error in [:error, :failure] and is_atom(reason) ->
@@ -59,7 +81,7 @@ defmodule Bedrock.Internal.Repo do
       {:error, :not_found} ->
         nil
 
-      {:failure, reason} when reason in [:timeout, :unavailable, :version_too_new] ->
+      {:failure, reason} when reason in @retryable_read_failures ->
         throw({__MODULE__, t, :retryable_failure, reason})
 
       {failure_or_error, reason} when failure_or_error in [:error, :failure] and is_atom(reason) ->
@@ -169,7 +191,7 @@ defmodule Bedrock.Internal.Repo do
       {:ok, {[first_row | rest], has_more}} ->
         emit_row_from_buffer(%{state | current_batch: rest, has_more: has_more}, first_row, rest)
 
-      {:failure, reason} when reason in [:timeout, :unavailable, :version_too_new, :no_servers_to_race] ->
+      {:failure, reason} when reason in @retryable_read_failures ->
         throw({__MODULE__, state.txn, :retryable_failure, reason})
 
       {:error, reason} ->
@@ -238,9 +260,10 @@ defmodule Bedrock.Internal.Repo do
     timeout_in_ms = Keyword.get(opts, :timeout_in_ms, @default_timeout_in_ms)
 
     TransactionContext.with_deadline(repo, timeout_in_ms, fn ->
-      run_retryable_transaction(repo, fun, 0, retry_limit, fn ->
+      run_retryable_transaction(repo, fun, 0, retry_limit, fn last_reason ->
+        maybe_invalidate_routing(link, last_reason)
         tsl = fetch_tsl_for_transaction(repo, provided_tsl, link)
-        start_transaction_builder(tsl, repo)
+        start_transaction_builder(tsl, routing_fn_for_transaction(cluster, provided_tsl, link), repo)
       end)
     end)
   after
@@ -251,12 +274,19 @@ defmodule Bedrock.Internal.Repo do
     timeout_in_ms = Keyword.get(opts, :timeout_in_ms, @default_timeout_in_ms)
 
     TransactionContext.with_deadline(repo, timeout_in_ms, fn ->
-      run_retryable_transaction(repo, fun, 0, nil, fn ->
+      run_retryable_transaction(repo, fun, 0, nil, fn _last_reason ->
         call_transaction(repo, txn, :nested_transaction)
         txn
       end)
     end)
   end
+
+  defp maybe_invalidate_routing(nil, _last_reason), do: :ok
+
+  defp maybe_invalidate_routing(link, last_reason) when last_reason in @routing_invalidating_failures,
+    do: Link.invalidate_routing(link)
+
+  defp maybe_invalidate_routing(_link, _last_reason), do: :ok
 
   defp fetch_tsl_for_transaction(repo, nil, link) do
     case Link.fetch_transaction_system_layout(link,
@@ -269,8 +299,53 @@ defmodule Bedrock.Internal.Repo do
 
   defp fetch_tsl_for_transaction(_repo, tsl, _link), do: tsl
 
-  defp start_transaction_builder(tsl, repo) do
-    case TransactionBuilder.start_link(transaction_system_layout: tsl) do
+  # A caller-provided TSL carries its own shard fields; the builder derives
+  # routing from them directly (no routing_fn). Otherwise routing is
+  # proxy-served and lazy: the builder calls this on its first read - Link
+  # cache first (the node's locationCache), fetch-through to a random
+  # commit proxy on a miss, caching the raw projection for the next
+  # transaction on this node. Runs in the builder process, so failures are
+  # returned (they surface as read failures), never thrown.
+  defp routing_fn_for_transaction(_cluster, provided_tsl, _link) when not is_nil(provided_tsl), do: nil
+
+  defp routing_fn_for_transaction(cluster, nil, link) do
+    fn ->
+      case Link.fetch_cached_routing(link) do
+        {:ok, routing} -> {:ok, callable_routing(cluster, routing)}
+        {:error, _not_cached} -> fetch_and_cache_routing(cluster, link)
+      end
+    end
+  end
+
+  defp fetch_and_cache_routing(cluster, link) do
+    with {:ok, tsl} <- Link.fetch_transaction_system_layout(link),
+         [_ | _] = proxies <- Map.get(tsl, :proxies, []),
+         {:ok, routing} <- proxies |> Enum.random() |> CommitProxy.fetch_routing() do
+      Link.cache_routing(link, routing)
+      {:ok, callable_routing(cluster, routing)}
+    else
+      [] -> {:error, :unavailable}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  # Turn the proxy's string-encoded materializer refs into callable
+  # `{otp_name, node}` refs. Worker OTP names are deterministic in the
+  # worker id; the node atom conversion is the documented exception to the
+  # no-atoms-on-decode rule - the values come from system-mode-gated
+  # writers and the atom count is bounded by cluster membership.
+  defp callable_routing(cluster, %{shard_layout: shard_layout, materializers: materializers}) do
+    callable =
+      Map.new(materializers, fn {tag, {worker_id, node}} ->
+        # credo:disable-for-next-line Credo.Check.Warning.UnsafeToAtom
+        {tag, {cluster.otp_name_for_worker(worker_id), String.to_atom(node)}}
+      end)
+
+    %{shard_layout: shard_layout, materializers: callable}
+  end
+
+  defp start_transaction_builder(tsl, routing_fn, repo) do
+    case TransactionBuilder.start_link(transaction_system_layout: tsl, routing_fn: routing_fn) do
       {:ok, txn} ->
         TransactionContext.put_builder(repo, txn)
         txn
@@ -280,15 +355,15 @@ defmodule Bedrock.Internal.Repo do
     end
   end
 
-  defp run_retryable_transaction(repo, fun, retry_count, retry_limit, restart_fn) do
+  defp run_retryable_transaction(repo, fun, retry_count, retry_limit, restart_fn, last_reason \\ nil) do
     TransactionContext.remaining_timeout!(repo, :timeout)
-    run_transaction(repo, restart_fn.(), fun)
+    run_transaction(repo, restart_fn.(last_reason), fun)
   catch
     {__MODULE__, failed_txn, :retryable_failure, reason} ->
       try_to_rollback(failed_txn)
       enforce_retry_limit(retry_count, retry_limit, reason)
       wait_before_retry(repo, retry_count, reason)
-      run_retryable_transaction(repo, fun, retry_count + 1, retry_limit, restart_fn)
+      run_retryable_transaction(repo, fun, retry_count + 1, retry_limit, restart_fn, reason)
 
     {__MODULE__, :rollback, reason} ->
       try_to_rollback(txn(repo))

--- a/lib/bedrock/internal/transaction_builder.ex
+++ b/lib/bedrock/internal/transaction_builder.ex
@@ -74,6 +74,7 @@ defmodule Bedrock.Internal.TransactionBuilder do
   @spec start_link(
           opts :: [
             transaction_system_layout: TransactionSystemLayout.t(),
+            routing_fn: (-> {:ok, %{shard_layout: map(), materializers: map()}} | {:error, atom()}),
             time_fn: (-> integer())
           ]
         ) ::
@@ -83,7 +84,7 @@ defmodule Bedrock.Internal.TransactionBuilder do
 
     GenServer.start_link(
       __MODULE__,
-      transaction_system_layout
+      {transaction_system_layout, Keyword.get(opts, :routing_fn)}
     )
   end
 
@@ -91,19 +92,66 @@ defmodule Bedrock.Internal.TransactionBuilder do
   def init(arg), do: {:ok, arg, {:continue, :initialization}}
 
   @impl true
-  def handle_continue(:initialization, transaction_system_layout) do
-    # Build the layout index once during initialization for O(log n) lookups
-    layout_index = LayoutIndex.build_index(transaction_system_layout)
+  def handle_continue(:initialization, {transaction_system_layout, routing_fn}) do
+    # Routing normally arrives proxy-served and LAZILY: like the read
+    # version, the layout index is built on first read, so a transaction
+    # that never reads never fetches routing (FDB fetches locations per
+    # read, not per transaction). A caller-provided TSL carries its own
+    # shard fields and indexes eagerly - no IO involved. That legacy
+    # derivation is deleted with bedrock-q67.9's final layer.
+    layout_index =
+      if routing_fn do
+        nil
+      else
+        %{shard_layout: shard_layout, materializers: materializers} =
+          routing_from_layout(transaction_system_layout)
+
+        LayoutIndex.build_index(shard_layout, materializers)
+      end
 
     noreply(%State{
       state: :valid,
       transaction_system_layout: transaction_system_layout,
       layout_index: layout_index,
+      routing_fn: routing_fn,
       read_version: nil
     })
   end
 
   def handle_continue(:stop, t), do: stop(t, :normal)
+
+  defp routing_from_layout(transaction_system_layout) do
+    materializers =
+      transaction_system_layout
+      |> Map.get(:shard_materializers)
+      |> Kernel.||(%{})
+      |> then(fn materializers ->
+        case Map.get(transaction_system_layout, :metadata_materializer) do
+          nil -> materializers
+          metadata_materializer -> Map.put_new(materializers, 0, metadata_materializer)
+        end
+      end)
+
+    %{
+      shard_layout: Map.get(transaction_system_layout, :shard_layout) || %{},
+      materializers: materializers
+    }
+  end
+
+  # Builds the layout index on first read (lazy, like the read version).
+  # A routing fetch failure replies like any other read failure - the
+  # Repo retry loop invalidates the node's routing cache and refetches.
+  defp with_layout_index(%State{layout_index: nil, routing_fn: routing_fn} = t, fun) do
+    case routing_fn.() do
+      {:ok, %{shard_layout: shard_layout, materializers: materializers}} ->
+        fun.(%{t | layout_index: LayoutIndex.build_index(shard_layout, materializers)})
+
+      {:error, reason} ->
+        reply(t, {:failure, reason})
+    end
+  end
+
+  defp with_layout_index(%State{} = t, fun), do: fun.(t)
 
   @impl true
   def handle_call(:nested_transaction, _from, t), do: reply(%{t | stack: [t.tx | t.stack]}, :ok)
@@ -128,42 +176,48 @@ defmodule Bedrock.Internal.TransactionBuilder do
   def handle_call({:get, key}, from, t) when is_binary(key), do: handle_call({:get, key, []}, from, t)
 
   def handle_call({:get, key, opts}, _from, t) when is_binary(key) and is_list(opts) do
-    t
-    |> get_key(key, opts)
-    |> then(fn
-      {t, {:error, _} = error} ->
-        reply(t, error)
+    with_layout_index(t, fn t ->
+      t
+      |> get_key(key, opts)
+      |> then(fn
+        {t, {:error, _} = error} ->
+          reply(t, error)
 
-      {t, {:failure, failures_by_reason}} ->
-        reply(t, {:failure, choose_a_reason(failures_by_reason)})
+        {t, {:failure, failures_by_reason}} ->
+          reply(t, {:failure, choose_a_reason(failures_by_reason)})
 
-      {t, {:ok, {^key, value}}} ->
-        reply(t, {:ok, value})
+        {t, {:ok, {^key, value}}} ->
+          reply(t, {:ok, value})
+      end)
     end)
   end
 
   def handle_call({:get_key_selector, %KeySelector{} = key_selector, opts}, _from, t) do
-    t
-    |> get_key_selector(key_selector, opts)
-    |> then(fn
-      {t, {:failure, failures_by_reason}} ->
-        reply(t, {:failure, choose_a_reason(failures_by_reason)})
+    with_layout_index(t, fn t ->
+      t
+      |> get_key_selector(key_selector, opts)
+      |> then(fn
+        {t, {:failure, failures_by_reason}} ->
+          reply(t, {:failure, choose_a_reason(failures_by_reason)})
 
-      {t, result} ->
-        reply(t, result)
+        {t, result} ->
+          reply(t, result)
+      end)
     end)
   end
 
   def handle_call({:get_range, start_key, end_key, batch_size, opts}, _from, t)
       when is_binary(start_key) and is_binary(end_key) do
-    t
-    |> get_range({start_key, end_key}, batch_size, opts)
-    |> then(fn
-      {t, {:failure, failures_by_reason}} ->
-        reply(t, {:failure, choose_a_reason(failures_by_reason)})
+    with_layout_index(t, fn t ->
+      t
+      |> get_range({start_key, end_key}, batch_size, opts)
+      |> then(fn
+        {t, {:failure, failures_by_reason}} ->
+          reply(t, {:failure, choose_a_reason(failures_by_reason)})
 
-      {t, result} ->
-        reply(t, result)
+        {t, result} ->
+          reply(t, result)
+      end)
     end)
   end
 
@@ -174,14 +228,16 @@ defmodule Bedrock.Internal.TransactionBuilder do
       ) do
     batch_size = Keyword.get(opts, :limit, 10_000)
 
-    t
-    |> get_range_selectors(start_selector, end_selector, batch_size, opts)
-    |> then(fn
-      {t, {:failure, failures_by_reason}} ->
-        reply(t, {:failure, choose_a_reason(failures_by_reason)})
+    with_layout_index(t, fn t ->
+      t
+      |> get_range_selectors(start_selector, end_selector, batch_size, opts)
+      |> then(fn
+        {t, {:failure, failures_by_reason}} ->
+          reply(t, {:failure, choose_a_reason(failures_by_reason)})
 
-      {t, result} ->
-        reply(t, result)
+        {t, result} ->
+          reply(t, result)
+      end)
     end)
   end
 

--- a/lib/bedrock/internal/transaction_builder/layout_index.ex
+++ b/lib/bedrock/internal/transaction_builder/layout_index.ex
@@ -22,22 +22,31 @@ defmodule Bedrock.Internal.TransactionBuilder.LayoutIndex do
   - {m, p} → [pid3]
   """
 
-  alias Bedrock.ControlPlane.Config.TransactionSystemLayout
-
   defstruct [:tree]
 
+  @typedoc "A callable materializer ref: a pid or a `{otp_name, node}` tuple."
+  @type server_ref :: pid() | {atom(), node()}
+
   @type t :: %__MODULE__{
-          tree: :gb_trees.tree(binary(), {binary(), [pid()]})
+          tree: :gb_trees.tree(binary(), {binary(), [server_ref()]})
         }
 
   @doc """
-  Builds a segmented index from a Transaction System Layout.
+  Builds a segmented index from shard boundaries and materializer refs.
+
+  `shard_layout` maps each shard's exclusive `end_key` to `{tag, start_key}`;
+  `materializers` maps tags to callable refs. Shards whose tag has no
+  materializer are dropped - a key landing in one fails the lookup, which
+  the client retry loop converts into an invalidate-and-refetch.
   """
-  @spec build_index(TransactionSystemLayout.t()) :: t()
-  def build_index(transaction_system_layout) do
+  @spec build_index(
+          %{Bedrock.key() => {Bedrock.range_tag(), Bedrock.key()}},
+          %{Bedrock.range_tag() => server_ref()}
+        ) :: t()
+  def build_index(shard_layout, materializers) when is_map(shard_layout) and is_map(materializers) do
     tree =
-      transaction_system_layout
-      |> collect_active_ranges()
+      shard_layout
+      |> collect_active_ranges(materializers)
       |> create_segments_with_pids()
       |> build_tree_from_segments()
 
@@ -115,38 +124,23 @@ defmodule Bedrock.Internal.TransactionBuilder.LayoutIndex do
 
   # Private implementation functions
 
-  # Build active ranges from shard_layout and available materializers.
-  # For each shard in the layout, we need a materializer process that can serve reads.
-  # Shards without materializers will have no read server, causing layout_lookup_failed.
-  @spec collect_active_ranges(TransactionSystemLayout.t()) ::
-          [{binary(), binary(), [pid()]}]
-  defp collect_active_ranges(transaction_system_layout) do
-    shard_layout = Map.get(transaction_system_layout, :shard_layout) || %{}
-    metadata_materializer = Map.get(transaction_system_layout, :metadata_materializer)
-    shard_materializers = Map.get(transaction_system_layout, :shard_materializers) || %{}
-
-    # Convert shard_layout to ranges with materializer servers
+  # Build active ranges from shard boundaries and available materializers.
+  # Shards without a materializer have no read server, causing
+  # layout_lookup_failed at lookup time.
+  @spec collect_active_ranges(
+          %{Bedrock.key() => {Bedrock.range_tag(), Bedrock.key()}},
+          %{Bedrock.range_tag() => server_ref()}
+        ) :: [{binary(), binary(), [server_ref()]}]
+  defp collect_active_ranges(shard_layout, materializers) do
     shard_layout
     |> Enum.map(fn {end_key, {tag, start_key}} ->
-      read_server = get_materializer_for_shard(tag, metadata_materializer, shard_materializers)
-      {start_key, end_key, read_server}
+      case Map.get(materializers, tag) do
+        nil -> {start_key, end_key, []}
+        ref -> {start_key, end_key, [ref]}
+      end
     end)
-    |> Enum.filter(fn {_start, _end, pids} -> pids != [] end)
-    |> Enum.sort_by(fn {start_key, _end, _pids} -> start_key end)
-  end
-
-  # Get materializer for a shard tag
-  defp get_materializer_for_shard(0, metadata_materializer, _shard_materializers) when is_pid(metadata_materializer) do
-    # System shard (tag 0) uses metadata_materializer
-    [metadata_materializer]
-  end
-
-  defp get_materializer_for_shard(tag, _metadata_materializer, shard_materializers) do
-    # Other shards use their assigned materializer from shard_materializers map
-    case Map.get(shard_materializers, tag) do
-      pid when is_pid(pid) -> [pid]
-      _ -> []
-    end
+    |> Enum.filter(fn {_start, _end, refs} -> refs != [] end)
+    |> Enum.sort_by(fn {start_key, _end, _refs} -> start_key end)
   end
 
   @spec create_segments_with_pids([{binary(), binary(), [pid()]}]) ::

--- a/lib/bedrock/internal/transaction_builder/state.ex
+++ b/lib/bedrock/internal/transaction_builder/state.ex
@@ -9,7 +9,8 @@ defmodule Bedrock.Internal.TransactionBuilder.State do
   @type t :: %__MODULE__{
           state: :valid | :committed | :rolled_back,
           transaction_system_layout: Bedrock.ControlPlane.Config.TransactionSystemLayout.t(),
-          layout_index: LayoutIndex.t(),
+          layout_index: LayoutIndex.t() | nil,
+          routing_fn: (-> {:ok, map()} | {:error, atom()}) | nil,
           #
           read_version: Bedrock.version() | nil,
           commit_version: Bedrock.version() | nil,
@@ -22,6 +23,7 @@ defmodule Bedrock.Internal.TransactionBuilder.State do
   defstruct state: nil,
             transaction_system_layout: nil,
             layout_index: nil,
+            routing_fn: nil,
             #
             read_version: nil,
             commit_version: nil,

--- a/test/bedrock/cluster/link/routing_cache_test.exs
+++ b/test/bedrock/cluster/link/routing_cache_test.exs
@@ -1,0 +1,46 @@
+defmodule Bedrock.Cluster.Link.RoutingCacheTest do
+  use ExUnit.Case, async: true
+
+  alias Bedrock.Cluster.Link.Server
+  alias Bedrock.Cluster.Link.State
+
+  defmodule TestCluster do
+    @moduledoc false
+    def otp_name(component) when is_atom(component), do: :"routing_cache_test_#{component}"
+  end
+
+  @projection %{shard_layout: %{<<0xFF, 0xFF>> => {0, <<>>}}, materializers: %{0 => {"wkr_sys", "n1@host"}}}
+
+  defp state(overrides \\ []) do
+    struct!(%State{node: node(), cluster: TestCluster, capabilities: []}, overrides)
+  end
+
+  describe "routing cache" do
+    test "empty cache misses" do
+      assert {:reply, {:error, :unavailable}, _} = Server.handle_call(:get_routing, self_from(), state())
+    end
+
+    test "cache_routing fills, get_routing hits" do
+      assert {:noreply, cached} = Server.handle_cast({:cache_routing, @projection}, state())
+      assert {:reply, {:ok, @projection}, _} = Server.handle_call(:get_routing, self_from(), cached)
+    end
+
+    test "invalidate_routing empties the cache" do
+      {:noreply, cached} = Server.handle_cast({:cache_routing, @projection}, state())
+      assert {:noreply, invalidated} = Server.handle_cast(:invalidate_routing, cached)
+      assert {:reply, {:error, :unavailable}, _} = Server.handle_call(:get_routing, self_from(), invalidated)
+    end
+
+    test "a wiring push drops the cached routing - new-epoch wiring must never pair with old-epoch routing" do
+      {:noreply, cached} = Server.handle_cast({:cache_routing, @projection}, state())
+
+      new_tsl = %{epoch: 2, sequencer: self(), proxies: [self()]}
+      assert {:noreply, updated} = Server.handle_info({:tsl_updated, new_tsl}, cached)
+
+      assert updated.transaction_system_layout == new_tsl
+      assert {:reply, {:error, :unavailable}, _} = Server.handle_call(:get_routing, self_from(), updated)
+    end
+  end
+
+  defp self_from, do: {self(), make_ref()}
+end

--- a/test/bedrock/data_plane/commit_proxy/fetch_routing_cadence_test.exs
+++ b/test/bedrock/data_plane/commit_proxy/fetch_routing_cadence_test.exs
@@ -1,0 +1,41 @@
+defmodule Bedrock.DataPlane.CommitProxy.FetchRoutingCadenceTest do
+  @moduledoc """
+  A routing fetch must not swallow the proxy's batch cadence: replying
+  without re-arming the GenServer timeout would strand an open batch (its
+  pending zero-timeout is cancelled by the arriving call) or silence the
+  empty-transaction heartbeat. Pinned here as direct handler assertions -
+  the integration tests are sequential and cannot see a stranded batch.
+  """
+  use ExUnit.Case, async: true
+
+  alias Bedrock.DataPlane.CommitProxy.Batch
+  alias Bedrock.DataPlane.CommitProxy.RoutingData
+  alias Bedrock.DataPlane.CommitProxy.Server
+  alias Bedrock.DataPlane.CommitProxy.State
+
+  defp running_state(overrides) do
+    struct!(
+      %State{
+        mode: :running,
+        empty_transaction_timeout_ms: 1_234,
+        routing_data: RoutingData.new_empty()
+      },
+      overrides
+    )
+  end
+
+  test "with no open batch, the heartbeat timeout is re-armed" do
+    assert {:noreply, _t, 1_234} = Server.handle_call(:fetch_routing, from(), running_state(batch: nil))
+  end
+
+  test "with an open batch, the zero timeout is re-armed so the batch still finalizes" do
+    assert {:noreply, _t, 0} = Server.handle_call(:fetch_routing, from(), running_state(batch: %Batch{}))
+  end
+
+  test "the reply arrives before the cadence resumes" do
+    Server.handle_call(:fetch_routing, from(), running_state(batch: nil))
+    assert_received {_ref, {:ok, %{shard_layout: %{}, materializers: %{}}}}
+  end
+
+  defp from, do: {self(), make_ref()}
+end

--- a/test/bedrock/internal/repo_error_handling_test.exs
+++ b/test/bedrock/internal/repo_error_handling_test.exs
@@ -212,7 +212,18 @@ defmodule Bedrock.Internal.RepoErrorHandlingTest do
 
   describe "error classification" do
     test "tuple is thrown for retryable errors" do
-      retryable_errors = [:unavailable, :timeout, :version_too_new]
+      # Routing-shaped failures (layout_lookup_failed, no_servers_to_race,
+      # locked) and version-window misses retry - FDB's wrong_shard_server
+      # model: staleness costs a retry, never surfaces to the user.
+      retryable_errors = [
+        :unavailable,
+        :timeout,
+        :version_too_new,
+        :version_too_old,
+        :layout_lookup_failed,
+        :no_servers_to_race,
+        :locked
+      ]
 
       for error_reason <- retryable_errors do
         txn =
@@ -235,7 +246,7 @@ defmodule Bedrock.Internal.RepoErrorHandlingTest do
     end
 
     test "TransactionError tuple is thrown for non-retryable errors" do
-      non_retryable_errors = [:invalid_key, :permission_denied, :version_too_old]
+      non_retryable_errors = [:invalid_key, :permission_denied]
 
       for error_reason <- non_retryable_errors do
         txn =

--- a/test/bedrock/internal/repo_transact_test.exs
+++ b/test/bedrock/internal/repo_transact_test.exs
@@ -386,6 +386,119 @@ defmodule Bedrock.Internal.RepoTransactTest do
     end
   end
 
+  describe "transact/4 proxy-served routing" do
+    defmodule RoutingCluster do
+      @moduledoc false
+      def link!, do: Process.get(:stub_link_pid)
+      def otp_name_for_worker(id), do: :"repo_transact_routing_worker_#{id}"
+    end
+
+    @projection %{
+      shard_layout: %{<<0xFF, 0xFF>> => {0, <<>>}},
+      materializers: %{0 => {"wkr1", nil}}
+    }
+
+    defp projection, do: put_in(@projection.materializers[0], {"wkr1", Atom.to_string(node())})
+
+    defp spawn_stub_materializer(test_pid) do
+      materializer =
+        spawn(fn ->
+          receive do
+            {:"$gen_call", from, {:get, key, _version, _opts}} ->
+              send(test_pid, {:materializer_got, key})
+              GenServer.reply(from, {:ok, "routed_value"})
+          end
+        end)
+
+      Process.register(materializer, RoutingCluster.otp_name_for_worker("wkr1"))
+      materializer
+    end
+
+    defp spawn_stub_sequencer do
+      spawn(fn ->
+        receive do
+          {:"$gen_call", from, {:next_read_version, _epoch}} ->
+            GenServer.reply(from, {:ok, Bedrock.DataPlane.Version.from_integer(1)})
+        end
+      end)
+    end
+
+    defp link_loop(tsl, cached_routing, test_pid) do
+      receive do
+        {:"$gen_call", from, :get_routing} ->
+          case cached_routing do
+            nil -> GenServer.reply(from, {:error, :unavailable})
+            routing -> GenServer.reply(from, {:ok, routing})
+          end
+
+          link_loop(tsl, cached_routing, test_pid)
+
+        {:"$gen_call", from, :get_transaction_system_layout} ->
+          GenServer.reply(from, {:ok, tsl})
+          link_loop(tsl, cached_routing, test_pid)
+
+        {:"$gen_cast", {:cache_routing, routing}} ->
+          send(test_pid, {:routing_cached, routing})
+          link_loop(tsl, routing, test_pid)
+      end
+    end
+
+    test "a cache miss fetches routing from a proxy, caches it at the link, and routes the read" do
+      test_pid = self()
+      spawn_stub_materializer(test_pid)
+      routing = projection()
+
+      proxy =
+        spawn(fn ->
+          receive do
+            {:"$gen_call", from, :fetch_routing} -> GenServer.reply(from, {:ok, routing})
+          end
+        end)
+
+      tsl = %{epoch: 1, sequencer: spawn_stub_sequencer(), proxies: [proxy]}
+      link = spawn(fn -> link_loop(tsl, nil, test_pid) end)
+      Process.put(:stub_link_pid, link)
+
+      result = Repo.transact(RoutingCluster, TestRepo, fn -> Repo.get(TestRepo, "some_key") end, [])
+
+      assert result == "routed_value"
+      assert_received {:materializer_got, "some_key"}
+      # The raw (string-ref) projection was cached back for the next
+      # transaction on this node - the Link is the locationCache.
+      assert_received {:routing_cached, ^routing}
+    end
+
+    test "a cache hit routes the read without touching any proxy" do
+      test_pid = self()
+      spawn_stub_materializer(test_pid)
+
+      # No proxies at all: a proxy fetch would fail loudly.
+      tsl = %{epoch: 1, sequencer: spawn_stub_sequencer(), proxies: []}
+      link = spawn(fn -> link_loop(tsl, projection(), test_pid) end)
+      Process.put(:stub_link_pid, link)
+
+      result = Repo.transact(RoutingCluster, TestRepo, fn -> Repo.get(TestRepo, "some_key") end, [])
+
+      assert result == "routed_value"
+      assert_received {:materializer_got, "some_key"}
+      refute_received {:routing_cached, _}
+    end
+
+    test "a transaction that never reads never fetches routing" do
+      test_pid = self()
+
+      # Link serves wiring only; a routing fetch would hit the empty proxy
+      # list and fail. Lazy routing means this commit-only (read-free)
+      # transaction never asks.
+      tsl = %{epoch: 1, sequencer: spawn_stub_sequencer(), proxies: []}
+      link = spawn(fn -> link_loop(tsl, nil, test_pid) end)
+      Process.put(:stub_link_pid, link)
+
+      assert Repo.transact(RoutingCluster, TestRepo, fn -> :no_reads end, []) == :no_reads
+      refute_received {:routing_cached, _}
+    end
+  end
+
   describe "transact/4 nested transactions" do
     test "a client read call cannot wait forever for an unresponsive transaction builder" do
       {:ok, txn} = ScriptedTxn.start_link([])


### PR DESCRIPTION
Third layer of the q67.9 stack, on #172/#173. The load-bearing layer: the client read path moves off the recovery-frozen TSL shard fields onto proxy-served routing — FDB's client location model, whole.

**What**: the Link becomes the node's locationCache (stores the raw projection, no TTL, dropped on every wiring push so new-epoch wiring never pairs with old-epoch routing). Routing is fetched **lazily** like the read version — the builder builds its LayoutIndex on first read through a `routing_fn` (Link cache → fetch-through to a random proxy → cast back); a transaction that never reads never fetches. String refs become callable refs at the client (deterministic worker OTP names; node-atom conversion is the documented no-atoms-on-decode exception).

**The load-bearing piece** (per the design audit): retry reclassification. `layout_lookup_failed` / `no_servers_to_race` / `version_too_old` / `:locked` join the retryable set (resolving the old get/get_range inconsistency), and retries invalidate the routing cache on routing-shaped failures only — version-window misses keep it. Staleness costs the user a retry, never an error, never a wrong answer.

Also pins the fetch_routing cadence as direct handler assertions (the #173 audit's one test gap).

Full suite green (2,563), credo --strict + dialyzer clean.