### PR TITLE
By-key routing resolution: proxies answer the covering entry, not the map

### DIFF
--- a/guides/quick-reads/system-keyspace.md
+++ b/guides/quick-reads/system-keyspace.md
@@ -41,10 +41,10 @@ durable bytes never creates atoms — and consumers derive the callable
 `{otp_name, node}` ref (worker OTP names are deterministic in the worker
 id, so a restart on the same node changes nothing).
 
-Readers: `RoutingData` → the client routing projection, and worker
-rejoin validation — a worker (or the proxy answering for the committed
-state) checks whether the entry for its tag still names it; absence means
-retire.
+Readers: `RoutingData` → per-key covering entries served to clients
+(`fetch_routing`), and worker rejoin validation — a worker (through the
+proxy answering for the committed state) checks whether the entry for
+its tag still names it; absence means retire.
 
 ### `layout/logs/<log_id>` → tag list
 

--- a/lib/bedrock/cluster/link.ex
+++ b/lib/bedrock/cluster/link.ex
@@ -62,30 +62,36 @@ defmodule Bedrock.Cluster.Link do
   end
 
   @doc """
-  Fetch the node's cached routing projection (shard boundaries plus
-  materializer refs, as served by `Bedrock.DataPlane.CommitProxy.fetch_routing/2`).
+  Fetch the cached covering entry for one key: the shard range and its
+  raw `{worker_id, node}` materializer ref, as fetched from
+  `Bedrock.DataPlane.CommitProxy.fetch_routing/3`.
 
   The Link is the node-wide location cache (FDB's `DatabaseContext`
-  locationCache): it only stores. On a miss the caller fetches from a
-  commit proxy and caches the result back with `cache_routing/2`.
+  locationCache), a partial coalescing index: it only stores. On a miss
+  the caller fetches the single covering entry from a commit proxy and
+  caches it back with `cache_routing_entry/2`.
   """
-  @spec fetch_cached_routing(ref(), opts :: [timeout_in_ms: Bedrock.timeout_in_ms()]) ::
-          {:ok, map()} | {:error, :unavailable | :timeout | :unknown}
-  def fetch_cached_routing(link, opts \\ []), do: call(link, :get_routing, opts[:timeout_in_ms] || 1000)
+  @spec fetch_covering_entry(ref(), Bedrock.key(), opts :: [timeout_in_ms: Bedrock.timeout_in_ms()]) ::
+          {:ok, {Bedrock.key_range(), {String.t(), String.t()}}}
+          | {:error, :not_cached | :unavailable | :timeout | :unknown}
+  def fetch_covering_entry(link, key, opts \\ []),
+    do: call(link, {:get_covering_entry, key}, opts[:timeout_in_ms] || 1000)
 
-  @doc "Caches a routing projection fetched from a commit proxy."
-  @spec cache_routing(ref(), map()) :: :ok
-  def cache_routing(link, routing), do: cast(link, {:cache_routing, routing})
+  @doc "Caches one covering entry fetched from a commit proxy."
+  @spec cache_routing_entry(ref(), {Bedrock.key(), Bedrock.key(), {String.t(), String.t()}}) :: :ok
+  def cache_routing_entry(link, entry), do: cast(link, {:cache_routing_entry, entry})
 
   @doc """
-  Drops the cached routing projection.
+  Drops the cached routing entries — the whole index, never a patch.
 
   Called by the client retry loop when a read fails in a routing-shaped way
   (unroutable key, dead materializer, unavailable) - a dead pid is exactly
   what a stale snapshot looks like, so the next transaction refetches.
+  Coarse on purpose (a named divergence from FDB's per-range eviction):
+  failures are rare and simple beats surgical.
 
   Synchronous on purpose: the retry that invalidates must not be able to
-  read the stale projection back on its next fetch. A cast would be
+  read the stale entries back on its next fetch. A cast would be
   ordered only by accident of the intervening wiring call.
   """
   @spec invalidate_routing(ref(), opts :: [timeout_in_ms: Bedrock.timeout_in_ms()]) ::

--- a/lib/bedrock/cluster/link/server.ex
+++ b/lib/bedrock/cluster/link/server.ex
@@ -15,6 +15,7 @@ defmodule Bedrock.Cluster.Link.Server do
 
   alias Bedrock.Cluster.Descriptor
   alias Bedrock.Cluster.Link.State
+  alias Bedrock.Internal.TransactionBuilder.LayoutIndex
 
   @spec child_spec(
           opts :: [
@@ -114,28 +115,32 @@ defmodule Bedrock.Cluster.Link.Server do
     reply(t, {:ok, t.descriptor})
   end
 
-  # The node-wide routing cache (FDB DatabaseContext locationCache): the Link
-  # only stores; callers fetch from a commit proxy on miss and cast the
-  # result back. No TTL - entries live until invalidated or a wiring push
-  # drops them; staleness is backstopped by the client retry loop.
-  @spec handle_call(:get_routing, GenServer.from(), State.t()) ::
-          {:reply, {:ok, map()} | {:error, :unavailable}, State.t()}
-  def handle_call(:get_routing, _, t) do
-    case t.routing do
-      nil -> reply(t, {:error, :unavailable})
-      routing -> reply(t, {:ok, routing})
+  # The node-wide routing cache (FDB DatabaseContext locationCache): a
+  # partial coalescing index of covering entries. The Link only stores;
+  # callers fetch the single covering entry from a commit proxy on miss
+  # and cast it back. No TTL - entries live until invalidated or a wiring
+  # push drops them; staleness is backstopped by the client retry loop.
+  @spec handle_call({:get_covering_entry, Bedrock.key()}, GenServer.from(), State.t()) ::
+          {:reply, {:ok, {Bedrock.key_range(), term()}} | {:error, :not_cached}, State.t()}
+  def handle_call({:get_covering_entry, key}, _, t) do
+    case LayoutIndex.lookup_key(t.routing, key) do
+      {:ok, entry} -> reply(t, {:ok, entry})
+      :not_cached -> reply(t, {:error, :not_cached})
     end
   end
 
-  # Synchronous: when the reply arrives the stale projection is gone -
+  # Synchronous: when the reply arrives the stale entries are gone -
   # ordering by construction, not by accident of intervening calls.
+  # Coarse (whole index): failures are rare and simple beats surgical.
   @spec handle_call(:invalidate_routing, GenServer.from(), State.t()) :: {:reply, :ok, State.t()}
-  def handle_call(:invalidate_routing, _, t), do: reply(%{t | routing: nil}, :ok)
+  def handle_call(:invalidate_routing, _, t), do: reply(%{t | routing: LayoutIndex.new()}, :ok)
 
   @doc false
   @impl true
-  @spec handle_cast({:cache_routing, map()}, State.t()) :: {:noreply, State.t()}
-  def handle_cast({:cache_routing, routing}, t), do: noreply(%{t | routing: routing})
+  @spec handle_cast({:cache_routing_entry, {Bedrock.key(), Bedrock.key(), term()}}, State.t()) ::
+          {:noreply, State.t()}
+  def handle_cast({:cache_routing_entry, {start_key, end_key, ref}}, t),
+    do: noreply(%{t | routing: LayoutIndex.insert(t.routing, start_key, end_key, ref)})
 
   @doc false
   @impl true
@@ -156,7 +161,7 @@ defmodule Bedrock.Cluster.Link.Server do
 
     # A wiring push means a recovery happened: drop the routing cache so
     # new-epoch wiring can never pair with old-epoch routing.
-    noreply(%{t | transaction_system_layout: new_tsl, routing: nil})
+    noreply(%{t | transaction_system_layout: new_tsl, routing: LayoutIndex.new()})
   end
 
   @spec handle_info({:DOWN, reference(), :process, term(), term()}, State.t()) ::

--- a/lib/bedrock/cluster/link/state.ex
+++ b/lib/bedrock/cluster/link/state.ex
@@ -4,6 +4,7 @@ defmodule Bedrock.Cluster.Link.State do
   alias Bedrock.Cluster.Descriptor
   alias Bedrock.ControlPlane.Config.TransactionSystemLayout
   alias Bedrock.ControlPlane.Coordinator
+  alias Bedrock.Internal.TransactionBuilder.LayoutIndex
 
   @type t :: %__MODULE__{
           node: node(),
@@ -15,7 +16,7 @@ defmodule Bedrock.Cluster.Link.State do
           mode: :passive | :active,
           capabilities: [Bedrock.Cluster.capability()],
           transaction_system_layout: TransactionSystemLayout.t() | nil,
-          routing: map() | nil
+          routing: LayoutIndex.t()
         }
   defstruct node: nil,
             cluster: nil,
@@ -26,5 +27,5 @@ defmodule Bedrock.Cluster.Link.State do
             mode: :active,
             capabilities: [],
             transaction_system_layout: nil,
-            routing: nil
+            routing: LayoutIndex.new()
 end

--- a/lib/bedrock/data_plane/commit_proxy.ex
+++ b/lib/bedrock/data_plane/commit_proxy.ex
@@ -47,22 +47,27 @@ defmodule Bedrock.DataPlane.CommitProxy do
     do: call(commit_proxy, {:recover_from, lock_token, sequencer, resolver_layout, routing_snapshot}, :infinity)
 
   @doc """
-  Fetches the client-facing routing projection: shard boundaries plus
-  materializer refs.
+  Fetches the covering routing entry for one key: the shard's bounds,
+  its tag, and the raw materializer ref.
 
-  This is FDB's `GetKeyServerLocations`, answered from the proxy's live
-  routing view - at least as fresh as the proxy's most recently applied
-  commit, unversioned by design. Locations are unverified hints; staleness
-  costs the caller a retry, never a wrong answer.
+  This is FDB's `GetKeyServerLocations`, answered per key from the
+  proxy's live routing view - a ceiling walk, never a bulk projection of
+  a map that can number in the thousands. The answer is at least as
+  fresh as the proxy's most recently applied commit, unversioned by
+  design. Locations are unverified hints; staleness costs the caller a
+  retry, never a wrong answer. `{:error, :not_found}` means the
+  committed state routes the key nowhere - to the client, an unroutable
+  key.
 
   A locked proxy replies `{:error, :locked}`: FDB parks location requests
   until its state is valid, Bedrock refuses and lets the client's retry
   loop be the parking lot.
   """
-  @spec fetch_routing(commit_proxy_ref :: ref(), opts :: [timeout_in_ms: Bedrock.timeout_in_ms()]) ::
-          {:ok, RoutingData.client_projection()}
-          | {:error, :locked | :timeout | :unavailable}
-  def fetch_routing(commit_proxy, opts \\ []), do: call(commit_proxy, :fetch_routing, opts[:timeout_in_ms] || 5_000)
+  @spec fetch_routing(commit_proxy_ref :: ref(), Bedrock.key(), opts :: [timeout_in_ms: Bedrock.timeout_in_ms()]) ::
+          {:ok, RoutingData.covering_entry()}
+          | {:error, :not_found | :locked | :timeout | :unavailable}
+  def fetch_routing(commit_proxy, key, opts \\ []),
+    do: call(commit_proxy, {:fetch_routing, key}, opts[:timeout_in_ms] || 5_000)
 
   @doc """
   Resolves the committed materializer assignment for one shard tag.

--- a/lib/bedrock/data_plane/commit_proxy/routing_data.ex
+++ b/lib/bedrock/data_plane/commit_proxy/routing_data.ex
@@ -35,6 +35,7 @@ defmodule Bedrock.DataPlane.CommitProxy.RoutingData do
   """
 
   alias Bedrock.DataPlane.Log
+  alias Bedrock.DataPlane.ShardRouter
   alias Bedrock.SystemKeys
   alias Bedrock.SystemKeys.Values
 
@@ -103,30 +104,11 @@ defmodule Bedrock.DataPlane.CommitProxy.RoutingData do
   """
   @spec covering_entry(t(), Bedrock.key()) :: {:ok, covering_entry()} | {:error, :not_found}
   def covering_entry(%__MODULE__{shards: shards, materializers: materializers}, key) do
-    with {:ok, end_key, {tag, start_key}} <- ceiling_entry(shards, key),
+    with {end_key, {tag, start_key}} <- ShardRouter.ceiling_entry(shards, key),
          {:ok, ref} <- Map.fetch(materializers, tag) do
       {:ok, {start_key, end_key, tag, ref}}
     else
       _ -> {:error, :not_found}
-    end
-  end
-
-  # First entry with end_key > key (end keys are exclusive bounds).
-  defp ceiling_entry(shards, key) do
-    key
-    |> :gb_trees.iterator_from(shards)
-    |> :gb_trees.next()
-    |> case do
-      {end_key, value, _iter} when end_key > key -> {:ok, end_key, value}
-      {_same_key, _value, iter} -> next_entry(iter)
-      :none -> {:error, :not_found}
-    end
-  end
-
-  defp next_entry(iter) do
-    case :gb_trees.next(iter) do
-      {end_key, value, _iter} -> {:ok, end_key, value}
-      :none -> {:error, :not_found}
     end
   end
 

--- a/lib/bedrock/data_plane/commit_proxy/routing_data.ex
+++ b/lib/bedrock/data_plane/commit_proxy/routing_data.ex
@@ -66,13 +66,11 @@ defmodule Bedrock.DataPlane.CommitProxy.RoutingData do
   defstruct [:shards, :log_map, :log_services, :replication_factor, materializers: %{}]
 
   @typedoc """
-  The client-facing slice of the routing view: shard boundaries plus
-  materializer refs. Log wiring stays proxy-internal.
+  The client-facing covering entry for one key: the shard's bounds, its
+  tag, and the raw materializer ref. Log wiring stays proxy-internal.
   """
-  @type client_projection :: %{
-          shard_layout: %{Bedrock.key() => {tag :: term(), start_key :: Bedrock.key()}},
-          materializers: %{Bedrock.range_tag() => materializer_ref()}
-        }
+  @type covering_entry ::
+          {start_key :: Bedrock.key(), end_key :: Bedrock.key(), tag :: term(), materializer_ref()}
 
   @doc """
   The committed materializer assignment for a shard tag, or
@@ -92,15 +90,44 @@ defmodule Bedrock.DataPlane.CommitProxy.RoutingData do
   end
 
   @doc """
-  Projects the client-facing slice of the routing view.
+  The covering entry for one key: a ceiling walk over the shard tree plus
+  the tag's committed materializer ref.
 
   Served to clients by the commit proxy (FDB's `GetKeyServerLocations`
-  answered from `keyInfo`). Locations are unverified hints: a stale
-  projection costs the client a retry, never a wrong answer.
+  answered from `keyInfo`) — one entry per ask, O(log n), never a bulk
+  projection of a map that can number in the thousands. Locations are
+  unverified hints: a stale entry costs the client a retry, never a
+  wrong answer. `{:error, :not_found}` covers both a key beyond every
+  boundary and a shard whose tag names no materializer — to the client
+  both are an unroutable key.
   """
-  @spec client_projection(t()) :: client_projection()
-  def client_projection(%__MODULE__{shards: shards, materializers: materializers}) do
-    %{shard_layout: Map.new(:gb_trees.to_list(shards)), materializers: materializers}
+  @spec covering_entry(t(), Bedrock.key()) :: {:ok, covering_entry()} | {:error, :not_found}
+  def covering_entry(%__MODULE__{shards: shards, materializers: materializers}, key) do
+    with {:ok, end_key, {tag, start_key}} <- ceiling_entry(shards, key),
+         {:ok, ref} <- Map.fetch(materializers, tag) do
+      {:ok, {start_key, end_key, tag, ref}}
+    else
+      _ -> {:error, :not_found}
+    end
+  end
+
+  # First entry with end_key > key (end keys are exclusive bounds).
+  defp ceiling_entry(shards, key) do
+    key
+    |> :gb_trees.iterator_from(shards)
+    |> :gb_trees.next()
+    |> case do
+      {end_key, value, _iter} when end_key > key -> {:ok, end_key, value}
+      {_same_key, _value, iter} -> next_entry(iter)
+      :none -> {:error, :not_found}
+    end
+  end
+
+  defp next_entry(iter) do
+    case :gb_trees.next(iter) do
+      {end_key, value, _iter} -> {:ok, end_key, value}
+      :none -> {:error, :not_found}
+    end
   end
 
   @doc """

--- a/lib/bedrock/data_plane/commit_proxy/server.ex
+++ b/lib/bedrock/data_plane/commit_proxy/server.ex
@@ -145,7 +145,7 @@ defmodule Bedrock.DataPlane.CommitProxy.Server do
           | {:commit, Bedrock.epoch(), Bedrock.transaction()}
           | {:commit, Bedrock.epoch(), Bedrock.transaction(), :user | :system}
           | {:apply_metadata_and_route, pos_integer(), Bedrock.version(), term()}
-          | :fetch_routing,
+          | {:fetch_routing, Bedrock.key()},
           GenServer.from(),
           State.t()
         ) ::
@@ -208,15 +208,16 @@ defmodule Bedrock.DataPlane.CommitProxy.Server do
   def handle_call({:apply_metadata_and_route, _seq, _cv, _window}, _from, %{mode: :locked} = t),
     do: reply(t, {:error, :locked})
 
-  # Client routing requests (FDB GetKeyServerLocations): answered from the
-  # live routing view. Replying resumes the batch cadence - a routing fetch
+  # Client routing requests (FDB GetKeyServerLocations): the single
+  # covering entry for the asked key, answered from the live routing view
+  # by ceiling walk. Replying resumes the batch cadence - a routing fetch
   # must not swallow an open batch's pending timeout.
-  def handle_call(:fetch_routing, from, %{mode: :running} = t) do
-    GenServer.reply(from, {:ok, RoutingData.client_projection(t.routing_data)})
+  def handle_call({:fetch_routing, key}, from, %{mode: :running} = t) do
+    GenServer.reply(from, RoutingData.covering_entry(t.routing_data, key))
     noreply_resuming_cadence(t)
   end
 
-  def handle_call(:fetch_routing, _from, %{mode: :locked} = t), do: reply(t, {:error, :locked})
+  def handle_call({:fetch_routing, _key}, _from, %{mode: :locked} = t), do: reply(t, {:error, :locked})
 
   # Worker rejoin validation (FDB's storage-server rejoin against the
   # proxy's txnStateStore): one tag-keyed lookup in the live routing view.

--- a/lib/bedrock/data_plane/shard_router.ex
+++ b/lib/bedrock/data_plane/shard_router.ex
@@ -224,9 +224,15 @@ defmodule Bedrock.DataPlane.ShardRouter do
     end
   end
 
-  # First entry with end_key strictly greater than key. iterator_from yields
-  # keys >= key, so at most the first entry needs skipping.
-  defp ceiling_entry(shards, key) do
+  @doc """
+  First entry with `end_key` strictly greater than `key` (end keys are
+  exclusive bounds), or `:none`. The one ceiling-walk authority: mutation
+  routing, key lookup, and the proxy's client-facing covering entry all
+  resolve through it.
+  """
+  @spec ceiling_entry(RoutingData.shard_tree(), binary()) ::
+          {Bedrock.key(), {tag :: term(), start_key :: Bedrock.key()}} | :none
+  def ceiling_entry(shards, key) do
     iter = :gb_trees.iterator_from(key, shards)
 
     case :gb_trees.next(iter) do

--- a/lib/bedrock/internal/repo.ex
+++ b/lib/bedrock/internal/repo.ex
@@ -302,47 +302,55 @@ defmodule Bedrock.Internal.Repo do
   # A caller-provided TSL is wiring only and gets no routing_fn: the
   # builder's index stays empty and reads fail as layout_lookup_failed
   # (the escape hatch serves commit-only flows and tests). Otherwise
-  # routing is proxy-served and lazy: the builder calls this on its first
-  # read - Link cache first (the node's locationCache), fetch-through to a
-  # random commit proxy on a miss, caching the raw projection for the next
-  # transaction on this node. Runs in the builder process, so failures are
-  # returned (they surface as read failures), never thrown.
+  # routing is proxy-served, BY KEY, and lazy: the builder calls this on
+  # each local index miss - Link cache first (the node's locationCache),
+  # fetch-through to a random commit proxy for the single covering entry
+  # on a miss, caching the raw entry back for the next transaction on
+  # this node. Never a whole-map fetch: materializers can number in the
+  # thousands, and FDB's GetKeyServerLocations answers per key. Runs in
+  # the builder process, so failures are returned (they surface as read
+  # failures), never thrown.
   defp routing_fn_for_transaction(_cluster, provided_tsl, _link) when not is_nil(provided_tsl), do: nil
 
   defp routing_fn_for_transaction(cluster, nil, link) do
-    fn ->
-      case Link.fetch_cached_routing(link) do
-        {:ok, routing} -> {:ok, callable_routing(cluster, routing)}
-        {:error, _not_cached} -> fetch_and_cache_routing(cluster, link)
+    fn key ->
+      case Link.fetch_covering_entry(link, key) do
+        {:ok, {{start_key, end_key}, raw_ref}} -> {:ok, {start_key, end_key, [callable_ref(cluster, raw_ref)]}}
+        {:error, :not_cached} -> fetch_and_cache_entry(cluster, link, key)
+        {:error, reason} -> {:error, reason}
       end
     end
   end
 
-  defp fetch_and_cache_routing(cluster, link) do
+  defp fetch_and_cache_entry(cluster, link, key) do
     with {:ok, tsl} <- Link.fetch_transaction_system_layout(link),
          [_ | _] = proxies <- Map.get(tsl, :proxies, []),
-         {:ok, routing} <- proxies |> Enum.random() |> CommitProxy.fetch_routing() do
-      Link.cache_routing(link, routing)
-      {:ok, callable_routing(cluster, routing)}
+         {:ok, {start_key, end_key, _tag, raw_ref}} <- proxies |> Enum.random() |> CommitProxy.fetch_routing(key) do
+      Link.cache_routing_entry(link, {start_key, end_key, raw_ref})
+      {:ok, {start_key, end_key, [callable_ref(cluster, raw_ref)]}}
     else
-      [] -> {:error, :unavailable}
-      {:error, reason} -> {:error, reason}
+      [] ->
+        {:error, :unavailable}
+
+      # The proxy's committed state names no shard or no materializer for
+      # the key - to the client that is an unroutable key, and the retry
+      # loop's routing-shaped classification handles it.
+      {:error, :not_found} ->
+        {:error, :layout_lookup_failed}
+
+      {:error, reason} ->
+        {:error, reason}
     end
   end
 
-  # Turn the proxy's string-encoded materializer refs into callable
-  # `{otp_name, node}` refs. Worker OTP names are deterministic in the
+  # Turn a string-encoded materializer ref into a callable
+  # `{otp_name, node}` ref. Worker OTP names are deterministic in the
   # worker id; the node atom conversion is the documented exception to the
   # no-atoms-on-decode rule - the values come from system-mode-gated
   # writers and the atom count is bounded by cluster membership.
-  defp callable_routing(cluster, %{shard_layout: shard_layout, materializers: materializers}) do
-    callable =
-      Map.new(materializers, fn {tag, {worker_id, node}} ->
-        # credo:disable-for-next-line Credo.Check.Warning.UnsafeToAtom
-        {tag, {cluster.otp_name_for_worker(worker_id), String.to_atom(node)}}
-      end)
-
-    %{shard_layout: shard_layout, materializers: callable}
+  defp callable_ref(cluster, {worker_id, node}) do
+    # credo:disable-for-next-line Credo.Check.Warning.UnsafeToAtom
+    {cluster.otp_name_for_worker(worker_id), String.to_atom(node)}
   end
 
   defp start_transaction_builder(tsl, routing_fn, repo) do

--- a/lib/bedrock/internal/repo.ex
+++ b/lib/bedrock/internal/repo.ex
@@ -14,6 +14,10 @@ defmodule Bedrock.Internal.Repo do
   # retry: version window misses resolve with a fresh read version, and the
   # rest are routing- or liveness-shaped (FDB's wrong_shard_server model:
   # they cost the caller a retry, never surface to the user).
+  # :unknown is a rescued unexpected exception inside a routing or read
+  # call (Internal.GenServer.Calls) - transient by construction, and the
+  # by-key routing path makes several such calls per miss; raising a user
+  # transaction over it would turn a blip into an error.
   @retryable_read_failures [
     :timeout,
     :unavailable,
@@ -21,7 +25,8 @@ defmodule Bedrock.Internal.Repo do
     :version_too_old,
     :layout_lookup_failed,
     :no_servers_to_race,
-    :locked
+    :locked,
+    :unknown
   ]
 
   # Of those, the ones that look like stale routing: an unroutable key, no
@@ -29,7 +34,7 @@ defmodule Bedrock.Internal.Repo do
   # exactly what a stale snapshot looks like, so the retry drops the node's
   # routing cache and refetches from a proxy. Version window misses are not
   # routing's fault and keep the cache.
-  @routing_invalidating_failures [:layout_lookup_failed, :no_servers_to_race, :unavailable, :timeout, :locked]
+  @routing_invalidating_failures [:layout_lookup_failed, :no_servers_to_race, :unavailable, :timeout, :locked, :unknown]
 
   @type transaction :: pid()
   @type key :: term()

--- a/lib/bedrock/internal/transaction_builder.ex
+++ b/lib/bedrock/internal/transaction_builder.ex
@@ -74,7 +74,8 @@ defmodule Bedrock.Internal.TransactionBuilder do
   @spec start_link(
           opts :: [
             transaction_system_layout: TransactionSystemLayout.t(),
-            routing_fn: (-> {:ok, %{shard_layout: map(), materializers: map()}} | {:error, atom()}),
+            routing_fn: (Bedrock.key() ->
+                           {:ok, {Bedrock.key(), Bedrock.key(), [LayoutIndex.server_ref()]}} | {:error, atom()}),
             time_fn: (-> integer())
           ]
         ) ::
@@ -93,39 +94,23 @@ defmodule Bedrock.Internal.TransactionBuilder do
 
   @impl true
   def handle_continue(:initialization, {transaction_system_layout, routing_fn}) do
-    # Routing arrives proxy-served and LAZILY: like the read version, the
-    # layout index is built on first read, so a transaction that never
-    # reads never fetches routing (FDB fetches locations per read, not per
-    # transaction). The TSL is wiring only - it carries no shard topology.
-    # Without a routing_fn (caller-provided wiring, tests) the index is
-    # empty and reads fail as layout_lookup_failed.
-    layout_index = if routing_fn, do: nil, else: LayoutIndex.build_index(%{}, %{})
-
+    # Routing arrives proxy-served, by key, and LAZILY: the partial index
+    # accumulates one covering entry per local miss, so a transaction that
+    # never reads never fetches routing, and one that reads a single key
+    # fetches a single entry (FDB fetches locations per read, never a bulk
+    # map). The TSL is wiring only - it carries no shard topology. Without
+    # a routing_fn (caller-provided wiring, tests) the index stays empty
+    # and reads fail as layout_lookup_failed.
     noreply(%State{
       state: :valid,
       transaction_system_layout: transaction_system_layout,
-      layout_index: layout_index,
+      layout_index: LayoutIndex.new(),
       routing_fn: routing_fn,
       read_version: nil
     })
   end
 
   def handle_continue(:stop, t), do: stop(t, :normal)
-
-  # Builds the layout index on first read (lazy, like the read version).
-  # A routing fetch failure replies like any other read failure - the
-  # Repo retry loop invalidates the node's routing cache and refetches.
-  defp with_layout_index(%State{layout_index: nil, routing_fn: routing_fn} = t, fun) do
-    case routing_fn.() do
-      {:ok, %{shard_layout: shard_layout, materializers: materializers}} ->
-        fun.(%{t | layout_index: LayoutIndex.build_index(shard_layout, materializers)})
-
-      {:error, reason} ->
-        reply(t, {:failure, reason})
-    end
-  end
-
-  defp with_layout_index(%State{} = t, fun), do: fun.(t)
 
   @impl true
   def handle_call(:nested_transaction, _from, t), do: reply(%{t | stack: [t.tx | t.stack]}, :ok)
@@ -150,48 +135,42 @@ defmodule Bedrock.Internal.TransactionBuilder do
   def handle_call({:get, key}, from, t) when is_binary(key), do: handle_call({:get, key, []}, from, t)
 
   def handle_call({:get, key, opts}, _from, t) when is_binary(key) and is_list(opts) do
-    with_layout_index(t, fn t ->
-      t
-      |> get_key(key, opts)
-      |> then(fn
-        {t, {:error, _} = error} ->
-          reply(t, error)
+    t
+    |> get_key(key, opts)
+    |> then(fn
+      {t, {:error, _} = error} ->
+        reply(t, error)
 
-        {t, {:failure, failures_by_reason}} ->
-          reply(t, {:failure, choose_a_reason(failures_by_reason)})
+      {t, {:failure, failures_by_reason}} ->
+        reply(t, {:failure, choose_a_reason(failures_by_reason)})
 
-        {t, {:ok, {^key, value}}} ->
-          reply(t, {:ok, value})
-      end)
+      {t, {:ok, {^key, value}}} ->
+        reply(t, {:ok, value})
     end)
   end
 
   def handle_call({:get_key_selector, %KeySelector{} = key_selector, opts}, _from, t) do
-    with_layout_index(t, fn t ->
-      t
-      |> get_key_selector(key_selector, opts)
-      |> then(fn
-        {t, {:failure, failures_by_reason}} ->
-          reply(t, {:failure, choose_a_reason(failures_by_reason)})
+    t
+    |> get_key_selector(key_selector, opts)
+    |> then(fn
+      {t, {:failure, failures_by_reason}} ->
+        reply(t, {:failure, choose_a_reason(failures_by_reason)})
 
-        {t, result} ->
-          reply(t, result)
-      end)
+      {t, result} ->
+        reply(t, result)
     end)
   end
 
   def handle_call({:get_range, start_key, end_key, batch_size, opts}, _from, t)
       when is_binary(start_key) and is_binary(end_key) do
-    with_layout_index(t, fn t ->
-      t
-      |> get_range({start_key, end_key}, batch_size, opts)
-      |> then(fn
-        {t, {:failure, failures_by_reason}} ->
-          reply(t, {:failure, choose_a_reason(failures_by_reason)})
+    t
+    |> get_range({start_key, end_key}, batch_size, opts)
+    |> then(fn
+      {t, {:failure, failures_by_reason}} ->
+        reply(t, {:failure, choose_a_reason(failures_by_reason)})
 
-        {t, result} ->
-          reply(t, result)
-      end)
+      {t, result} ->
+        reply(t, result)
     end)
   end
 
@@ -202,16 +181,14 @@ defmodule Bedrock.Internal.TransactionBuilder do
       ) do
     batch_size = Keyword.get(opts, :limit, 10_000)
 
-    with_layout_index(t, fn t ->
-      t
-      |> get_range_selectors(start_selector, end_selector, batch_size, opts)
-      |> then(fn
-        {t, {:failure, failures_by_reason}} ->
-          reply(t, {:failure, choose_a_reason(failures_by_reason)})
+    t
+    |> get_range_selectors(start_selector, end_selector, batch_size, opts)
+    |> then(fn
+      {t, {:failure, failures_by_reason}} ->
+        reply(t, {:failure, choose_a_reason(failures_by_reason)})
 
-        {t, result} ->
-          reply(t, result)
-      end)
+      {t, result} ->
+        reply(t, result)
     end)
   end
 

--- a/lib/bedrock/internal/transaction_builder/layout_index.ex
+++ b/lib/bedrock/internal/transaction_builder/layout_index.ex
@@ -5,11 +5,17 @@ defmodule Bedrock.Internal.TransactionBuilder.LayoutIndex do
   proxy-served by-key routing fetches (FDB's locationCache shape - built
   from `GetKeyServerLocations` answers, never a bulk dump).
 
-  Entries are exact shard ranges keyed by exclusive `end_key`, so within
-  one routing epoch they never overlap and re-inserting a shard is
-  idempotent. Cross-epoch mixing is precluded by coarse invalidation:
-  the whole index is dropped on a wiring push or a routing-shaped read
-  failure, never patched.
+  Entries are exact shard ranges keyed by exclusive `end_key`. Today the
+  only shard-boundary writer is recovery's per-epoch rewrite, so entries
+  fetched into one index are disjoint (the lookup's correctness depends
+  on this) and re-inserting a shard is idempotent. Coarse invalidation -
+  the whole index dropped on a wiring push or a routing-shaped read
+  failure, never patched - keeps epochs from mixing; an in-flight cache
+  cast can land after an invalidation, and that stale entry self-heals
+  through the same invalidate-on-failure loop. LIABILITY (bedrock-q67.21):
+  when the Distributor mutates boundaries mid-epoch, superseded ranges
+  can coexist with their replacements in a live index - the insert must
+  become overlap-aware (or eviction per-range) before that lands.
 
   Lookups are a single O(log n) ceiling search; a key no fetched entry
   covers returns `:not_cached`, which the owner resolves through its

--- a/lib/bedrock/internal/transaction_builder/layout_index.ex
+++ b/lib/bedrock/internal/transaction_builder/layout_index.ex
@@ -1,12 +1,19 @@
 defmodule Bedrock.Internal.TransactionBuilder.LayoutIndex do
   @moduledoc """
-  The client's shard-lookup index: a gb_tree of `end_key => {start_key,
-  [materializer ref]}` built from the proxy-served routing projection.
+  A partial, coalescing shard-lookup index: a gb_tree of `end_key =>
+  {start_key, value}` accumulated one covering entry at a time from
+  proxy-served by-key routing fetches (FDB's locationCache shape - built
+  from `GetKeyServerLocations` answers, never a bulk dump).
 
-  Shards are non-overlapping by construction, so lookups are a single
-  O(log n) ceiling search. Shards whose tag has no materializer are
-  absent - a key landing in the gap fails the lookup, which the client
-  retry loop converts into an invalidate-and-refetch.
+  Entries are exact shard ranges keyed by exclusive `end_key`, so within
+  one routing epoch they never overlap and re-inserting a shard is
+  idempotent. Cross-epoch mixing is precluded by coarse invalidation:
+  the whole index is dropped on a wiring push or a routing-shaped read
+  failure, never patched.
+
+  Lookups are a single O(log n) ceiling search; a key no fetched entry
+  covers returns `:not_cached`, which the owner resolves through its
+  routing fetch.
   """
 
   defstruct [:tree]
@@ -15,70 +22,46 @@ defmodule Bedrock.Internal.TransactionBuilder.LayoutIndex do
   @type server_ref :: pid() | {atom(), node()}
 
   @type t :: %__MODULE__{
-          tree: :gb_trees.tree(binary(), {binary(), [server_ref()]})
+          tree: :gb_trees.tree(binary(), {binary(), term()})
         }
 
+  @doc "An empty index; entries accumulate per fetched covering entry."
+  @spec new() :: t()
+  def new, do: %__MODULE__{tree: :gb_trees.empty()}
+
   @doc """
-  Builds a segmented index from shard boundaries and materializer refs.
-
-  `shard_layout` maps each shard's exclusive `end_key` to `{tag, start_key}`;
-  `materializers` maps tags to callable refs. Shards whose tag has no
-  materializer are dropped - a key landing in one fails the lookup, which
-  the client retry loop converts into an invalidate-and-refetch.
+  Inserts one covering entry: the shard `[start_key, end_key)` and the
+  value cached for it (callable refs in the transaction builder, raw
+  keyspace refs in the Link's node-wide cache).
   """
-  @spec build_index(
-          %{Bedrock.key() => {Bedrock.range_tag(), Bedrock.key()}},
-          %{Bedrock.range_tag() => server_ref()}
-        ) :: t()
-  def build_index(shard_layout, materializers) when is_map(shard_layout) and is_map(materializers) do
-    # Shards are non-overlapping by construction (the layout is keyed by
-    # exclusive end_key), so the index is a direct end_key => {start_key,
-    # [ref]} tree - no segmenting pass. Shards without a materializer are
-    # dropped: a key landing in the gap fails the lookup, which the client
-    # retry loop converts into an invalidate-and-refetch.
-    tree =
-      shard_layout
-      |> Enum.flat_map(fn {end_key, {tag, start_key}} ->
-        case Map.get(materializers, tag) do
-          nil -> []
-          ref -> [{end_key, {start_key, [ref]}}]
-        end
-      end)
-      |> Enum.sort()
-      |> :gb_trees.from_orddict()
-
-    %__MODULE__{tree: tree}
+  @spec insert(t(), Bedrock.key(), Bedrock.key(), term()) :: t()
+  def insert(%__MODULE__{tree: tree} = t, start_key, end_key, value) do
+    %{t | tree: :gb_trees.enter(end_key, {start_key, value}, tree)}
   end
 
   @doc """
-  Looks up storage servers for a single key using recursive tree traversal.
-
-  Returns a {key_range, [pid]} tuple for the segment containing the key.
-  The end key will be the binary sentinel `<<0xFF, 0xFF>>` for unbounded ranges.
-  Raises if no segment is found. This is an O(log n) operation.
+  Looks up the cached covering entry for a key: `{:ok, {key_range, value}}`
+  or `:not_cached` when no fetched entry covers it. O(log n).
   """
-  @spec lookup_key!(t(), binary()) :: {{binary(), binary()}, [pid()]}
-  def lookup_key!(%__MODULE__{tree: tree}, key) do
+  @spec lookup_key(t(), binary()) :: {:ok, {Bedrock.key_range(), term()}} | :not_cached
+  def lookup_key(%__MODULE__{tree: tree}, key) do
     case segment_for_key(tree, key) do
-      {:ok, {start, end_key}, pids} ->
-        {{start, end_key}, pids}
-
-      :not_found ->
-        raise "No segment found containing key: #{inspect(key)}"
+      {:ok, key_range, value} -> {:ok, {key_range, value}}
+      :not_found -> :not_cached
     end
   end
 
   # Private implementation functions
 
-  @spec segment_for_key(:gb_trees.tree(binary(), {binary(), [pid()]}), binary()) ::
-          {:ok, {binary(), binary()}, [pid()]} | :not_found
+  @spec segment_for_key(:gb_trees.tree(binary(), {binary(), term()}), binary()) ::
+          {:ok, {binary(), binary()}, term()} | :not_found
   defp segment_for_key({0, _}, _key), do: :not_found
   defp segment_for_key({_, tree_node}, key), do: node_for_key(tree_node, key)
   defp segment_for_key(_, _key), do: :not_found
 
-  defp node_for_key({tree_end_key, {segment_start, pids}, _left, _right}, key)
+  defp node_for_key({tree_end_key, {segment_start, value}, _left, _right}, key)
        when key >= segment_start and (key < tree_end_key or (key == tree_end_key and tree_end_key == <<0xFF, 0xFF>>)),
-       do: {:ok, {segment_start, tree_end_key}, pids}
+       do: {:ok, {segment_start, tree_end_key}, value}
 
   defp node_for_key({tree_end_key, _, left, _right}, key) when key < tree_end_key, do: node_for_key(left, key)
   defp node_for_key({_tree_end_key, _, _left, right}, key), do: node_for_key(right, key)

--- a/lib/bedrock/internal/transaction_builder/state.ex
+++ b/lib/bedrock/internal/transaction_builder/state.ex
@@ -9,8 +9,10 @@ defmodule Bedrock.Internal.TransactionBuilder.State do
   @type t :: %__MODULE__{
           state: :valid | :committed | :rolled_back,
           transaction_system_layout: Bedrock.ControlPlane.Config.TransactionSystemLayout.t(),
-          layout_index: LayoutIndex.t() | nil,
-          routing_fn: (-> {:ok, map()} | {:error, atom()}) | nil,
+          layout_index: LayoutIndex.t(),
+          routing_fn:
+            (Bedrock.key() -> {:ok, {Bedrock.key(), Bedrock.key(), [LayoutIndex.server_ref()]}} | {:error, atom()})
+            | nil,
           #
           read_version: Bedrock.version() | nil,
           commit_version: Bedrock.version() | nil,

--- a/lib/bedrock/internal/transaction_builder/state.ex
+++ b/lib/bedrock/internal/transaction_builder/state.ex
@@ -24,7 +24,7 @@ defmodule Bedrock.Internal.TransactionBuilder.State do
         }
   defstruct state: nil,
             transaction_system_layout: nil,
-            layout_index: nil,
+            layout_index: LayoutIndex.new(),
             routing_fn: nil,
             #
             read_version: nil,

--- a/lib/bedrock/internal/transaction_builder/storage_racing.ex
+++ b/lib/bedrock/internal/transaction_builder/storage_racing.ex
@@ -40,19 +40,38 @@ defmodule Bedrock.Internal.TransactionBuilder.StorageRacing do
            {:ok, {any(), Bedrock.key_range()}}
            | {:failure, %{atom() => [pid()]}}}
   def race_storage_servers(%State{} = state, key, operation_fn) do
-    state.layout_index
-    |> LayoutIndex.lookup_key!(key)
-    |> case do
-      {_key_range, []} ->
-        raise "No storage servers configured for keyspace - this indicates a layout configuration error"
-
-      {key_range, storage_pids} ->
+    case LayoutIndex.lookup_key(state.layout_index, key) do
+      {:ok, {key_range, storage_refs}} ->
         state.fastest_storage_servers
         |> Map.get(key_range)
-        |> try_fastest_server(state, key_range, storage_pids, operation_fn)
+        |> try_fastest_server(state, key_range, storage_refs, operation_fn)
+
+      :not_cached ->
+        resolve_then_race(state, key, operation_fn)
     end
-  rescue
-    RuntimeError -> {state, {:failure, %{layout_lookup_failed: []}}}
+  end
+
+  # The by-key resolve-through (FDB fetches locations per read): a local
+  # miss asks the routing fn for the single covering entry and caches it
+  # into the builder's partial index for the transaction's lifetime.
+  # Without a routing fn (caller-provided wiring, tests) resolution is
+  # impossible and the read fails as layout_lookup_failed. Fetch failures
+  # surface as read failures; the Repo retry loop classifies them.
+  defp resolve_then_race(%State{routing_fn: nil} = state, _key, _operation_fn),
+    do: {state, {:failure, %{layout_lookup_failed: []}}}
+
+  defp resolve_then_race(%State{routing_fn: routing_fn} = state, key, operation_fn) do
+    case routing_fn.(key) do
+      {:ok, {start_key, end_key, [_ | _] = storage_refs}} ->
+        state = %{state | layout_index: LayoutIndex.insert(state.layout_index, start_key, end_key, storage_refs)}
+        try_fastest_server(nil, state, {start_key, end_key}, storage_refs, operation_fn)
+
+      {:ok, {_start_key, _end_key, []}} ->
+        {state, {:failure, %{layout_lookup_failed: []}}}
+
+      {:error, reason} ->
+        {state, {:failure, %{reason => []}}}
+    end
   end
 
   # Private helper functions

--- a/test/bedrock/cluster/link/routing_cache_test.exs
+++ b/test/bedrock/cluster/link/routing_cache_test.exs
@@ -9,36 +9,66 @@ defmodule Bedrock.Cluster.Link.RoutingCacheTest do
     def otp_name(component) when is_atom(component), do: :"routing_cache_test_#{component}"
   end
 
-  @projection %{shard_layout: %{<<0xFF, 0xFF>> => {0, <<>>}}, materializers: %{0 => {"wkr_sys", "n1@host"}}}
+  @entry {<<>>, <<0xFF, 0xFF>>, {"wkr_sys", "n1@host"}}
 
   defp state(overrides \\ []) do
     struct!(%State{node: node(), cluster: TestCluster, capabilities: []}, overrides)
   end
 
+  defp cache(state, entry), do: elem(Server.handle_cast({:cache_routing_entry, entry}, state), 1)
+
   describe "routing cache" do
     test "empty cache misses" do
-      assert {:reply, {:error, :unavailable}, _} = Server.handle_call(:get_routing, self_from(), state())
+      assert {:reply, {:error, :not_cached}, _} =
+               Server.handle_call({:get_covering_entry, "a"}, self_from(), state())
     end
 
-    test "cache_routing fills, get_routing hits" do
-      assert {:noreply, cached} = Server.handle_cast({:cache_routing, @projection}, state())
-      assert {:reply, {:ok, @projection}, _} = Server.handle_call(:get_routing, self_from(), cached)
+    test "a cached covering entry answers keys in its range, and only those" do
+      cached = cache(state(), {"m", "z", {"wkr_a", "n1@host"}})
+
+      assert {:reply, {:ok, {{"m", "z"}, {"wkr_a", "n1@host"}}}, _} =
+               Server.handle_call({:get_covering_entry, "pear"}, self_from(), cached)
+
+      # Keys outside the fetched range are honest misses — the cache is
+      # partial by design, never a whole-map projection.
+      assert {:reply, {:error, :not_cached}, _} =
+               Server.handle_call({:get_covering_entry, "apple"}, self_from(), cached)
+
+      assert {:reply, {:error, :not_cached}, _} =
+               Server.handle_call({:get_covering_entry, "z"}, self_from(), cached)
     end
 
-    test "invalidate_routing empties the cache synchronously" do
-      {:noreply, cached} = Server.handle_cast({:cache_routing, @projection}, state())
+    test "entries coalesce: each fetched shard adds coverage" do
+      cached =
+        state()
+        |> cache({"m", "z", {"wkr_a", "n1@host"}})
+        |> cache({<<>>, "m", {"wkr_b", "n2@host"}})
+
+      assert {:reply, {:ok, {{<<>>, "m"}, {"wkr_b", "n2@host"}}}, _} =
+               Server.handle_call({:get_covering_entry, "apple"}, self_from(), cached)
+
+      assert {:reply, {:ok, {{"m", "z"}, {"wkr_a", "n1@host"}}}, _} =
+               Server.handle_call({:get_covering_entry, "pear"}, self_from(), cached)
+    end
+
+    test "invalidate_routing empties the whole cache synchronously — coarse by design" do
+      cached = cache(state(), @entry)
       assert {:reply, :ok, invalidated} = Server.handle_call(:invalidate_routing, self_from(), cached)
-      assert {:reply, {:error, :unavailable}, _} = Server.handle_call(:get_routing, self_from(), invalidated)
+
+      assert {:reply, {:error, :not_cached}, _} =
+               Server.handle_call({:get_covering_entry, "a"}, self_from(), invalidated)
     end
 
     test "a wiring push drops the cached routing - new-epoch wiring must never pair with old-epoch routing" do
-      {:noreply, cached} = Server.handle_cast({:cache_routing, @projection}, state())
+      cached = cache(state(), @entry)
 
       new_tsl = %{epoch: 2, sequencer: self(), proxies: [self()]}
       assert {:noreply, updated} = Server.handle_info({:tsl_updated, new_tsl}, cached)
 
       assert updated.transaction_system_layout == new_tsl
-      assert {:reply, {:error, :unavailable}, _} = Server.handle_call(:get_routing, self_from(), updated)
+
+      assert {:reply, {:error, :not_cached}, _} =
+               Server.handle_call({:get_covering_entry, "a"}, self_from(), updated)
     end
   end
 

--- a/test/bedrock/data_plane/commit_proxy/fetch_routing_cadence_test.exs
+++ b/test/bedrock/data_plane/commit_proxy/fetch_routing_cadence_test.exs
@@ -24,17 +24,39 @@ defmodule Bedrock.DataPlane.CommitProxy.FetchRoutingCadenceTest do
     )
   end
 
+  defp seeded_routing do
+    RoutingData.from_snapshot(%{
+      shard_layout: %{<<0xFF, 0xFF>> => {0, <<>>}},
+      log_map: %{},
+      log_services: %{},
+      materializers: %{0 => {"wkr_sys", "n1@host"}},
+      replication_factor: 1
+    })
+  end
+
   test "with no open batch, the heartbeat timeout is re-armed" do
-    assert {:noreply, _t, 1_234} = Server.handle_call(:fetch_routing, from(), running_state(batch: nil))
+    assert {:noreply, _t, 1_234} = Server.handle_call({:fetch_routing, "a"}, from(), running_state(batch: nil))
   end
 
   test "with an open batch, the zero timeout is re-armed so the batch still finalizes" do
-    assert {:noreply, _t, 0} = Server.handle_call(:fetch_routing, from(), running_state(batch: %Batch{}))
+    assert {:noreply, _t, 0} = Server.handle_call({:fetch_routing, "a"}, from(), running_state(batch: %Batch{}))
   end
 
-  test "the reply arrives before the cadence resumes" do
-    Server.handle_call(:fetch_routing, from(), running_state(batch: nil))
-    assert_received {_ref, {:ok, %{shard_layout: %{}, materializers: %{}}}}
+  test "the reply is the single covering entry, and arrives before the cadence resumes" do
+    state = running_state(batch: nil, routing_data: seeded_routing())
+
+    Server.handle_call({:fetch_routing, "a"}, from(), state)
+    assert_received {_ref, {:ok, {<<>>, <<0xFF, 0xFF>>, 0, {"wkr_sys", "n1@host"}}}}
+  end
+
+  test "a key the committed state routes nowhere answers :not_found" do
+    Server.handle_call({:fetch_routing, "a"}, from(), running_state(batch: nil))
+    assert_received {_ref, {:error, :not_found}}
+  end
+
+  test "a locked proxy refuses routing fetches" do
+    assert {:reply, {:error, :locked}, _t} =
+             Server.handle_call({:fetch_routing, "a"}, from(), struct!(%State{mode: :locked}, []))
   end
 
   describe "resolve_materializer" do

--- a/test/bedrock/data_plane/commit_proxy/metadata_distribution_integration_test.exs
+++ b/test/bedrock/data_plane/commit_proxy/metadata_distribution_integration_test.exs
@@ -225,7 +225,7 @@ defmodule Bedrock.DataPlane.CommitProxy.MetadataDistributionIntegrationTest do
     # even when the window is empty - but nothing polluted the stream.
   end
 
-  describe "fetch_routing/2 - the GetKeyServerLocations analogue" do
+  describe "fetch_routing/3 - the GetKeyServerLocations analogue" do
     test "a locked proxy refuses routing requests until recover_from seeds it", %{epoch: epoch} do
       locked_proxy =
         start_supervised!(
@@ -244,19 +244,15 @@ defmodule Bedrock.DataPlane.CommitProxy.MetadataDistributionIntegrationTest do
           id: :locked_proxy
         )
 
-      assert {:error, :locked} = CommitProxy.fetch_routing(locked_proxy)
+      assert {:error, :locked} = CommitProxy.fetch_routing(locked_proxy, "any_key")
     end
 
-    test "an unlocked proxy serves the seeded projection", %{proxy: proxy} do
-      assert {:ok, projection} = CommitProxy.fetch_routing(proxy)
-
-      assert projection == %{
-               shard_layout: %{<<0xFF, 0xFF>> => {0, <<>>}},
-               materializers: %{0 => {"wkr_sys", "n1@host"}}
-             }
+    test "an unlocked proxy serves the seeded covering entry for a key", %{proxy: proxy} do
+      assert {:ok, {<<>>, <<0xFF, 0xFF>>, 0, {"wkr_sys", "n1@host"}}} =
+               CommitProxy.fetch_routing(proxy, "some_key")
     end
 
-    test "committed shard and materializer mutations reach the served projection", %{proxy: proxy, epoch: epoch} do
+    test "committed shard and materializer mutations reach served covering entries", %{proxy: proxy, epoch: epoch} do
       mutations = [
         {:set, SystemKeys.shard_key("m"), Values.encode_shard_key_entry(7, "")},
         {:set, SystemKeys.materializer_key(7), Values.encode_materializer_ref("wkr_new", "n2@host")}
@@ -265,18 +261,19 @@ defmodule Bedrock.DataPlane.CommitProxy.MetadataDistributionIntegrationTest do
       version = commit!(proxy, epoch, mutations, "routing_key")
       wait_until(fn -> proxy_applied_version(proxy) == version end)
 
-      assert {:ok, projection} = CommitProxy.fetch_routing(proxy)
-      assert projection.shard_layout["m"] == {7, ""}
-      assert projection.materializers[7] == {"wkr_new", "n2@host"}
+      # The new shard covers ["", "m"); a key inside it resolves to the
+      # committed assignment - one entry per ask, never a bulk map.
+      assert {:ok, {<<>>, "m", 7, {"wkr_new", "n2@host"}}} = CommitProxy.fetch_routing(proxy, "apple")
 
-      # The projection is exactly the client slice - no log wiring leaks.
-      assert projection |> Map.keys() |> Enum.sort() == [:materializers, :shard_layout]
+      # Keys past the new boundary still resolve through the seeded shard.
+      assert {:ok, {_start, <<0xFF, 0xFF>>, 0, {"wkr_sys", "n1@host"}}} =
+               CommitProxy.fetch_routing(proxy, "zebra")
     end
 
     test "commits still flow while routing is being served", %{proxy: proxy, epoch: epoch} do
-      assert {:ok, _} = CommitProxy.fetch_routing(proxy)
+      assert {:ok, _} = CommitProxy.fetch_routing(proxy, "k")
       assert commit!(proxy, epoch, [{:set, "after_fetch", "v"}], "after_fetch")
-      assert {:ok, _} = CommitProxy.fetch_routing(proxy)
+      assert {:ok, _} = CommitProxy.fetch_routing(proxy, "k")
     end
   end
 

--- a/test/bedrock/data_plane/commit_proxy/routing_data_test.exs
+++ b/test/bedrock/data_plane/commit_proxy/routing_data_test.exs
@@ -62,22 +62,42 @@ defmodule Bedrock.DataPlane.CommitProxy.RoutingDataTest do
     end
   end
 
-  describe "client_projection/1" do
-    test "exposes shard boundaries and materializer refs; log wiring stays proxy-internal" do
-      snapshot = %{
+  describe "covering_entry/2" do
+    defp routing_two_shards do
+      RoutingData.from_snapshot(%{
         shard_layout: %{"m" => {1, ""}, <<0xFF, 0xFF>> => {0, "m"}},
         log_map: %{0 => "log-a"},
         log_services: %{"log-a" => {:log_a, :node1}},
         materializers: %{0 => {"wkr_sys", "n1@host"}, 1 => {"wkr_a", "n1@host"}},
         replication_factor: 1
-      }
+      })
+    end
 
-      projection = snapshot |> RoutingData.from_snapshot() |> RoutingData.client_projection()
+    test "answers one covering entry per key by ceiling walk; log wiring stays proxy-internal" do
+      routing = routing_two_shards()
 
-      assert projection == %{
-               shard_layout: %{"m" => {1, ""}, <<0xFF, 0xFF>> => {0, "m"}},
-               materializers: %{0 => {"wkr_sys", "n1@host"}, 1 => {"wkr_a", "n1@host"}}
-             }
+      assert RoutingData.covering_entry(routing, "apple") == {:ok, {"", "m", 1, {"wkr_a", "n1@host"}}}
+      # An end key is exclusive: "m" belongs to the NEXT shard.
+      assert RoutingData.covering_entry(routing, "m") == {:ok, {"m", <<0xFF, 0xFF>>, 0, {"wkr_sys", "n1@host"}}}
+      assert RoutingData.covering_entry(routing, "zebra") == {:ok, {"m", <<0xFF, 0xFF>>, 0, {"wkr_sys", "n1@host"}}}
+    end
+
+    test "a key beyond every boundary is :not_found" do
+      assert RoutingData.covering_entry(routing_two_shards(), <<0xFF, 0xFF>>) == {:error, :not_found}
+      assert RoutingData.covering_entry(RoutingData.new_empty(), "a") == {:error, :not_found}
+    end
+
+    test "a shard whose tag names no materializer is :not_found — an unroutable key" do
+      routing =
+        RoutingData.from_snapshot(%{
+          shard_layout: %{"m" => {1, ""}},
+          log_map: %{},
+          log_services: %{},
+          materializers: %{},
+          replication_factor: 1
+        })
+
+      assert RoutingData.covering_entry(routing, "apple") == {:error, :not_found}
     end
   end
 

--- a/test/bedrock/internal/repo_transact_test.exs
+++ b/test/bedrock/internal/repo_transact_test.exs
@@ -400,18 +400,21 @@ defmodule Bedrock.Internal.RepoTransactTest do
     # The shape the Link caches: {start, end, raw_ref}.
     defp cached_entry({start_key, end_key, _tag, raw_ref}), do: {start_key, end_key, raw_ref}
 
-    defp spawn_stub_materializer(test_pid) do
-      materializer =
-        spawn(fn ->
-          receive do
-            {:"$gen_call", from, {:get, key, _version, _opts}} ->
-              send(test_pid, {:materializer_got, key})
-              GenServer.reply(from, {:ok, "routed_value"})
-          end
-        end)
-
+    defp spawn_stub_materializer(test_pid, answers \\ 1) do
+      materializer = spawn(fn -> materializer_loop(test_pid, answers) end)
       Process.register(materializer, RoutingCluster.otp_name_for_worker("wkr1"))
       materializer
+    end
+
+    defp materializer_loop(_test_pid, 0), do: :ok
+
+    defp materializer_loop(test_pid, answers) do
+      receive do
+        {:"$gen_call", from, {:get, key, _version, _opts}} ->
+          send(test_pid, {:materializer_got, key})
+          GenServer.reply(from, {:ok, "routed_value"})
+          materializer_loop(test_pid, answers - 1)
+      end
     end
 
     defp spawn_stub_sequencer do
@@ -532,6 +535,83 @@ defmodule Bedrock.Internal.RepoTransactTest do
       assert_received :routing_invalidated
       refute_received :routing_invalidated
       assert_received {:routing_cached, ^expected_cached}
+    end
+
+    test "a second read in the same shard uses the builder-local entry — no re-ask" do
+      test_pid = self()
+      spawn_stub_materializer(test_pid, 2)
+      entry = covering_entry()
+
+      # The proxy answers exactly once and the Link never caches (always
+      # :not_cached): a second resolve would hang on the dead proxy, so
+      # the second read completing proves the builder-local index served
+      # it (FDB: DatabaseContext locationCache + per-read resolution).
+      proxy =
+        spawn(fn ->
+          receive do
+            {:"$gen_call", from, {:fetch_routing, _key}} -> GenServer.reply(from, {:ok, entry})
+          end
+        end)
+
+      never_caching_link = fn loop ->
+        receive do
+          {:"$gen_call", from, {:get_covering_entry, _key}} ->
+            GenServer.reply(from, {:error, :not_cached})
+            loop.(loop)
+
+          {:"$gen_call", from, :get_transaction_system_layout} ->
+            GenServer.reply(from, {:ok, %{epoch: 1, sequencer: spawn_stub_sequencer(), proxies: [proxy]}})
+            loop.(loop)
+
+          {:"$gen_cast", {:cache_routing_entry, _entry}} ->
+            loop.(loop)
+        end
+      end
+
+      link = spawn(fn -> never_caching_link.(never_caching_link) end)
+      Process.put(:stub_link_pid, link)
+
+      result =
+        Repo.transact(
+          RoutingCluster,
+          TestRepo,
+          fn -> {Repo.get(TestRepo, "key_one"), Repo.get(TestRepo, "key_two")} end,
+          []
+        )
+
+      assert result == {"routed_value", "routed_value"}
+      assert_received {:materializer_got, "key_one"}
+      assert_received {:materializer_got, "key_two"}
+    end
+
+    test "a locked proxy is a retry, not an error: the next attempt refetches and succeeds" do
+      test_pid = self()
+      spawn_stub_materializer(test_pid)
+      entry = covering_entry()
+
+      # First ask: the proxy is still locked (recovery in flight from the
+      # client's view). :locked classifies as retryable AND routing-
+      # invalidating; the retry refetches and the second ask succeeds.
+      proxy =
+        spawn(fn ->
+          receive do
+            {:"$gen_call", from, {:fetch_routing, _key}} ->
+              GenServer.reply(from, {:error, :locked})
+
+              receive do
+                {:"$gen_call", from2, {:fetch_routing, _key2}} -> GenServer.reply(from2, {:ok, entry})
+              end
+          end
+        end)
+
+      tsl = %{epoch: 1, sequencer: spawn_stub_sequencer(), proxies: [proxy]}
+      link = spawn(fn -> link_loop(tsl, nil, test_pid) end)
+      Process.put(:stub_link_pid, link)
+
+      result = Repo.transact(RoutingCluster, TestRepo, fn -> Repo.get(TestRepo, "some_key") end, [])
+
+      assert result == "routed_value"
+      assert_received :routing_invalidated
     end
 
     test "a transaction that never reads never fetches routing" do

--- a/test/bedrock/internal/repo_transact_test.exs
+++ b/test/bedrock/internal/repo_transact_test.exs
@@ -393,12 +393,12 @@ defmodule Bedrock.Internal.RepoTransactTest do
       def otp_name_for_worker(id), do: :"repo_transact_routing_worker_#{id}"
     end
 
-    @projection %{
-      shard_layout: %{<<0xFF, 0xFF>> => {0, <<>>}},
-      materializers: %{0 => {"wkr1", nil}}
-    }
+    # A covering entry as the proxy serves it: shard bounds, tag, raw
+    # string-encoded materializer ref.
+    defp covering_entry(worker_id \\ "wkr1"), do: {<<>>, <<0xFF, 0xFF>>, 0, {worker_id, Atom.to_string(node())}}
 
-    defp projection, do: put_in(@projection.materializers[0], {"wkr1", Atom.to_string(node())})
+    # The shape the Link caches: {start, end, raw_ref}.
+    defp cached_entry({start_key, end_key, _tag, raw_ref}), do: {start_key, end_key, raw_ref}
 
     defp spawn_stub_materializer(test_pid) do
       materializer =
@@ -426,23 +426,27 @@ defmodule Bedrock.Internal.RepoTransactTest do
       end
     end
 
-    defp link_loop(tsl, cached_routing, test_pid) do
+    # A one-entry Link cache: covers [start, end) or nothing.
+    defp link_loop(tsl, cached_entry, test_pid) do
       receive do
-        {:"$gen_call", from, :get_routing} ->
-          case cached_routing do
-            nil -> GenServer.reply(from, {:error, :unavailable})
-            routing -> GenServer.reply(from, {:ok, routing})
+        {:"$gen_call", from, {:get_covering_entry, key}} ->
+          case cached_entry do
+            {start_key, end_key, raw_ref} when key >= start_key and key < end_key ->
+              GenServer.reply(from, {:ok, {{start_key, end_key}, raw_ref}})
+
+            _ ->
+              GenServer.reply(from, {:error, :not_cached})
           end
 
-          link_loop(tsl, cached_routing, test_pid)
+          link_loop(tsl, cached_entry, test_pid)
 
         {:"$gen_call", from, :get_transaction_system_layout} ->
           GenServer.reply(from, {:ok, tsl})
-          link_loop(tsl, cached_routing, test_pid)
+          link_loop(tsl, cached_entry, test_pid)
 
-        {:"$gen_cast", {:cache_routing, routing}} ->
-          send(test_pid, {:routing_cached, routing})
-          link_loop(tsl, routing, test_pid)
+        {:"$gen_cast", {:cache_routing_entry, entry}} ->
+          send(test_pid, {:routing_cached, entry})
+          link_loop(tsl, entry, test_pid)
 
         {:"$gen_call", from, :invalidate_routing} ->
           GenServer.reply(from, :ok)
@@ -451,15 +455,18 @@ defmodule Bedrock.Internal.RepoTransactTest do
       end
     end
 
-    test "a cache miss fetches routing from a proxy, caches it at the link, and routes the read" do
+    test "a cache miss fetches the single covering entry from a proxy, caches it, and routes the read" do
       test_pid = self()
       spawn_stub_materializer(test_pid)
-      routing = projection()
+      entry = covering_entry()
+      expected_cached = cached_entry(entry)
 
       proxy =
         spawn(fn ->
           receive do
-            {:"$gen_call", from, :fetch_routing} -> GenServer.reply(from, {:ok, routing})
+            {:"$gen_call", from, {:fetch_routing, key}} ->
+              send(test_pid, {:proxy_asked, key})
+              GenServer.reply(from, {:ok, entry})
           end
         end)
 
@@ -471,9 +478,11 @@ defmodule Bedrock.Internal.RepoTransactTest do
 
       assert result == "routed_value"
       assert_received {:materializer_got, "some_key"}
-      # The raw (string-ref) projection was cached back for the next
+      # The ask was by key (GetKeyServerLocations, never a bulk map), and
+      # the raw (string-ref) entry was cached back for the next
       # transaction on this node - the Link is the locationCache.
-      assert_received {:routing_cached, ^routing}
+      assert_received {:proxy_asked, "some_key"}
+      assert_received {:routing_cached, ^expected_cached}
     end
 
     test "a cache hit routes the read without touching any proxy" do
@@ -482,7 +491,7 @@ defmodule Bedrock.Internal.RepoTransactTest do
 
       # No proxies at all: a proxy fetch would fail loudly.
       tsl = %{epoch: 1, sequencer: spawn_stub_sequencer(), proxies: []}
-      link = spawn(fn -> link_loop(tsl, projection(), test_pid) end)
+      link = spawn(fn -> link_loop(tsl, cached_entry(covering_entry()), test_pid) end)
       Process.put(:stub_link_pid, link)
 
       result = Repo.transact(RoutingCluster, TestRepo, fn -> Repo.get(TestRepo, "some_key") end, [])
@@ -496,17 +505,18 @@ defmodule Bedrock.Internal.RepoTransactTest do
       test_pid = self()
       spawn_stub_materializer(test_pid)
 
-      # The cached projection routes to a worker that is not registered:
-      # the read fails :unavailable (a dead ref IS what a stale snapshot
+      # The cached entry routes to a worker that is not registered: the
+      # read fails :unavailable (a dead ref IS what a stale snapshot
       # looks like). The retry must invalidate, refetch from the proxy -
-      # whose fresh projection names the live worker - and succeed.
-      stale = put_in(projection().materializers[0], {"wkr_gone", Atom.to_string(node())})
-      fresh = projection()
+      # whose fresh entry names the live worker - and succeed.
+      stale = cached_entry(covering_entry("wkr_gone"))
+      fresh = covering_entry()
+      expected_cached = cached_entry(fresh)
 
       proxy =
         spawn(fn ->
           receive do
-            {:"$gen_call", from, :fetch_routing} -> GenServer.reply(from, {:ok, fresh})
+            {:"$gen_call", from, {:fetch_routing, _key}} -> GenServer.reply(from, {:ok, fresh})
           end
         end)
 
@@ -521,7 +531,7 @@ defmodule Bedrock.Internal.RepoTransactTest do
       # first attempt (no prior failure) must not.
       assert_received :routing_invalidated
       refute_received :routing_invalidated
-      assert_received {:routing_cached, ^fresh}
+      assert_received {:routing_cached, ^expected_cached}
     end
 
     test "a transaction that never reads never fetches routing" do

--- a/test/bedrock/internal/repo_transact_test.exs
+++ b/test/bedrock/internal/repo_transact_test.exs
@@ -484,8 +484,8 @@ defmodule Bedrock.Internal.RepoTransactTest do
       # The ask was by key (GetKeyServerLocations, never a bulk map), and
       # the raw (string-ref) entry was cached back for the next
       # transaction on this node - the Link is the locationCache.
-      assert_received {:proxy_asked, "some_key"}
-      assert_received {:routing_cached, ^expected_cached}
+      assert_receive {:proxy_asked, "some_key"}
+      assert_receive {:routing_cached, ^expected_cached}
     end
 
     test "a cache hit routes the read without touching any proxy" do
@@ -532,9 +532,9 @@ defmodule Bedrock.Internal.RepoTransactTest do
       assert result == "routed_value"
       # Exactly one invalidation: the failed attempt's reason fired it; the
       # first attempt (no prior failure) must not.
-      assert_received :routing_invalidated
+      assert_receive :routing_invalidated
       refute_received :routing_invalidated
-      assert_received {:routing_cached, ^expected_cached}
+      assert_receive {:routing_cached, ^expected_cached}
     end
 
     test "a second read in the same shard uses the builder-local entry — no re-ask" do
@@ -611,7 +611,7 @@ defmodule Bedrock.Internal.RepoTransactTest do
       result = Repo.transact(RoutingCluster, TestRepo, fn -> Repo.get(TestRepo, "some_key") end, [])
 
       assert result == "routed_value"
-      assert_received :routing_invalidated
+      assert_receive :routing_invalidated
     end
 
     test "a transaction that never reads never fetches routing" do

--- a/test/bedrock/internal/transaction_builder/layout_index_test.exs
+++ b/test/bedrock/internal/transaction_builder/layout_index_test.exs
@@ -1,0 +1,46 @@
+defmodule Bedrock.Internal.TransactionBuilder.LayoutIndexTest do
+  use ExUnit.Case, async: true
+
+  alias Bedrock.Internal.TransactionBuilder.LayoutIndex
+
+  test "an empty index misses" do
+    assert LayoutIndex.lookup_key(LayoutIndex.new(), "a") == :not_cached
+  end
+
+  test "a covering entry answers keys in [start, end) and only those" do
+    index = LayoutIndex.insert(LayoutIndex.new(), "m", "z", [:ref])
+
+    assert LayoutIndex.lookup_key(index, "m") == {:ok, {{"m", "z"}, [:ref]}}
+    assert LayoutIndex.lookup_key(index, "pear") == {:ok, {{"m", "z"}, [:ref]}}
+    assert LayoutIndex.lookup_key(index, "z") == :not_cached
+    assert LayoutIndex.lookup_key(index, "apple") == :not_cached
+  end
+
+  test "a key in a gap between fetched entries is an honest miss — the index is partial" do
+    # Non-adjacent fetches: [a, c) and [m, z). Keys between them must not
+    # be answered by either neighbor.
+    index =
+      LayoutIndex.new()
+      |> LayoutIndex.insert("m", "z", [:right])
+      |> LayoutIndex.insert("a", "c", [:left])
+
+    assert LayoutIndex.lookup_key(index, "b") == {:ok, {{"a", "c"}, [:left]}}
+    assert LayoutIndex.lookup_key(index, "g") == :not_cached
+    assert LayoutIndex.lookup_key(index, "pear") == {:ok, {{"m", "z"}, [:right]}}
+  end
+
+  test "re-inserting a shard is idempotent and refreshes the value" do
+    index =
+      LayoutIndex.new()
+      |> LayoutIndex.insert("m", "z", [:stale])
+      |> LayoutIndex.insert("m", "z", [:fresh])
+
+    assert LayoutIndex.lookup_key(index, "pear") == {:ok, {{"m", "z"}, [:fresh]}}
+  end
+
+  test "the end-of-keyspace sentinel is inclusive at its own bound" do
+    index = LayoutIndex.insert(LayoutIndex.new(), "m", <<0xFF, 0xFF>>, [:ref])
+
+    assert LayoutIndex.lookup_key(index, <<0xFF, 0xFF>>) == {:ok, {{"m", <<0xFF, 0xFF>>}, [:ref]}}
+  end
+end


### PR DESCRIPTION
## Why

Course item D (bedrock-q67.40). Cache-until-failure was already built (#174) and stays exactly as is — what changes is the **miss path**, which fetched the WHOLE routing projection to route one key: O(shards) with materializer maps that can number in the thousands, a bulk projection the arc's corollary forbids. FDB's `GetKeyServerLocations` answers per key from the proxy's `keyInfo`; Bedrock now does the same.

## What

- **Proxy**: `CommitProxy.fetch_routing/3` takes the key and answers the single covering entry `{start_key, end_key, tag, materializer_ref}` — a ceiling walk over `RoutingData` (O(log n), no `gb_trees.to_list`), under the same cadence rule as before. `:not_found` means the committed state routes the key nowhere; the client maps it to `layout_lookup_failed` (retryable + invalidating). `client_projection` is deleted.
- **Client, two tiers** (FDB ops share `DatabaseContext` in-process): `LayoutIndex` becomes a **partial coalescing index** — entries accumulate one covering entry per miss, gaps are honest misses. The transaction builder accumulates fetched entries for its lifetime and hits the Link (the node-wide locationCache, now the same index over raw string refs) only on local miss; a proxy only on Link miss.
- **Resolution site**: moved into `StorageRacing.race_storage_servers` — the single point every read already passes through — so per-key laziness is structural: a read-free transaction fetches nothing; a one-key transaction fetches one entry. The builder's eager `with_layout_index` wrapper is deleted.
- **Invalidation**: coarse whole-index drop kept (a named divergence from FDB's per-range eviction: failures are rare, simple beats surgical) — which is also what makes cross-epoch entry mixing structurally impossible.

Deferred to the Distributor era (recorded on the ticket): client-side keyspace-READ resolution over a replicated metadata shard.

## How

`RoutingData.covering_entry/2` (ceiling walk + materializer lookup), `LayoutIndex.new/insert/lookup_key` (the gap-honest partial tree, unit-pinned including the between-entries miss), Link `{:get_covering_entry, key}`/`{:cache_routing_entry, entry}`/coarse `invalidate_routing`, Repo's `routing_fn` becomes by-key with the Link→proxy fetch-through. Tests: the exactly-once invalidation e2e survives unchanged in shape; the cache-miss test now also pins that the proxy was asked **by key**; integration tests assert served covering entries reflect committed mutations.

Full suite (2587 tests), credo --strict, dialyzer green.