### PR TITLE
Distributor lock: the keyspace-enforced write fence

### DIFF
--- a/lib/bedrock/control_plane/distributor/lock.ex
+++ b/lib/bedrock/control_plane/distributor/lock.ex
@@ -76,6 +76,19 @@ defmodule Bedrock.ControlPlane.Distributor.Lock do
   inside the mutating transaction; commit the returned mutations with
   it, or abandon the transaction (and the distributor) on
   `{:error, :superseded}`.
+
+  Runner obligations (bedrock-q67.21.4):
+
+  - Read the owner key first; read the write key ONLY when the owner is
+    not `my_owner` — the steady-state branch ignores `current_write`
+    (pass nil). FDB reads the write key only in the previous-owner
+    branch for a reason: an unconditional read puts a read conflict on
+    a key this same transaction writes, which would make every pair of
+    concurrent same-owner distributor transactions mutually conflict
+    and serialize.
+  - Pass an absent key through as nil, UNDECODED: nil is
+    protocol-meaningful here (fresh cluster / stomped lock), while
+    `Values.decode_lock_uid(nil)` is a decode error by design.
   """
   @spec check(t(), current_owner :: uid() | nil, current_write :: uid() | nil) ::
           {:ok, [mutation()]} | {:error, :superseded}

--- a/lib/bedrock/control_plane/distributor/lock.ex
+++ b/lib/bedrock/control_plane/distributor/lock.ex
@@ -1,0 +1,111 @@
+defmodule Bedrock.ControlPlane.Distributor.Lock do
+  @moduledoc """
+  The distributor's write fence: a port of FoundationDB's MoveKeys lock
+  (`fdbserver/MoveKeys.actor.cpp`, `takeMoveKeysLock`/
+  `checkPersistentMoveKeysLock`).
+
+  Ownership enforcement lives in the keyspace, not in process
+  supervision: two system keys (`distributor_lock/owner`,
+  `distributor_lock/write`) hold opaque UIDs, and every mutating
+  distributor transaction proves — inside its own serializable commit —
+  that no newer owner has appeared. Supervision-level singleton-ness
+  (the director recruiting one distributor per epoch) is best-effort;
+  this lock is what makes a zombie's writes impossible rather than
+  merely unlikely.
+
+  The protocol, exactly FDB's:
+
+  - **take** reads both keys, remembers what it observed
+    (`prev_owner`/`prev_write`), and writes a fresh `my_owner` UID to
+    the owner key — and deliberately NOT the write key: the write key's
+    untouched-ness is the evidence the unobserved-take branch depends
+    on.
+  - **check**, prepended to every mutating transaction, branches three
+    ways: owner is mine → touch the write key with a fresh UID (the
+    touch is what makes any concurrent take conflict with this commit);
+    owner is still the previous one → if the write key also still holds
+    what take observed, our take-commit simply hasn't been observed and
+    ownership is re-asserted (owner + fresh write), otherwise someone
+    else committed under that owner after our read and we are
+    superseded; anyone else owns → superseded.
+  - **poll** is the read-only verdict for the poll-to-die loop
+    (`pollMoveKeysLock`, every ~5s): a superseded distributor exits
+    promptly even when idle.
+
+  Named divergence: FDB additionally marks the write-key touch
+  self-conflicting so a transaction cannot commit twice
+  (`makeSelfConflicting`); Bedrock's commit pipeline never re-submits a
+  transaction (fail-fast, no proxy retries), so the hazard that guards
+  is structurally precluded here.
+
+  These functions are pure — reads in, mutations out. The transaction
+  runner that supplies the reads and commits the mutations arrives with
+  the distributor's mutating operations (bedrock-q67.21.4).
+  """
+
+  alias Bedrock.SystemKeys
+
+  @type uid :: <<_::128>>
+  @type mutation :: {:set, Bedrock.key(), uid()}
+
+  @type t :: %__MODULE__{
+          my_owner: uid(),
+          prev_owner: uid() | nil,
+          prev_write: uid() | nil
+        }
+  @enforce_keys [:my_owner]
+  defstruct [:my_owner, :prev_owner, :prev_write]
+
+  @doc "A fresh opaque 16-byte lock UID."
+  @spec new_uid() :: uid()
+  def new_uid, do: :crypto.strong_rand_bytes(16)
+
+  @doc """
+  Claims ownership: remembers the observed owner/write values and
+  proposes writing a fresh owner UID. Run the returned mutations in the
+  same transaction as the reads that produced the arguments.
+  """
+  @spec take(current_owner :: uid() | nil, current_write :: uid() | nil) :: {t(), [mutation()]}
+  def take(current_owner, current_write) do
+    lock = %__MODULE__{my_owner: new_uid(), prev_owner: current_owner, prev_write: current_write}
+    {lock, [{:set, SystemKeys.distributor_lock_owner(), lock.my_owner}]}
+  end
+
+  @doc """
+  The read-check-write fence: call with the owner/write values read
+  inside the mutating transaction; commit the returned mutations with
+  it, or abandon the transaction (and the distributor) on
+  `{:error, :superseded}`.
+  """
+  @spec check(t(), current_owner :: uid() | nil, current_write :: uid() | nil) ::
+          {:ok, [mutation()]} | {:error, :superseded}
+  def check(%__MODULE__{my_owner: mine}, mine, _current_write),
+    do: {:ok, [{:set, SystemKeys.distributor_lock_write(), new_uid()}]}
+
+  def check(%__MODULE__{prev_owner: prev, prev_write: prev_write} = lock, prev, current_write) do
+    if current_write == prev_write do
+      {:ok,
+       [
+         {:set, SystemKeys.distributor_lock_owner(), lock.my_owner},
+         {:set, SystemKeys.distributor_lock_write(), new_uid()}
+       ]}
+    else
+      {:error, :superseded}
+    end
+  end
+
+  def check(%__MODULE__{}, _current_owner, _current_write), do: {:error, :superseded}
+
+  @doc """
+  The read-only poll-to-die verdict: same branches as `check/3`, no
+  mutations. A superseded distributor stops rather than waiting to lose
+  a commit race.
+  """
+  @spec poll(t(), current_owner :: uid() | nil, current_write :: uid() | nil) :: :ok | :superseded
+  def poll(%__MODULE__{} = lock, current_owner, current_write) do
+    case check(lock, current_owner, current_write) do
+      {:ok, _mutations} -> :ok
+      {:error, :superseded} -> :superseded
+    end
+  end
+end

--- a/lib/bedrock/system_keys.ex
+++ b/lib/bedrock/system_keys.ex
@@ -13,7 +13,11 @@ defmodule Bedrock.SystemKeys do
   consumers and cluster-introspection tools, a queryable statement of
   which logs the current epoch runs. Materializer refs are runtime hints
   for clients, never recovery input: bootstrap rebuilds assignment from
-  `shard_keys/` plus live foreman discovery. A system key without a
+  `shard_keys/` plus live foreman discovery. `distributor_lock/{owner,
+  write}` is the distributor's write fence (FDB's MoveKeys lock,
+  bedrock-q67.21): opaque UIDs read-checked-written inside every
+  mutating distributor transaction, so ownership is enforced by the
+  commit pipeline itself. A system key without a
   reader is inventory, not communication - unread MACHINERY is deleted,
   while durable observability keys stay by decision, named as such;
   families return here when their readers do (config authority with
@@ -21,6 +25,14 @@ defmodule Bedrock.SystemKeys do
   """
 
   @system_prefix "\xff/system"
+
+  @doc "Distributor write-fence owner UID: `distributor_lock/owner` (FDB's moveKeysLockOwnerKey)"
+  @spec distributor_lock_owner() :: Bedrock.key()
+  def distributor_lock_owner, do: "#{@system_prefix}/distributor_lock/owner"
+
+  @doc "Distributor write-fence write UID: `distributor_lock/write` (FDB's moveKeysLockWriteKey)"
+  @spec distributor_lock_write() :: Bedrock.key()
+  def distributor_lock_write, do: "#{@system_prefix}/distributor_lock/write"
 
   @doc "Shard boundary entry: `shard_keys/<end_key>` -> `{tag, start_key}` (ceiling search)"
   @spec shard_key(Bedrock.key()) :: Bedrock.key()
@@ -54,8 +66,11 @@ defmodule Bedrock.SystemKeys do
           {:layout_log, String.t()}
           | {:shard_key, Bedrock.key()}
           | {:materializer_key, Bedrock.range_tag()}
+          | {:distributor_lock, :owner | :write}
           | :unknown
           | :error
+  def parse_key(<<@system_prefix, "/distributor_lock/owner">>), do: {:distributor_lock, :owner}
+  def parse_key(<<@system_prefix, "/distributor_lock/write">>), do: {:distributor_lock, :write}
   def parse_key(<<@system_prefix, "/layout/logs/", rest::binary>>), do: {:layout_log, rest}
   def parse_key(<<@system_prefix, "/shard_keys/", rest::binary>>), do: {:shard_key, rest}
 

--- a/lib/bedrock/system_keys/values.ex
+++ b/lib/bedrock/system_keys/values.ex
@@ -72,6 +72,7 @@ defmodule Bedrock.SystemKeys.Values do
   `Bedrock.SystemKeys.parse_key/1`).
   """
   @spec decode_for(term(), binary()) :: {:ok, term()} | decode_error()
+  def decode_for({:distributor_lock, _which}, value), do: decode_lock_uid(value)
   def decode_for({:shard_key, _end_key}, value), do: decode_shard_key_entry(value)
   def decode_for({:layout_log, _log_id}, value), do: decode_tag_list(value)
   def decode_for({:materializer_key, _tag}, value), do: decode_materializer_ref(value)
@@ -90,4 +91,21 @@ defmodule Bedrock.SystemKeys.Values do
   end
 
   defp safe_unpack(_not_binary, _valid?), do: {:error, :invalid_encoding}
+
+  @doc """
+  Encodes a distributor-lock UID: an opaque 16-byte token stored raw
+  (there is nothing to structure; the value's only property is
+  freshness-and-equality).
+  """
+  @spec encode_lock_uid(binary()) :: binary()
+  def encode_lock_uid(uid) when is_binary(uid) and byte_size(uid) == 16, do: uid
+
+  def encode_lock_uid(other) do
+    raise ArgumentError, "distributor lock UID must be a 16-byte binary: #{inspect(other)}"
+  end
+
+  @doc "Decodes a distributor-lock UID; never raises, never creates atoms."
+  @spec decode_lock_uid(binary()) :: {:ok, binary()} | decode_error()
+  def decode_lock_uid(uid) when is_binary(uid) and byte_size(uid) == 16, do: {:ok, uid}
+  def decode_lock_uid(_other), do: {:error, :invalid_encoding}
 end

--- a/test/bedrock/control_plane/distributor/lock_test.exs
+++ b/test/bedrock/control_plane/distributor/lock_test.exs
@@ -66,6 +66,7 @@ defmodule Bedrock.ControlPlane.Distributor.LockTest do
 
       assert {:ok, mutations} = Lock.check(lock, prev_owner, prev_write)
 
+      assert length(mutations) == 2
       assert {:set, SystemKeys.distributor_lock_owner(), lock.my_owner} in mutations
 
       assert [{:set, _write_key, fresh_write}] =

--- a/test/bedrock/control_plane/distributor/lock_test.exs
+++ b/test/bedrock/control_plane/distributor/lock_test.exs
@@ -1,0 +1,124 @@
+defmodule Bedrock.ControlPlane.Distributor.LockTest do
+  @moduledoc """
+  The distributor lock is FDB's MoveKeys lock: ownership enforcement
+  lives in the keyspace, not in process supervision. Every mutating
+  transaction proves, inside its own serializable commit, that no newer
+  owner has appeared — recruitment races and zombie distributors resolve
+  by commit conflict, with no consensus beyond the commit pipeline.
+  """
+  use ExUnit.Case, async: true
+
+  alias Bedrock.ControlPlane.Distributor.Lock
+  alias Bedrock.SystemKeys
+
+  describe "take/2" do
+    test "on a fresh cluster remembers absent previous state and claims ownership" do
+      {lock, mutations} = Lock.take(nil, nil)
+
+      assert lock.prev_owner == nil
+      assert lock.prev_write == nil
+      assert byte_size(lock.my_owner) == 16
+
+      assert mutations == [{:set, SystemKeys.distributor_lock_owner(), lock.my_owner}]
+    end
+
+    test "over an existing owner remembers exactly what it observed" do
+      prev_owner = Lock.new_uid()
+      prev_write = Lock.new_uid()
+
+      {lock, mutations} = Lock.take(prev_owner, prev_write)
+
+      assert lock.prev_owner == prev_owner
+      assert lock.prev_write == prev_write
+      assert lock.my_owner != prev_owner
+      assert mutations == [{:set, SystemKeys.distributor_lock_owner(), lock.my_owner}]
+    end
+
+    test "does NOT touch the write key — FDB parity" do
+      # takeMoveKeysLock writes only the Owner key; the Write key is
+      # first touched by the checked transaction that follows. Writing it
+      # at take time would destroy the interleaved-writer evidence the
+      # unobserved-take branch depends on.
+      {_lock, mutations} = Lock.take(Lock.new_uid(), Lock.new_uid())
+
+      refute Enum.any?(mutations, fn {:set, key, _} -> key == SystemKeys.distributor_lock_write() end)
+    end
+  end
+
+  describe "check/3 — the read-check-write fence" do
+    test "steady state (owner is mine): touches the write key with a fresh UID" do
+      {lock, _} = Lock.take(nil, nil)
+
+      assert {:ok, [{:set, write_key, touch}]} = Lock.check(lock, lock.my_owner, Lock.new_uid())
+      assert write_key == SystemKeys.distributor_lock_write()
+      assert byte_size(touch) == 16
+
+      # Fresh per check: two touches must differ (FDB's fresh
+      # deterministicRandom UID per transaction).
+      assert {:ok, [{:set, _, touch2}]} = Lock.check(lock, lock.my_owner, touch)
+      assert touch2 != touch
+    end
+
+    test "unobserved take (owner still the previous, write untouched): re-asserts ownership" do
+      prev_owner = Lock.new_uid()
+      prev_write = Lock.new_uid()
+      {lock, _} = Lock.take(prev_owner, prev_write)
+
+      assert {:ok, mutations} = Lock.check(lock, prev_owner, prev_write)
+
+      assert {:set, SystemKeys.distributor_lock_owner(), lock.my_owner} in mutations
+
+      assert [{:set, _write_key, fresh_write}] =
+               Enum.filter(mutations, fn {:set, key, _} -> key == SystemKeys.distributor_lock_write() end)
+
+      assert byte_size(fresh_write) == 16
+      assert fresh_write != prev_write
+    end
+
+    test "unobserved take on a fresh cluster (both nil) also re-asserts" do
+      {lock, _} = Lock.take(nil, nil)
+
+      assert {:ok, mutations} = Lock.check(lock, nil, nil)
+      assert {:set, SystemKeys.distributor_lock_owner(), lock.my_owner} in mutations
+    end
+
+    test "an interleaved writer under the previous owner is supersession" do
+      # Owner key unchanged, but someone committed a checked transaction
+      # (fresh Write UID) under that owner after our take read it: our
+      # view of the world is stale and we must not write.
+      prev_owner = Lock.new_uid()
+      prev_write = Lock.new_uid()
+      {lock, _} = Lock.take(prev_owner, prev_write)
+
+      assert {:error, :superseded} = Lock.check(lock, prev_owner, Lock.new_uid())
+    end
+
+    test "a new owner is supersession" do
+      {lock, _} = Lock.take(nil, nil)
+
+      assert {:error, :superseded} = Lock.check(lock, Lock.new_uid(), Lock.new_uid())
+    end
+  end
+
+  describe "poll/3 — the read-only poll-to-die verdict" do
+    test "mirrors check verdicts without proposing mutations" do
+      prev_owner = Lock.new_uid()
+      prev_write = Lock.new_uid()
+      {lock, _} = Lock.take(prev_owner, prev_write)
+
+      assert Lock.poll(lock, lock.my_owner, Lock.new_uid()) == :ok
+      assert Lock.poll(lock, prev_owner, prev_write) == :ok
+      assert Lock.poll(lock, prev_owner, Lock.new_uid()) == :superseded
+      assert Lock.poll(lock, Lock.new_uid(), Lock.new_uid()) == :superseded
+    end
+  end
+
+  describe "new_uid/0" do
+    test "is 16 bytes and collision-averse" do
+      uids = for _ <- 1..64, do: Lock.new_uid()
+
+      assert Enum.all?(uids, &(byte_size(&1) == 16))
+      assert length(Enum.uniq(uids)) == 64
+    end
+  end
+end

--- a/test/bedrock/system_keys/values_test.exs
+++ b/test/bedrock/system_keys/values_test.exs
@@ -74,4 +74,23 @@ defmodule Bedrock.SystemKeys.ValuesTest do
       assert {:error, :unknown_family} = Values.decode_for(:error, "anything")
     end
   end
+
+  describe "distributor lock UIDs" do
+    test "round-trips a 16-byte token and dispatches through decode_for" do
+      uid = :crypto.strong_rand_bytes(16)
+
+      assert Values.encode_lock_uid(uid) == uid
+      assert Values.decode_lock_uid(uid) == {:ok, uid}
+      assert Values.decode_for({:distributor_lock, :owner}, uid) == {:ok, uid}
+      assert Values.decode_for({:distributor_lock, :write}, uid) == {:ok, uid}
+    end
+
+    test "the encoder refuses non-16-byte input; the decoder never raises" do
+      assert_raise ArgumentError, fn -> Values.encode_lock_uid("short") end
+      assert_raise ArgumentError, fn -> Values.encode_lock_uid(:not_a_binary) end
+
+      assert Values.decode_lock_uid("short") == {:error, :invalid_encoding}
+      assert Values.decode_lock_uid(:crypto.strong_rand_bytes(17)) == {:error, :invalid_encoding}
+    end
+  end
 end

--- a/test/bedrock/system_keys_test.exs
+++ b/test/bedrock/system_keys_test.exs
@@ -38,4 +38,19 @@ defmodule Bedrock.SystemKeysTest do
       assert SystemKeys.parse_key(:not_a_key) == :error
     end
   end
+
+  describe "distributor lock keys" do
+    test "construct under the system prefix and parse back" do
+      assert SystemKeys.distributor_lock_owner() == "\xff/system/distributor_lock/owner"
+      assert SystemKeys.distributor_lock_write() == "\xff/system/distributor_lock/write"
+
+      assert SystemKeys.parse_key(SystemKeys.distributor_lock_owner()) == {:distributor_lock, :owner}
+      assert SystemKeys.parse_key(SystemKeys.distributor_lock_write()) == {:distributor_lock, :write}
+    end
+
+    test "near-miss keys under the family prefix are unknown, not lock keys" do
+      assert SystemKeys.parse_key("\xff/system/distributor_lock/other") == :unknown
+      assert SystemKeys.parse_key("\xff/system/distributor_lock/owner2") == :unknown
+    end
+  end
 end


### PR DESCRIPTION
## Why

Phase 1 of the settled bedrock-q67.21 course (decision record on the ticket, 2026-08-21). The Distributor will be Bedrock's first mid-epoch system-keyspace writer, and FDB's answer to "what stops two of them" is not process supervision — it's the MoveKeys lock: every mutating transaction proves, **inside its own serializable commit**, that no newer owner has appeared. Supervision-level singleton-ness stays best-effort; the keyspace is the authority. That is keyspace-is-the-channel applied to ownership itself, and everything later in the course (recruit/heal transactions, q67.21.4) depends on it.

## What

- `SystemKeys.distributor_lock_owner/0` + `distributor_lock_write/0` (`distributor_lock/{owner,write}`), parsed as `{:distributor_lock, :owner | :write}`; `Values.encode_lock_uid/decode_lock_uid` (opaque 16-byte tokens, raw — the value's only property is freshness-and-equality; decoder never raises, never creates atoms).
- `Bedrock.ControlPlane.Distributor.Lock`: pure `take/2` (remember observed owner+write, claim the **owner key only** — FDB parity, pinned: writing the write key at take time would destroy the interleaved-writer evidence), `check/3` (the three-way read-check-write fence: mine → touch write with fresh UID; still-previous-and-write-untouched → re-assert; else superseded), `poll/3` (read-only verdict for the 5s poll-to-die loop).

Named divergence in the moduledoc: no `makeSelfConflicting` analogue — Bedrock's pipeline never re-submits a transaction, so the double-commit hazard it guards is structurally precluded.

## How

Pure functions — reads in, mutations out. The transaction runner that supplies reads and commits mutations arrives with the distributor's mutating operations (q67.21.4); until then nothing calls this in production, which is deliberate phasing (the lock is small, self-contained, and everything else depends on its exact semantics being right first).

TDD: the full branch matrix was written first (fresh-cluster nils, unobserved take, interleaved-writer supersession, new-owner supersession, fresh-UID-per-touch, poll mirroring, take-does-not-touch-write).

Full suite (2609 tests), credo --strict, dialyzer green.