### PR TITLE
Drain the bootstrap shard-layout read's continuation

### DIFF
--- a/lib/bedrock/control_plane/director/recovery/materializer_bootstrap_phase.ex
+++ b/lib/bedrock/control_plane/director/recovery/materializer_bootstrap_phase.ex
@@ -513,11 +513,13 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhase do
   # degraded layout — it is a WRONG one (missing shards read as holes in
   # the keyspace), so the continuation must be drained, never dropped.
   defp default_get_shard_layout(materializer_pid, read_version) do
-    prefix = Bedrock.SystemKeys.shard_keys_prefix()
-    end_key = prefix <> <<0xFF, 0xFF, 0xFF, 0xFF>>
+    # The same bound construction the writer uses (persistence phase's
+    # clear_prefix), so reader and writer ranges are definitionally
+    # identical rather than two hand-rolled sentinels kept in agreement.
+    {_range_start, range_end} = Bedrock.KeyRange.from_prefix(Bedrock.SystemKeys.shard_keys_prefix())
 
     range_read_fn = fn start_key ->
-      Materializer.get_range(materializer_pid, start_key, end_key, read_version, limit: 1000)
+      Materializer.get_range(materializer_pid, start_key, range_end, read_version, limit: 1000)
     end
 
     case read_all_shard_entries(range_read_fn) do

--- a/lib/bedrock/control_plane/director/recovery/materializer_bootstrap_phase.ex
+++ b/lib/bedrock/control_plane/director/recovery/materializer_bootstrap_phase.ex
@@ -508,14 +508,49 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhase do
     get_layout_fn.(materializer_pid, read_version)
   end
 
+  # Read the shard_keys/ family via paged range reads. The family is
+  # unbounded in shard count, and a truncated boundary map is not a
+  # degraded layout — it is a WRONG one (missing shards read as holes in
+  # the keyspace), so the continuation must be drained, never dropped.
   defp default_get_shard_layout(materializer_pid, read_version) do
-    # Query the materializer for shard layout via get_range on shard_keys prefix
     prefix = Bedrock.SystemKeys.shard_keys_prefix()
     end_key = prefix <> <<0xFF, 0xFF, 0xFF, 0xFF>>
 
-    case Materializer.get_range(materializer_pid, prefix, end_key, read_version, limit: 1000) do
-      {:ok, {entries, _more}} ->
-        shard_layout_from_entries(entries)
+    range_read_fn = fn start_key ->
+      Materializer.get_range(materializer_pid, start_key, end_key, read_version, limit: 1000)
+    end
+
+    case read_all_shard_entries(range_read_fn) do
+      {:ok, entries} -> shard_layout_from_entries(entries)
+      {:error, _} = error -> error
+    end
+  end
+
+  @doc false
+  # Pages the shard_keys/ range read to exhaustion, resuming each page
+  # immediately after the last returned key. Any failure mid-continuation
+  # fails the whole read: partial success would BE the silent truncation
+  # this exists to preclude. An empty page claiming more is a broken read
+  # contract and is surfaced as an error rather than looped on.
+  @spec read_all_shard_entries((Bedrock.key() ->
+                                  {:ok, {[{Bedrock.key(), binary()}], more :: boolean()}}
+                                  | {:error, term()}
+                                  | {:failure, term(), term()})) ::
+          {:ok, [{Bedrock.key(), binary()}]} | {:error, {:shard_layout_query_failed, term()}}
+  def read_all_shard_entries(range_read_fn),
+    do: page_shard_entries(range_read_fn, Bedrock.SystemKeys.shard_keys_prefix(), [])
+
+  defp page_shard_entries(range_read_fn, start_key, pages) do
+    case range_read_fn.(start_key) do
+      {:ok, {entries, false}} ->
+        {:ok, [entries | pages] |> Enum.reverse() |> Enum.concat()}
+
+      {:ok, {[], true}} ->
+        {:error, {:shard_layout_query_failed, :empty_continuation_page}}
+
+      {:ok, {entries, true}} ->
+        {last_key, _value} = List.last(entries)
+        page_shard_entries(range_read_fn, Bedrock.Key.key_after(last_key), [entries | pages])
 
       {:error, reason} ->
         {:error, {:shard_layout_query_failed, reason}}

--- a/test/bedrock/control_plane/director/recovery/materializer_bootstrap_phase_test.exs
+++ b/test/bedrock/control_plane/director/recovery/materializer_bootstrap_phase_test.exs
@@ -555,6 +555,61 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhaseTest 
     end
   end
 
+  describe "read_all_shard_entries/1" do
+    alias Bedrock.SystemKeys, as: Keys
+
+    # A scripted range read keyed by the start key it expects: paging must
+    # resume each page exactly after the last returned key.
+    defp scripted(script), do: fn start_key -> Map.fetch!(script, start_key) end
+
+    test "a single page under the limit passes through" do
+      entries = [{Keys.shard_key("m"), "v1"}]
+      script = %{Keys.shard_keys_prefix() => {:ok, {entries, false}}}
+
+      assert {:ok, ^entries} = MaterializerBootstrapPhase.read_all_shard_entries(scripted(script))
+    end
+
+    test "pages through the continuation until the read reports no more" do
+      page1 = [{Keys.shard_key("b"), "v1"}, {Keys.shard_key("f"), "v2"}]
+      page2 = [{Keys.shard_key("m"), "v3"}]
+      page3 = [{Keys.shard_key(<<0xFF, 0xFF>>), "v4"}]
+
+      script = %{
+        Keys.shard_keys_prefix() => {:ok, {page1, true}},
+        Bedrock.Key.key_after(Keys.shard_key("f")) => {:ok, {page2, true}},
+        Bedrock.Key.key_after(Keys.shard_key("m")) => {:ok, {page3, false}}
+      }
+
+      assert {:ok, entries} = MaterializerBootstrapPhase.read_all_shard_entries(scripted(script))
+      assert entries == page1 ++ page2 ++ page3
+    end
+
+    test "an empty layout is an empty list, not an error" do
+      script = %{Keys.shard_keys_prefix() => {:ok, {[], false}}}
+
+      assert {:ok, []} = MaterializerBootstrapPhase.read_all_shard_entries(scripted(script))
+    end
+
+    test "a mid-continuation failure surfaces as a query failure — never a truncated layout" do
+      page1 = [{Keys.shard_key("b"), "v1"}]
+
+      script = %{
+        Keys.shard_keys_prefix() => {:ok, {page1, true}},
+        Bedrock.Key.key_after(Keys.shard_key("b")) => {:failure, :timeout, :ref}
+      }
+
+      assert {:error, {:shard_layout_query_failed, :timeout}} =
+               MaterializerBootstrapPhase.read_all_shard_entries(scripted(script))
+    end
+
+    test "an empty page claiming more is a broken contract, not an infinite loop" do
+      script = %{Keys.shard_keys_prefix() => {:ok, {[], true}}}
+
+      assert {:error, {:shard_layout_query_failed, :empty_continuation_page}} =
+               MaterializerBootstrapPhase.read_all_shard_entries(scripted(script))
+    end
+  end
+
   describe "shard_layout_from_entries/1" do
     alias Bedrock.SystemKeys
     alias Bedrock.SystemKeys.Values


### PR DESCRIPTION
## Why

bedrock-q67.42 (filed from a PR #181 audit note): `default_get_shard_layout` read the `shard_keys/` family with `limit: 1000` and discarded the `_more` continuation flag. Past a thousand shards the recovered layout silently truncated — and a truncated boundary map is not a degraded layout, it is a **wrong** one: missing shards read as holes in the keyspace. With carried start keys (#181) the hole is at least visible rather than a plausible-but-wrong contiguous map, but the read itself had to be bounded correctly before shard counts grow.

## What

`read_all_shard_entries/1` pages the range read to exhaustion, resuming each page immediately after its last returned key (`Bedrock.Key.key_after/1`, the same resume convention the Repo's range streaming uses). Two deliberate hard edges:

- A **mid-continuation failure fails the whole read** (`{:error, {:shard_layout_query_failed, reason}}` → recovery stalls and retries) — partial success would *be* the silent truncation this exists to preclude.
- An **empty page claiming `more`** is a broken read contract from another process and is surfaced as `:empty_continuation_page` rather than looped on — this is a real inter-process contract boundary, not a structurally-precluded state, so an error return (not an assertion) is the right form.

## How

TDD: the paging contract was pinned first (exact resume points, cross-page ordering, single-page passthrough, empty layout, mid-page failure, degenerate empty-with-more) against the then-missing function. The production wiring is a one-line closure over `Materializer.get_range`; injected `get_shard_layout_fn` test seams are untouched.

Full suite (2595 tests), credo --strict, dialyzer green.