### PR TITLE
Recovery reads and heals the mapping families

### DIFF
--- a/guides/quick-reads/system-keyspace.md
+++ b/guides/quick-reads/system-keyspace.md
@@ -69,9 +69,11 @@ recovery never rewrites the mapping (bedrock-q67.21.2):
   analogue); an existing cluster's layout is read back, and boundaries
   never change without splits, so nothing is written.
 - `materializers/` — durable across epochs. Recovery reads the family
-  (it is bootstrap's re-adoption authority: a family-named worker beats
-  the most-advanced-durable contest) and writes exactly the assignments
-  it changed. Entries recovery didn't touch — including strays for tags
+  (it is bootstrap's re-adoption authority: a family-named worker that
+  this epoch locked, and whose own shard assignment agrees, beats the
+  most-advanced-durable contest — which stays the fallback, including
+  for tag 0, chosen before the family can be read) and writes exactly
+  the assignments it changed. Entries recovery didn't touch — including strays for tags
   outside the layout — are not recovery's to clean.
 
 The Distributor (bedrock-q67.21) completes the ownership transfer: a

--- a/guides/quick-reads/system-keyspace.md
+++ b/guides/quick-reads/system-keyspace.md
@@ -56,20 +56,29 @@ statement of which logs the current epoch runs.
 
 ## Who writes, and the ownership handoff
 
-Today every family is written by recovery's **persistence phase** in one
-system transaction per epoch: each rewritten family is range-cleared and
-rewritten atomically, so shrinking layouts leave no ghosts and readers
-never observe a gap. The transaction commits in `:system` mode — user
-commits are bounded below `\xFF` (`Bedrock.end_of_user_keyspace/0`);
-system commits below `\xFF\xFF` (FDB's `ACCESS_SYSTEM_KEYS` trust model).
+Recovery's **persistence phase** commits one system transaction per
+epoch (`:system` mode — user commits are bounded below `\xFF`,
+`Bedrock.end_of_user_keyspace/0`; system commits below `\xFF\xFF`,
+FDB's `ACCESS_SYSTEM_KEYS` trust model), and follows FDB's rule that
+recovery never rewrites the mapping (bedrock-q67.21.2):
 
-The per-epoch rewrite is deliberate scaffolding. In FoundationDB the Data
-Distributor owns `keyServers/`/`serverKeys/` — it writes every
-assignment, split, and move transactionally, and recovery never rewrites
-the mapping, only re-reads it. Bedrock's Distributor (bedrock-q67.21)
-takes over the same ownership: shard and materializer entries become
-durable across epochs, mutated mid-epoch by ordinary transactions, and
-recovery's job shrinks to re-reading and healing.
+- `layout/logs/` — the one epoch-scoped family: cleared and rewritten
+  each recovery (which logs THIS epoch runs).
+- `shard_keys/` — durable across epochs. Seeded only when this recovery
+  invented the layout (fresh cluster, FDB's `seedShardServers`
+  analogue); an existing cluster's layout is read back, and boundaries
+  never change without splits, so nothing is written.
+- `materializers/` — durable across epochs. Recovery reads the family
+  (it is bootstrap's re-adoption authority: a family-named worker beats
+  the most-advanced-durable contest) and writes exactly the assignments
+  it changed. Entries recovery didn't touch — including strays for tags
+  outside the layout — are not recovery's to clean.
+
+The Distributor (bedrock-q67.21) completes the ownership transfer: a
+keyspace-enforced write fence (`distributor_lock/{owner,write}`, the
+MoveKeys-lock port) fences its mid-epoch mutations, and stale-entry
+reconciliation and data-tag healing become its job, with recovery's
+shrinking to the tag-0 metadata shard.
 
 ## How it moves
 

--- a/lib/bedrock/control_plane/config/recovery_attempt.ex
+++ b/lib/bedrock/control_plane/config/recovery_attempt.ex
@@ -55,6 +55,8 @@ defmodule Bedrock.ControlPlane.Config.RecoveryAttempt do
     :transaction_system_layout,
     :shard_layout,
     shard_materializers: %{},
+    seeded_layout?: false,
+    prior_materializer_refs: nil,
     lock_failed_service_ids: MapSet.new()
   ]
 
@@ -80,6 +82,8 @@ defmodule Bedrock.ControlPlane.Config.RecoveryAttempt do
           service_pids: %{Worker.id() => pid()},
           transaction_system_layout: TransactionSystemLayout.t() | nil,
           shard_materializers: %{Bedrock.range_tag() => {Worker.id(), node_name :: String.t()}},
+          seeded_layout?: boolean(),
+          prior_materializer_refs: %{Bedrock.range_tag() => {Worker.id(), String.t()}} | nil,
           lock_failed_service_ids: MapSet.t(Worker.id()),
           shard_layout: shard_layout() | nil
         }
@@ -119,6 +123,8 @@ defmodule Bedrock.ControlPlane.Config.RecoveryAttempt do
       transaction_system_layout: nil,
       shard_layout: nil,
       shard_materializers: %{},
+      seeded_layout?: false,
+      prior_materializer_refs: nil,
       lock_failed_service_ids: MapSet.new()
     }
   end

--- a/lib/bedrock/control_plane/director/recovery/materializer_bootstrap_phase.ex
+++ b/lib/bedrock/control_plane/director/recovery/materializer_bootstrap_phase.ex
@@ -635,10 +635,12 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhase do
   # this reader consumes it — the same meaning RoutingData.apply_mutation
   # gives it; two readers of one family must not disagree about what the
   # value means. Adjacency reconstruction (each shard starts where the
-  # previous ends) survives only for legacy term_to_binary snapshots that
-  # predate carried start keys; the family rewrites atomically each
-  # epoch, so a snapshot is encoding-uniform and the fallback covers the
-  # whole read. (Dies with bedrock-q67.20.7.)
+  # previous ends) survives only for legacy term_to_binary snapshots
+  # that predate carried start keys. Recovery no longer rewrites the
+  # family (read-and-heal, bedrock-q67.21.2), so a legacy family stays
+  # legacy — encoding-uniform, which the any-legacy-falls-back-whole
+  # rule covers — until bedrock-q67.20.7 retires the fallback with an
+  # explicit one-time migration.
   @spec shard_layout_from_entries([{Bedrock.key(), binary()}]) ::
           {:ok, RecoveryAttempt.shard_layout()} | {:error, {:invalid_shard_value, Bedrock.key()}}
   def shard_layout_from_entries(entries) do
@@ -692,9 +694,10 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhase do
     end
   end
 
-  # Clusters created before Bedrock.SystemKeys.Values wrote shard_key values
-  # with term_to_binary; their first completed recovery re-encodes them.
-  # Remove once no supported release can carry the old encoding.
+  # Clusters created before Bedrock.SystemKeys.Values wrote shard_key
+  # values with term_to_binary. Recovery no longer rewrites the family,
+  # so these values persist AS-IS until bedrock-q67.20.7's explicit
+  # migration retires them along with this fallback.
   defp decode_legacy_shard_tag(value) do
     case :erlang.binary_to_term(value, [:safe]) do
       tag when is_integer(tag) -> {:ok, {:legacy, tag}}

--- a/lib/bedrock/control_plane/director/recovery/materializer_bootstrap_phase.ex
+++ b/lib/bedrock/control_plane/director/recovery/materializer_bootstrap_phase.ex
@@ -92,6 +92,11 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhase do
           recovery_attempt
           |> Map.put(:shard_layout, shard_layout)
           |> Map.put(:shard_materializers, to_materializer_refs(shard_materializers))
+          # Provenance for the persistence phase: this recovery INVENTED
+          # the layout (fresh cluster), so it seeds the durable families;
+          # the empty prior means every assignment writes.
+          |> Map.put(:seeded_layout?, true)
+          |> Map.put(:prior_materializer_refs, %{})
           |> Map.update!(:transaction_services, &Map.merge(&1, created_services))
 
         {updated_attempt, CommitProxyStartupPhase}
@@ -234,10 +239,11 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhase do
              context
            ),
          {:ok, shard_layout} <- get_shard_layout(materializer_pid, recovery_version, context),
+         {:ok, prior_refs} <- read_prior_refs(materializer_pid, recovery_version, context),
          {:ok, shard_materializers, created_services} <-
            ensure_materializers_for_shards(
              shard_layout,
-             existing_by_shard,
+             prefer_family_named(existing_by_shard, prior_refs, recovery_attempt),
              %{
                RecoveryAttempt.system_shard_id() => {system_worker_id, node(materializer_pid), materializer_pid}
              },
@@ -256,6 +262,11 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhase do
         recovery_attempt
         |> Map.put(:shard_layout, shard_layout)
         |> Map.put(:shard_materializers, to_materializer_refs(shard_materializers))
+        # Provenance for the persistence phase: the layout was READ from
+        # the durable family (nothing to rewrite), and the prior refs are
+        # the diff base for materializer writes.
+        |> Map.put(:seeded_layout?, false)
+        |> Map.put(:prior_materializer_refs, prior_refs)
         |> Map.put(:resolvers, resolver_descriptors_for_layout(shard_layout))
         |> Map.update!(:transaction_services, &Map.merge(&1, all_created))
 
@@ -372,6 +383,62 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhase do
           {:ok, assignment, %{worker_id => descriptor}}
         end
     end
+  end
+
+  # The committed materializers/ family is the re-adoption authority: a
+  # family-named worker that this epoch's locking phase actually locked
+  # (and whose own shard assignment agrees) is preferred over the
+  # most-advanced-durable contest, which remains the fallback for tags
+  # the family does not name — and for tag 0, whose selection happens
+  # before the family can be read (the family lives IN the system shard).
+  defp prefer_family_named(existing_by_shard, prior_refs, recovery_attempt) do
+    named =
+      for {tag, {worker_id, _node}} <- prior_refs,
+          match?(%{shard_id: ^tag}, Map.get(recovery_attempt.materializer_recovery_info_by_id, worker_id)),
+          %{status: {:up, ref}} <- [Map.get(recovery_attempt.transaction_services, worker_id)],
+          into: %{},
+          do: {tag, {worker_id, {:materializer, ref}}}
+
+    Map.merge(existing_by_shard, named)
+  end
+
+  # Read the durable materializers/ family at the recovery version: the
+  # re-adoption input and the persistence phase's diff base. Read from
+  # the same materializer, at the same version, as the shard layout — a
+  # torn view is impossible (the families rewrite transactionally).
+  defp read_prior_refs(materializer_pid, read_version, context) do
+    read_fn = Map.get(context, :read_prior_refs_fn, &default_read_prior_refs/2)
+    read_fn.(materializer_pid, read_version)
+  end
+
+  defp default_read_prior_refs(materializer_pid, read_version) do
+    prefix = Bedrock.SystemKeys.materializers_prefix()
+    {_range_start, range_end} = Bedrock.KeyRange.from_prefix(prefix)
+
+    range_read_fn = fn start_key ->
+      Materializer.get_range(materializer_pid, start_key, range_end, read_version, limit: 1000)
+    end
+
+    with {:ok, entries} <- page_entries(range_read_fn, prefix, :prior_refs_query_failed, []) do
+      decode_prior_refs(entries)
+    end
+  end
+
+  @doc false
+  # Public for tests: the default in-recovery reader is injected away in
+  # unit tests, so the decode contract is pinned directly.
+  @spec decode_prior_refs([{Bedrock.key(), binary()}]) ::
+          {:ok, %{Bedrock.range_tag() => {Worker.id(), String.t()}}}
+          | {:error, {:invalid_materializer_entry, Bedrock.key()}}
+  def decode_prior_refs(entries) do
+    Enum.reduce_while(entries, {:ok, %{}}, fn {key, value}, {:ok, acc} ->
+      with {:materializer_key, tag} <- Bedrock.SystemKeys.parse_key(key),
+           {:ok, ref} <- Values.decode_materializer_ref(value) do
+        {:cont, {:ok, Map.put(acc, tag, ref)}}
+      else
+        _ -> {:halt, {:error, {:invalid_materializer_entry, key}}}
+      end
+    end)
   end
 
   # Find a node that can host materializers
@@ -529,7 +596,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhase do
   end
 
   @doc false
-  # Pages the shard_keys/ range read to exhaustion, resuming each page
+  # Pages a system-family range read to exhaustion, resuming each page
   # immediately after the last returned key. Any failure mid-continuation
   # fails the whole read: partial success would BE the silent truncation
   # this exists to preclude. An empty page claiming more is a broken read
@@ -540,25 +607,25 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhase do
                                   | {:failure, term(), term()})) ::
           {:ok, [{Bedrock.key(), binary()}]} | {:error, {:shard_layout_query_failed, term()}}
   def read_all_shard_entries(range_read_fn),
-    do: page_shard_entries(range_read_fn, Bedrock.SystemKeys.shard_keys_prefix(), [])
+    do: page_entries(range_read_fn, Bedrock.SystemKeys.shard_keys_prefix(), :shard_layout_query_failed, [])
 
-  defp page_shard_entries(range_read_fn, start_key, pages) do
+  defp page_entries(range_read_fn, start_key, error_tag, pages) do
     case range_read_fn.(start_key) do
       {:ok, {entries, false}} ->
         {:ok, [entries | pages] |> Enum.reverse() |> Enum.concat()}
 
       {:ok, {[], true}} ->
-        {:error, {:shard_layout_query_failed, :empty_continuation_page}}
+        {:error, {error_tag, :empty_continuation_page}}
 
       {:ok, {entries, true}} ->
         {last_key, _value} = List.last(entries)
-        page_shard_entries(range_read_fn, Bedrock.Key.key_after(last_key), [entries | pages])
+        page_entries(range_read_fn, Bedrock.Key.key_after(last_key), error_tag, [entries | pages])
 
       {:error, reason} ->
-        {:error, {:shard_layout_query_failed, reason}}
+        {:error, {error_tag, reason}}
 
       {:failure, reason, _ref} ->
-        {:error, {:shard_layout_query_failed, reason}}
+        {:error, {error_tag, reason}}
     end
   end
 

--- a/lib/bedrock/control_plane/director/recovery/persistence_phase.ex
+++ b/lib/bedrock/control_plane/director/recovery/persistence_phase.ex
@@ -202,6 +202,10 @@ defmodule Bedrock.ControlPlane.Director.Recovery.PersistencePhase do
   # readers do (bedrock-q67.9, q67.25).
   @spec build_readable_keys(Tx.t(), RecoveryAttempt.t()) :: Tx.t()
   defp build_readable_keys(tx, recovery_attempt) do
+    # layout/logs is an epoch-scoped statement (which logs THIS epoch
+    # runs), so it alone is cleared and rewritten each recovery. The
+    # mapping families below are durable, distributor-era state: recovery
+    # reads and heals, never blanket-clears (bedrock-q67.21.2).
     tx = clear_prefix(tx, SystemKeys.layout_logs_prefix())
 
     tx =
@@ -209,17 +213,21 @@ defmodule Bedrock.ControlPlane.Director.Recovery.PersistencePhase do
         Tx.set(tx, SystemKeys.layout_log(log_id), Values.encode_tag_list(log_descriptor))
       end)
 
-    tx = build_shard_keys(tx, recovery_attempt.shard_layout)
+    tx = build_shard_keys(tx, recovery_attempt)
     build_materializer_keys(tx, recovery_attempt)
   end
 
-  # Creates materializer_key(tag) -> {worker_id, node} entries: the
-  # attempt already carries the refs in the keyspace-value shape (both
-  # strings; the reader derives the callable ref), so they are written
-  # verbatim — the routing-snapshot seed embeds the same map, so keyspace
-  # and seed are one map read twice. Gated like shard_keys, on the same
-  # INPUT: shard_materializers absent/empty means shard management is not
-  # active, so existing entries are untouched.
+  # Creates materializer_key(tag) -> {worker_id, node} entries as a DIFF
+  # against the prior family (read by bootstrap): only assignments this
+  # recovery changed are written; unchanged entries are left in place,
+  # and entries for tags outside this layout are not recovery's to clean
+  # — read-and-heal means stale reconciliation belongs to the
+  # distributor (bedrock-q67.21.4). A nil prior means the family was not
+  # read (fresh cluster, legacy path): every assignment writes, the safe
+  # direction. The attempt carries refs in the keyspace-value shape, so
+  # keyspace and routing-snapshot seed remain one map read twice. Gated
+  # on the same INPUT as before: shard_materializers absent/empty means
+  # shard management is not active.
   @spec build_materializer_keys(Tx.t(), RecoveryAttempt.t()) :: Tx.t()
   defp build_materializer_keys(tx, recovery_attempt) do
     case Map.get(recovery_attempt, :shard_materializers) do
@@ -230,16 +238,18 @@ defmodule Bedrock.ControlPlane.Director.Recovery.PersistencePhase do
         tx
 
       materializers ->
-        tx = clear_prefix(tx, SystemKeys.materializers_prefix())
+        prior = Map.get(recovery_attempt, :prior_materializer_refs) || %{}
 
-        Enum.reduce(materializers, tx, fn {tag, {worker_id, node}}, tx ->
+        materializers
+        |> Enum.reject(fn {tag, ref} -> Map.get(prior, tag) == ref end)
+        |> Enum.reduce(tx, fn {tag, {worker_id, node}}, tx ->
           Tx.set(tx, SystemKeys.materializer_key(tag), Values.encode_materializer_ref(worker_id, node))
         end)
     end
   end
 
-  # Rewritten-every-recovery keyed families are cleared before their entries
-  # are written so a shrinking layout leaves no stale entries behind. The clear
+  # The epoch-scoped layout/logs family is cleared before its entries are
+  # written so a changed log set leaves no stale entries behind. The clear
   # and the rewrite land in the same system transaction, so readers never
   # observe a gap.
   @spec clear_prefix(Tx.t(), Bedrock.key()) :: Tx.t()
@@ -248,21 +258,24 @@ defmodule Bedrock.ControlPlane.Director.Recovery.PersistencePhase do
     Tx.clear_range(tx, start_key, end_key)
   end
 
-  # Creates shard_key(end_key) -> {tag, start_key} entries (ceiling search).
-  # shard_layout format: %{end_key => {tag, start_key}}
-  #
-  # A nil or empty layout means shard management is not active for this
-  # recovery, so existing entries are left untouched rather than cleared.
-  @spec build_shard_keys(Tx.t(), RecoveryAttempt.shard_layout() | nil) :: Tx.t()
-  defp build_shard_keys(tx, nil), do: tx
-  defp build_shard_keys(tx, shard_layout) when map_size(shard_layout) == 0, do: tx
+  # Creates shard_key(end_key) -> {tag, start_key} entries (ceiling
+  # search) ONLY when this recovery seeded the layout (fresh cluster —
+  # FDB's seedShardServers analogue). An existing cluster's layout was
+  # READ from the family, and boundaries never change without splits, so
+  # there is nothing to write; the family is durable across epochs. The
+  # seed writes into a definitionally empty family (a fresh cluster has
+  # no committed data), so no clear is needed.
+  @spec build_shard_keys(Tx.t(), RecoveryAttempt.t()) :: Tx.t()
+  defp build_shard_keys(tx, recovery_attempt) do
+    shard_layout = recovery_attempt.shard_layout
 
-  defp build_shard_keys(tx, shard_layout) when is_map(shard_layout) do
-    tx = clear_prefix(tx, SystemKeys.shard_keys_prefix())
-
-    Enum.reduce(shard_layout, tx, fn {end_key, {tag, start_key}}, tx ->
-      Tx.set(tx, SystemKeys.shard_key(end_key), Values.encode_shard_key_entry(tag, start_key))
-    end)
+    if Map.get(recovery_attempt, :seeded_layout?, false) and is_map(shard_layout) and map_size(shard_layout) > 0 do
+      Enum.reduce(shard_layout, tx, fn {end_key, {tag, start_key}}, tx ->
+        Tx.set(tx, SystemKeys.shard_key(end_key), Values.encode_shard_key_entry(tag, start_key))
+      end)
+    else
+      tx
+    end
   end
 
   @spec submit_system_transaction(Transaction.encoded(), [pid()], Bedrock.epoch(), map()) ::

--- a/test/bedrock/control_plane/director/recovery/materializer_bootstrap_phase_test.exs
+++ b/test/bedrock/control_plane/director/recovery/materializer_bootstrap_phase_test.exs
@@ -555,6 +555,169 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhaseTest 
     end
   end
 
+  describe "prior materializer family as re-adoption input" do
+    defp existing_context(recovery_version, overrides) do
+      base =
+        [
+          old_transaction_system_layout: %{logs: %{"log_1" => [0, 1]}}
+        ]
+        |> create_test_context()
+        |> Map.put(:available_services, %{})
+        |> Map.put(:lock_materializer_fn, fn {:materializer, ref}, _epoch -> {:ok, ref} end)
+        |> Map.put(:unlock_materializer_fn, fn _pid, _version, _sources -> :ok end)
+        |> Map.put(:materializer_info_fn, fn _pid, [:current_version] ->
+          {:ok, %{current_version: recovery_version}}
+        end)
+        |> Map.put(:get_shard_layout_fn, fn _pid, _version ->
+          {:ok, %{<<0xFF>> => {1, <<>>}, Bedrock.end_of_keyspace() => {0, <<0xFF>>}}}
+        end)
+
+      Map.merge(base, overrides)
+    end
+
+    defp two_claimants_attempt(recovery_version, named_pid, stray_pid, sys_pid) do
+      recovery_attempt()
+      |> Map.put(:shard_layout, nil)
+      |> Map.put(:logs, %{"log_1" => [0, 1]})
+      |> Map.put(:version_vector, {Version.from_integer(0), recovery_version})
+      |> Map.put(:materializer_recovery_info_by_id, %{
+        "mat_sys" => %{kind: :materializer, shard_id: 0, durable_version: recovery_version},
+        "mat_named" => %{kind: :materializer, shard_id: 1, durable_version: Version.from_integer(1)},
+        "mat_stray" => %{kind: :materializer, shard_id: 1, durable_version: recovery_version}
+      })
+      |> Map.put(:transaction_services, %{
+        "mat_sys" => %{kind: :materializer, status: {:up, sys_pid}},
+        "mat_named" => %{kind: :materializer, status: {:up, named_pid}},
+        "mat_stray" => %{kind: :materializer, status: {:up, stray_pid}},
+        "log_1" => %{kind: :log, status: {:up, self()}}
+      })
+    end
+
+    test "the family-named locked survivor beats a more-advanced stray" do
+      # The committed assignment is the authority; the contest (most
+      # advanced durable state wins) is only the fallback for tags the
+      # family does not name.
+      recovery_version = Version.from_integer(500)
+      sys_pid = spawn(fn -> Process.sleep(:infinity) end)
+      named_pid = spawn(fn -> Process.sleep(:infinity) end)
+      stray_pid = spawn(fn -> Process.sleep(:infinity) end)
+
+      context =
+        existing_context(recovery_version, %{
+          read_prior_refs_fn: fn _pid, _version ->
+            {:ok, %{1 => {"mat_named", Atom.to_string(node())}}}
+          end
+        })
+
+      recovery_attempt = two_claimants_attempt(recovery_version, named_pid, stray_pid, sys_pid)
+
+      ExUnit.CaptureLog.capture_log(fn ->
+        assert {updated_attempt, CommitProxyStartupPhase} =
+                 MaterializerBootstrapPhase.execute(recovery_attempt, context)
+
+        assert {"mat_named", _node} = updated_attempt.shard_materializers[1]
+        assert updated_attempt.prior_materializer_refs == %{1 => {"mat_named", Atom.to_string(node())}}
+        refute updated_attempt.seeded_layout?
+      end)
+    end
+
+    test "a family entry naming an unlocked worker falls back to the contest" do
+      recovery_version = Version.from_integer(500)
+      sys_pid = spawn(fn -> Process.sleep(:infinity) end)
+      named_pid = spawn(fn -> Process.sleep(:infinity) end)
+      stray_pid = spawn(fn -> Process.sleep(:infinity) end)
+
+      context =
+        existing_context(recovery_version, %{
+          read_prior_refs_fn: fn _pid, _version ->
+            {:ok, %{1 => {"mat_gone", Atom.to_string(node())}}}
+          end
+        })
+
+      recovery_attempt = two_claimants_attempt(recovery_version, named_pid, stray_pid, sys_pid)
+
+      ExUnit.CaptureLog.capture_log(fn ->
+        assert {updated_attempt, CommitProxyStartupPhase} =
+                 MaterializerBootstrapPhase.execute(recovery_attempt, context)
+
+        # "mat_gone" was not locked this epoch: the most-advanced
+        # claimant wins as before.
+        assert {"mat_stray", _node} = updated_attempt.shard_materializers[1]
+      end)
+    end
+
+    test "a failed family read stalls the attempt — never a silently unnamed layout" do
+      recovery_version = Version.from_integer(500)
+      sys_pid = spawn(fn -> Process.sleep(:infinity) end)
+      named_pid = spawn(fn -> Process.sleep(:infinity) end)
+      stray_pid = spawn(fn -> Process.sleep(:infinity) end)
+
+      context =
+        existing_context(recovery_version, %{
+          read_prior_refs_fn: fn _pid, _version -> {:error, {:prior_refs_query_failed, :timeout}} end
+        })
+
+      recovery_attempt = two_claimants_attempt(recovery_version, named_pid, stray_pid, sys_pid)
+
+      assert {_attempt, {:stalled, {:prior_refs_query_failed, :timeout}}} =
+               MaterializerBootstrapPhase.execute(recovery_attempt, context)
+    end
+
+    test "the fresh path marks the layout seeded with an empty prior family" do
+      recovery_attempt =
+        recovery_attempt()
+        |> Map.put(:shard_layout, nil)
+        |> Map.put(:logs, %{"log_1" => [0, 1]})
+
+      context =
+        [
+          old_transaction_system_layout: %{logs: %{}},
+          node_capabilities: %{log: [Node.self()], materializer: [Node.self()]}
+        ]
+        |> create_test_context()
+        |> Map.put(:create_worker_fn, fn _foreman_ref, _worker_id, :materializer, _opts ->
+          {:ok, :new_materializer_ref}
+        end)
+        |> Map.put(:lock_materializer_fn, fn {:materializer, _ref, _shard_tag}, _epoch ->
+          {:ok, spawn(fn -> Process.sleep(:infinity) end)}
+        end)
+        |> Map.put(:unlock_materializer_fn, fn _pid, _version, _sources -> :ok end)
+
+      ExUnit.CaptureLog.capture_log(fn ->
+        assert {updated_attempt, CommitProxyStartupPhase} =
+                 MaterializerBootstrapPhase.execute(recovery_attempt, context)
+
+        assert updated_attempt.seeded_layout?
+        assert updated_attempt.prior_materializer_refs == %{}
+      end)
+    end
+  end
+
+  describe "decode_prior_refs/1" do
+    alias Bedrock.SystemKeys, as: SK
+    alias Bedrock.SystemKeys.Values, as: V
+
+    test "decodes tag-keyed refs and rejects foreign or undecodable entries" do
+      entries = [
+        {SK.materializer_key(0), V.encode_materializer_ref("wkr_sys", "n@h")},
+        {SK.materializer_key(7), V.encode_materializer_ref("wkr_a", "n@h")}
+      ]
+
+      assert {:ok, %{0 => {"wkr_sys", "n@h"}, 7 => {"wkr_a", "n@h"}}} =
+               MaterializerBootstrapPhase.decode_prior_refs(entries)
+
+      bad_key = SK.shard_key("m")
+
+      assert {:error, {:invalid_materializer_entry, ^bad_key}} =
+               MaterializerBootstrapPhase.decode_prior_refs([{bad_key, "x"}])
+
+      garbage = SK.materializer_key(1)
+
+      assert {:error, {:invalid_materializer_entry, ^garbage}} =
+               MaterializerBootstrapPhase.decode_prior_refs([{garbage, <<0xEE>>}])
+    end
+  end
+
   describe "read_all_shard_entries/1" do
     alias Bedrock.SystemKeys, as: Keys
 

--- a/test/bedrock/control_plane/director/recovery/persistence_phase_test.exs
+++ b/test/bedrock/control_plane/director/recovery/persistence_phase_test.exs
@@ -4,7 +4,6 @@ defmodule Bedrock.ControlPlane.Director.Recovery.PersistencePhaseTest do
   import Bedrock.Test.ControlPlane.RecoveryTestSupport
 
   alias Bedrock.ControlPlane.Director.Recovery.PersistencePhase
-  alias Bedrock.DataPlane.CommitProxy.RoutingData
   alias Bedrock.DataPlane.Transaction
   alias Bedrock.Key
   alias Bedrock.KeyRange

--- a/test/bedrock/control_plane/director/recovery/persistence_phase_test.exs
+++ b/test/bedrock/control_plane/director/recovery/persistence_phase_test.exs
@@ -45,6 +45,8 @@ defmodule Bedrock.ControlPlane.Director.Recovery.PersistencePhaseTest do
       <<0xFF, 0xFF>> => {0, <<0xFF>>}
     })
     |> Map.put(:shard_materializers, %{0 => {"wkr_sys", node_string()}, 1 => {"wkr_user", node_string()}})
+    |> Map.put(:seeded_layout?, true)
+    |> Map.put(:prior_materializer_refs, %{})
     |> Map.put(:transaction_system_layout, mock_transaction_system_layout())
   end
 
@@ -222,81 +224,106 @@ defmodule Bedrock.ControlPlane.Director.Recovery.PersistencePhaseTest do
     |> Enum.sort()
   end
 
-  describe "stale entry clearing on recovery rewrite" do
-    test "clears each rewritten keyed family's prefix before writing its entries" do
+  describe "read-and-heal: recovery writes what it changed, never blanket-clears" do
+    test "only layout/logs is cleared and rewritten; the mapping families are never blanket-cleared" do
       mutations = captured_system_mutations(base_recovery_attempt())
 
-      for prefix <- [
-            SystemKeys.shard_keys_prefix(),
-            SystemKeys.layout_logs_prefix(),
-            SystemKeys.materializers_prefix()
-          ] do
+      {log_clear_start, log_clear_end} = KeyRange.from_prefix(SystemKeys.layout_logs_prefix())
+
+      clear_index =
+        Enum.find_index(mutations, fn
+          {:clear_range, ^log_clear_start, ^log_clear_end} -> true
+          _ -> false
+        end)
+
+      assert clear_index, "expected clear_range over layout/logs"
+
+      first_log_set =
+        Enum.find_index(mutations, fn
+          {:set, key, _} -> String.starts_with?(key, SystemKeys.layout_logs_prefix())
+          _ -> false
+        end)
+
+      assert clear_index < first_log_set
+
+      # The mapping families are durable, distributor-era state: recovery
+      # may seed or update entries, never erase the families wholesale.
+      for prefix <- [SystemKeys.shard_keys_prefix(), SystemKeys.materializers_prefix()] do
         {clear_start, clear_end} = KeyRange.from_prefix(prefix)
 
-        clear_index =
-          Enum.find_index(mutations, fn
-            {:clear_range, ^clear_start, ^clear_end} -> true
-            _ -> false
-          end)
-
-        assert clear_index, "expected clear_range over #{inspect(prefix)}"
-
-        first_set_index =
-          Enum.find_index(mutations, fn
-            {:set, key, _} -> String.starts_with?(key, prefix)
-            _ -> false
-          end)
-
-        assert first_set_index, "expected set mutations under #{inspect(prefix)}"
-
-        assert clear_index < first_set_index,
-               "clear_range over #{inspect(prefix)} must precede its set mutations"
+        refute Enum.any?(mutations, &match?({:clear_range, ^clear_start, ^clear_end}, &1)),
+               "unexpected blanket clear over #{inspect(prefix)}"
       end
     end
 
-    test "shrinking shard layout (3 -> 2) leaves exactly 2 entries visible to the bootstrap range read" do
-      # Previous epoch persisted 3 shards; the third ends at <<0x80>>.
-      stale_store =
-        %{}
-        |> Map.put(SystemKeys.shard_key(<<0x40>>), Values.encode_shard_key_entry(2, <<>>))
-        |> Map.put(SystemKeys.shard_key(<<0x80>>), Values.encode_shard_key_entry(3, <<0x40>>))
-        |> Map.put(SystemKeys.shard_key(<<0xFF, 0xFF>>), Values.encode_shard_key_entry(4, <<0x80>>))
-        |> Map.put(SystemKeys.layout_log("old_log"), Values.encode_tag_list([9]))
-
-      # This epoch's layout has only 2 shards (see mock_transaction_system_layout/0).
+    test "a fresh cluster seeds shard_keys; the seed needs no clear (the family is definitionally empty)" do
       mutations = captured_system_mutations(base_recovery_attempt())
-      store = apply_to_store(stale_store, mutations)
 
-      # (a) Bootstrap cross-epoch read: exactly the 2 current shard_key entries.
-      assert [
-               {shard_key_1, _},
-               {shard_key_2, _}
-             ] = range_read(store, SystemKeys.shard_keys_prefix())
+      shard_sets =
+        Enum.filter(mutations, fn
+          {:set, key, _} -> String.starts_with?(key, SystemKeys.shard_keys_prefix())
+          _ -> false
+        end)
 
-      assert shard_key_1 == SystemKeys.shard_key(<<0xFF>>)
-      assert shard_key_2 == SystemKeys.shard_key(<<0xFF, 0xFF>>)
-
-      # Stale layout_log entries are gone too.
-      log_keys = store |> range_read(SystemKeys.layout_logs_prefix()) |> Enum.map(&elem(&1, 0))
-      assert log_keys == [SystemKeys.layout_log("log_1")]
+      assert length(shard_sets) == 2
     end
 
-    test "shrinking shard layout leaves exactly 2 entries visible to RoutingData" do
-      mutations = captured_system_mutations(base_recovery_attempt())
+    test "an existing cluster's recovery leaves the durable shard_keys family untouched" do
+      # Boundaries never change without splits; the family was read, not
+      # invented, so recovery writes nothing under it.
+      recovery_attempt = Map.put(base_recovery_attempt(), :seeded_layout?, false)
 
-      routing_data =
-        RoutingData.new_empty()
-        |> RoutingData.insert_shard(<<0x40>>, 2, <<>>)
-        |> RoutingData.insert_shard(<<0x80>>, 3, <<0x40>>)
-        |> RoutingData.insert_shard(<<0xFF, 0xFF>>, 4, <<0x80>>)
+      stale_store = %{
+        SystemKeys.shard_key(<<0xFF>>) => Values.encode_shard_key_entry(1, <<>>),
+        SystemKeys.shard_key(<<0xFF, 0xFF>>) => Values.encode_shard_key_entry(0, <<0xFF>>)
+      }
 
-      updated =
-        RoutingData.apply_mutations(routing_data, [{Bedrock.DataPlane.Version.from_integer(1), mutations}])
+      mutations = captured_system_mutations(recovery_attempt)
+      store = apply_to_store(stale_store, mutations)
 
-      assert :gb_trees.to_list(updated.shards) == [
-               {<<0xFF>>, {1, <<>>}},
-               {<<0xFF, 0xFF>>, {0, <<0xFF>>}}
+      refute Enum.any?(mutations, fn
+               {:set, key, _} -> String.starts_with?(key, SystemKeys.shard_keys_prefix())
+               _ -> false
+             end)
+
+      assert range_read(store, SystemKeys.shard_keys_prefix()) == Enum.sort(stale_store)
+    end
+
+    test "materializer writes are a diff against the prior family; unnamed entries are not recovery's to clean" do
+      # tag 0's assignment is unchanged (not rewritten); tag 1's changed
+      # (rewritten); tag 9's entry names a tag outside this layout and is
+      # left alone — read-and-heal means stale entries are the
+      # distributor's to reconcile, never recovery's to erase.
+      prior = %{
+        0 => {"wkr_sys", node_string()},
+        1 => {"wkr_departed", node_string()},
+        9 => {"wkr_stray", node_string()}
+      }
+
+      recovery_attempt = Map.put(base_recovery_attempt(), :prior_materializer_refs, prior)
+
+      stale_store =
+        Map.new(prior, fn {tag, {id, node}} ->
+          {SystemKeys.materializer_key(tag), Values.encode_materializer_ref(id, node)}
+        end)
+
+      mutations = captured_system_mutations(recovery_attempt)
+      store = apply_to_store(stale_store, mutations)
+
+      materializer_sets =
+        for {:set, key, value} <- mutations,
+            String.starts_with?(key, SystemKeys.materializers_prefix()),
+            do: {key, value}
+
+      assert materializer_sets == [
+               {SystemKeys.materializer_key(1), Values.encode_materializer_ref("wkr_user", node_string())}
              ]
+
+      assert {:ok, {"wkr_sys", _}} =
+               Values.decode_materializer_ref(Map.fetch!(store, SystemKeys.materializer_key(0)))
+
+      assert {:ok, {"wkr_stray", _}} =
+               Values.decode_materializer_ref(Map.fetch!(store, SystemKeys.materializer_key(9)))
     end
 
     test "cleared prefix ranges do not cover any other system-key family" do
@@ -305,7 +332,6 @@ defmodule Bedrock.ControlPlane.Director.Recovery.PersistencePhaseTest do
       # bytes (e.g. a "shards/" neighbor of "shard_keys/": '_' (0x5F) < 's'
       # (0x73) puts strinc("...shard_keys/") = "...shard_keys0" below it).
       cleared_prefixes = %{
-        shard_key: SystemKeys.shard_keys_prefix(),
         layout_log: SystemKeys.layout_logs_prefix()
       }
 
@@ -332,7 +358,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery.PersistencePhaseTest do
     end
 
     test "prefix range end is exact: a key at strinc(prefix) is not cleared" do
-      prefix = SystemKeys.shard_keys_prefix()
+      prefix = SystemKeys.layout_logs_prefix()
       boundary_key = Key.strinc(prefix)
 
       # A neighbor key exactly at the exclusive range end must survive, as must

--- a/test/support/control_plane/recovery_test_support.ex
+++ b/test/support/control_plane/recovery_test_support.ex
@@ -47,6 +47,9 @@ defmodule Bedrock.Test.ControlPlane.RecoveryTestSupport do
     %{
       node_capabilities: node_capabilities,
       old_transaction_system_layout: old_transaction_system_layout,
+      # Deterministic default for the bootstrap's durable-family read;
+      # tests exercising the read path override it.
+      read_prior_refs_fn: fn _materializer_pid, _read_version -> {:ok, %{}} end,
       cluster_config: %{
         coordinators: [],
         parameters: %{


### PR DESCRIPTION
## Why

Phase 2 of the settled bedrock-q67.21 course. FDB's recovery never rewrites the mapping — `keyServers/`/`serverKeys/` flow through recovery like user data, written only by `seedShardServers` for a brand-new database. Bedrock's per-epoch blanket clear+rewrite of `shard_keys/` and `materializers/` was explicitly labeled scaffolding; the Distributor cannot own state that recovery erases every epoch.

## What

- **`layout/logs/`** stays the one epoch-scoped family (clear+rewrite: which logs THIS epoch runs).
- **`shard_keys/`** seeds **only-when-invented** (fresh cluster; provenance rides the attempt as `seeded_layout?`). Existing clusters write nothing under it — the layout was read, and boundaries never change without splits. The seed needs no clear (a fresh cluster's family is definitionally empty), so **no blanket clear exists anywhere for the mapping families** (pinned).
- **`materializers/`** writes are a **diff against the prior family**: bootstrap now reads it (reusing the paged reader, at the recovery version, from the same materializer as the shard layout — single-version multi-page reads can't tear) into `prior_materializer_refs`; persistence writes exactly what changed. Strays for tags outside the layout are preserved — read-and-heal means reconciliation is the distributor's (q67.21.4), never recovery's.
- **The durable family is bootstrap's re-adoption authority**: a family-named worker that this epoch locked (and whose own shard assignment agrees) beats the most-advanced-durable contest; the contest remains the fallback for unnamed tags — and for **tag 0**, whose selection necessarily precedes the family read (it lives *in* the system shard: the settled carve-out).
- A failed family read **stalls** the attempt — proceeding with a silently unnamed layout would resurrect exactly the drift this arc exists to kill.

## How

TDD: the read-and-heal contract was pinned first (no-blanket-clear, seed-without-clear, untouched-durable-family with store-level survival, diff-with-stray-preservation, family-beats-contest, unlocked-name-falls-back, stall-on-failure, decode contract). The paged reader generalized (`page_entries/4`) with `read_all_shard_entries/1` keeping its exact contract. Test support gained a deterministic `read_prior_refs_fn` default (the real reader against stub pids would hang on an infinite-timeout call — caught when the suite did exactly that). The system-keyspace guide's ownership section updated to match.

Full suite (2615 tests), credo --strict, dialyzer green.