### PR TITLE
Seed materializer unlocks with typed pull sources

### DIFF
--- a/lib/bedrock/control_plane/director/recovery/materializer_bootstrap_phase.ex
+++ b/lib/bedrock/control_plane/director/recovery/materializer_bootstrap_phase.ex
@@ -367,22 +367,26 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhase do
   defp pull_sources_for_shard(shard_tag, recovery_attempt) do
     logs = recovery_attempt.logs
     services = recovery_attempt.transaction_services
+    replica_set = ShardRouter.log_ids_for_tag(shard_tag, ShardRouter.log_map(Map.keys(logs)), max(1, map_size(logs)))
 
-    log_map =
-      logs
-      |> Map.keys()
-      |> Enum.sort()
-      |> Enum.with_index()
-      |> Map.new(fn {log_id, index} -> {index, log_id} end)
+    sources =
+      Enum.flat_map(replica_set, fn log_id ->
+        case Map.get(services, log_id) do
+          %{status: {:up, ref}} -> [{log_id, ref}]
+          _ -> []
+        end
+      end)
 
-    shard_tag
-    |> ShardRouter.log_ids_for_tag(log_map, max(1, map_size(logs)))
-    |> Enum.flat_map(fn log_id ->
-      case Map.get(services, log_id) do
-        %{status: {:up, ref}} -> [{log_id, ref}]
-        _ -> []
-      end
-    end)
+    # Recruitment records every log with an up ref, so a shrunken seed
+    # means the attempt's own bookkeeping disagrees with itself — worth a
+    # trail, since the materializer would wait on the missing replicas
+    # with no director-side symptom.
+    if length(sources) < length(replica_set) do
+      missing = replica_set -- Enum.map(sources, fn {log_id, _ref} -> log_id end)
+      Logger.warning("Pull-source seed for shard #{shard_tag} is missing log refs: #{inspect(missing)}")
+    end
+
+    sources
   end
 
   # Unlock the materializer with its pull sources. The version is the

--- a/lib/bedrock/control_plane/director/recovery/materializer_bootstrap_phase.ex
+++ b/lib/bedrock/control_plane/director/recovery/materializer_bootstrap_phase.ex
@@ -18,7 +18,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhase do
   1. Find materializer with shard_id = 0 (system shard) in available_services
   2. If not found, create a new materializer on a capable node
   3. Lock materializer for recovery
-  4. Unlock it with system shard logs to start pulling
+  4. Unlock it with its replica set of pull sources to start pulling
   5. Wait for materializer to catch up (60s timeout)
   6. Query shard layout from `\\xff/system/shard_keys/*`
 
@@ -34,6 +34,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhase do
 
   alias Bedrock.ControlPlane.Director.Recovery.CommitProxyStartupPhase
   alias Bedrock.DataPlane.Materializer
+  alias Bedrock.DataPlane.ShardRouter
   alias Bedrock.Service.Foreman
   alias Bedrock.Service.Worker
   alias Bedrock.SystemKeys.Values
@@ -163,24 +164,13 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhase do
     lock_fn.(service, epoch)
   end
 
-  # Start materializer pulling from logs for its shard
+  # Start materializer pulling from its replica set of logs
   defp start_materializer_pulling(pid, shard_tag, recovery_attempt, context) do
-    shard_logs = filter_logs_for_shard(recovery_attempt.logs, shard_tag)
-
-    tsl = %{
-      epoch: recovery_attempt.epoch,
-      sequencer: recovery_attempt.sequencer,
-      proxies: recovery_attempt.proxies,
-      resolvers: recovery_attempt.resolvers,
-      logs: shard_logs,
-      services: recovery_attempt.transaction_services
-    }
-
     # For fresh cluster, start from version zero
     durable_version = Bedrock.DataPlane.Version.zero()
     unlock_fn = Map.get(context, :unlock_materializer_fn, &default_unlock_materializer/3)
 
-    case unlock_fn.(pid, durable_version, tsl) do
+    case unlock_fn.(pid, durable_version, pull_sources_for_shard(shard_tag, recovery_attempt)) do
       :ok -> :ok
       {:error, reason} -> {:error, {:unlock_failed, reason}}
       {:failure, reason, _ref} -> {:error, {:unlock_failed, reason}}
@@ -368,43 +358,48 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhase do
     end
   end
 
-  # Filter logs to only those relevant for the given shard (by tag)
-  defp filter_logs_for_shard(logs, shard_id) do
-    logs
-    |> Enum.filter(fn {_log_id, tags} -> log_routes_to_shard?(tags, shard_id) end)
-    |> Map.new()
+  # The unlock seed: this shard's replica set as {log_id, log_ref} pairs,
+  # resolved once here through the same ShardRouter walk the commit
+  # proxies route with. The materializer receives exactly its own
+  # sources — never the cluster's services map (FDB gives each storage
+  # server its own tag and assignments, not ServerDBInfo's membership).
+  @spec pull_sources_for_shard(non_neg_integer(), RecoveryAttempt.t()) :: Materializer.pull_sources()
+  defp pull_sources_for_shard(shard_tag, recovery_attempt) do
+    logs = recovery_attempt.logs
+    services = recovery_attempt.transaction_services
+
+    log_map =
+      logs
+      |> Map.keys()
+      |> Enum.sort()
+      |> Enum.with_index()
+      |> Map.new(fn {log_id, index} -> {index, log_id} end)
+
+    shard_tag
+    |> ShardRouter.log_ids_for_tag(log_map, max(1, map_size(logs)))
+    |> Enum.flat_map(fn log_id ->
+      case Map.get(services, log_id) do
+        %{status: {:up, ref}} -> [{log_id, ref}]
+        _ -> []
+      end
+    end)
   end
 
-  defp log_routes_to_shard?([], _shard_id), do: true
-  defp log_routes_to_shard?(tags, shard_id), do: shard_id in tags
-
-  # Unlock materializer with only the logs it needs to start pulling. The
-  # version is the recovery (rollback) version — vector last — never the
-  # durable floor, which regresses to zero on restart by design.
+  # Unlock the materializer with its pull sources. The version is the
+  # recovery (rollback) version — vector last — never the durable floor,
+  # which regresses to zero on restart by design.
   defp unlock_and_start_pulling(materializer_pid, shard_tag, recovery_version, recovery_attempt, context) do
-    shard_logs = filter_logs_for_shard(recovery_attempt.logs, shard_tag)
-
-    # TransactionSystemLayout is a type, not a struct, so we build a map
-    tsl = %{
-      epoch: recovery_attempt.epoch,
-      sequencer: recovery_attempt.sequencer,
-      proxies: recovery_attempt.proxies,
-      resolvers: recovery_attempt.resolvers,
-      logs: shard_logs,
-      services: recovery_attempt.transaction_services
-    }
-
     unlock_fn = Map.get(context, :unlock_materializer_fn, &default_unlock_materializer/3)
 
-    case unlock_fn.(materializer_pid, recovery_version, tsl) do
+    case unlock_fn.(materializer_pid, recovery_version, pull_sources_for_shard(shard_tag, recovery_attempt)) do
       :ok -> :ok
       {:error, reason} -> {:error, {:unlock_failed, reason}}
       {:failure, reason, _ref} -> {:error, {:unlock_failed, reason}}
     end
   end
 
-  defp default_unlock_materializer(pid, durable_version, tsl) do
-    Materializer.unlock_after_recovery(pid, durable_version, tsl, timeout_in_ms: 30_000)
+  defp default_unlock_materializer(pid, durable_version, pull_sources) do
+    Materializer.unlock_after_recovery(pid, durable_version, pull_sources, timeout_in_ms: 30_000)
   end
 
   # Poll until materializer reaches target version. The label — shard and

--- a/lib/bedrock/control_plane/director/recovery/topology_phase.ex
+++ b/lib/bedrock/control_plane/director/recovery/topology_phase.ex
@@ -60,6 +60,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery.TopologyPhase do
   alias Bedrock.ControlPlane.Config.TSLTypeValidator
   alias Bedrock.DataPlane.CommitProxy
   alias Bedrock.DataPlane.Log
+  alias Bedrock.DataPlane.ShardRouter
   alias Bedrock.Service.Worker
 
   @doc """
@@ -247,13 +248,9 @@ defmodule Bedrock.ControlPlane.Director.Recovery.TopologyPhase do
   @spec build_routing_snapshot(TransactionSystemLayout.t(), RecoveryAttempt.t()) :: CommitProxy.RoutingData.snapshot()
   defp build_routing_snapshot(%{logs: logs, services: services}, recovery_attempt) do
     shard_layout = recovery_attempt.shard_layout
-    # Build log_map: index -> log_id
-    log_map =
-      logs
-      |> Map.keys()
-      |> Enum.sort()
-      |> Enum.with_index()
-      |> Map.new(fn {log_id, index} -> {index, log_id} end)
+    # Build log_map: index -> log_id (the shared construction — see
+    # ShardRouter.log_map/1 — so seeds and routing cannot diverge)
+    log_map = ShardRouter.log_map(Map.keys(logs))
 
     # Build log_services: log_id -> pid or {name, node}
     log_services =

--- a/lib/bedrock/data_plane/commit_proxy/finalization.ex
+++ b/lib/bedrock/data_plane/commit_proxy/finalization.ex
@@ -760,7 +760,7 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization do
     sorted =
       tagged_mutations_list
       |> Enum.reverse()
-      |> Enum.sort_by(fn {_mutation, tag} -> tag_to_integer(tag) end, &<=/2)
+      |> Enum.sort_by(fn {_mutation, tag} -> ShardRouter.normalize_tag(tag) end, &<=/2)
 
     # 2. Build shard index from sorted list
     shard_index = build_shard_index(sorted)
@@ -781,10 +781,10 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization do
 
   defp build_shard_index(sorted_tagged_mutations) do
     sorted_tagged_mutations
-    |> Enum.chunk_by(fn {_mutation, tag} -> tag_to_integer(tag) end)
+    |> Enum.chunk_by(fn {_mutation, tag} -> ShardRouter.normalize_tag(tag) end)
     |> Enum.map(fn chunk ->
       {_mutation, tag} = hd(chunk)
-      {tag_to_integer(tag), length(chunk)}
+      {ShardRouter.normalize_tag(tag), length(chunk)}
     end)
   end
 
@@ -865,24 +865,12 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization do
           non_neg_integer()
         ) :: %{Log.id() => [term()]}
   defp add_tagged_mutation_to_logs({mutation, tag}, acc, log_map, m) do
-    log_ids = tag |> tag_to_integer() |> ShardRouter.log_ids_for_tag(log_map, m)
+    log_ids = ShardRouter.log_ids_for_tag(tag, log_map, m)
 
     Enum.reduce(log_ids, acc, fn log_id, acc_inner ->
       Map.update!(acc_inner, log_id, &[{mutation, tag} | &1])
     end)
   end
-
-  # Convert tag to integer for golden ratio algorithm
-  # Production code uses integer tags, but tests may use strings
-  @spec tag_to_integer(term()) :: non_neg_integer()
-  defp tag_to_integer(tag) when is_integer(tag), do: tag
-
-  defp tag_to_integer(tag) when is_binary(tag) do
-    # Hash string tags to integers
-    :erlang.phash2(tag)
-  end
-
-  defp tag_to_integer(tag), do: :erlang.phash2(tag)
 
   @spec mutation_to_key_or_range(
           {:set, Bedrock.key(), Bedrock.value()}

--- a/lib/bedrock/data_plane/commit_proxy/finalization.ex
+++ b/lib/bedrock/data_plane/commit_proxy/finalization.ex
@@ -848,11 +848,9 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization do
       {:halt, {:error, {:storage_team_coverage_error, key_or_range}}}
     else
       # For each (mutation, tag) pair, find logs and add the tagged mutation
-      n = map_size(log_map)
-
       updated_acc =
         Enum.reduce(tagged_mutations, mutations_acc, fn {split_mutation, tag}, acc ->
-          add_tagged_mutation_to_logs({split_mutation, tag}, acc, log_map, n, m)
+          add_tagged_mutation_to_logs({split_mutation, tag}, acc, log_map, m)
         end)
 
       {:cont, {:ok, updated_acc}}
@@ -864,16 +862,10 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization do
           {term(), non_neg_integer()},
           %{Log.id() => [term()]},
           %{non_neg_integer() => Log.id()},
-          non_neg_integer(),
           non_neg_integer()
         ) :: %{Log.id() => [term()]}
-  defp add_tagged_mutation_to_logs({mutation, tag}, acc, log_map, n, m) do
-    numeric_tag = tag_to_integer(tag)
-
-    log_ids =
-      numeric_tag
-      |> ShardRouter.get_log_indices(n, m)
-      |> Enum.map(&Map.fetch!(log_map, &1))
+  defp add_tagged_mutation_to_logs({mutation, tag}, acc, log_map, m) do
+    log_ids = tag |> tag_to_integer() |> ShardRouter.log_ids_for_tag(log_map, m)
 
     Enum.reduce(log_ids, acc, fn log_id, acc_inner ->
       Map.update!(acc_inner, log_id, &[{mutation, tag} | &1])

--- a/lib/bedrock/data_plane/materializer.ex
+++ b/lib/bedrock/data_plane/materializer.ex
@@ -7,13 +7,21 @@ defmodule Bedrock.DataPlane.Materializer do
 
   # Removed: import Bedrock.Internal.GenServer.Calls
 
-  alias Bedrock.ControlPlane.Config.TransactionSystemLayout
+  alias Bedrock.DataPlane.Log
   alias Bedrock.DataPlane.Materializer.Telemetry
   alias Bedrock.KeySelector
   alias Bedrock.Service.Worker
 
   @type ref :: Worker.ref()
   @type id :: Worker.id()
+
+  @typedoc """
+  A shard's replica set for stream pulling: the logs that receive this
+  shard's slices, as `{log_id, log_ref}` pairs. Resolved once by the
+  director at unlock (`ShardRouter.log_ids_for_tag/3`); the materializer
+  never re-derives placement and never sees a cluster services map.
+  """
+  @type pull_sources :: [{Log.id(), Log.ref()}]
   @type key_range :: Bedrock.key_range()
   @type fact_name ::
           Worker.fact_name()
@@ -274,21 +282,24 @@ defmodule Bedrock.DataPlane.Materializer do
   Unlocks the materializer after recovery is complete. This allows the materializer
   to start accepting new transactions again and continue normal operation.
 
-  The durable version and transaction system layout must be provided to
-  ensure that the materializer is unlocked at the correct state.
+  The durable version and the shard's pull sources — its replica set of
+  `{log_id, log_ref}` pairs, resolved once by the director through the
+  same `ShardRouter` walk the commit proxies route with — must be
+  provided so the materializer resumes at the correct state. The seed is
+  exactly this shard's sources, never a cluster map.
   """
   @spec unlock_after_recovery(
           storage :: ref(),
           durable_version :: Bedrock.version(),
-          TransactionSystemLayout.t(),
+          pull_sources(),
           opts :: [timeout_in_ms: Bedrock.timeout_in_ms()]
         ) :: :ok | {:error, :unavailable} | {:failure, :timeout, ref()}
-  def unlock_after_recovery(storage, durable_version, transaction_system_layout, opts \\ []) do
+  def unlock_after_recovery(storage, durable_version, pull_sources, opts \\ []) do
     timeout = opts[:timeout_in_ms] || :infinity
     start_time = System.monotonic_time()
 
     try do
-      result = GenServer.call(storage, {:unlock_after_recovery, durable_version, transaction_system_layout}, timeout)
+      result = GenServer.call(storage, {:unlock_after_recovery, durable_version, pull_sources}, timeout)
 
       Telemetry.emit_materializer_operation(
         :unlock_after_recovery_success,

--- a/lib/bedrock/data_plane/materializer/olivine/logic.ex
+++ b/lib/bedrock/data_plane/materializer/olivine/logic.ex
@@ -4,7 +4,6 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Logic do
   import Bedrock.DataPlane.Materializer.Olivine.State,
     only: [update_mode: 2, update_director_and_epoch: 3, reset_puller: 1, put_puller: 2]
 
-  alias Bedrock.ControlPlane.Config.TransactionSystemLayout
   alias Bedrock.ControlPlane.Director
   alias Bedrock.DataPlane.Materializer
   alias Bedrock.DataPlane.Materializer.Olivine.CompactionWriter.SplitFile, as: SplitFileWriter
@@ -164,14 +163,14 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Logic do
     %{t | pending_ingest: nil}
   end
 
-  @spec unlock_after_recovery(State.t(), Bedrock.version(), TransactionSystemLayout.t()) ::
+  @spec unlock_after_recovery(State.t(), Bedrock.version(), Materializer.pull_sources()) ::
           {:ok, State.t()}
-  def unlock_after_recovery(t, durable_version, %{logs: logs, services: services}) do
+  def unlock_after_recovery(t, durable_version, pull_sources) when is_list(pull_sources) do
     t =
       t
       |> stop_pulling()
       |> rollback_uncommitted(durable_version)
-      |> Map.put(:pull_sources, {logs, services})
+      |> Map.put(:pull_sources, pull_sources)
 
     t
     |> start_pulling_from(resume_position(t))
@@ -224,14 +223,14 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Logic do
   defp start_pulling_from(%{shard_num: nil} = t, _start_after), do: t
   defp start_pulling_from(%{pull_sources: nil} = t, _start_after), do: t
 
-  defp start_pulling_from(%{shard_num: shard_num, pull_sources: {logs, services}} = t, start_after) do
+  defp start_pulling_from(%{shard_num: shard_num, pull_sources: sources} = t, start_after) when is_list(sources) do
     # The stream puller: everything — history, recent data, and version
     # currency — comes from this shard's ShardServer. Batches are handed
     # over synchronously; the server withholds the reply for backpressure.
     server = self()
     ingest_fn = fn transactions, kcv -> GenServer.call(server, {:ingest, transactions, kcv}, :infinity) end
 
-    puller = Streaming.start_pulling(shard_num, start_after, logs, services, ingest_fn)
+    puller = Streaming.start_pulling(shard_num, start_after, sources, ingest_fn)
     put_puller(t, puller)
   end
 

--- a/lib/bedrock/data_plane/materializer/olivine/server.ex
+++ b/lib/bedrock/data_plane/materializer/olivine/server.ex
@@ -164,8 +164,8 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Server do
   end
 
   @impl true
-  def handle_call({:unlock_after_recovery, durable_version, transaction_system_layout}, {_director, _}, t) do
-    {:ok, updated_state} = Logic.unlock_after_recovery(t, durable_version, transaction_system_layout)
+  def handle_call({:unlock_after_recovery, durable_version, pull_sources}, {_director, _}, t) do
+    {:ok, updated_state} = Logic.unlock_after_recovery(t, durable_version, pull_sources)
     reply(updated_state, :ok)
   end
 

--- a/lib/bedrock/data_plane/materializer/olivine/state.ex
+++ b/lib/bedrock/data_plane/materializer/olivine/state.ex
@@ -2,6 +2,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.State do
   @moduledoc false
 
   alias Bedrock.ControlPlane.Director
+  alias Bedrock.DataPlane.Log
   alias Bedrock.DataPlane.Materializer.Olivine.Database
   alias Bedrock.DataPlane.Materializer.Olivine.IndexManager
   alias Bedrock.DataPlane.Materializer.Olivine.IntakeQueue
@@ -28,7 +29,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.State do
           compaction_task: Task.t() | nil,
           allow_window_advancement: boolean(),
           snapshot: Snapshot.t() | nil,
-          pull_sources: {logs :: map(), services :: map()} | nil,
+          pull_sources: [{Log.id(), Log.ref()}] | nil,
           shard_num: non_neg_integer() | nil,
           known_committed_version: Bedrock.version() | nil,
           pending_ingest: GenServer.from() | nil

--- a/lib/bedrock/data_plane/materializer/olivine/streaming.ex
+++ b/lib/bedrock/data_plane/materializer/olivine/streaming.ex
@@ -10,13 +10,14 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Streaming do
 
   ## Discovery
 
-  Shard-to-log placement is deterministic arithmetic shared with the commit
-  proxies: the index map is the sorted log ids and the golden-ratio walk is
-  `ShardRouter.get_log_indices/3` (see `topology_phase.build_routing_data/1`
-  — the two sites must agree). Any replica works: every replica sees the
-  same slices and the same cuts, so their chunks are byte-identical and
-  their buffers hold the same suffix. Failover walks the replica set with
-  the same circuit-breaker pattern the old log puller used.
+  The replica set arrives in the unlock seed: `[{log_id, log_ref}]`,
+  resolved once by the director through the same `ShardRouter` walk the
+  commit proxies route with (`ShardRouter.log_ids_for_tag/3`) — the
+  puller never re-derives placement. Any replica works: every replica
+  sees the same slices and the same cuts, so their chunks are
+  byte-identical and their buffers hold the same suffix. Failover walks
+  the replica set with the same circuit-breaker pattern the old log
+  puller used.
 
   ## Currency
 
@@ -33,21 +34,19 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Streaming do
   """
   import Bedrock.DataPlane.Materializer.Telemetry
 
-  alias Bedrock.ControlPlane.Config.LogDescriptor
-  alias Bedrock.ControlPlane.Config.ServiceDescriptor
   alias Bedrock.DataPlane.Demux.ShardServer
   alias Bedrock.DataPlane.Log
-  alias Bedrock.DataPlane.ShardRouter
   alias Bedrock.DataPlane.Transaction
   alias Bedrock.DataPlane.Version
 
   @type ingest_fn :: ([Transaction.encoded()], kcv :: Bedrock.version() | nil -> :ok)
 
+  @type source :: {Log.id(), Log.ref()}
+
   @type puller_state :: %{
           shard_num: non_neg_integer(),
           next_version: Bedrock.version(),
-          logs: %{Log.id() => LogDescriptor.t()},
-          services: %{String.t() => ServiceDescriptor.t()},
+          sources: [source()],
           failed_logs: %{Log.id() => integer()},
           shard_server: pid() | nil,
           current_log_id: Log.id() | nil,
@@ -57,16 +56,14 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Streaming do
   @spec start_pulling(
           shard_num :: non_neg_integer(),
           start_after :: Bedrock.version(),
-          logs :: %{Log.id() => LogDescriptor.t()},
-          services :: %{String.t() => ServiceDescriptor.t()},
+          sources :: [source()],
           ingest_fn()
         ) :: Task.t()
-  def start_pulling(shard_num, start_after, logs, services, ingest_fn) do
+  def start_pulling(shard_num, start_after, sources, ingest_fn) do
     state = %{
       shard_num: shard_num,
       next_version: Version.increment(start_after),
-      logs: logs,
-      services: services,
+      sources: sources,
       failed_logs: %{},
       shard_server: nil,
       current_log_id: nil,
@@ -93,27 +90,6 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Streaming do
 
   @spec pull_limit() :: pos_integer()
   def pull_limit, do: 100
-
-  @doc """
-  The replica set for a shard: the log ids that receive this shard's
-  slices, in golden-ratio order over the sorted log-id list.
-
-  Mirrors the commit proxies' routing exactly (the index map built in
-  `topology_phase.build_routing_data/1` is the sorted log ids, and the
-  replication factor currently spans all logs).
-  """
-  @spec candidate_log_ids(non_neg_integer(), %{Log.id() => LogDescriptor.t()}) :: [Log.id()]
-  def candidate_log_ids(_shard_num, logs) when map_size(logs) == 0, do: []
-
-  def candidate_log_ids(shard_num, logs) do
-    sorted = logs |> Map.keys() |> Enum.sort()
-    n = length(sorted)
-    m = max(1, n)
-
-    shard_num
-    |> ShardRouter.get_log_indices(n, m)
-    |> Enum.map(&Enum.at(sorted, &1))
-  end
 
   @spec stream_loop(puller_state()) :: no_return()
   def stream_loop(state) do
@@ -164,7 +140,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Streaming do
 
   def ensure_shard_server(state) do
     case select_log(state) do
-      {:ok, {log_id, %{status: {:up, worker}}}} ->
+      {:ok, {log_id, worker}} ->
         case safe_get_shard_server(worker, state.shard_num) do
           {:ok, pid} ->
             {:ok, %{state | shard_server: pid, current_log_id: log_id}}
@@ -180,20 +156,17 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Streaming do
 
   # Select a replica for this shard, excluding those with active circuit breakers
   @spec select_log(puller_state()) ::
-          {:ok, {Log.id(), ServiceDescriptor.t()}} | :no_available_logs
-  def select_log(%{shard_num: shard_num, logs: logs, services: services, failed_logs: failed_logs}) do
+          {:ok, source()} | :no_available_logs
+  def select_log(%{sources: sources, failed_logs: failed_logs}) do
     now = System.monotonic_time(:millisecond)
 
-    shard_num
-    |> candidate_log_ids(logs)
-    |> Enum.filter(fn log_id ->
+    sources
+    |> Enum.filter(fn {log_id, _ref} ->
       case Map.get(failed_logs, log_id) do
         nil -> true
         retry_timestamp -> now >= retry_timestamp
       end
     end)
-    |> Enum.map(&{&1, Map.get(services, &1)})
-    |> Enum.reject(&match?({_, nil}, &1))
     |> case do
       [] -> :no_available_logs
       available -> {:ok, Enum.random(available)}

--- a/lib/bedrock/data_plane/shard_router.ex
+++ b/lib/bedrock/data_plane/shard_router.ex
@@ -24,6 +24,7 @@ defmodule Bedrock.DataPlane.ShardRouter do
   """
 
   alias Bedrock.DataPlane.CommitProxy.RoutingData
+  alias Bedrock.DataPlane.Log
 
   # Golden ratio constant (2^64 / phi) for good distribution
   @golden 0x9E3779B97F4A7C15
@@ -74,6 +75,25 @@ defmodule Bedrock.DataPlane.ShardRouter do
     else
       h
     end
+  end
+
+  @doc """
+  The replica set for a shard tag: log ids resolved through `log_map`
+  (index → log id over the epoch's sorted log ids, built once by the
+  topology phase) via the golden-ratio walk.
+
+  This is the single site for shard→log placement. Commit-proxy mutation
+  routing and the director's materializer pull-source seeds both resolve
+  through it, so they cannot disagree.
+  """
+  @spec log_ids_for_tag(non_neg_integer(), %{non_neg_integer() => Log.id()}, non_neg_integer()) ::
+          [Log.id()]
+  def log_ids_for_tag(_tag, log_map, _replication_factor) when map_size(log_map) == 0, do: []
+
+  def log_ids_for_tag(tag, log_map, replication_factor) do
+    tag
+    |> get_log_indices(map_size(log_map), replication_factor)
+    |> Enum.map(&Map.fetch!(log_map, &1))
   end
 
   @doc ~S"""

--- a/lib/bedrock/data_plane/shard_router.ex
+++ b/lib/bedrock/data_plane/shard_router.ex
@@ -78,23 +78,48 @@ defmodule Bedrock.DataPlane.ShardRouter do
   end
 
   @doc """
+  The index map for an epoch's logs: index → log id over the sorted ids.
+
+  Both consumers of `log_ids_for_tag/3` build their map here, so the
+  sort and indexing cannot diverge between them.
+  """
+  @spec log_map([Log.id()]) :: %{non_neg_integer() => Log.id()}
+  def log_map(log_ids) do
+    log_ids
+    |> Enum.sort()
+    |> Enum.with_index()
+    |> Map.new(fn {log_id, index} -> {index, log_id} end)
+  end
+
+  @doc """
   The replica set for a shard tag: log ids resolved through `log_map`
-  (index → log id over the epoch's sorted log ids, built once by the
-  topology phase) via the golden-ratio walk.
+  (index → log id over the epoch's sorted log ids — see `log_map/1`)
+  via the golden-ratio walk. Non-integer tags are normalized by hashing,
+  so both consumers agree on the walk's input.
 
   This is the single site for shard→log placement. Commit-proxy mutation
   routing and the director's materializer pull-source seeds both resolve
   through it, so they cannot disagree.
   """
-  @spec log_ids_for_tag(non_neg_integer(), %{non_neg_integer() => Log.id()}, non_neg_integer()) ::
+  @spec log_ids_for_tag(term(), %{non_neg_integer() => Log.id()}, non_neg_integer()) ::
           [Log.id()]
   def log_ids_for_tag(_tag, log_map, _replication_factor) when map_size(log_map) == 0, do: []
 
   def log_ids_for_tag(tag, log_map, replication_factor) do
     tag
+    |> normalize_tag()
     |> get_log_indices(map_size(log_map), replication_factor)
     |> Enum.map(&Map.fetch!(log_map, &1))
   end
+
+  @doc """
+  Normalizes a shard tag for the golden-ratio walk. Production tags are
+  integers; anything else (test fixtures) hashes to one so the walk
+  stays defined — and every consumer normalizes identically.
+  """
+  @spec normalize_tag(term()) :: integer()
+  def normalize_tag(tag) when is_integer(tag), do: tag
+  def normalize_tag(tag), do: :erlang.phash2(tag)
 
   @doc ~S"""
   Looks up the shard tag for a key using ceiling search.

--- a/test/bedrock/control_plane/director/recovery/materializer_bootstrap_phase_test.exs
+++ b/test/bedrock/control_plane/director/recovery/materializer_bootstrap_phase_test.exs
@@ -82,19 +82,25 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhaseTest 
       :ets.delete(created_shards)
     end
 
-    test "for fresh cluster, unlocks shard materializers with empty log descriptors" do
+    test "for fresh cluster, seeds shard materializers with the epoch's pull sources" do
       system_materializer_pid = spawn(fn -> Process.sleep(:infinity) end)
       user_materializer_pid = spawn(fn -> Process.sleep(:infinity) end)
+      log_1_pid = spawn(fn -> Process.sleep(:infinity) end)
+      log_2_pid = spawn(fn -> Process.sleep(:infinity) end)
 
       logs = %{
-        {:vacancy, 1} => [],
-        {:vacancy, 2} => []
+        "log_1" => [],
+        "log_2" => []
       }
 
       recovery_attempt =
         recovery_attempt()
         |> Map.put(:shard_layout, nil)
         |> Map.put(:logs, logs)
+        |> Map.put(:transaction_services, %{
+          "log_1" => %{kind: :log, status: {:up, log_1_pid}},
+          "log_2" => %{kind: :log, status: {:up, log_2_pid}}
+        })
 
       unlocks = :ets.new(:materializer_unlocks, [:bag, :public])
 
@@ -114,8 +120,8 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhaseTest 
           pid = if shard_tag == 0, do: system_materializer_pid, else: user_materializer_pid
           {:ok, pid}
         end)
-        |> Map.put(:unlock_materializer_fn, fn pid, _version, tsl ->
-          :ets.insert(unlocks, {:unlock, pid, tsl.logs})
+        |> Map.put(:unlock_materializer_fn, fn pid, _version, pull_sources ->
+          :ets.insert(unlocks, {:unlock, pid, pull_sources})
           :ok
         end)
 
@@ -124,8 +130,17 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhaseTest 
 
       assert updated_attempt.shard_materializers[RecoveryAttempt.system_shard_id()] == system_materializer_pid
 
-      assert {:unlock, system_materializer_pid, logs} in :ets.lookup(unlocks, :unlock)
-      assert {:unlock, user_materializer_pid, logs} in :ets.lookup(unlocks, :unlock)
+      # Replication spans all logs today, so every shard's replica set
+      # covers both — each seed carries {log_id, ref} pairs, never a
+      # cluster services map.
+      expected = [{"log_1", log_1_pid}, {"log_2", log_2_pid}]
+
+      for pid <- [system_materializer_pid, user_materializer_pid] do
+        assert [{:unlock, ^pid, sources}] =
+                 unlocks |> :ets.lookup(:unlock) |> Enum.filter(&match?({:unlock, ^pid, _}, &1))
+
+        assert Enum.sort(sources) == expected
+      end
 
       :ets.delete(unlocks)
     end
@@ -444,15 +459,15 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhaseTest 
       assert log =~ "System shard materializer not found, creating new one"
     end
 
-    test "filters logs to only system shard when unlocking" do
+    test "seeds each unlocked materializer with its replica set of pull sources" do
       materializer_pid = spawn(fn -> Process.sleep(:infinity) end)
+      log_1_pid = spawn(fn -> Process.sleep(:infinity) end)
+      log_2_pid = spawn(fn -> Process.sleep(:infinity) end)
       durable_version = Version.from_integer(100)
 
-      # Logs with different shard assignments
-      # log_1 handles shard 0 (system), log_2 handles shard 1 (user)
       logs = %{
-        "log_1" => [0],
-        "log_2" => [1]
+        "log_1" => [],
+        "log_2" => []
       }
 
       recovery_attempt =
@@ -467,10 +482,12 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhaseTest 
         })
         |> Map.put(:transaction_services, %{
           "mat_sys" => %{kind: :materializer, status: {:up, materializer_pid}},
-          "mat_user" => %{kind: :materializer, status: {:up, spawn(fn -> Process.sleep(:infinity) end)}}
+          "mat_user" => %{kind: :materializer, status: {:up, spawn(fn -> Process.sleep(:infinity) end)}},
+          "log_1" => %{kind: :log, status: {:up, log_1_pid}},
+          "log_2" => %{kind: :log, status: {:up, log_2_pid}}
         })
 
-      received_tsl = :ets.new(:test_tsl, [:set, :public])
+      received_sources = :ets.new(:test_sources, [:set, :public])
 
       context =
         [
@@ -481,8 +498,8 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhaseTest 
         |> create_test_context()
         |> Map.put(:available_services, %{})
         |> Map.put(:lock_materializer_fn, fn {:materializer, ref}, _epoch -> {:ok, ref} end)
-        |> Map.put(:unlock_materializer_fn, fn pid, _version, tsl ->
-          :ets.insert(received_tsl, {pid, tsl.logs})
+        |> Map.put(:unlock_materializer_fn, fn pid, _version, pull_sources ->
+          :ets.insert(received_sources, {pid, pull_sources})
           :ok
         end)
         |> Map.put(:materializer_info_fn, fn _pid, [:current_version] ->
@@ -497,15 +514,17 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhaseTest 
           assert {_updated_attempt, CommitProxyStartupPhase} =
                    MaterializerBootstrapPhase.execute(recovery_attempt, context)
 
-          # Verify per-shard log filtering: the system materializer got
-          # only log_1, the user materializer only log_2
-          assert [{_, sys_logs}] = :ets.lookup(received_tsl, materializer_pid)
-          assert Map.keys(sys_logs) == ["log_1"]
+          # The seed is the shard's replica set — {log_id, ref} pairs
+          # resolved by the director, not a services map for the
+          # materializer to re-derive placement from. Replication spans
+          # all logs today, so the system shard's set covers both.
+          assert [{_, sources}] = :ets.lookup(received_sources, materializer_pid)
+          assert Enum.sort(sources) == [{"log_1", log_1_pid}, {"log_2", log_2_pid}]
         end)
 
       assert log =~ "Materializer caught up to version"
 
-      :ets.delete(received_tsl)
+      :ets.delete(received_sources)
     end
   end
 

--- a/test/bedrock/data_plane/materializer/olivine/compaction_cutover_test.exs
+++ b/test/bedrock/data_plane/materializer/olivine/compaction_cutover_test.exs
@@ -102,12 +102,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.CompactionCutoverTest do
   defp unlock_with_stream(pid, log_stub) do
     {:ok, _pid, _info} = GenServer.call(pid, {:lock_for_recovery, 1})
 
-    layout = %{
-      logs: %{"log-a" => []},
-      services: %{"log-a" => %{kind: :log, status: {:up, log_stub}}}
-    }
-
-    :ok = GenServer.call(pid, {:unlock_after_recovery, Version.zero(), layout})
+    :ok = GenServer.call(pid, {:unlock_after_recovery, Version.zero(), [{"log-a", log_stub}]})
   end
 
   defp slice(version, value) do

--- a/test/bedrock/data_plane/materializer/olivine/genserver_integration_test.exs
+++ b/test/bedrock/data_plane/materializer/olivine/genserver_integration_test.exs
@@ -376,12 +376,11 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.GenServerIntegrationTest do
 
           # Test unlock after recovery
           durable_version = Version.zero()
-          transaction_system_layout = %{logs: [], services: []}
 
           unlock_result =
             GenServer.call(
               pid,
-              {:unlock_after_recovery, durable_version, transaction_system_layout},
+              {:unlock_after_recovery, durable_version, []},
               @timeout
             )
 
@@ -649,9 +648,8 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.GenServerIntegrationTest do
 
           # Test unlock
           durable_version = Version.zero()
-          tsl = %{logs: [], services: []}
 
-          unlock_result = Materializer.unlock_after_recovery(pid, durable_version, tsl)
+          unlock_result = Materializer.unlock_after_recovery(pid, durable_version, [])
           assert unlock_result == :ok
 
         {:error, _reason} ->

--- a/test/bedrock/data_plane/materializer/olivine/ingest_test.exs
+++ b/test/bedrock/data_plane/materializer/olivine/ingest_test.exs
@@ -41,8 +41,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.IngestTest do
     epoch = 1
     {:ok, _pid, _info} = GenServer.call(pid, {:lock_for_recovery, epoch})
 
-    layout = %{logs: %{}, services: %{}}
-    :ok = GenServer.call(pid, {:unlock_after_recovery, Version.zero(), layout})
+    :ok = GenServer.call(pid, {:unlock_after_recovery, Version.zero(), []})
   end
 
   setup do
@@ -98,8 +97,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.IngestTest do
 
       # Recovery rolls the cluster back to v2: the v3 suffix must vanish.
       {:ok, _pid, _info} = GenServer.call(pid, {:lock_for_recovery, 2})
-      layout = %{logs: %{}, services: %{}}
-      :ok = GenServer.call(pid, {:unlock_after_recovery, v2, layout})
+      :ok = GenServer.call(pid, {:unlock_after_recovery, v2, []})
 
       assert {:ok, "b"} = GenServer.call(pid, {:get, "key", v2, []})
 
@@ -118,8 +116,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.IngestTest do
 
       # Nothing was applied: after unlock, the key does not exist at the
       # current (zero) version.
-      layout = %{logs: %{}, services: %{}}
-      :ok = GenServer.call(pid, {:unlock_after_recovery, Version.zero(), layout})
+      :ok = GenServer.call(pid, {:unlock_after_recovery, Version.zero(), []})
       assert {:error, :not_found} = GenServer.call(pid, {:get, "key", Version.zero(), []})
     end
   end

--- a/test/bedrock/data_plane/materializer/olivine/logic_test.exs
+++ b/test/bedrock/data_plane/materializer/olivine/logic_test.exs
@@ -139,11 +139,10 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.LogicTest do
     test "without a shard assignment the materializer unlocks static — no puller", %{test_dir: test_dir} do
       state = create_test_state(test_dir)
       locked_state = %{state | mode: :locked, epoch: 1}
-      layout = %{logs: %{}, services: %{}}
       durable_version = Version.from_integer(100)
 
       assert {:ok, %State{mode: :running, pull_task: nil}} =
-               Logic.unlock_after_recovery(locked_state, durable_version, layout)
+               Logic.unlock_after_recovery(locked_state, durable_version, [])
 
       Logic.shutdown(locked_state)
     end
@@ -151,11 +150,10 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.LogicTest do
     test "with a shard assignment the stream puller is installed", %{test_dir: test_dir} do
       state = create_test_state(test_dir)
       locked_state = %{state | mode: :locked, epoch: 1, shard_num: 1}
-      layout = %{logs: %{}, services: %{}}
       durable_version = Version.from_integer(100)
 
       assert {:ok, %State{mode: :running, pull_task: %Task{}} = unlocked_state} =
-               Logic.unlock_after_recovery(locked_state, durable_version, layout)
+               Logic.unlock_after_recovery(locked_state, durable_version, [])
 
       Logic.shutdown(unlocked_state)
     end

--- a/test/bedrock/data_plane/materializer/olivine/stream_read_test.exs
+++ b/test/bedrock/data_plane/materializer/olivine/stream_read_test.exs
@@ -86,12 +86,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.StreamReadTest do
 
     {:ok, _pid, _info} = GenServer.call(olivine, {:lock_for_recovery, 1})
 
-    layout = %{
-      logs: %{"log-a" => []},
-      services: %{"log-a" => %{kind: :log, status: {:up, log}}}
-    }
-
-    :ok = GenServer.call(olivine, {:unlock_after_recovery, Version.zero(), layout})
+    :ok = GenServer.call(olivine, {:unlock_after_recovery, Version.zero(), [{"log-a", log}]})
 
     %{demux: demux, olivine: olivine}
   end

--- a/test/bedrock/data_plane/materializer/olivine/streaming_test.exs
+++ b/test/bedrock/data_plane/materializer/olivine/streaming_test.exs
@@ -58,32 +58,12 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.StreamingTest do
     })
   end
 
-  defp services_for(logs_to_stubs) do
-    Map.new(logs_to_stubs, fn {log_id, stub} -> {log_id, %{kind: :log, status: {:up, stub}}} end)
-  end
-
-  describe "candidate_log_ids/2" do
-    test "is deterministic and drawn from the sorted log-id list" do
-      logs = %{"log-c" => [], "log-a" => [], "log-b" => []}
-
-      ids = Streaming.candidate_log_ids(7, logs)
-
-      assert Enum.sort(ids) == ["log-a", "log-b", "log-c"]
-      assert ids == Streaming.candidate_log_ids(7, logs)
-    end
-
-    test "returns an empty list with no logs" do
-      assert Streaming.candidate_log_ids(0, %{}) == []
-    end
-  end
-
   describe "pull_once/1" do
     defp state_with(shard_server, ingest_fn) do
       %{
         shard_num: 1,
         next_version: Version.from_integer(1001),
-        logs: %{},
-        services: %{},
+        sources: [],
         failed_logs: %{},
         shard_server: shard_server,
         current_log_id: "log-a",
@@ -162,8 +142,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.StreamingTest do
       state = %{
         shard_num: 1,
         next_version: Version.from_integer(1),
-        logs: %{"log-a" => []},
-        services: services_for(%{"log-a" => log_stub}),
+        sources: [{"log-a", log_stub}],
         failed_logs: %{},
         shard_server: nil,
         current_log_id: nil,
@@ -181,8 +160,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.StreamingTest do
       state = %{
         shard_num: 1,
         next_version: Version.from_integer(1),
-        logs: %{"log-a" => []},
-        services: %{"log-a" => %{kind: :log, status: {:up, self()}}},
+        sources: [{"log-a", self()}],
         failed_logs: %{"log-a" => future},
         shard_server: nil,
         current_log_id: nil,
@@ -231,8 +209,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.StreamingTest do
         Streaming.start_pulling(
           1,
           Version.from_integer(99),
-          %{"log-a" => []},
-          services_for(%{"log-a" => log}),
+          [{"log-a", log}],
           ingest_fn
         )
 

--- a/test/bedrock/data_plane/shard_router_test.exs
+++ b/test/bedrock/data_plane/shard_router_test.exs
@@ -103,6 +103,31 @@ defmodule Bedrock.DataPlane.ShardRouterTest do
     }).shards
   end
 
+  describe "log_ids_for_tag/3 - replica set resolution" do
+    test "resolves indices through the log map" do
+      log_map = %{0 => "log-a", 1 => "log-b", 2 => "log-c"}
+
+      log_ids = ShardRouter.log_ids_for_tag(7, log_map, 2)
+
+      expected = 7 |> ShardRouter.get_log_indices(3, 2) |> Enum.map(&Map.fetch!(log_map, &1))
+      assert log_ids == expected
+      assert length(log_ids) == 2
+      assert Enum.all?(log_ids, &(&1 in Map.values(log_map)))
+    end
+
+    test "full replication returns every log exactly once" do
+      log_map = %{0 => "log-a", 1 => "log-b", 2 => "log-c"}
+
+      log_ids = ShardRouter.log_ids_for_tag(3, log_map, 3)
+
+      assert Enum.sort(log_ids) == ["log-a", "log-b", "log-c"]
+    end
+
+    test "returns an empty list with no logs" do
+      assert ShardRouter.log_ids_for_tag(0, %{}, 1) == []
+    end
+  end
+
   describe "lookup_shard/2 - ceiling search" do
     setup do
       # Shard ranges are [min, max) - start inclusive, end exclusive


### PR DESCRIPTION
## Why

The olivine unlock received a synthetic TSL carrying the **entire** `transaction_services` map — O(workers), sent to every materializer — plus dead `proxies`/`resolvers` fields the pattern match ignored. FDB gives each storage server exactly its own tag and assignments, never a cluster map. Worse, the materializer then *re-derived* its shard→log placement (streaming's `candidate_log_ids` golden-ratio walk) under a comment demanding it agree with the topology phase — a coupling that would silently break the day either side changed.

Course item A of the side-channel completion campaign (bedrock-q67.37, settled 2026-08-20); extends #140's recovery-input/runnable-layout separation.

## What

- The unlock seed is now typed: `Materializer.pull_sources() :: [{log_id, log_ref}]` — exactly this shard's replica set, resolved **once** by the director. The synthetic TSLs in the bootstrap phase are gone.
- `ShardRouter.log_ids_for_tag/3` is the new single site for shard→log placement: commit-proxy mutation routing (`Finalization`) and the director's seed computation both resolve through it, so they cannot disagree. Streaming's `candidate_log_ids/2` re-derivation is **deleted**.
- The vestigial per-shard log filter in the bootstrap phase dies (recruited log descriptors are empty tag lists, so every log matched anyway) — the replica-set choice is explicit in the seed.

## How

- `materializer_bootstrap_phase.pull_sources_for_shard/2` builds the epoch's index map (sorted log ids) and walks it with `ShardRouter.log_ids_for_tag(tag, log_map, max(1, n))` — the identical construction `topology_phase.build_routing_snapshot/2` ships to proxies — then resolves refs from `recovery_attempt.transaction_services`.
- `Streaming` state drops `logs`/`services` for `sources`; `select_log` filters circuit-broken entries from the seeded list; failover behavior unchanged.
- `Olivine.Logic.unlock_after_recovery/3` stores the list; the no-shard/no-sources static-materializer guards are preserved.

Tests: seed-shape assertions in the bootstrap phase tests (replica-set pairs, never a services map), `ShardRouter.log_ids_for_tag/3` unit tests, streaming tests converted to the sources shape. Full suite, credo --strict, dialyzer green.