### PR TITLE
Post-merge evaluation cleanup: spec honesty, precluded residues, eviction parity

### DIFF
--- a/lib/bedrock/control_plane/config/transaction_system_layout.ex
+++ b/lib/bedrock/control_plane/config/transaction_system_layout.ex
@@ -6,9 +6,7 @@ defmodule Bedrock.ControlPlane.Config.TransactionSystemLayout do
 
   alias Bedrock.ControlPlane.Config.LogDescriptor
   alias Bedrock.ControlPlane.Config.ResolverDescriptor
-  alias Bedrock.ControlPlane.Config.ServiceDescriptor
   alias Bedrock.DataPlane.Log
-  alias Bedrock.Service.Worker
 
   @typedoc """
   The transaction system's runtime wiring, published once per recovery -
@@ -34,7 +32,6 @@ defmodule Bedrock.ControlPlane.Config.TransactionSystemLayout do
   @type proxy_list :: [pid()]
   @type resolver_list :: [ResolverDescriptor.t()]
   @type log_map :: %{Log.id() => LogDescriptor.t()}
-  @type service_map :: %{Worker.id() => ServiceDescriptor.t()}
 
   @type t :: %{
           required(:epoch) => non_neg_integer(),

--- a/lib/bedrock/data_plane/commit_proxy.ex
+++ b/lib/bedrock/data_plane/commit_proxy.ex
@@ -108,7 +108,7 @@ defmodule Bedrock.DataPlane.CommitProxy do
           opts :: [mode: :user | :system]
         ) ::
           {:ok, version :: Bedrock.version(), index :: non_neg_integer()}
-          | {:error, :wrong_epoch | :locked | :abort | :timeout | :unavailable}
+          | {:error, :wrong_epoch | :locked | :aborted | :timeout | :unavailable}
           | {:error, {:key_out_of_range, Bedrock.key()}}
           | {:error, :invalid_transaction}
   def commit(commit_proxy, epoch, transaction, opts \\ []) do

--- a/lib/bedrock/data_plane/commit_proxy/server.ex
+++ b/lib/bedrock/data_plane/commit_proxy/server.ex
@@ -205,8 +205,13 @@ defmodule Bedrock.DataPlane.CommitProxy.Server do
     noreply_resuming_cadence(%{t | pending_applies: pending})
   end
 
-  def handle_call({:apply_metadata_and_route, _seq, _cv, _window}, _from, %{mode: :locked} = t),
-    do: reply(t, {:error, :locked})
+  # No :locked clause for :apply_metadata_and_route, deliberately: the
+  # apply call is made only by finalization tasks this proxy spawned
+  # while :running, and a proxy never re-locks (a new epoch starts new
+  # proxies). If one ever arrives locked, the FunctionClauseError crashes
+  # the proxy into recovery - the correct outcome for a violated
+  # invariant, reached by construction rather than by a guard for a
+  # state that cannot occur.
 
   # Client routing requests (FDB GetKeyServerLocations): the single
   # covering entry for the asked key, answered from the live routing view

--- a/lib/bedrock/data_plane/resolver/server.ex
+++ b/lib/bedrock/data_plane/resolver/server.ex
@@ -120,6 +120,14 @@ defmodule Bedrock.DataPlane.Resolver.Server do
     )
   end
 
+  # No clause exists for a same-epoch call with last_version <
+  # t.last_version, deliberately: the hazard is structurally precluded.
+  # The sequencer hands out a strictly advancing version chain and
+  # proxies never retry a resolver call (fail-fast into recovery), so a
+  # stale window cannot be re-presented within an epoch. If one ever
+  # arrives, the chain has been violated and the FunctionClauseError
+  # crashes this resolver into recovery — the correct outcome, reached by
+  # construction rather than by a guard for a state that cannot occur.
   @impl true
   def handle_call(
         {:resolve_transactions, epoch, {last_version, next_version}, transactions, metadata_per_tx, proxy_id},

--- a/lib/bedrock/internal/repo.ex
+++ b/lib/bedrock/internal/repo.ex
@@ -29,12 +29,16 @@ defmodule Bedrock.Internal.Repo do
     :unknown
   ]
 
-  # Of those, the ones that look like stale routing: an unroutable key, no
-  # servers to race, or a server that stopped answering. A dead pid is
-  # exactly what a stale snapshot looks like, so the retry drops the node's
-  # routing cache and refetches from a proxy. Version window misses are not
-  # routing's fault and keep the cache.
-  @routing_invalidating_failures [:layout_lookup_failed, :no_servers_to_race, :unavailable, :timeout, :locked, :unknown]
+  # Of those, the ones that are DEFINITIVELY routing-shaped evict the
+  # node's routing cache: an unroutable key, no servers to race, a dead
+  # ref (:unavailable - a dead pid is exactly what a stale snapshot looks
+  # like), or a locked proxy (recovery in flight; the new epoch's entries
+  # must be refetched). :timeout and :unknown stay retryable but keep the
+  # cache - FDB's locationCache survives timeouts for the same reason:
+  # slow is not stale, and evicting on it converts overload latency into
+  # node-wide cache-thrash and refetch traffic. Version window misses are
+  # not routing's fault and keep the cache too.
+  @routing_invalidating_failures [:layout_lookup_failed, :no_servers_to_race, :unavailable, :locked]
 
   @type transaction :: pid()
   @type key :: term()

--- a/lib/bedrock/repo.ex
+++ b/lib/bedrock/repo.ex
@@ -247,6 +247,14 @@ defmodule Bedrock.Repo do
 
   - `:no_write_conflict` - If true, disables write conflict detection (default: false)
 
+  The range must stay inside the user keyspace: commits are bounded below
+  `Bedrock.end_of_user_keyspace/0` (`0xFF`), and a range end past it —
+  including one built with the `:end` sentinel, which converts to the
+  full-keyspace bound — is rejected at commit as a permanent
+  `{:key_out_of_range, key}` rather than clamped (FDB parity: system keys
+  are reachable only through system-mode commits). Use
+  `Bedrock.end_of_user_keyspace/0` as the widest legal end key.
+
   ## Examples
 
       transact(fn ->

--- a/test/bedrock/data_plane/commit_proxy/metadata_window_application_test.exs
+++ b/test/bedrock/data_plane/commit_proxy/metadata_window_application_test.exs
@@ -144,8 +144,8 @@ defmodule Bedrock.DataPlane.CommitProxy.MetadataWindowApplicationTest do
     assert :gb_trees.lookup("a", routing.shards) == {:value, {9, ""}}
   end
 
-  test "requests are rejected while locked" do
-    locked = %{state() | mode: :locked}
-    {{:reply, {:error, :locked}, _state}, _ref} = request(locked, 1, v(1), nil)
-  end
+  # There is deliberately no locked-mode test: the apply call is made only
+  # by finalization tasks a running proxy spawned, and a proxy never
+  # re-locks — the state is structurally precluded, and an arriving call
+  # would crash the proxy into recovery by FunctionClauseError.
 end

--- a/test/bedrock/internal/repo_transact_test.exs
+++ b/test/bedrock/internal/repo_transact_test.exs
@@ -614,6 +614,37 @@ defmodule Bedrock.Internal.RepoTransactTest do
       assert_receive :routing_invalidated
     end
 
+    test "a slow materializer retries without dropping the node's routing cache — slow is not stale" do
+      test_pid = self()
+
+      # The materializer holds the call forever: the read times out. A
+      # timeout is retryable but NOT routing-shaped — FDB's locationCache
+      # survives timeouts (only definitive signals evict: an unroutable
+      # key, no servers, a dead ref). Under overload, evicting on timeout
+      # would convert latency into node-wide cache-thrash and refetch
+      # traffic. A dead materializer surfaces as :unavailable, which does
+      # evict.
+      materializer = spawn(fn -> Process.sleep(:infinity) end)
+      on_exit(fn -> Process.exit(materializer, :kill) end)
+      Process.register(materializer, RoutingCluster.otp_name_for_worker("wkr1"))
+
+      tsl = %{epoch: 1, sequencer: spawn_stub_sequencer(), proxies: []}
+      link = spawn(fn -> link_loop(tsl, cached_entry(covering_entry()), test_pid) end)
+      Process.put(:stub_link_pid, link)
+
+      assert_raise RuntimeError, ~r/retry limit/, fn ->
+        Repo.transact(
+          RoutingCluster,
+          TestRepo,
+          fn -> Repo.get(TestRepo, "some_key") end,
+          retry_limit: 1,
+          timeout_in_ms: 2_000
+        )
+      end
+
+      refute_received :routing_invalidated
+    end
+
     test "a transaction that never reads never fetches routing" do
       test_pid = self()
 


### PR DESCRIPTION
## Why

The post-merge fresh-agent acceptance review of the integration branch returned ACCEPT-WITH-NOTES; this addresses findings 1–5 and 7 (finding 6 is ticketed separately as bedrock-q67.42). Ticket: bedrock-q67.43.

## What

1. **Spec honesty**: `commit/4` declared `{:error, :abort}` while every reply site sends `:aborted`.
2. **Dead types**: `service_map` + `ServiceDescriptor`/`Worker` aliases had no referent since `services` left the TSL (#180).
3. **Precluded-hazard residue**: the `:locked` clause for `:apply_metadata_and_route` was unreachable (apply calls come only from finalization tasks a running proxy spawned; a proxy never re-locks). Deleted per guard-only-real-hazards, with the preclusion argument written where the clause was; the test pinning the precluded state dies with it.
4. **Legibility**: the resolver's missing stale-window clause is deliberate (sequencer version chain + fail-fast proxies preclude re-presentation); the invariant is now stated at the clause head instead of implied by FunctionClauseError fallthrough.
5. **Eviction parity**: `@routing_invalidating_failures` narrows to the definitively routing-shaped signals (`layout_lookup_failed`, `no_servers_to_race`, `unavailable`, `locked`). `:timeout`/`:unknown` stay retryable but keep the cache — FDB's locationCache survives timeouts for the same reason: slow is not stale, and evicting on timeout converts overload latency into node-wide cache-thrash and refetch traffic. A dead materializer still evicts (it surfaces as `:unavailable`). **TDD**: the new e2e pin (slow materializer retries without dropping the cache) was written first and failed under the old list.
7. **Doc trap**: `Repo.clear_range` now documents the user-keyspace commit bound and the `:end`-sentinel `{:key_out_of_range, _}` trap, pointing at `Bedrock.end_of_user_keyspace/0`.

Full suite (2589 tests), credo --strict, dialyzer green.