### PR TITLE
Name the resolver's stale-window violation instead of an anonymous crash

### DIFF
--- a/lib/bedrock/data_plane/resolver/server.ex
+++ b/lib/bedrock/data_plane/resolver/server.ex
@@ -120,14 +120,22 @@ defmodule Bedrock.DataPlane.Resolver.Server do
     )
   end
 
-  # No clause exists for a same-epoch call with last_version <
-  # t.last_version, deliberately: the hazard is structurally precluded.
-  # The sequencer hands out a strictly advancing version chain and
-  # proxies never retry a resolver call (fail-fast into recovery), so a
-  # stale window cannot be re-presented within an epoch. If one ever
-  # arrives, the chain has been violated and the FunctionClauseError
-  # crashes this resolver into recovery — the correct outcome, reached by
-  # construction rather than by a guard for a state that cannot occur.
+  # Structurally precluded: the sequencer hands out a strictly advancing
+  # version chain and proxies never retry a resolver call (fail-fast into
+  # recovery), so a same-epoch window below the floor cannot be
+  # re-presented. This clause is an assertion, not a guard - it cannot
+  # continue anything; it names the violated invariant and dies into
+  # recovery (the metadata_coverage_gap idiom).
+  @impl true
+  def handle_call(
+        {:resolve_transactions, epoch, {last_version, _next_version}, _transactions, _metadata_per_tx, _proxy_id},
+        _from,
+        t
+      )
+      when epoch == t.epoch and is_binary(last_version) and last_version < t.last_version do
+    exit({:stale_window_re_presented, %{floor: t.last_version, got: last_version}})
+  end
+
   @impl true
   def handle_call(
         {:resolve_transactions, epoch, {last_version, next_version}, transactions, metadata_per_tx, proxy_id},

--- a/test/bedrock/data_plane/resolver/server_test.exs
+++ b/test/bedrock/data_plane/resolver/server_test.exs
@@ -649,4 +649,25 @@ defmodule Bedrock.DataPlane.Resolver.ServerTest do
       assert {:error, :timeout} = result
     end
   end
+
+  describe "stale-window assertion" do
+    test "a same-epoch window below the floor exits with the named invariant" do
+      # The sequencer's strictly advancing chain plus fail-fast proxies
+      # preclude re-presenting a stale window within an epoch. If one
+      # arrives anyway, the crash must NAME the violated invariant - an
+      # anonymous FunctionClauseError would force the operator to
+      # reconstruct the preclusion from the clause list.
+      t = %State{epoch: 1, last_version: Version.from_integer(10)}
+
+      window = {Version.from_integer(5), Version.from_integer(6)}
+
+      assert {:stale_window_re_presented, %{floor: floor, got: got}} =
+               catch_exit(Server.handle_call({:resolve_transactions, 1, window, [], [], :proxy_1}, from(), t))
+
+      assert floor == Version.from_integer(10)
+      assert got == Version.from_integer(5)
+    end
+  end
+
+  defp from, do: {self(), make_ref()}
 end


### PR DESCRIPTION
## Why

Follow-on from the #183 discussion (ticket bedrock-q67.43 → bedrock-q67.45): if the stale-window preclusion were ever violated, it manifested as an anonymous `FunctionClauseError` — the operator had to reconstruct the invariant from the clause list and stumble across a comment. The settled convention: **value-level protocol violations get explicit clauses with inline structured exits** (OTP's house style — `bad_return_value`-shaped reasons — already precedented in this codebase by `{:metadata_coverage_gap, _}`); **shape-level impossibilities keep assertive-match fallthrough** (the officially endorsed non-assertive-pattern-matching remedy). No assertion module: inline, at four-sites scale, is the idiomatic form.

## What

The resolver's deliberate missing clause becomes an asserting clause: same-epoch `last_version < t.last_version` now exits `{:stale_window_re_presented, %{floor: ..., got: ...}}` into recovery. It is an assertion, not a guard — it cannot continue anything, so the guard-only-real-hazards rule is intact. The comment shrinks to the *why*; the clause states the *what*.

## How

TDD: the `catch_exit` pin was written first and failed against the anonymous `FunctionClauseError`. Behavior is otherwise unchanged — either form crashes the resolver into recovery; only the forensics differ.

Full suite (2590 tests), credo --strict, dialyzer green.