### PR TITLE
Log wiring is epoch-constant; readers consume carried facts

### DIFF
--- a/lib/bedrock/control_plane/config/recovery_attempt.ex
+++ b/lib/bedrock/control_plane/config/recovery_attempt.ex
@@ -79,7 +79,7 @@ defmodule Bedrock.ControlPlane.Config.RecoveryAttempt do
           transaction_services: %{Worker.id() => ServiceDescriptor.t()},
           service_pids: %{Worker.id() => pid()},
           transaction_system_layout: TransactionSystemLayout.t() | nil,
-          shard_materializers: %{Bedrock.range_tag() => pid()},
+          shard_materializers: %{Bedrock.range_tag() => {Worker.id(), node(), pid()}},
           lock_failed_service_ids: MapSet.t(Worker.id()),
           shard_layout: shard_layout() | nil
         }
@@ -121,5 +121,24 @@ defmodule Bedrock.ControlPlane.Config.RecoveryAttempt do
       shard_materializers: %{},
       lock_failed_service_ids: MapSet.new()
     }
+  end
+
+  @doc """
+  The string-encoded refs the `materializers/` keyspace family carries,
+  projected from the attempt's shard assignment:
+  `%{tag => {worker_id, node}}`. Both the persistence phase (the family's
+  writer) and the routing snapshot (the recover_from seed) derive from
+  this, so the seed and the keyspace cannot disagree. Worker ids and
+  nodes are carried from creation/lock — never recovered by inverting a
+  services map.
+  """
+  @spec materializer_refs(%{Bedrock.range_tag() => {Worker.id(), node(), pid()}} | nil) ::
+          %{Bedrock.range_tag() => {String.t(), String.t()}}
+  def materializer_refs(nil), do: %{}
+
+  def materializer_refs(shard_materializers) do
+    Map.new(shard_materializers, fn {tag, {worker_id, node, _pid}} ->
+      {tag, {worker_id, Atom.to_string(node)}}
+    end)
   end
 end

--- a/lib/bedrock/control_plane/config/recovery_attempt.ex
+++ b/lib/bedrock/control_plane/config/recovery_attempt.ex
@@ -79,7 +79,7 @@ defmodule Bedrock.ControlPlane.Config.RecoveryAttempt do
           transaction_services: %{Worker.id() => ServiceDescriptor.t()},
           service_pids: %{Worker.id() => pid()},
           transaction_system_layout: TransactionSystemLayout.t() | nil,
-          shard_materializers: %{Bedrock.range_tag() => {Worker.id(), node(), pid()}},
+          shard_materializers: %{Bedrock.range_tag() => {Worker.id(), node_name :: String.t()}},
           lock_failed_service_ids: MapSet.t(Worker.id()),
           shard_layout: shard_layout() | nil
         }
@@ -121,24 +121,5 @@ defmodule Bedrock.ControlPlane.Config.RecoveryAttempt do
       shard_materializers: %{},
       lock_failed_service_ids: MapSet.new()
     }
-  end
-
-  @doc """
-  The string-encoded refs the `materializers/` keyspace family carries,
-  projected from the attempt's shard assignment:
-  `%{tag => {worker_id, node}}`. Both the persistence phase (the family's
-  writer) and the routing snapshot (the recover_from seed) derive from
-  this, so the seed and the keyspace cannot disagree. Worker ids and
-  nodes are carried from creation/lock — never recovered by inverting a
-  services map.
-  """
-  @spec materializer_refs(%{Bedrock.range_tag() => {Worker.id(), node(), pid()}} | nil) ::
-          %{Bedrock.range_tag() => {String.t(), String.t()}}
-  def materializer_refs(nil), do: %{}
-
-  def materializer_refs(shard_materializers) do
-    Map.new(shard_materializers, fn {tag, {worker_id, node, _pid}} ->
-      {tag, {worker_id, Atom.to_string(node)}}
-    end)
   end
 end

--- a/lib/bedrock/control_plane/config/transaction_system_layout.ex
+++ b/lib/bedrock/control_plane/config/transaction_system_layout.ex
@@ -43,32 +43,4 @@ defmodule Bedrock.ControlPlane.Config.TransactionSystemLayout do
           required(:resolvers) => resolver_list(),
           required(:logs) => log_map()
         }
-
-  @doc """
-  Inverts a `%{tag => materializer pid}` assignment through a services map
-  into the string-encoded refs the `materializers/` keyspace family
-  carries: `%{tag => {worker_id, node}}`. Both the persistence phase (the
-  family's writer) and the routing snapshot (the recover_from seed) derive
-  from this, so the seed and the keyspace cannot disagree.
-
-  A pid without a matching materializer service record is skipped - the
-  family only names workers the layout actually references.
-  """
-  @spec materializer_refs(%{Bedrock.range_tag() => pid()} | nil, service_map()) ::
-          %{Bedrock.range_tag() => {String.t(), String.t()}}
-  def materializer_refs(shard_materializers, services) do
-    shard_materializers
-    |> Kernel.||(%{})
-    |> Enum.flat_map(fn
-      {tag, pid} when is_pid(pid) ->
-        case Enum.find(services, &match?({_, %{kind: :materializer, status: {:up, ^pid}}}, &1)) do
-          {worker_id, _descriptor} -> [{tag, {worker_id, Atom.to_string(node(pid))}}]
-          nil -> []
-        end
-
-      _ ->
-        []
-    end)
-    |> Map.new()
-  end
 end

--- a/lib/bedrock/control_plane/director/recovery.ex
+++ b/lib/bedrock/control_plane/director/recovery.ex
@@ -180,13 +180,10 @@ defmodule Bedrock.ControlPlane.Director.Recovery do
   defp layout_reference_ids(completed_attempt) do
     log_ids = completed_attempt.logs |> Map.keys() |> MapSet.new()
 
-    active_materializer_pids = completed_attempt.shard_materializers |> Map.values() |> MapSet.new()
-
     materializer_ids =
-      for {id, %{status: {:up, pid}}} <- completed_attempt.transaction_services,
-          MapSet.member?(active_materializer_pids, pid),
+      for {_tag, {worker_id, _node, _pid}} <- completed_attempt.shard_materializers,
           into: MapSet.new(),
-          do: id
+          do: worker_id
 
     MapSet.union(log_ids, materializer_ids)
   end

--- a/lib/bedrock/control_plane/director/recovery.ex
+++ b/lib/bedrock/control_plane/director/recovery.ex
@@ -181,7 +181,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery do
     log_ids = completed_attempt.logs |> Map.keys() |> MapSet.new()
 
     materializer_ids =
-      for {_tag, {worker_id, _node, _pid}} <- completed_attempt.shard_materializers,
+      for {_tag, {worker_id, _node}} <- completed_attempt.shard_materializers,
           into: MapSet.new(),
           do: worker_id
 

--- a/lib/bedrock/control_plane/director/recovery/materializer_bootstrap_phase.ex
+++ b/lib/bedrock/control_plane/director/recovery/materializer_bootstrap_phase.ex
@@ -91,7 +91,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhase do
         updated_attempt =
           recovery_attempt
           |> Map.put(:shard_layout, shard_layout)
-          |> Map.put(:shard_materializers, shard_materializers)
+          |> Map.put(:shard_materializers, to_materializer_refs(shard_materializers))
           |> Map.update!(:transaction_services, &Map.merge(&1, created_services))
 
         {updated_attempt, CommitProxyStartupPhase}
@@ -100,6 +100,24 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhase do
         Logger.warning("Failed to create materializers for fresh cluster: #{inspect(reason)}")
         {recovery_attempt, {:stalled, {:materializer_creation_failed, reason}}}
     end
+  end
+
+  # The one projection, at the one boundary it belongs: the phase
+  # orchestrates with live pids (lock, unlock, catchup), but the attempt
+  # carries the refs exactly as every reader consumes them — the
+  # keyspace-value shape {worker_id, node}, both strings. The persistence
+  # writer and the routing-snapshot seed embed this map verbatim, so the
+  # seed and the keyspace are the same map read twice; ghost pruning
+  # takes its worker ids from it directly. A pid is phase-local
+  # orchestration state, not a fact any reader needs — a future consumer
+  # that wants one should ask where it lives (the directory, or the
+  # worker), not have it carried speculatively.
+  @spec to_materializer_refs(%{Bedrock.range_tag() => {Worker.id(), node(), pid()}}) ::
+          %{Bedrock.range_tag() => {Worker.id(), String.t()}}
+  defp to_materializer_refs(shard_materializers) do
+    Map.new(shard_materializers, fn {tag, {worker_id, node, _pid}} ->
+      {tag, {worker_id, Atom.to_string(node)}}
+    end)
   end
 
   # Extract unique shard tags from shard_layout
@@ -237,7 +255,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhase do
       updated_attempt =
         recovery_attempt
         |> Map.put(:shard_layout, shard_layout)
-        |> Map.put(:shard_materializers, shard_materializers)
+        |> Map.put(:shard_materializers, to_materializer_refs(shard_materializers))
         |> Map.put(:resolvers, resolver_descriptors_for_layout(shard_layout))
         |> Map.update!(:transaction_services, &Map.merge(&1, all_created))
 

--- a/lib/bedrock/control_plane/director/recovery/materializer_bootstrap_phase.ex
+++ b/lib/bedrock/control_plane/director/recovery/materializer_bootstrap_phase.ex
@@ -118,8 +118,8 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhase do
   defp create_materializers_for_shards(shard_tags, recovery_attempt, context) do
     Enum.reduce_while(shard_tags, {:ok, %{}, %{}}, fn shard_tag, {:ok, by_shard, services} ->
       case create_and_start_materializer(shard_tag, recovery_attempt, context) do
-        {:ok, pid, {worker_id, descriptor}} ->
-          {:cont, {:ok, Map.put(by_shard, shard_tag, pid), Map.put(services, worker_id, descriptor)}}
+        {:ok, {_worker_id, _node, _pid} = assignment, {worker_id, descriptor}} ->
+          {:cont, {:ok, Map.put(by_shard, shard_tag, assignment), Map.put(services, worker_id, descriptor)}}
 
         {:error, reason} ->
           {:halt, {:error, {shard_tag, reason}}}
@@ -128,7 +128,9 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhase do
   end
 
   # Create a materializer for a specific shard and start it pulling.
-  # Returns the pid plus the service record ({id, descriptor}) that must
+  # Returns the {worker_id, node, pid} assignment (the worker id rides the
+  # assignment from creation — it is never recovered by inverting a
+  # services map) plus the service record ({id, descriptor}) that must
   # travel into transaction_services so the layout references the creation.
   defp create_and_start_materializer(shard_tag, recovery_attempt, context) do
     with {:ok, node} <- find_materializer_capable_node(context),
@@ -138,7 +140,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhase do
            lock_new_materializer({:materializer, {worker_ref, node}, shard_tag}, recovery_attempt.epoch, context),
          :ok <- start_materializer_pulling(pid, shard_tag, recovery_attempt, context) do
       descriptor = %{kind: :materializer, last_seen: {worker_ref, node}, status: {:up, pid}}
-      {:ok, pid, {worker_id, descriptor}}
+      {:ok, {worker_id, node, pid}, {worker_id, descriptor}}
     end
   end
 
@@ -192,7 +194,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhase do
     # durable state, including the shard layout this phase exists to read.
     existing_by_shard = existing_materializers_by_shard(recovery_attempt)
 
-    with {:ok, materializer_service, created_system} <-
+    with {:ok, {system_worker_id, materializer_service}, created_system} <-
            find_or_create_materializer(existing_by_shard, recovery_attempt, context),
          {:ok, materializer_pid} <- lock_materializer(materializer_service, recovery_attempt.epoch, context),
          # Unlock with logs so it streams the replayed WAL from the demux
@@ -218,7 +220,9 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhase do
            ensure_materializers_for_shards(
              shard_layout,
              existing_by_shard,
-             %{RecoveryAttempt.system_shard_id() => materializer_pid},
+             %{
+               RecoveryAttempt.system_shard_id() => {system_worker_id, node(materializer_pid), materializer_pid}
+             },
              recovery_version,
              recovery_attempt,
              context
@@ -271,15 +275,15 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhase do
     |> Enum.flat_map(fn {id, info} ->
       with shard_id when is_integer(shard_id) <- Map.get(info, :shard_id),
            %{status: {:up, ref}} <- Map.get(recovery_attempt.transaction_services, id) do
-        [{shard_id, Map.get(info, :durable_version), {:materializer, ref}}]
+        [{shard_id, Map.get(info, :durable_version), {id, {:materializer, ref}}}]
       else
         _ -> []
       end
     end)
-    |> Enum.group_by(fn {shard_id, _durable, _service} -> shard_id end)
+    |> Enum.group_by(fn {shard_id, _durable, _entry} -> shard_id end)
     |> Map.new(fn {shard_id, candidates} ->
-      {_shard, _durable, service} = Enum.max_by(candidates, fn {_shard, durable, _service} -> durable end)
-      {shard_id, service}
+      {_shard, _durable, entry} = Enum.max_by(candidates, fn {_shard, durable, _entry} -> durable end)
+      {shard_id, entry}
     end)
   end
 
@@ -289,8 +293,8 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhase do
   # services once the lock provides the pid.
   defp find_or_create_materializer(existing_by_shard, recovery_attempt, context) do
     case Map.fetch(existing_by_shard, RecoveryAttempt.system_shard_id()) do
-      {:ok, service} ->
-        {:ok, service, nil}
+      {:ok, {worker_id, service}} ->
+        {:ok, {worker_id, service}, nil}
 
       :error ->
         Logger.info("System shard materializer not found, creating new one")
@@ -298,7 +302,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhase do
         with {:ok, node} <- find_materializer_capable_node(context),
              {:ok, {worker_id, worker_ref, node}} <-
                create_materializer_worker(node, RecoveryAttempt.system_shard_id(), recovery_attempt, context) do
-          {:ok, {:materializer, {worker_ref, node}}, {worker_id, {worker_ref, node}}}
+          {:ok, {worker_id, {:materializer, {worker_ref, node}}}, {worker_id, {worker_ref, node}}}
         end
     end
   end
@@ -317,15 +321,15 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhase do
     |> extract_shard_tags()
     |> Enum.reduce_while({:ok, already_started, %{}}, fn shard_tag, {:ok, acc, services} ->
       case Map.fetch(acc, shard_tag) do
-        {:ok, _pid} ->
+        {:ok, _assignment} ->
           {:cont, {:ok, acc, services}}
 
         :error ->
           shard_tag
           |> start_materializer_for_shard(existing_by_shard, recovery_version, recovery_attempt, context)
           |> case do
-            {:ok, pid, created} ->
-              {:cont, {:ok, Map.put(acc, shard_tag, pid), Map.merge(services, created)}}
+            {:ok, assignment, created} ->
+              {:cont, {:ok, Map.put(acc, shard_tag, assignment), Map.merge(services, created)}}
 
             {:error, reason} ->
               {:halt, {:error, {shard_tag, reason}}}
@@ -336,18 +340,18 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhase do
 
   defp start_materializer_for_shard(shard_tag, existing_by_shard, recovery_version, recovery_attempt, context) do
     case Map.fetch(existing_by_shard, shard_tag) do
-      {:ok, service} ->
+      {:ok, {worker_id, service}} ->
         with {:ok, pid} <- lock_materializer(service, recovery_attempt.epoch, context),
              :ok <- unlock_and_start_pulling(pid, shard_tag, recovery_version, recovery_attempt, context) do
-          {:ok, pid, %{}}
+          {:ok, {worker_id, node(pid), pid}, %{}}
         end
 
       :error ->
         Logger.info("Materializer for shard #{shard_tag} not found, creating new one")
 
-        with {:ok, pid, {worker_id, descriptor}} <-
+        with {:ok, assignment, {worker_id, descriptor}} <-
                create_and_start_materializer(shard_tag, recovery_attempt, context) do
-          {:ok, pid, %{worker_id => descriptor}}
+          {:ok, assignment, %{worker_id => descriptor}}
         end
     end
   end
@@ -505,36 +509,52 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhase do
 
   @doc false
   # Key format: \xff/system/shard_keys/<end_key>; value: {tag, start_key}
-  # (see Bedrock.SystemKeys.Values). Ranges are contiguous, so start keys
-  # are rebuilt from the sorted end keys — each shard starts where the
-  # previous one ends, the first at the empty key — which also covers
-  # legacy values that carried only the tag.
+  # (see Bedrock.SystemKeys.Values). The value CARRIES the start key and
+  # this reader consumes it — the same meaning RoutingData.apply_mutation
+  # gives it; two readers of one family must not disagree about what the
+  # value means. Adjacency reconstruction (each shard starts where the
+  # previous ends) survives only for legacy term_to_binary snapshots that
+  # predate carried start keys; the family rewrites atomically each
+  # epoch, so a snapshot is encoding-uniform and the fallback covers the
+  # whole read. (Dies with bedrock-q67.20.7.)
   @spec shard_layout_from_entries([{Bedrock.key(), binary()}]) ::
           {:ok, RecoveryAttempt.shard_layout()} | {:error, {:invalid_shard_value, Bedrock.key()}}
   def shard_layout_from_entries(entries) do
     entries
     |> Enum.reduce_while({:ok, []}, fn {key, value}, {:ok, acc} ->
-      case decode_shard_tag(value) do
-        {:ok, tag} -> {:cont, {:ok, [{extract_end_key_from_shard_key(key), tag} | acc]}}
+      case decode_shard_entry(value) do
+        {:ok, decoded} -> {:cont, {:ok, [{extract_end_key_from_shard_key(key), decoded} | acc]}}
         {:error, _} -> {:halt, {:error, {:invalid_shard_value, key}}}
       end
     end)
     |> case do
-      {:ok, tags_by_end_key} ->
-        shard_layout =
-          tags_by_end_key
-          |> Enum.sort_by(fn {end_key, _tag} -> end_key end)
-          |> Enum.map_reduce(<<>>, fn {end_key, tag}, start_key ->
-            {{end_key, {tag, start_key}}, end_key}
-          end)
-          |> elem(0)
-          |> Map.new()
-
-        {:ok, shard_layout}
-
-      error ->
-        error
+      {:ok, decoded_by_end_key} -> {:ok, build_shard_layout(decoded_by_end_key)}
+      error -> error
     end
+  end
+
+  defp build_shard_layout(decoded_by_end_key) do
+    if Enum.any?(decoded_by_end_key, &match?({_end_key, {:legacy, _tag}}, &1)) do
+      rebuild_start_keys_by_adjacency(decoded_by_end_key)
+    else
+      Map.new(decoded_by_end_key, fn {end_key, {tag, start_key}} -> {end_key, {tag, start_key}} end)
+    end
+  end
+
+  defp rebuild_start_keys_by_adjacency(decoded_by_end_key) do
+    decoded_by_end_key
+    |> Enum.sort_by(fn {end_key, _decoded} -> end_key end)
+    |> Enum.map_reduce(<<>>, fn {end_key, decoded}, start_key ->
+      tag =
+        case decoded do
+          {:legacy, tag} -> tag
+          {tag, _carried_start} -> tag
+        end
+
+      {{end_key, {tag, start_key}}, end_key}
+    end)
+    |> elem(0)
+    |> Map.new()
   end
 
   defp extract_end_key_from_shard_key(key) do
@@ -543,9 +563,9 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhase do
     binary_part(key, prefix_len, byte_size(key) - prefix_len)
   end
 
-  defp decode_shard_tag(value) do
+  defp decode_shard_entry(value) do
     case Values.decode_shard_key_entry(value) do
-      {:ok, {tag, _start_key}} -> {:ok, tag}
+      {:ok, {tag, start_key}} -> {:ok, {tag, start_key}}
       {:error, _} -> decode_legacy_shard_tag(value)
     end
   end
@@ -555,8 +575,8 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhase do
   # Remove once no supported release can carry the old encoding.
   defp decode_legacy_shard_tag(value) do
     case :erlang.binary_to_term(value, [:safe]) do
-      tag when is_integer(tag) -> {:ok, tag}
-      {tag, _start_key} when is_integer(tag) -> {:ok, tag}
+      tag when is_integer(tag) -> {:ok, {:legacy, tag}}
+      {tag, _start_key} when is_integer(tag) -> {:ok, {:legacy, tag}}
       _ -> {:error, :invalid_encoding}
     end
   rescue

--- a/lib/bedrock/control_plane/director/recovery/persistence_phase.ex
+++ b/lib/bedrock/control_plane/director/recovery/persistence_phase.ex
@@ -188,9 +188,8 @@ defmodule Bedrock.ControlPlane.Director.Recovery.PersistencePhase do
     Tx.commit(tx, nil)
   end
 
-  # Every key written here has a named reader: layout/logs/ keys feed each
-  # proxy's RoutingData log wiring through resolver windows, shard_keys/
-  # feeds both RoutingData and the next recovery's materializer bootstrap,
+  # Every key written here has a named purpose: shard_keys/ feeds both
+  # RoutingData and the next recovery's materializer bootstrap,
   # and materializers/ refs feed the client-facing routing projection
   # (FDB's serverList analogue - runtime hints, never recovery input) and
   # worker rejoin validation. layout/logs/ has no code reader by design:

--- a/lib/bedrock/control_plane/director/recovery/persistence_phase.ex
+++ b/lib/bedrock/control_plane/director/recovery/persistence_phase.ex
@@ -213,12 +213,13 @@ defmodule Bedrock.ControlPlane.Director.Recovery.PersistencePhase do
     build_materializer_keys(tx, recovery_attempt)
   end
 
-  # Creates materializer_key(tag) -> {worker_id, node} entries (strings;
-  # the reader derives the callable ref). Gated like shard_keys, on the
-  # same INPUT: shard_materializers absent/empty means shard management is
-  # not active, so existing entries are untouched. Worker ids ride the
-  # assignment from creation (no services-map inversion), and the unlock
-  # seed derives from the same projection, so keyspace and seed agree.
+  # Creates materializer_key(tag) -> {worker_id, node} entries: the
+  # attempt already carries the refs in the keyspace-value shape (both
+  # strings; the reader derives the callable ref), so they are written
+  # verbatim — the routing-snapshot seed embeds the same map, so keyspace
+  # and seed are one map read twice. Gated like shard_keys, on the same
+  # INPUT: shard_materializers absent/empty means shard management is not
+  # active, so existing entries are untouched.
   @spec build_materializer_keys(Tx.t(), RecoveryAttempt.t()) :: Tx.t()
   defp build_materializer_keys(tx, recovery_attempt) do
     case Map.get(recovery_attempt, :shard_materializers) do
@@ -231,9 +232,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery.PersistencePhase do
       materializers ->
         tx = clear_prefix(tx, SystemKeys.materializers_prefix())
 
-        materializers
-        |> RecoveryAttempt.materializer_refs()
-        |> Enum.reduce(tx, fn {tag, {worker_id, node}}, tx ->
+        Enum.reduce(materializers, tx, fn {tag, {worker_id, node}}, tx ->
           Tx.set(tx, SystemKeys.materializer_key(tag), Values.encode_materializer_ref(worker_id, node))
         end)
     end

--- a/lib/bedrock/control_plane/director/recovery/persistence_phase.ex
+++ b/lib/bedrock/control_plane/director/recovery/persistence_phase.ex
@@ -22,7 +22,6 @@ defmodule Bedrock.ControlPlane.Director.Recovery.PersistencePhase do
 
   alias Bedrock.ClusterBootstrap.Discovery
   alias Bedrock.ControlPlane.Config.RecoveryAttempt
-  alias Bedrock.ControlPlane.Config.TransactionSystemLayout
   alias Bedrock.DataPlane.CommitProxy
   alias Bedrock.DataPlane.Transaction
   alias Bedrock.Internal.Id
@@ -193,12 +192,15 @@ defmodule Bedrock.ControlPlane.Director.Recovery.PersistencePhase do
   # proxy's RoutingData log wiring through resolver windows, shard_keys/
   # feeds both RoutingData and the next recovery's materializer bootstrap,
   # and materializers/ refs feed the client-facing routing projection
-  # (FDB's serverList analogue - runtime hints, never recovery input).
-  # Nothing else is written - a system key without a reader is inventory,
-  # not communication (config and policy travel via the object-storage
-  # cluster bootstrap, which the coordinator actually reads; services are
-  # rebuilt each recovery from foreman discovery). Families return to the
-  # keyspace when their readers do (bedrock-q67.9, q67.25).
+  # (FDB's serverList analogue - runtime hints, never recovery input) and
+  # worker rejoin validation. layout/logs/ has no code reader by design:
+  # log wiring is epoch-constant and rides the unlock seed
+  # (bedrock-q67.41); the family stays durable for other consumers and
+  # cluster-introspection tools. Nothing else is written (config and
+  # policy travel via the object-storage cluster bootstrap, which the
+  # coordinator actually reads; services are rebuilt each recovery from
+  # foreman discovery). Families return to the keyspace when their
+  # readers do (bedrock-q67.9, q67.25).
   @spec build_readable_keys(Tx.t(), RecoveryAttempt.t()) :: Tx.t()
   defp build_readable_keys(tx, recovery_attempt) do
     tx = clear_prefix(tx, SystemKeys.layout_logs_prefix())
@@ -212,12 +214,12 @@ defmodule Bedrock.ControlPlane.Director.Recovery.PersistencePhase do
     build_materializer_keys(tx, recovery_attempt)
   end
 
-  # Creates materializer_key(tag) -> {worker_id, node} entries (strings; the
-  # reader derives the callable ref). Gated like shard_keys, on the same
-  # INPUT: shard_materializers absent/empty means shard management is not
-  # active, so existing entries are untouched. When active, the prefix is
-  # cleared even if no pid inverts to a service record - the keyspace and
-  # the unlock seed must agree, and the seed derives from the same refs.
+  # Creates materializer_key(tag) -> {worker_id, node} entries (strings;
+  # the reader derives the callable ref). Gated like shard_keys, on the
+  # same INPUT: shard_materializers absent/empty means shard management is
+  # not active, so existing entries are untouched. Worker ids ride the
+  # assignment from creation (no services-map inversion), and the unlock
+  # seed derives from the same projection, so keyspace and seed agree.
   @spec build_materializer_keys(Tx.t(), RecoveryAttempt.t()) :: Tx.t()
   defp build_materializer_keys(tx, recovery_attempt) do
     case Map.get(recovery_attempt, :shard_materializers) do
@@ -231,7 +233,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery.PersistencePhase do
         tx = clear_prefix(tx, SystemKeys.materializers_prefix())
 
         materializers
-        |> TransactionSystemLayout.materializer_refs(recovery_attempt.transaction_services)
+        |> RecoveryAttempt.materializer_refs()
         |> Enum.reduce(tx, fn {tag, {worker_id, node}}, tx ->
           Tx.set(tx, SystemKeys.materializer_key(tag), Values.encode_materializer_ref(worker_id, node))
         end)

--- a/lib/bedrock/control_plane/director/recovery/topology_phase.ex
+++ b/lib/bedrock/control_plane/director/recovery/topology_phase.ex
@@ -210,7 +210,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery.TopologyPhase do
       shard_layout: shard_layout || %{},
       log_map: log_map,
       log_services: log_services,
-      materializers: RecoveryAttempt.materializer_refs(Map.get(recovery_attempt, :shard_materializers)),
+      materializers: Map.get(recovery_attempt, :shard_materializers) || %{},
       replication_factor: max(1, map_size(logs))
     }
   end

--- a/lib/bedrock/control_plane/director/recovery/topology_phase.ex
+++ b/lib/bedrock/control_plane/director/recovery/topology_phase.ex
@@ -210,8 +210,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery.TopologyPhase do
       shard_layout: shard_layout || %{},
       log_map: log_map,
       log_services: log_services,
-      materializers:
-        TransactionSystemLayout.materializer_refs(Map.get(recovery_attempt, :shard_materializers), services),
+      materializers: RecoveryAttempt.materializer_refs(Map.get(recovery_attempt, :shard_materializers)),
       replication_factor: max(1, map_size(logs))
     }
   end

--- a/lib/bedrock/data_plane/commit_proxy/routing_data.ex
+++ b/lib/bedrock/data_plane/commit_proxy/routing_data.ex
@@ -29,11 +29,9 @@ defmodule Bedrock.DataPlane.CommitProxy.RoutingData do
   - `insert_shard/4` - Adds or updates a shard entry
   - `delete_shard/2` - Removes a shard entry
 
-  ## Log Updates
-
-  - `insert_log/2` - Adds a log to log_map at next index (idempotent by id)
-  - `remove_log/2` - Removes a log and reindexes
-  - `delete_log_service/2` - Removes a log service reference
+  Log wiring (`log_map`, `log_services`, `replication_factor`) is
+  epoch-constant: seeded once at unlock and never mutated — changing log
+  topology IS a recovery (bedrock-q67.41).
   """
 
   alias Bedrock.DataPlane.Log
@@ -169,52 +167,10 @@ defmodule Bedrock.DataPlane.CommitProxy.RoutingData do
   end
 
   @doc """
-  Adds a log to the log_map at the next available index.
-
-  Idempotent by log id: a re-set of an already-known log (a legitimate
-  layout_log update, or the same entry seen again) keeps its index instead
-  of appending a duplicate that would corrupt golden-ratio routing.
-  """
-  @spec insert_log(t(), Log.id()) :: t()
-  def insert_log(%__MODULE__{log_map: log_map} = routing_data, log_id) do
-    if Enum.any?(log_map, fn {_index, id} -> id == log_id end) do
-      routing_data
-    else
-      %{routing_data | log_map: Map.put(log_map, map_size(log_map), log_id)}
-    end
-  end
-
-  @doc """
-  Removes a log from the log_map and reindexes remaining entries.
-
-  Maintains contiguous indices starting from 0.
-  """
-  @spec remove_log(t(), Log.id()) :: t()
-  def remove_log(%__MODULE__{log_map: log_map} = routing_data, log_id) do
-    new_map =
-      log_map
-      |> Enum.reject(fn {_index, id} -> id == log_id end)
-      |> Enum.sort_by(fn {index, _id} -> index end)
-      |> Enum.with_index()
-      |> Map.new(fn {{_old_index, id}, new_index} -> {new_index, id} end)
-
-    %{routing_data | log_map: new_map}
-  end
-
-  @doc """
-  Removes a log service reference.
-  """
-  @spec delete_log_service(t(), Log.id()) :: t()
-  def delete_log_service(%__MODULE__{log_services: log_services} = routing_data, log_id) do
-    %{routing_data | log_services: Map.delete(log_services, log_id)}
-  end
-
-  @doc """
   Applies metadata mutations to update routing data.
 
-  Handles shard_key and layout_log mutations:
-  - shard_key: Updates the shard tree
-  - layout_log: Updates both log_map and log_services
+  Handles shard_key and materializer_key mutations; layout_log mutations
+  are deliberately ignored (see the fold's layout_log clause).
 
   ## Parameters
 
@@ -242,14 +198,20 @@ defmodule Bedrock.DataPlane.CommitProxy.RoutingData do
           {:error, _} -> routing_data
         end
 
-      {:layout_log, log_id} ->
-        # The value (log descriptor tags) is not needed for routing; LOG
-        # service refs are populated at runtime by the director, not from
-        # persisted data (this epoch's log wiring is runtime state - the
-        # ServerDBInfo analogue). Materializer refs below deliberately DO
-        # ride persisted data: they are client-facing hints, FDB serverList
-        # style, and the Distributor mutates them mid-epoch (bedrock-q67.21).
-        insert_log(routing_data, log_id)
+      {:layout_log, _log_id} ->
+        # Log wiring is epoch-constant and seed-only: changing log
+        # topology IS a recovery (FDB: a new generation, a new
+        # logSystemConfig), so the only layout_log mutations that ever
+        # flow through a window are the recovery transaction's rewrite of
+        # the very set this proxy was just seeded with. Folding them was
+        # a second way of managing one table, guarding a hazard the
+        # recovery boundary precludes. The layout/logs/ FAMILY stays
+        # durable for other consumers and cluster-introspection tools —
+        # this fold just isn't a reader. Materializer refs below
+        # deliberately DO ride persisted data: they are client-facing
+        # hints, FDB serverList style, and the Distributor mutates them
+        # mid-epoch (bedrock-q67.21).
+        routing_data
 
       {:materializer_key, tag} ->
         # Undecodable values are ignored, keeping the last good ref.
@@ -268,10 +230,9 @@ defmodule Bedrock.DataPlane.CommitProxy.RoutingData do
       {:shard_key, end_key} ->
         delete_shard(routing_data, end_key)
 
-      {:layout_log, log_id} ->
+      {:layout_log, _log_id} ->
+        # Epoch-constant; see the set clause.
         routing_data
-        |> remove_log(log_id)
-        |> delete_log_service(log_id)
 
       {:materializer_key, tag} ->
         %{routing_data | materializers: Map.delete(routing_data.materializers, tag)}
@@ -287,7 +248,6 @@ defmodule Bedrock.DataPlane.CommitProxy.RoutingData do
   defp apply_mutation({:clear_range, start_key, end_key}, routing_data) do
     routing_data
     |> clear_shards_in_range(start_key, end_key)
-    |> clear_logs_in_range(start_key, end_key)
     |> clear_materializers_in_range(start_key, end_key)
   end
 
@@ -314,19 +274,5 @@ defmodule Bedrock.DataPlane.CommitProxy.RoutingData do
       end)
 
     %{routing_data | materializers: kept}
-  end
-
-  defp clear_logs_in_range(%__MODULE__{log_map: log_map} = routing_data, start_key, end_key) do
-    log_map
-    |> Map.values()
-    |> Enum.filter(fn log_id ->
-      full_key = SystemKeys.layout_log(log_id)
-      full_key >= start_key and full_key < end_key
-    end)
-    |> Enum.reduce(routing_data, fn log_id, routing_data ->
-      routing_data
-      |> remove_log(log_id)
-      |> delete_log_service(log_id)
-    end)
   end
 end

--- a/lib/bedrock/data_plane/commit_proxy/routing_data.ex
+++ b/lib/bedrock/data_plane/commit_proxy/routing_data.ex
@@ -130,10 +130,11 @@ defmodule Bedrock.DataPlane.CommitProxy.RoutingData do
   end
 
   @doc """
-  Creates empty routing data for dynamic population via metadata.
+  Creates empty routing data.
 
-  Starts with no shards, no logs, and replication factor of 1. All fields
-  are populated incrementally as metadata mutations arrive.
+  Starts with no shards, no logs, and replication factor of 1. Shard and
+  materializer entries populate incrementally as metadata mutations
+  arrive; log wiring is epoch-constant and only `from_snapshot/1` sets it.
   """
   @spec new_empty() :: t()
   def new_empty do

--- a/lib/bedrock/system_keys.ex
+++ b/lib/bedrock/system_keys.ex
@@ -2,15 +2,20 @@ defmodule Bedrock.SystemKeys do
   @moduledoc """
   The `\\xFF/system` keys Bedrock writes and reads.
 
-  Every key defined here has a named reader: `shard_keys/<end_key>` feeds each
-  commit proxy's routing view (through resolver metadata windows) and the next
-  recovery's materializer bootstrap; `layout/logs/<log_id>` keys feed the
-  routing view's log wiring (the tag-list value is not consumed by routing);
-  `materializers/<tag>` refs feed the client-facing routing projection served
-  by commit proxies (FDB's `serverList/` analogue - interfaces ride the
-  keyspace). Materializer refs are runtime hints for clients, never recovery
-  input: bootstrap rebuilds assignment from `shard_keys/` plus live foreman
-  discovery. A system key without a reader is inventory, not communication -
+  Every key defined here has a named purpose: `shard_keys/<end_key>` feeds
+  each commit proxy's routing view (through resolver metadata windows) and
+  the next recovery's materializer bootstrap; `materializers/<tag>` refs
+  feed the client-facing routing projection served by commit proxies
+  (FDB's `serverList/` analogue - interfaces ride the keyspace) and answer
+  worker rejoin validation. `layout/logs/<log_id>` keys have no code
+  reader by design: log wiring is epoch-constant and rides the recovery
+  unlock seed (bedrock-q67.41) - the family stays durable for other
+  consumers and cluster-introspection tools, a queryable statement of
+  which logs the current epoch runs. Materializer refs are runtime hints
+  for clients, never recovery input: bootstrap rebuilds assignment from
+  `shard_keys/` plus live foreman discovery. A system key without a
+  reader is inventory, not communication - unread MACHINERY is deleted,
+  while durable observability keys stay by decision, named as such;
   families return here when their readers do (config authority with
   bedrock-q67.25).
   """

--- a/lib/bedrock/system_keys/values.ex
+++ b/lib/bedrock/system_keys/values.ex
@@ -7,11 +7,12 @@ defmodule Bedrock.SystemKeys.Values do
   input; decoders handle durable bytes and never raise. Decoding durable
   bytes must never create atoms.
 
-  The surface is exactly the families with readers - `shard_keys/` entries
-  (the routing boundary map), `layout/logs/` tag lists, and `materializers/`
-  refs (worker id and node as strings; consumers derive the callable
-  `{otp_name, node}` ref, so the no-atoms rule holds through decode).
-  Families return here when their readers do.
+  The surface is exactly the written families - `shard_keys/` entries
+  (the routing boundary map), `layout/logs/` tag lists (no code reader by
+  design: kept durable for introspection, see `Bedrock.SystemKeys`), and
+  `materializers/` refs (worker id and node as strings; consumers derive
+  the callable `{otp_name, node}` ref, so the no-atoms rule holds through
+  decode). Families return here when their readers do.
   """
 
   alias Bedrock.Encoding.Tuple, as: TupleEncoding
@@ -31,10 +32,10 @@ defmodule Bedrock.SystemKeys.Values do
   @doc """
   Encodes a shard key entry: `{tag, start_key}`.
 
-  The key carries the shard's `end_key`; the value carries the tag and the
-  range's start key. (Readers currently rebuild start keys from adjacency -
-  the explicit start key exists so a future reader of a single entry does
-  not have to.)
+  The key carries the shard's `end_key`; the value carries the tag and
+  the range's start key, and readers consume the carried start key
+  verbatim - a single entry is self-describing, no adjacency
+  reconstruction.
   """
   @spec encode_shard_key_entry(Bedrock.range_tag(), Bedrock.key()) :: binary()
   def encode_shard_key_entry(tag, start_key) when is_integer(tag) and is_binary(start_key),

--- a/test/bedrock/control_plane/director/recovery/materializer_bootstrap_phase_test.exs
+++ b/test/bedrock/control_plane/director/recovery/materializer_bootstrap_phase_test.exs
@@ -60,8 +60,10 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhaseTest 
           assert Map.has_key?(updated_attempt.shard_materializers, 0)
           assert Map.has_key?(updated_attempt.shard_materializers, 1)
 
-          assert {_id, _node, ^system_materializer_pid} =
+          assert {<<_::binary>>, node_string} =
                    updated_attempt.shard_materializers[RecoveryAttempt.system_shard_id()]
+
+          assert node_string == Atom.to_string(node())
 
           # Every creation reaches transaction_services — the layout is
           # built from it, and reconciliation retires anything the layout
@@ -129,7 +131,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhaseTest 
       assert {updated_attempt, CommitProxyStartupPhase} =
                MaterializerBootstrapPhase.execute(recovery_attempt, context)
 
-      assert {_id, _node, ^system_materializer_pid} =
+      assert {<<_::binary>>, <<_::binary>>} =
                updated_attempt.shard_materializers[RecoveryAttempt.system_shard_id()]
 
       # Replication spans all logs today, so every shard's replica set
@@ -229,13 +231,12 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhaseTest 
                    MaterializerBootstrapPhase.execute(recovery_attempt, context)
 
           # The system-shard survivor answers the layout query...
-          assert {_id, _node, ^system_pid} = updated_attempt.shard_materializers[RecoveryAttempt.system_shard_id()]
+          assert {"mat_sys", _node} = updated_attempt.shard_materializers[RecoveryAttempt.system_shard_id()]
           assert updated_attempt.shard_layout
 
           # ...and every shard in the layout gets its surviving
           # materializer — nothing newly created, nothing orphaned.
-          assert %{0 => {"mat_sys", _, ^system_pid}, 1 => {"mat_user", _, ^user_pid}} =
-                   updated_attempt.shard_materializers
+          assert %{0 => {"mat_sys", _}, 1 => {"mat_user", _}} = updated_attempt.shard_materializers
 
           assert map_size(updated_attempt.shard_materializers) == 2
         end)
@@ -289,8 +290,8 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhaseTest 
         assert {updated_attempt, CommitProxyStartupPhase} =
                  MaterializerBootstrapPhase.execute(recovery_attempt, context)
 
-        assert {_id, _node, ^real_pid} = updated_attempt.shard_materializers[RecoveryAttempt.system_shard_id()]
-        assert %{0 => {"mat_real", _, ^real_pid}} = updated_attempt.shard_materializers
+        assert {"mat_real", _node} = updated_attempt.shard_materializers[RecoveryAttempt.system_shard_id()]
+        assert %{0 => {"mat_real", _}} = updated_attempt.shard_materializers
         assert map_size(updated_attempt.shard_materializers) == 1
       end)
     end
@@ -334,7 +335,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhaseTest 
           assert {updated_attempt, CommitProxyStartupPhase} =
                    MaterializerBootstrapPhase.execute(recovery_attempt, context)
 
-          assert {_id, _node, ^materializer_pid} = updated_attempt.shard_materializers[0]
+          assert {<<_::binary>>, <<_::binary>>} = updated_attempt.shard_materializers[0]
           assert updated_attempt.shard_layout
 
           # The creation is recorded: the layout will reference it, so

--- a/test/bedrock/control_plane/director/recovery/materializer_bootstrap_phase_test.exs
+++ b/test/bedrock/control_plane/director/recovery/materializer_bootstrap_phase_test.exs
@@ -590,6 +590,21 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhaseTest 
                MaterializerBootstrapPhase.shard_layout_from_entries(entries)
     end
 
+    test "any legacy entry falls the whole snapshot back to adjacency" do
+      # Structurally precluded in production (the family rewrites
+      # atomically each epoch, so snapshots are encoding-uniform), but the
+      # branch is live: a modern entry's carried start key is discarded
+      # and its tag still extracted when a legacy sibling forces the
+      # adjacency rebuild.
+      entries = [
+        {SystemKeys.shard_key("m"), Values.encode_shard_key_entry(1, "carried-start")},
+        {SystemKeys.shard_key(<<0xFF, 0xFF>>), :erlang.term_to_binary(0)}
+      ]
+
+      assert {:ok, %{"m" => {1, ""}, <<0xFF, 0xFF>> => {0, "m"}}} =
+               MaterializerBootstrapPhase.shard_layout_from_entries(entries)
+    end
+
     test "rejects values that decode in neither encoding" do
       key = SystemKeys.shard_key("m")
 

--- a/test/bedrock/control_plane/director/recovery/materializer_bootstrap_phase_test.exs
+++ b/test/bedrock/control_plane/director/recovery/materializer_bootstrap_phase_test.exs
@@ -60,7 +60,8 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhaseTest 
           assert Map.has_key?(updated_attempt.shard_materializers, 0)
           assert Map.has_key?(updated_attempt.shard_materializers, 1)
 
-          assert updated_attempt.shard_materializers[RecoveryAttempt.system_shard_id()] == system_materializer_pid
+          assert {_id, _node, ^system_materializer_pid} =
+                   updated_attempt.shard_materializers[RecoveryAttempt.system_shard_id()]
 
           # Every creation reaches transaction_services — the layout is
           # built from it, and reconciliation retires anything the layout
@@ -128,7 +129,8 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhaseTest 
       assert {updated_attempt, CommitProxyStartupPhase} =
                MaterializerBootstrapPhase.execute(recovery_attempt, context)
 
-      assert updated_attempt.shard_materializers[RecoveryAttempt.system_shard_id()] == system_materializer_pid
+      assert {_id, _node, ^system_materializer_pid} =
+               updated_attempt.shard_materializers[RecoveryAttempt.system_shard_id()]
 
       # Replication spans all logs today, so every shard's replica set
       # covers both — each seed carries {log_id, ref} pairs, never a
@@ -227,12 +229,15 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhaseTest 
                    MaterializerBootstrapPhase.execute(recovery_attempt, context)
 
           # The system-shard survivor answers the layout query...
-          assert updated_attempt.shard_materializers[RecoveryAttempt.system_shard_id()] == system_pid
+          assert {_id, _node, ^system_pid} = updated_attempt.shard_materializers[RecoveryAttempt.system_shard_id()]
           assert updated_attempt.shard_layout
 
           # ...and every shard in the layout gets its surviving
           # materializer — nothing newly created, nothing orphaned.
-          assert updated_attempt.shard_materializers == %{0 => system_pid, 1 => user_pid}
+          assert %{0 => {"mat_sys", _, ^system_pid}, 1 => {"mat_user", _, ^user_pid}} =
+                   updated_attempt.shard_materializers
+
+          assert map_size(updated_attempt.shard_materializers) == 2
         end)
 
       # Both were unlocked at the recovery version (vector last), never at
@@ -284,8 +289,9 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhaseTest 
         assert {updated_attempt, CommitProxyStartupPhase} =
                  MaterializerBootstrapPhase.execute(recovery_attempt, context)
 
-        assert updated_attempt.shard_materializers[RecoveryAttempt.system_shard_id()] == real_pid
-        assert updated_attempt.shard_materializers == %{0 => real_pid}
+        assert {_id, _node, ^real_pid} = updated_attempt.shard_materializers[RecoveryAttempt.system_shard_id()]
+        assert %{0 => {"mat_real", _, ^real_pid}} = updated_attempt.shard_materializers
+        assert map_size(updated_attempt.shard_materializers) == 1
       end)
     end
 
@@ -328,7 +334,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhaseTest 
           assert {updated_attempt, CommitProxyStartupPhase} =
                    MaterializerBootstrapPhase.execute(recovery_attempt, context)
 
-          assert updated_attempt.shard_materializers[0] == materializer_pid
+          assert {_id, _node, ^materializer_pid} = updated_attempt.shard_materializers[0]
           assert updated_attempt.shard_layout
 
           # The creation is recorded: the layout will reference it, so
@@ -552,13 +558,25 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhaseTest 
     alias Bedrock.SystemKeys
     alias Bedrock.SystemKeys.Values
 
-    test "decodes tuple-encoded shard values and rebuilds contiguous start keys" do
+    test "decodes tuple-encoded shard values, consuming the carried start keys" do
       entries = [
         {SystemKeys.shard_key(<<0xFF, 0xFF>>), Values.encode_shard_key_entry(0, "m")},
         {SystemKeys.shard_key("m"), Values.encode_shard_key_entry(1, "")}
       ]
 
       assert {:ok, %{"m" => {1, ""}, <<0xFF, 0xFF>> => {0, "m"}}} =
+               MaterializerBootstrapPhase.shard_layout_from_entries(entries)
+    end
+
+    test "the carried start key is consumed verbatim — no adjacency reconstruction" do
+      # The value carries the fact; readers must not rebuild it. Under
+      # adjacency reconstruction this entry's start would come out as the
+      # empty key (the first shard "starts where nothing ended"), so a
+      # carried non-empty start surviving proves the value is consumed —
+      # the same meaning RoutingData.apply_mutation gives it.
+      entries = [{SystemKeys.shard_key("m"), Values.encode_shard_key_entry(1, "gap")}]
+
+      assert {:ok, %{"m" => {1, "gap"}}} =
                MaterializerBootstrapPhase.shard_layout_from_entries(entries)
     end
 

--- a/test/bedrock/control_plane/director/recovery/persistence_phase_test.exs
+++ b/test/bedrock/control_plane/director/recovery/persistence_phase_test.exs
@@ -24,6 +24,8 @@ defmodule Bedrock.ControlPlane.Director.Recovery.PersistencePhaseTest do
     }
   end
 
+  defp node_string, do: Atom.to_string(node())
+
   defp base_recovery_attempt do
     mat_sys = spawn(fn -> Process.sleep(:infinity) end)
     mat_user = spawn(fn -> Process.sleep(:infinity) end)
@@ -42,7 +44,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery.PersistencePhaseTest do
       <<0xFF>> => {1, <<>>},
       <<0xFF, 0xFF>> => {0, <<0xFF>>}
     })
-    |> Map.put(:shard_materializers, %{0 => {"wkr_sys", node(), mat_sys}, 1 => {"wkr_user", node(), mat_user}})
+    |> Map.put(:shard_materializers, %{0 => {"wkr_sys", node_string()}, 1 => {"wkr_user", node_string()}})
     |> Map.put(:transaction_system_layout, mock_transaction_system_layout())
   end
 

--- a/test/bedrock/control_plane/director/recovery/persistence_phase_test.exs
+++ b/test/bedrock/control_plane/director/recovery/persistence_phase_test.exs
@@ -42,7 +42,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery.PersistencePhaseTest do
       <<0xFF>> => {1, <<>>},
       <<0xFF, 0xFF>> => {0, <<0xFF>>}
     })
-    |> Map.put(:shard_materializers, %{0 => mat_sys, 1 => mat_user})
+    |> Map.put(:shard_materializers, %{0 => {"wkr_sys", node(), mat_sys}, 1 => {"wkr_user", node(), mat_user}})
     |> Map.put(:transaction_system_layout, mock_transaction_system_layout())
   end
 
@@ -128,9 +128,12 @@ defmodule Bedrock.ControlPlane.Director.Recovery.PersistencePhaseTest do
              end)
     end
 
-    test "active shard management with zero matching service records still clears the family" do
-      # Keyspace and seed must agree: the seed would be empty, so the
-      # keyspace must end empty too - the clear fires even with no sets.
+    test "assignments write from the carried refs — no services-map inversion, no skips" do
+      # Worker ids and nodes ride the assignment from creation, so the
+      # family is written even when the services map has no matching
+      # record: the keyspace names exactly what the attempt assigned.
+      # (Under the old inversion, a missing record silently dropped the
+      # entry — an orphan the seed and keyspace then disagreed about.)
       recovery_attempt =
         update_in(
           base_recovery_attempt(),
@@ -140,34 +143,12 @@ defmodule Bedrock.ControlPlane.Director.Recovery.PersistencePhaseTest do
 
       mutations = captured_system_mutations(recovery_attempt)
 
-      prefix = SystemKeys.materializers_prefix()
-      {clear_start, clear_end} = KeyRange.from_prefix(prefix)
-
-      assert Enum.any?(mutations, &match?({:clear_range, ^clear_start, ^clear_end}, &1))
-
-      refute Enum.any?(mutations, fn
-               {:set, key, _} -> String.starts_with?(key, prefix)
-               _ -> false
-             end)
-    end
-
-    test "a materializer pid without a service record is skipped, not invented" do
-      orphan = spawn(fn -> Process.sleep(:infinity) end)
-
-      recovery_attempt =
-        update_in(base_recovery_attempt(), [Access.key!(:shard_materializers)], &Map.put(&1, 9, orphan))
-
-      mutations = captured_system_mutations(recovery_attempt)
-
-      refute Enum.any?(mutations, fn
-               {:set, key, _} -> key == SystemKeys.materializer_key(9)
-               _ -> false
-             end)
-
-      assert Enum.any?(mutations, fn
-               {:set, key, _} -> key == SystemKeys.materializer_key(0)
-               _ -> false
-             end)
+      for tag <- [0, 1] do
+        assert Enum.any?(mutations, fn
+                 {:set, key, _} -> key == SystemKeys.materializer_key(tag)
+                 _ -> false
+               end)
+      end
     end
 
     test "commits the system transaction in system mode by default" do

--- a/test/bedrock/control_plane/director/recovery/persistence_phase_test.exs
+++ b/test/bedrock/control_plane/director/recovery/persistence_phase_test.exs
@@ -108,7 +108,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery.PersistencePhaseTest do
       assert decoded[{:layout_log, "log_1"}] == [1, 2]
 
       # Materializer refs: worker id + node as strings (FDB serverList
-      # analogue), derived by inverting shard_materializers through services.
+      # analogue), projected from the carried shard_materializers refs.
       node_string = Atom.to_string(node())
       assert decoded[{:materializer_key, 0}] == {"wkr_sys", node_string}
       assert decoded[{:materializer_key, 1}] == {"wkr_user", node_string}

--- a/test/bedrock/control_plane/director/recovery/topology_phase_test.exs
+++ b/test/bedrock/control_plane/director/recovery/topology_phase_test.exs
@@ -98,7 +98,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery.TopologyPhaseTest do
           "log_1" => %{status: {:up, self()}, kind: :log, last_seen: {:log_1, :node1}},
           "wkr_sys" => %{status: {:up, mat_sys}, kind: :materializer, last_seen: {:wkr_sys_name, node()}}
         })
-        |> Map.put(:shard_materializers, %{0 => mat_sys})
+        |> Map.put(:shard_materializers, %{0 => {"wkr_sys", node(), mat_sys}})
 
       context =
         recovery_context()

--- a/test/bedrock/control_plane/director/recovery/topology_phase_test.exs
+++ b/test/bedrock/control_plane/director/recovery/topology_phase_test.exs
@@ -98,7 +98,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery.TopologyPhaseTest do
           "log_1" => %{status: {:up, self()}, kind: :log, last_seen: {:log_1, :node1}},
           "wkr_sys" => %{status: {:up, mat_sys}, kind: :materializer, last_seen: {:wkr_sys_name, node()}}
         })
-        |> Map.put(:shard_materializers, %{0 => {"wkr_sys", node(), mat_sys}})
+        |> Map.put(:shard_materializers, %{0 => {"wkr_sys", Atom.to_string(node())}})
 
       context =
         recovery_context()

--- a/test/bedrock/control_plane/director/recovery_test.exs
+++ b/test/bedrock/control_plane/director/recovery_test.exs
@@ -180,7 +180,7 @@ defmodule Bedrock.ControlPlane.Director.RecoveryTest do
 
       completed = %{
         logs: %{"live_log" => []},
-        shard_materializers: %{0 => live_mat_pid},
+        shard_materializers: %{0 => {"live_mat", node(), live_mat_pid}},
         transaction_services: %{
           "live_log" => %{kind: :log, status: {:up, self()}},
           "live_mat" => %{kind: :materializer, status: {:up, live_mat_pid}}
@@ -220,7 +220,7 @@ defmodule Bedrock.ControlPlane.Director.RecoveryTest do
 
       completed = %{
         logs: %{},
-        shard_materializers: %{0 => active_pid},
+        shard_materializers: %{0 => {"active_mat", node(), active_pid}},
         transaction_services: %{
           "active_mat" => %{kind: :materializer, status: {:up, active_pid}},
           "inactive_mat" => %{kind: :materializer, status: {:up, inactive_pid}}

--- a/test/bedrock/control_plane/director/recovery_test.exs
+++ b/test/bedrock/control_plane/director/recovery_test.exs
@@ -209,6 +209,23 @@ defmodule Bedrock.ControlPlane.Director.RecoveryTest do
       assert Recovery.ghost_directory_ids(services, completed) == []
     end
 
+    test "an assigned materializer with no services record is still referenced — never pruned" do
+      # Worker ids ride the assignment triple, so the reference set does
+      # not depend on the services map at all; a missing record cannot
+      # deregister the worker the epoch assigned.
+      assigned_pid = spawn(fn -> Process.sleep(:infinity) end)
+
+      services = %{"assigned_mat" => {:materializer, {:a, :node1}}}
+
+      completed = %{
+        logs: %{},
+        shard_materializers: %{0 => {"assigned_mat", node(), assigned_pid}},
+        transaction_services: %{}
+      }
+
+      assert Recovery.ghost_directory_ids(services, completed) == []
+    end
+
     test "a locked-but-inactive materializer is not referenced — it is a ghost candidate" do
       active_pid = spawn(fn -> Process.sleep(:infinity) end)
       inactive_pid = spawn(fn -> Process.sleep(:infinity) end)

--- a/test/bedrock/control_plane/director/recovery_test.exs
+++ b/test/bedrock/control_plane/director/recovery_test.exs
@@ -180,7 +180,7 @@ defmodule Bedrock.ControlPlane.Director.RecoveryTest do
 
       completed = %{
         logs: %{"live_log" => []},
-        shard_materializers: %{0 => {"live_mat", node(), live_mat_pid}},
+        shard_materializers: %{0 => {"live_mat", Atom.to_string(node())}},
         transaction_services: %{
           "live_log" => %{kind: :log, status: {:up, self()}},
           "live_mat" => %{kind: :materializer, status: {:up, live_mat_pid}}
@@ -210,16 +210,14 @@ defmodule Bedrock.ControlPlane.Director.RecoveryTest do
     end
 
     test "an assigned materializer with no services record is still referenced — never pruned" do
-      # Worker ids ride the assignment triple, so the reference set does
+      # Worker ids ride the assignment refs, so the reference set does
       # not depend on the services map at all; a missing record cannot
       # deregister the worker the epoch assigned.
-      assigned_pid = spawn(fn -> Process.sleep(:infinity) end)
-
       services = %{"assigned_mat" => {:materializer, {:a, :node1}}}
 
       completed = %{
         logs: %{},
-        shard_materializers: %{0 => {"assigned_mat", node(), assigned_pid}},
+        shard_materializers: %{0 => {"assigned_mat", Atom.to_string(node())}},
         transaction_services: %{}
       }
 
@@ -237,7 +235,7 @@ defmodule Bedrock.ControlPlane.Director.RecoveryTest do
 
       completed = %{
         logs: %{},
-        shard_materializers: %{0 => {"active_mat", node(), active_pid}},
+        shard_materializers: %{0 => {"active_mat", Atom.to_string(node())}},
         transaction_services: %{
           "active_mat" => %{kind: :materializer, status: {:up, active_pid}},
           "inactive_mat" => %{kind: :materializer, status: {:up, inactive_pid}}

--- a/test/bedrock/data_plane/commit_proxy/metadata_distribution_integration_test.exs
+++ b/test/bedrock/data_plane/commit_proxy/metadata_distribution_integration_test.exs
@@ -280,7 +280,10 @@ defmodule Bedrock.DataPlane.CommitProxy.MetadataDistributionIntegrationTest do
     end
   end
 
-  test "routing families update the routing view; unknown system keys are ignored", %{proxy: proxy, epoch: epoch} do
+  test "routing families update the routing view; layout_log and unknown system keys are ignored",
+       %{proxy: proxy, epoch: epoch} do
+    wiring_before = :sys.get_state(proxy).routing_data.log_map
+
     mutations = [
       {:set, SystemKeys.shard_key("g"), Values.encode_shard_key_entry(3, "")},
       {:set, SystemKeys.layout_log("log-abc"), Values.encode_tag_list([0, 1])},
@@ -293,7 +296,9 @@ defmodule Bedrock.DataPlane.CommitProxy.MetadataDistributionIntegrationTest do
 
     routing_data = :sys.get_state(proxy).routing_data
     assert proxy_shard(proxy, "g") == 3
-    assert "log-abc" in Map.values(routing_data.log_map)
+    # Log wiring is epoch-constant and seed-only: the durable layout_log
+    # write rides the window but the routing view does not fold it.
+    assert routing_data.log_map == wiring_before
     # Unknown families ride the window harmlessly (forward compatibility) -
     # the version still advances so the resolver can prune.
     assert proxy_applied_version(proxy) == version

--- a/test/bedrock/data_plane/commit_proxy/metadata_window_application_test.exs
+++ b/test/bedrock/data_plane/commit_proxy/metadata_window_application_test.exs
@@ -48,8 +48,6 @@ defmodule Bedrock.DataPlane.CommitProxy.MetadataWindowApplicationTest do
 
   defp shard_set(key, tag), do: {:set, SystemKeys.shard_key(key), Values.encode_shard_key_entry(tag, "")}
 
-  defp log_set(log_id), do: {:set, SystemKeys.layout_log(log_id), Values.encode_tag_list([1])}
-
   defp request(state, seq, commit_version, window) do
     from = {self(), make_ref()}
     result = Server.handle_call({:apply_metadata_and_route, seq, commit_version, window}, from, state)
@@ -63,20 +61,19 @@ defmodule Bedrock.DataPlane.CommitProxy.MetadataWindowApplicationTest do
   end
 
   test "an in-order request applies the window and returns the routing snapshot in one step" do
-    window = {nil, v(1), [{v(1), [shard_set("a", 7), log_set("log_a")]}]}
+    window = {nil, v(1), [{v(1), [shard_set("a", 7)]}]}
 
     {updated, routing_data} = apply_in_order(state(), 1, v(1), window)
 
     assert updated.applied_version == v(1)
     assert updated.routed_seq == 1
-    assert routing_data.log_map == %{0 => "log_a"}
     assert :gb_trees.lookup("a", routing_data.shards) == {:value, {7, ""}}
     assert updated.routing_data == routing_data
   end
 
   test "an out-of-order request waits for its predecessor, then both reply in chain order" do
-    w1 = {nil, v(1), [{v(1), [log_set("log_a")]}]}
-    w2 = {v(1), v(2), [{v(2), [log_set("log_b")]}]}
+    w1 = {nil, v(1), [{v(1), [shard_set("a", 1)]}]}
+    w2 = {v(1), v(2), [{v(2), [shard_set("b", 2)]}]}
 
     # Batch 2's request arrives first: no reply, request held.
     {{:noreply, held, _timeout}, ref2} = request(state(), 2, v(2), w2)
@@ -87,8 +84,9 @@ defmodule Bedrock.DataPlane.CommitProxy.MetadataWindowApplicationTest do
 
     assert_receive {^ref1, {:ok, routing1}}
     assert_receive {^ref2, {:ok, routing2}}
-    assert routing1.log_map == %{0 => "log_a"}
-    assert routing2.log_map == %{0 => "log_a", 1 => "log_b"}
+    assert :gb_trees.lookup("a", routing1.shards) == {:value, {1, ""}}
+    assert :gb_trees.lookup("b", routing1.shards) == :none
+    assert :gb_trees.lookup("b", routing2.shards) == {:value, {2, ""}}
     assert updated.routed_seq == 2
     assert updated.pending_applies == %{}
   end
@@ -97,11 +95,10 @@ defmodule Bedrock.DataPlane.CommitProxy.MetadataWindowApplicationTest do
     # The window covers through the batch's own commit version (verdicts
     # already resolved at the merge), so applying it gives the batch
     # same-batch visibility and honestly advances the ack to its version.
-    window = {nil, v(2), [{v(2), [shard_set("a", 3), log_set("log_a")]}]}
+    window = {nil, v(2), [{v(2), [shard_set("a", 3)]}]}
 
     {updated, routing_data} = apply_in_order(state(), 1, v(2), window)
 
-    assert routing_data.log_map == %{0 => "log_a"}
     assert :gb_trees.lookup("a", routing_data.shards) == {:value, {3, ""}}
     assert updated.applied_version == v(2)
   end
@@ -141,10 +138,10 @@ defmodule Bedrock.DataPlane.CommitProxy.MetadataWindowApplicationTest do
     # them, so this proxy's consecutive batches have non-adjacent versions.
     # The chain must still link: sequence 1 then 2, whatever the versions.
     {updated, _routing} = apply_in_order(state(), 1, v(100), {nil, v(100), []})
-    {updated, routing} = apply_in_order(updated, 2, v(250), {v(100), v(250), [{v(250), [log_set("log_a")]}]})
+    {updated, routing} = apply_in_order(updated, 2, v(250), {v(100), v(250), [{v(250), [shard_set("a", 9)]}]})
 
     assert updated.routed_seq == 2
-    assert routing.log_map == %{0 => "log_a"}
+    assert :gb_trees.lookup("a", routing.shards) == {:value, {9, ""}}
   end
 
   test "requests are rejected while locked" do

--- a/test/bedrock/data_plane/commit_proxy/routing_data_test.exs
+++ b/test/bedrock/data_plane/commit_proxy/routing_data_test.exs
@@ -115,92 +115,19 @@ defmodule Bedrock.DataPlane.CommitProxy.RoutingDataTest do
     end
   end
 
-  describe "insert_log/2" do
-    test "adds log to empty log_map at index 0" do
-      updated = RoutingData.insert_log(RoutingData.new_empty(), "log-1")
-
-      assert updated.log_map == %{0 => "log-1"}
-    end
-
-    test "adds logs at sequential indices" do
-      updated =
-        RoutingData.new_empty()
-        |> RoutingData.insert_log("log-a")
-        |> RoutingData.insert_log("log-b")
-        |> RoutingData.insert_log("log-c")
-
-      assert updated.log_map == %{0 => "log-a", 1 => "log-b", 2 => "log-c"}
-    end
-
-    test "is idempotent by log id: a re-inserted log keeps its index" do
-      updated =
-        RoutingData.new_empty()
-        |> RoutingData.insert_log("log-a")
-        |> RoutingData.insert_log("log-b")
-        |> RoutingData.insert_log("log-a")
-
-      assert updated.log_map == %{0 => "log-a", 1 => "log-b"}
-    end
-
-    test "does not modify other fields" do
-      routing_data = RoutingData.new_empty()
-
-      updated = RoutingData.insert_log(routing_data, "log-1")
-
-      assert updated.shards == routing_data.shards
-      assert updated.log_services == %{}
-      assert updated.replication_factor == 1
-    end
-  end
-
-  describe "remove_log/2" do
-    test "removes log from log_map and reindexes to contiguous indices" do
-      updated =
-        RoutingData.new_empty()
-        |> RoutingData.insert_log("log-a")
-        |> RoutingData.insert_log("log-b")
-        |> RoutingData.insert_log("log-c")
-        |> RoutingData.remove_log("log-b")
-
-      assert updated.log_map == %{0 => "log-a", 1 => "log-c"}
-    end
-
-    test "removes first log and reindexes" do
-      updated =
-        RoutingData.new_empty()
-        |> RoutingData.insert_log("log-a")
-        |> RoutingData.insert_log("log-b")
-        |> RoutingData.insert_log("log-c")
-        |> RoutingData.remove_log("log-a")
-
-      assert updated.log_map == %{0 => "log-b", 1 => "log-c"}
-    end
-
-    test "no-op if log not found, including on an empty map" do
-      updated =
-        RoutingData.new_empty()
-        |> RoutingData.insert_log("log-a")
-        |> RoutingData.remove_log("nonexistent")
-
-      assert updated.log_map == %{0 => "log-a"}
-      assert RoutingData.remove_log(RoutingData.new_empty(), "nonexistent").log_map == %{}
-    end
-  end
-
   describe "integration: typical usage pattern" do
-    test "builds complete routing data incrementally and routes with it" do
+    test "builds complete routing data from the seed and routes with it" do
       routing_data =
-        RoutingData.new_empty()
-        |> RoutingData.insert_log("log-1")
-        |> RoutingData.insert_log("log-2")
-        |> RoutingData.insert_log("log-3")
-        |> Map.update!(:log_services, fn _ ->
-          %{"log-1" => {:log_1, :n1@host}, "log-2" => {:log_2, :n2@host}, "log-3" => {:log_3, :n3@host}}
-        end)
+        %{
+          shard_layout: %{},
+          log_map: %{0 => "log-1", 1 => "log-2", 2 => "log-3"},
+          log_services: %{"log-1" => {:log_1, :n1@host}, "log-2" => {:log_2, :n2@host}, "log-3" => {:log_3, :n3@host}},
+          replication_factor: 3
+        }
+        |> RoutingData.from_snapshot()
         |> RoutingData.insert_shard("m", 0, "")
         |> RoutingData.insert_shard("z", 1, "m")
         |> RoutingData.insert_shard(<<0xFF, 0xFF>>, 2, "z")
-        |> Map.put(:replication_factor, 3)
 
       assert routing_data.replication_factor == 3
 
@@ -214,6 +141,17 @@ defmodule Bedrock.DataPlane.CommitProxy.RoutingDataTest do
       assert ShardRouter.lookup_shard(routing_data.shards, "pear") == 1
       assert ShardRouter.lookup_shard(routing_data.shards, <<0xFF, "/system/x">>) == 2
     end
+  end
+
+  # An unlock-seeded wiring fixture: log wiring arrives in the seed and is
+  # epoch-constant thereafter.
+  defp seeded_wiring do
+    RoutingData.from_snapshot(%{
+      shard_layout: %{},
+      log_map: %{0 => "log-a", 1 => "log-b"},
+      log_services: %{"log-a" => {:log_a, :n1@host}, "log-b" => {:log_b, :n2@host}},
+      replication_factor: 2
+    })
   end
 
   describe "apply_mutations/2" do
@@ -250,29 +188,26 @@ defmodule Bedrock.DataPlane.CommitProxy.RoutingDataTest do
       assert shard_list(updated) == [{"m", {42, ""}}]
     end
 
-    test "handles layout_log set mutation - updates log_map only" do
-      updates = [{v(100), [{:set, SystemKeys.layout_log("log-1"), Values.encode_tag_list([0])}]}]
+    test "layout_log mutations are ignored — log wiring is epoch-constant and seed-only" do
+      # The recovery transaction still writes the layout/logs/ family (it
+      # stays durable for introspection), but the fold is not a reader:
+      # the only such mutations a window can carry are the rewrite of the
+      # set this proxy was seeded with, and mid-epoch topology change is
+      # precluded (changing log topology IS a recovery).
+      seeded = seeded_wiring()
 
-      updated = RoutingData.apply_mutations(RoutingData.new_empty(), updates)
-
-      assert updated.log_map == %{0 => "log-1"}
-      # log_services are NOT populated from persisted data
-      assert updated.log_services == %{}
-    end
-
-    test "a re-set layout_log key keeps its index" do
       updates = [
-        {v(100), [{:set, SystemKeys.layout_log("log-1"), Values.encode_tag_list([0])}]},
-        {v(101),
+        {v(100),
          [
-           {:set, SystemKeys.layout_log("log-1"), Values.encode_tag_list([1])},
-           {:set, SystemKeys.layout_log("log-2"), Values.encode_tag_list([2])}
+           {:set, SystemKeys.layout_log("log-x"), Values.encode_tag_list([0])},
+           {:clear, SystemKeys.layout_log("log-a")}
          ]}
       ]
 
-      updated = RoutingData.apply_mutations(RoutingData.new_empty(), updates)
+      updated = RoutingData.apply_mutations(seeded, updates)
 
-      assert updated.log_map == %{0 => "log-1", 1 => "log-2"}
+      assert updated.log_map == seeded.log_map
+      assert updated.log_services == seeded.log_services
     end
 
     test "handles materializer_key set mutation - decoded refs stay strings" do
@@ -330,20 +265,6 @@ defmodule Bedrock.DataPlane.CommitProxy.RoutingDataTest do
       updated = RoutingData.apply_mutations(routing_data, updates)
 
       assert shard_list(updated) == []
-    end
-
-    test "handles layout_log clear mutation" do
-      routing_data =
-        RoutingData.new_empty()
-        |> RoutingData.insert_log("log-123")
-        |> Map.update!(:log_services, &Map.put(&1, "log-123", {:my_log, :node@host}))
-
-      updates = [{v(100), [{:clear, SystemKeys.layout_log("log-123")}]}]
-
-      updated = RoutingData.apply_mutations(routing_data, updates)
-
-      assert updated.log_services == %{}
-      assert updated.log_map == %{}
     end
 
     test "applies updates from multiple versions in order; later version wins" do
@@ -410,37 +331,26 @@ defmodule Bedrock.DataPlane.CommitProxy.RoutingDataTest do
       assert shard_list(updated) == []
     end
 
-    test "clear_range removes layout_log entries in range, reindexing log_map and dropping services" do
-      routing_data =
-        RoutingData.new_empty()
-        |> RoutingData.insert_log("log-a")
-        |> RoutingData.insert_log("log-b")
-        |> RoutingData.insert_log("log-c")
-        |> Map.update!(:log_services, fn _ ->
-          %{"log-a" => {:log_a, :n1@host}, "log-b" => {:log_b, :n2@host}}
-        end)
+    test "recovery's layout_log clear_range leaves the seeded wiring untouched" do
+      seeded = seeded_wiring()
 
-      # Clear [layout_log("log-a"), layout_log("log-c")) - "log-c" survives
       updates = [{v(100), [{:clear_range, SystemKeys.layout_log("log-a"), SystemKeys.layout_log("log-c")}]}]
 
-      updated = RoutingData.apply_mutations(routing_data, updates)
+      updated = RoutingData.apply_mutations(seeded, updates)
 
-      assert updated.log_map == %{0 => "log-c"}
-      assert updated.log_services == %{}
+      assert updated.log_map == seeded.log_map
+      assert updated.log_services == seeded.log_services
     end
 
     test "clear_range outside routing families leaves routing data unchanged" do
-      routing_data =
-        RoutingData.new_empty()
-        |> RoutingData.insert_shard("m", 1, "")
-        |> RoutingData.insert_log("log-1")
+      routing_data = RoutingData.insert_shard(seeded_wiring(), "m", 1, "")
 
       updates = [{v(100), [{:clear_range, "user/a", "user/z"}]}]
 
       updated = RoutingData.apply_mutations(routing_data, updates)
 
       assert shard_list(updated) == [{"m", {1, ""}}]
-      assert updated.log_map == %{0 => "log-1"}
+      assert updated.log_map == seeded_wiring().log_map
     end
 
     test "recovery-style rewrite: clear_range then sets shrinks 3 shards to 2" do
@@ -466,7 +376,7 @@ defmodule Bedrock.DataPlane.CommitProxy.RoutingDataTest do
       assert shard_list(updated) == [{"m", {10, ""}}, {<<0xFF, 0xFF>>, {11, "m"}}]
     end
 
-    test "handles mixed shard_key and layout_log mutations" do
+    test "mixed mutations: shard_key entries apply, layout_log entries do not" do
       updates = [
         {v(100),
          [
@@ -480,7 +390,7 @@ defmodule Bedrock.DataPlane.CommitProxy.RoutingDataTest do
       updated = RoutingData.apply_mutations(RoutingData.new_empty(), updates)
 
       assert shard_list(updated) == [{"m", {1, ""}}, {"z", {2, "m"}}]
-      assert updated.log_map == %{0 => "log-1", 1 => "log-2"}
+      assert updated.log_map == %{}
       assert updated.log_services == %{}
     end
   end


### PR DESCRIPTION
## Why

Course item E (bedrock-q67.41). Two forms of re-derivation survived the arc so far:

1. `RoutingData` kept a **second way of managing the log table** — `insert_log` arrival-order append, `remove_log` reindex, `delete_log_service`, `clear_logs_in_range` in the mutation fold. FDB confirms the doctrine this guards against cannot occur: TLog membership is generation-constant — changing log topology IS a recovery (new epoch, new logSystemConfig). The only `layout_log` mutations that ever flow through a window are the recovery transaction's rewrite of the set the proxy was just seeded with: a structurally-precluded hazard.
2. Readers rebuilt facts the system already carried: `shard_layout_from_entries` discarded the decoded `start_key` and reconstructed it from end-key adjacency (while `RoutingData.apply_mutation` consumed it — two readers of one family disagreeing about what the value means), and `materializer_refs` linear-scanned the services map to recover worker ids the bootstrap had in hand at creation.

## What

- **Deleted**: the fold's log handling. Log wiring (`log_map`, `log_services`, `replication_factor`) is seed-only: populated at unlock, never mutated. The `layout/logs/` **family stays** — recovery keeps writing it for other consumers and cluster-introspection tools (named as such in `SystemKeys` and the persistence phase, per the unread-machinery-vs-observability distinction).
- **Carried start keys consumed**: adjacency reconstruction survives only for legacy `term_to_binary` snapshots (encoding-uniform per epoch; dies with q67.20.7). Pinned by a test where a carried non-empty start survives — adjacency would have produced the empty key.
- **Worker ids ride the assignment**: `shard_materializers` is now `%{tag => {worker_id, node, pid}}` from creation/lock. `RecoveryAttempt.materializer_refs/1` projects the keyspace refs directly; the persistence writer and the routing-snapshot seed share the projection; ghost pruning reads ids without pid inversion; `TransactionSystemLayout.materializer_refs/2` is deleted. A missing services record can no longer silently drop a keyspace entry the seed then disagrees about (the old orphan-skip is replaced by its inverse pin: assignments write from carried refs, no skips).

## How

Two commits: the fold deletion (with `routing_data_test` rewritten to pin the ignore-contract — seeded wiring untouched by `layout_log` sets/clears/clear_ranges, including through the live proxy in the metadata-distribution integration test), then the carried-facts change (bootstrap emits triples at every insertion point; consumers converted; fixtures updated).

Full suite (2575 tests), credo --strict, dialyzer green.