### PR TITLE
The TSL loses its services map: no membership rides the broadcast

### DIFF
--- a/lib/bedrock/control_plane/config/transaction_system_layout.ex
+++ b/lib/bedrock/control_plane/config/transaction_system_layout.ex
@@ -22,8 +22,13 @@ defmodule Bedrock.ControlPlane.Config.TransactionSystemLayout do
     - `proxies` - The pids of the commit proxies (commits, routing fetches).
     - `resolvers` - Resolver descriptors, consumed at proxy unlock.
     - `logs` - Log descriptors: each log's id and the tags it services.
-    - `services` - Every worker the layout references (types, ids, refs);
-       the Foreman retires hosted workers absent from this map.
+
+  No membership map rides here (FDB's ServerDBInfo carries no storage
+  membership either): logs self-check against the epoch-constant log
+  set, materializers rejoin-validate against the committed keyspace
+  through a commit proxy, and director-internal readers consume the
+  recovery attempt's transaction_services. Nothing O(workers) may ever
+  be added to this broadcast.
   """
   @type process_ref :: pid() | nil
   @type proxy_list :: [pid()]
@@ -36,8 +41,7 @@ defmodule Bedrock.ControlPlane.Config.TransactionSystemLayout do
           required(:sequencer) => process_ref(),
           required(:proxies) => proxy_list(),
           required(:resolvers) => resolver_list(),
-          required(:logs) => log_map(),
-          required(:services) => service_map()
+          required(:logs) => log_map()
         }
 
   @doc """

--- a/lib/bedrock/control_plane/director/recovery.ex
+++ b/lib/bedrock/control_plane/director/recovery.ex
@@ -125,7 +125,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery do
         |> Map.put(:transaction_system_layout, completed.transaction_system_layout)
         |> persist_config()
         |> persist_new_transaction_system_layout()
-        |> prune_service_directory()
+        |> prune_service_directory(completed)
 
       {{:stalled, reason}, stalled} ->
         trace_recovery_stalled(Interval.between(stalled.started_at, now()), reason)
@@ -162,19 +162,38 @@ defmodule Bedrock.ControlPlane.Director.Recovery do
   """
   @spec ghost_directory_ids(
           services :: %{Worker.id() => term()},
-          TransactionSystemLayout.t()
+          RecoveryAttempt.t()
         ) :: [Worker.id()]
-  def ghost_directory_ids(services, %{services: layout_services}) when is_map(layout_services) do
+  def ghost_directory_ids(services, completed_attempt) do
+    referenced = layout_reference_ids(completed_attempt)
+
     services
     |> Map.keys()
-    |> Enum.reject(&Map.has_key?(layout_services, &1))
+    |> Enum.reject(&MapSet.member?(referenced, &1))
   end
 
-  def ghost_directory_ids(_services, _layout), do: []
+  # The completed layout's statement of what exists: the new-generation
+  # logs and the active shard materializers — computed from the attempt
+  # (the TSL carries no membership map). Ghost pruning treats anything
+  # the completed recovery does not reference as a candidate ghost.
+  @spec layout_reference_ids(RecoveryAttempt.t()) :: MapSet.t(Worker.id())
+  defp layout_reference_ids(completed_attempt) do
+    log_ids = completed_attempt.logs |> Map.keys() |> MapSet.new()
 
-  @spec prune_service_directory(State.t()) :: State.t()
-  defp prune_service_directory(t) do
-    case ghost_directory_ids(t.services, t.transaction_system_layout) do
+    active_materializer_pids = completed_attempt.shard_materializers |> Map.values() |> MapSet.new()
+
+    materializer_ids =
+      for {id, %{status: {:up, pid}}} <- completed_attempt.transaction_services,
+          MapSet.member?(active_materializer_pids, pid),
+          into: MapSet.new(),
+          do: id
+
+    MapSet.union(log_ids, materializer_ids)
+  end
+
+  @spec prune_service_directory(State.t(), RecoveryAttempt.t()) :: State.t()
+  defp prune_service_directory(t, completed_attempt) do
+    case ghost_directory_ids(t.services, completed_attempt) do
       [] ->
         t
 

--- a/lib/bedrock/control_plane/director/recovery/monitoring_phase.ex
+++ b/lib/bedrock/control_plane/director/recovery/monitoring_phase.ex
@@ -25,28 +25,35 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MonitoringPhase do
 
     monitor_fn = Map.get(context, :monitor_fn, &Process.monitor/1)
 
-    recovery_attempt.transaction_system_layout
+    recovery_attempt
     |> extract_pids_to_monitor()
     |> monitor_all_pids(monitor_fn)
 
     {recovery_attempt, Bedrock.ControlPlane.Director.Recovery.PersistencePhase}
   end
 
+  # Monitored: sequencer, proxies, resolvers, and the epoch's logs (their
+  # pids read from the attempt's transaction_services — the TSL carries no
+  # membership map). Materializers are deliberately absent: they
+  # self-organize from logs and their failure is not epoch-fatal.
   @spec extract_pids_to_monitor(map()) :: [pid()]
-  defp extract_pids_to_monitor(layout) do
+  defp extract_pids_to_monitor(recovery_attempt) do
     resolver_pids =
-      Enum.map(layout.resolvers, fn {_start_key, pid} -> pid end)
+      Enum.map(recovery_attempt.resolvers, fn {_start_key, pid} -> pid end)
 
-    service_pids =
-      layout.services
-      |> Enum.filter(fn {_service_id, service} -> service.kind != :materializer end)
-      |> Enum.map(fn {_service_id, %{status: {:up, pid}}} -> pid end)
+    # Fail fast on a log that is missing or not up: an epoch whose log
+    # cannot be monitored is an epoch that cannot detect its own failure.
+    log_pids =
+      Enum.map(Map.keys(recovery_attempt.logs), fn log_id ->
+        %{status: {:up, pid}} = Map.fetch!(recovery_attempt.transaction_services, log_id)
+        pid
+      end)
 
     Enum.concat([
-      [layout.sequencer],
-      layout.proxies,
+      [recovery_attempt.sequencer],
+      recovery_attempt.proxies,
       resolver_pids,
-      service_pids
+      log_pids
     ])
   end
 

--- a/lib/bedrock/control_plane/director/recovery/persistence_phase.ex
+++ b/lib/bedrock/control_plane/director/recovery/persistence_phase.ex
@@ -231,7 +231,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery.PersistencePhase do
         tx = clear_prefix(tx, SystemKeys.materializers_prefix())
 
         materializers
-        |> TransactionSystemLayout.materializer_refs(recovery_attempt.transaction_system_layout.services)
+        |> TransactionSystemLayout.materializer_refs(recovery_attempt.transaction_services)
         |> Enum.reduce(tx, fn {tag, {worker_id, node}}, tx ->
           Tx.set(tx, SystemKeys.materializer_key(tag), Values.encode_materializer_ref(worker_id, node))
         end)

--- a/lib/bedrock/control_plane/director/recovery/topology_phase.ex
+++ b/lib/bedrock/control_plane/director/recovery/topology_phase.ex
@@ -117,85 +117,21 @@ defmodule Bedrock.ControlPlane.Director.Recovery.TopologyPhase do
 
   # The TSL is runtime wiring only (ClientDBInfo analogue): shard topology
   # lives in the keyspace and reaches clients through the proxies' routing
-  # views, never through this broadcast.
-  defp build_transaction_system_layout(recovery_attempt, context) do
+  # views, never through this broadcast — and it carries no membership
+  # map. Logs check themselves against the epoch-constant log set;
+  # materializers rejoin-validate against the committed keyspace through
+  # a proxy; director-internal readers consume the attempt's
+  # transaction_services. FDB's ServerDBInfo never carries storage
+  # membership either; nothing O(workers) rides this channel.
+  defp build_transaction_system_layout(recovery_attempt, _context) do
     {:ok,
      %{
        epoch: recovery_attempt.epoch,
        sequencer: recovery_attempt.sequencer,
        proxies: recovery_attempt.proxies,
        resolvers: recovery_attempt.resolvers,
-       logs: recovery_attempt.logs,
-       services:
-         build_services_for_layout(
-           recovery_attempt,
-           context
-         )
+       logs: recovery_attempt.logs
      }}
-  end
-
-  @spec build_services_for_layout(RecoveryAttempt.t(), RecoveryPhase.context()) ::
-          %{String.t() => ServiceDescriptor.t()}
-  defp build_services_for_layout(recovery_attempt, context) do
-    recovery_attempt
-    |> extract_service_ids()
-    |> Enum.map(fn service_id ->
-      {service_id, build_service_descriptor(service_id, recovery_attempt, context)}
-    end)
-    |> Enum.reject(fn {_id, descriptor} -> is_nil(descriptor) end)
-    |> Map.new()
-  end
-
-  # The TSL's services map is the layout's statement of what exists: the
-  # new-generation logs and the active shard materializers. Reconciliation
-  # treats it as the single source of truth — any worker a foreman hosts
-  # that is not referenced here gets retired once this layout is durable.
-  defp extract_service_ids(recovery_attempt) do
-    log_ids = recovery_attempt.logs |> Map.keys() |> MapSet.new()
-
-    active_materializer_pids = recovery_attempt.shard_materializers |> Map.values() |> MapSet.new()
-
-    materializer_ids =
-      for {id, %{status: {:up, pid}}} <- recovery_attempt.transaction_services,
-          MapSet.member?(active_materializer_pids, pid),
-          into: MapSet.new(),
-          do: id
-
-    MapSet.union(log_ids, materializer_ids)
-  end
-
-  @spec build_service_descriptor(
-          String.t(),
-          RecoveryAttempt.t(),
-          RecoveryPhase.context()
-        ) :: ServiceDescriptor.t() | nil
-  defp build_service_descriptor(service_id, recovery_attempt, context) do
-    case Map.get(context.available_services, service_id) do
-      {kind, last_seen} = _service ->
-        status = determine_service_status(service_id, recovery_attempt.service_pids)
-
-        %{
-          kind: kind,
-          last_seen: last_seen,
-          status: status
-        }
-
-      _ ->
-        # Not advertised yet — workers created during THIS recovery attempt
-        # can't be in the directory (advertisement is async), but the
-        # attempt holds their full service records. Dropping them here
-        # would strike them from the layout and they would self-retire on
-        # the push — workers recovery just created.
-        Map.get(recovery_attempt.transaction_services, service_id)
-    end
-  end
-
-  @spec determine_service_status(String.t(), %{String.t() => pid()}) :: ServiceDescriptor.status()
-  defp determine_service_status(service_id, service_pids) do
-    case Map.get(service_pids, service_id) do
-      pid when is_pid(pid) -> {:up, pid}
-      _ -> :down
-    end
   end
 
   # Unlock commit proxies before exercising the transaction system
@@ -228,7 +164,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery.TopologyPhase do
     # Extract what proxies need from TSL
     sequencer = transaction_system_layout.sequencer
     resolver_layout = CommitProxy.ResolverLayout.from_layout(transaction_system_layout)
-    routing_snapshot = build_routing_snapshot(transaction_system_layout, recovery_attempt)
+    routing_snapshot = build_routing_snapshot(recovery_attempt)
 
     proxies
     |> Task.async_stream(
@@ -245,8 +181,9 @@ defmodule Bedrock.ControlPlane.Director.Recovery.TopologyPhase do
   # Build the plain-data routing snapshot proxies need at unlock. Each proxy
   # turns it into its own RoutingData (`RoutingData.from_snapshot/1`); proxies
   # may live on other nodes, so nothing process- or node-local goes in here.
-  @spec build_routing_snapshot(TransactionSystemLayout.t(), RecoveryAttempt.t()) :: CommitProxy.RoutingData.snapshot()
-  defp build_routing_snapshot(%{logs: logs, services: services}, recovery_attempt) do
+  @spec build_routing_snapshot(RecoveryAttempt.t()) :: CommitProxy.RoutingData.snapshot()
+  defp build_routing_snapshot(recovery_attempt) do
+    %{logs: logs, transaction_services: services} = recovery_attempt
     shard_layout = recovery_attempt.shard_layout
     # Build log_map: index -> log_id (the shared construction — see
     # ShardRouter.log_map/1 — so seeds and routing cannot diverge)

--- a/lib/bedrock/control_plane/director/server.ex
+++ b/lib/bedrock/control_plane/director/server.ex
@@ -21,11 +21,9 @@ defmodule Bedrock.ControlPlane.Director.Server do
   import Bedrock.Internal.GenServer.Replies
 
   alias Bedrock.ControlPlane.Config
-  alias Bedrock.ControlPlane.Config.ServiceDescriptor
   alias Bedrock.ControlPlane.Config.TransactionSystemLayout
   alias Bedrock.ControlPlane.Coordinator
   alias Bedrock.ControlPlane.Director.State
-  alias Bedrock.Service.Worker
 
   require Logger
 
@@ -179,12 +177,6 @@ defmodule Bedrock.ControlPlane.Director.Server do
 
   @spec now() :: DateTime.t()
   defp now, do: DateTime.utc_now()
-
-  @spec get_services_from_transaction_system_layout(TransactionSystemLayout.t()) ::
-          %{Worker.id() => ServiceDescriptor.t()}
-  def get_services_from_transaction_system_layout(%{services: services}), do: services || %{}
-
-  def get_services_from_transaction_system_layout(_), do: %{}
 
   @spec add_services_to_directory(State.t(), [{String.t(), atom(), {atom(), node()}}]) ::
           State.t()

--- a/test/bedrock/control_plane/coordinator/tsl_replay_test.exs
+++ b/test/bedrock/control_plane/coordinator/tsl_replay_test.exs
@@ -36,7 +36,7 @@ defmodule Bedrock.ControlPlane.Coordinator.TslReplayTest do
   end
 
   test "registration replays the current layout to the new subscriber" do
-    tsl = %{id: "layout-1", epoch: 7, logs: %{}, services: %{}}
+    tsl = %{epoch: 7, sequencer: nil, proxies: [], resolvers: [], logs: %{}}
     state = follower_state(%{transaction_system_layout: tsl})
 
     assert {:noreply, updated} = register(state)
@@ -79,7 +79,7 @@ defmodule Bedrock.ControlPlane.Coordinator.TslReplayTest do
   end
 
   test "duplicate registration is idempotent: one subscription, same snapshot each time" do
-    tsl = %{id: "layout-1", epoch: 7, logs: %{}, services: %{}}
+    tsl = %{epoch: 7, sequencer: nil, proxies: [], resolvers: [], logs: %{}}
     state = follower_state(%{transaction_system_layout: tsl})
 
     assert {:noreply, state} = register(state)

--- a/test/bedrock/control_plane/director/recovery/monitoring_phase_test.exs
+++ b/test/bedrock/control_plane/director/recovery/monitoring_phase_test.exs
@@ -9,26 +9,25 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MonitoringPhaseTest do
   # Helper to create test process that sleeps briefly
   defp test_process, do: spawn(fn -> :timer.sleep(100) end)
 
-  # Helper to create test transaction system layout
-  defp create_layout(opts \\ []) do
-    sequencer = Keyword.get(opts, :sequencer, test_process())
-    proxies = Keyword.get(opts, :proxies, [test_process()])
-    resolvers = Keyword.get(opts, :resolvers, [{"start_key", test_process()}])
+  # Helper to build a recovery attempt with monitored components. The
+  # TSL carries no membership map; log pids come from the attempt's
+  # transaction_services.
+  defp attempt_with(opts \\ []) do
     logs = Keyword.get(opts, :logs, %{{:log, 1} => %{}})
 
-    # Create services map based on the components
-    services =
-      Keyword.get(opts, :services, %{
-        {:log, 1} => %{kind: :log, status: {:up, test_process()}}
-      })
+    transaction_services =
+      Keyword.get(
+        opts,
+        :transaction_services,
+        Map.new(logs, fn {log_id, _} -> {log_id, %{kind: :log, status: {:up, test_process()}}} end)
+      )
 
-    %{
-      sequencer: sequencer,
-      proxies: proxies,
-      resolvers: resolvers,
-      logs: logs,
-      services: services
-    }
+    recovery_attempt()
+    |> Map.put(:sequencer, Keyword.get(opts, :sequencer, test_process()))
+    |> Map.put(:proxies, Keyword.get(opts, :proxies, [test_process()]))
+    |> Map.put(:resolvers, Keyword.get(opts, :resolvers, [{"start_key", test_process()}]))
+    |> Map.put(:logs, logs)
+    |> Map.put(:transaction_services, transaction_services)
   end
 
   # Helper to execute monitoring and verify next phase
@@ -43,43 +42,28 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MonitoringPhaseTest do
         make_ref()
       end
 
-      recovery_attempt = Map.put(recovery_attempt(), :transaction_system_layout, create_layout())
-
-      execute_and_verify(recovery_attempt, %{monitor_fn: monitor_fn})
+      execute_and_verify(attempt_with(), %{monitor_fn: monitor_fn})
 
       # Should have monitored sequencer, 1 proxy, 1 resolver, 1 log (4 total)
       for _ <- 1..4, do: assert_received({:monitored, _})
     end
 
     test "uses default Process.monitor when no monitor_fn provided" do
-      recovery_attempt = Map.put(recovery_attempt(), :transaction_system_layout, create_layout())
-
-      execute_and_verify(recovery_attempt, %{})
+      execute_and_verify(attempt_with(), %{})
     end
 
     test "monitors multiple components correctly" do
-      log1_pid = test_process()
-      log2_pid = test_process()
-
-      recovery_attempt = %{
-        transaction_system_layout:
-          create_layout(
-            proxies: [test_process(), test_process()],
-            resolvers: [{"key1", test_process()}, {"key2", test_process()}],
-            logs: %{{:log, 1} => %{}, {:log, 2} => %{}},
-            services: %{
-              {:log, 1} => %{kind: :log, status: {:up, log1_pid}},
-              {:log, 2} => %{kind: :log, status: {:up, log2_pid}},
-              # Storage services shouldn't be monitored
-              {:materializer, 1} => %{kind: :materializer, status: {:up, test_process()}}
-            }
-          )
-      }
+      recovery_attempt =
+        attempt_with(
+          proxies: [test_process(), test_process()],
+          resolvers: [{"key1", test_process()}, {"key2", test_process()}],
+          logs: %{{:log, 1} => %{}, {:log, 2} => %{}}
+        )
 
       execute_and_verify(recovery_attempt, %{})
     end
 
-    test "excludes storage services from monitoring" do
+    test "monitors only the layout's logs — materializers are not epoch-fatal" do
       storage_pid = test_process()
 
       monitor_fn = fn pid ->
@@ -87,15 +71,14 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MonitoringPhaseTest do
         make_ref()
       end
 
-      recovery_attempt = %{
-        transaction_system_layout:
-          create_layout(
-            services: %{
-              {:log, 1} => %{kind: :log, status: {:up, test_process()}},
-              {:materializer, 1} => %{kind: :materializer, status: {:up, storage_pid}}
-            }
-          )
-      }
+      recovery_attempt =
+        attempt_with(
+          logs: %{{:log, 1} => %{}},
+          transaction_services: %{
+            {:log, 1} => %{kind: :log, status: {:up, test_process()}},
+            {:materializer, 1} => %{kind: :materializer, status: {:up, storage_pid}}
+          }
+        )
 
       execute_and_verify(recovery_attempt, %{monitor_fn: monitor_fn})
 
@@ -103,7 +86,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MonitoringPhaseTest do
       refute_received {:monitored, ^storage_pid}
     end
 
-    test "crashes if services are not in :up status" do
+    test "crashes if a layout log is not up — an epoch that cannot watch its logs must not run" do
       down_log_pid = test_process()
 
       monitor_fn = fn pid ->
@@ -111,19 +94,16 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MonitoringPhaseTest do
         make_ref()
       end
 
-      recovery_attempt = %{
-        transaction_system_layout:
-          create_layout(
-            logs: %{{:log, 1} => %{}, {:log, 2} => %{}},
-            services: %{
-              {:log, 1} => %{kind: :log, status: {:up, test_process()}},
-              {:log, 2} => %{kind: :log, status: {:down, down_log_pid}}
-            }
-          )
-      }
+      recovery_attempt =
+        attempt_with(
+          logs: %{{:log, 1} => %{}, {:log, 2} => %{}},
+          transaction_services: %{
+            {:log, 1} => %{kind: :log, status: {:up, test_process()}},
+            {:log, 2} => %{kind: :log, status: {:down, down_log_pid}}
+          }
+        )
 
-      # Should crash when trying to extract PID from :down service
-      assert_raise FunctionClauseError, fn ->
+      assert_raise MatchError, fn ->
         MonitoringPhase.execute(recovery_attempt, %{monitor_fn: monitor_fn})
       end
     end

--- a/test/bedrock/control_plane/director/recovery/persistence_phase_test.exs
+++ b/test/bedrock/control_plane/director/recovery/persistence_phase_test.exs
@@ -11,16 +11,16 @@ defmodule Bedrock.ControlPlane.Director.Recovery.PersistencePhaseTest do
   alias Bedrock.SystemKeys
   alias Bedrock.SystemKeys.Values
 
-  # Shared test data setup: the TSL is wiring only; shard topology rides
-  # the recovery attempt (and from there the keyspace).
-  defp mock_transaction_system_layout(services) do
+  # Shared test data setup: the TSL is wiring only (no membership map);
+  # shard topology and service records ride the recovery attempt (and
+  # from there the keyspace).
+  defp mock_transaction_system_layout do
     %{
       epoch: 1,
       sequencer: self(),
       proxies: [self()],
       resolvers: [{<<0>>, self()}],
-      logs: %{"log_1" => [1, 2]},
-      services: services
+      logs: %{"log_1" => [1, 2]}
     }
   end
 
@@ -28,26 +28,22 @@ defmodule Bedrock.ControlPlane.Director.Recovery.PersistencePhaseTest do
     mat_sys = spawn(fn -> Process.sleep(:infinity) end)
     mat_user = spawn(fn -> Process.sleep(:infinity) end)
 
-    services = %{
-      "log_1" => %{status: {:up, self()}, kind: :log, last_seen: {:log_1, :node1}},
-      "wkr_sys" => %{status: {:up, mat_sys}, kind: :materializer, last_seen: {:wkr_sys_name, node()}},
-      "wkr_user" => %{status: {:up, mat_user}, kind: :materializer, last_seen: {:wkr_user_name, node()}}
-    }
-
     recovery_attempt()
     |> with_sequencer(self())
     |> with_proxies([self()])
     |> with_resolvers([{<<0>>, self()}])
     |> with_logs(%{"log_1" => [1, 2]})
     |> with_transaction_services(%{
-      "log_1" => %{status: {:up, self()}, kind: :log, last_seen: {:log_1, :node1}}
+      "log_1" => %{status: {:up, self()}, kind: :log, last_seen: {:log_1, :node1}},
+      "wkr_sys" => %{status: {:up, mat_sys}, kind: :materializer, last_seen: {:wkr_sys_name, node()}},
+      "wkr_user" => %{status: {:up, mat_user}, kind: :materializer, last_seen: {:wkr_user_name, node()}}
     })
     |> Map.put(:shard_layout, %{
       <<0xFF>> => {1, <<>>},
       <<0xFF, 0xFF>> => {0, <<0xFF>>}
     })
     |> Map.put(:shard_materializers, %{0 => mat_sys, 1 => mat_user})
-    |> Map.put(:transaction_system_layout, mock_transaction_system_layout(services))
+    |> Map.put(:transaction_system_layout, mock_transaction_system_layout())
   end
 
   describe "execute/2" do
@@ -138,7 +134,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery.PersistencePhaseTest do
       recovery_attempt =
         update_in(
           base_recovery_attempt(),
-          [Access.key!(:transaction_system_layout), :services],
+          [Access.key!(:transaction_services)],
           &Map.drop(&1, ["wkr_sys", "wkr_user"])
         )
 

--- a/test/bedrock/control_plane/director/recovery/topology_phase_test.exs
+++ b/test/bedrock/control_plane/director/recovery/topology_phase_test.exs
@@ -139,85 +139,27 @@ defmodule Bedrock.ControlPlane.Director.Recovery.TopologyPhaseTest do
       assert {_result, ^expected_error} = TopologyPhase.execute(recovery_attempt, context)
     end
 
-    test "builds transaction system layout with correct service descriptors" do
-      recovery_attempt =
-        base_recovery_attempt()
-        |> with_logs(%{"log_1" => [1, 2], "log_2" => [3, 4]})
-        |> with_transaction_services(%{
-          "log_1" => %{status: {:up, self()}, kind: :log, last_seen: {:log_1, :node1}},
-          "log_2" => %{status: {:up, self()}, kind: :log, last_seen: {:log_2, :node1}}
-        })
-
-      context =
-        with_available_services(successful_unlock_context(), %{
-          "log_1" => {:log, {:log_1, :node1}},
-          "log_2" => {:log, {:log_2, :node1}}
-        })
-
-      {result, _next_phase} = TopologyPhase.execute(recovery_attempt, context)
-
-      # Pattern match the expected service structure - only log services
-      assert %{
-               transaction_system_layout: %{
-                 services:
-                   %{
-                     "log_1" => %{kind: :log},
-                     "log_2" => %{kind: :log}
-                   } = services
-               }
-             } = result
-
-      assert map_size(services) == 2
-    end
-
-    test "the layout references active shard materializers alongside the logs" do
-      materializer_pid = spawn(fn -> Process.sleep(:infinity) end)
-
+    test "the TSL is wiring only — it carries no membership map" do
       recovery_attempt =
         base_recovery_attempt()
         |> with_logs(%{"log_1" => [1, 2]})
         |> with_transaction_services(%{
-          "log_1" => %{status: {:up, self()}, kind: :log, last_seen: {:log_1, :node1}},
-          "mat_1" => %{status: {:up, materializer_pid}, kind: :materializer, last_seen: {:mat_1, :node1}},
-          "locked_but_inactive" => %{status: {:up, spawn(fn -> :ok end)}, kind: :materializer, last_seen: {:x, :node1}}
+          "log_1" => %{status: {:up, self()}, kind: :log, last_seen: {:log_1, :node1}}
         })
-        |> Map.put(:shard_materializers, %{0 => materializer_pid})
 
       context =
         with_available_services(successful_unlock_context(), %{
-          "log_1" => {:log, {:log_1, :node1}},
-          "mat_1" => {:materializer, {:mat_1, :node1}}
+          "log_1" => {:log, {:log_1, :node1}}
         })
 
       {result, _next_phase} = TopologyPhase.execute(recovery_attempt, context)
 
-      # The services map is the layout's statement of what should exist:
-      # the logs, and exactly the materializers serving shards — a locked
-      # but inactive materializer is not referenced (and reconciliation
-      # will retire it).
-      assert %{
-               transaction_system_layout: %{
-                 services: %{"log_1" => %{kind: :log}, "mat_1" => %{kind: :materializer}} = services
-               }
-             } = result
-
-      assert map_size(services) == 2
-    end
-
-    test "a worker created this attempt (not yet advertised) keeps its place in the layout" do
-      recovery_attempt =
-        base_recovery_attempt()
-        |> with_logs(%{"new_log" => []})
-        |> with_transaction_services(%{
-          "new_log" => %{status: {:up, self()}, kind: :log, last_seen: {:new_log_otp, :node1}}
-        })
-
-      # NOT in available_services: created moments ago, advertisement async
-      context = with_available_services(successful_unlock_context(), %{})
-
-      {result, _next_phase} = TopologyPhase.execute(recovery_attempt, context)
-
-      assert %{transaction_system_layout: %{services: %{"new_log" => %{kind: :log}}}} = result
+      # ServerDBInfo parity: epoch, sequencer, proxies, resolvers, logs —
+      # and nothing else. Membership questions are answered by workers
+      # themselves (log-set check, keyspace rejoin validation), never by
+      # an O(workers) map on the broadcast.
+      assert Enum.sort(Map.keys(result.transaction_system_layout)) ==
+               [:epoch, :logs, :proxies, :resolvers, :sequencer]
     end
   end
 end

--- a/test/bedrock/control_plane/director/recovery_test.exs
+++ b/test/bedrock/control_plane/director/recovery_test.exs
@@ -190,6 +190,25 @@ defmodule Bedrock.ControlPlane.Director.RecoveryTest do
       assert Recovery.ghost_directory_ids(services, completed) == ["ghost"]
     end
 
+    test "a worker created this attempt (not yet in the directory) is referenced — never pruned" do
+      # Attempt-created workers reach transaction_services at creation;
+      # advertisement to the coordinator directory is async and may lag.
+      # The reference set is computed from the attempt alone, so the lag
+      # can never deregister a worker the epoch references.
+      services = %{"old_log" => {:log, {:a, :node1}}}
+
+      completed = %{
+        logs: %{"old_log" => [], "brand_new_log" => []},
+        shard_materializers: %{},
+        transaction_services: %{
+          "old_log" => %{kind: :log, status: {:up, self()}},
+          "brand_new_log" => %{kind: :log, status: {:up, self()}}
+        }
+      }
+
+      assert Recovery.ghost_directory_ids(services, completed) == []
+    end
+
     test "a locked-but-inactive materializer is not referenced — it is a ghost candidate" do
       active_pid = spawn(fn -> Process.sleep(:infinity) end)
       inactive_pid = spawn(fn -> Process.sleep(:infinity) end)

--- a/test/bedrock/control_plane/director/recovery_test.exs
+++ b/test/bedrock/control_plane/director/recovery_test.exs
@@ -169,21 +169,46 @@ defmodule Bedrock.ControlPlane.Director.RecoveryTest do
   end
 
   describe "ghost_directory_ids/2" do
-    test "selects exactly the directory entries the layout does not reference" do
+    test "selects exactly the directory entries the completed recovery does not reference" do
+      live_mat_pid = spawn(fn -> Process.sleep(:infinity) end)
+
       services = %{
         "live_log" => {:log, {:a, :node1}},
         "live_mat" => {:materializer, {:b, :node1}},
         "ghost" => {:log, {:c, :dead@nowhere}}
       }
 
-      layout = %{services: %{"live_log" => %{}, "live_mat" => %{}}}
+      completed = %{
+        logs: %{"live_log" => []},
+        shard_materializers: %{0 => live_mat_pid},
+        transaction_services: %{
+          "live_log" => %{kind: :log, status: {:up, self()}},
+          "live_mat" => %{kind: :materializer, status: {:up, live_mat_pid}}
+        }
+      }
 
-      assert Recovery.ghost_directory_ids(services, layout) == ["ghost"]
+      assert Recovery.ghost_directory_ids(services, completed) == ["ghost"]
     end
 
-    test "an invalid layout selects nothing" do
-      assert Recovery.ghost_directory_ids(%{"x" => {:log, {:a, :n}}}, %{}) == []
-      assert Recovery.ghost_directory_ids(%{"x" => {:log, {:a, :n}}}, nil) == []
+    test "a locked-but-inactive materializer is not referenced — it is a ghost candidate" do
+      active_pid = spawn(fn -> Process.sleep(:infinity) end)
+      inactive_pid = spawn(fn -> Process.sleep(:infinity) end)
+
+      services = %{
+        "active_mat" => {:materializer, {:a, :node1}},
+        "inactive_mat" => {:materializer, {:b, :node1}}
+      }
+
+      completed = %{
+        logs: %{},
+        shard_materializers: %{0 => active_pid},
+        transaction_services: %{
+          "active_mat" => %{kind: :materializer, status: {:up, active_pid}},
+          "inactive_mat" => %{kind: :materializer, status: {:up, inactive_pid}}
+        }
+      }
+
+      assert Recovery.ghost_directory_ids(services, completed) == ["inactive_mat"]
     end
   end
 
@@ -413,16 +438,15 @@ defmodule Bedrock.ControlPlane.Director.RecoveryTest do
       # Should complete without errors
       recovery_attempt =
         recovery_attempt(%{
-          transaction_system_layout: %{
-            sequencer: spawn(fn -> :ok end),
-            proxies: [spawn(fn -> :ok end), spawn(fn -> :ok end)],
-            resolvers: [{"start", spawn(fn -> :ok end)}],
-            services: %{
-              "log_service_1" => %{status: {:up, spawn(fn -> :ok end)}, kind: :log},
-              "log_service_2" => %{status: {:up, spawn(fn -> :ok end)}, kind: :log},
-              "storage_service_1" => %{status: {:up, spawn(fn -> :ok end)}, kind: :materializer},
-              "storage_service_2" => %{status: {:up, spawn(fn -> :ok end)}, kind: :materializer}
-            }
+          sequencer: spawn(fn -> :ok end),
+          proxies: [spawn(fn -> :ok end), spawn(fn -> :ok end)],
+          resolvers: [{"start", spawn(fn -> :ok end)}],
+          logs: %{"log_service_1" => [], "log_service_2" => []},
+          transaction_services: %{
+            "log_service_1" => %{status: {:up, spawn(fn -> :ok end)}, kind: :log},
+            "log_service_2" => %{status: {:up, spawn(fn -> :ok end)}, kind: :log},
+            "storage_service_1" => %{status: {:up, spawn(fn -> :ok end)}, kind: :materializer},
+            "storage_service_2" => %{status: {:up, spawn(fn -> :ok end)}, kind: :materializer}
           }
         })
 

--- a/test/bedrock/data_plane/commit_proxy/server_test.exs
+++ b/test/bedrock/data_plane/commit_proxy/server_test.exs
@@ -71,8 +71,10 @@ defmodule Bedrock.DataPlane.CommitProxy.ServerTest do
     Map.merge(base, overrides)
   end
 
-  # Build the plain routing snapshot recover_from carries, as the director's
-  # topology phase would assemble it from a transaction system layout.
+  # Build the plain routing snapshot recover_from carries. The fixture map
+  # bundles logs + a local services map for convenience; production
+  # assembles the snapshot from the recovery attempt (the TSL carries no
+  # membership map).
   defp build_routing_snapshot(transaction_system_layout) do
     logs = Map.get(transaction_system_layout, :logs, %{})
     services = Map.get(transaction_system_layout, :services, %{})


### PR DESCRIPTION
## Why

With logs checking themselves against the pushed log set and materializers rejoin-validating against the committed keyspace (#179), nothing consumed the TSL's `services` map from the broadcast — it existed to answer membership questions the workers now answer themselves. FDB's ServerDBInfo never carries storage membership either, and a materializer map can number in the thousands: **nothing O(workers) may ride this channel** (arc corollary, bedrock-q67.38 second half).

## What

The TSL type is ServerDBInfo parity: `{epoch, sequencer, proxies, resolvers, logs}`. `build_services_for_layout` (and its descriptor plumbing) and the already-dead `get_services_from_transaction_system_layout` are deleted. The type's doc now states the invariant so the field cannot quietly return.

## How

Director-internal readers move to the attempt's `transaction_services` (they never needed the broadcast copy):

- **Monitoring** extracts the epoch's log pids from `recovery_attempt.logs` × `transaction_services`, fail-fast when a layout log is missing or not up (an epoch that cannot watch its logs must not run — pinned by test).
- **Ghost pruning** compares the coordinator directory against what the completed attempt references (`layout_reference_ids`: log ids + active shard materializers — the exact statement `build_services_for_layout` used to encode; the locked-but-inactive-materializer case is pinned by a new test).
- **Persistence** inverts materializer refs through `recovery_attempt.transaction_services` instead of the TSL copy.
- **The routing snapshot builder** reads the attempt directly.

The wiring-only shape is pinned: `topology_phase_test` asserts the TSL's exact key set.

Full suite (2583 tests), credo --strict, dialyzer green.