### PR TITLE
Distributor singleton: fenced take, poll-to-die, director recruitment

### DIFF
--- a/lib/bedrock/control_plane/director/recovery.ex
+++ b/lib/bedrock/control_plane/director/recovery.ex
@@ -33,8 +33,11 @@ defmodule Bedrock.ControlPlane.Director.Recovery do
   alias Bedrock.ControlPlane.Config.TransactionSystemLayout
   alias Bedrock.ControlPlane.Coordinator
   alias Bedrock.ControlPlane.Director.State
+  alias Bedrock.ControlPlane.Distributor
   alias Bedrock.Internal.Time.Interval
   alias Bedrock.Service.Worker
+
+  require Logger
 
   @type recovery_context :: %{
           cluster_config: Config.t(),
@@ -126,6 +129,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery do
         |> persist_config()
         |> persist_new_transaction_system_layout()
         |> prune_service_directory(completed)
+        |> maybe_start_distributor()
 
       {{:stalled, reason}, stalled} ->
         trace_recovery_stalled(Interval.between(stalled.started_at, now()), reason)
@@ -186,6 +190,57 @@ defmodule Bedrock.ControlPlane.Director.Recovery do
           do: worker_id
 
     MapSet.union(log_ids, materializer_ids)
+  end
+
+  @doc """
+  Recruits the per-epoch Distributor singleton once the transaction
+  system is running (FDB's CC recruits DD only after recovery accepts
+  commits). Unlinked + monitored: a ceded exit (`:normal`) is final for
+  this epoch; failures are retried by the director's timer. The lock —
+  not this supervision — is what fences a stale instance's writes.
+  """
+  @spec maybe_start_distributor(State.t()) :: State.t()
+  def maybe_start_distributor(%{state: :running, distributor: nil, transaction_system_layout: tsl} = t)
+      when tsl != nil do
+    start_fn = t.distributor_start_fn || (&Distributor.Server.start/1)
+
+    case start_fn.(
+           cluster: t.cluster,
+           epoch: t.epoch,
+           director: self(),
+           sequencer: tsl.sequencer,
+           proxies: tsl.proxies
+         ) do
+      {:ok, pid} ->
+        %{t | distributor: pid, distributor_monitor: Process.monitor(pid)}
+
+      {:error, reason} ->
+        Logger.warning("Distributor start failed: #{inspect(reason)}; retrying")
+        schedule_distributor_retry(t)
+    end
+  end
+
+  def maybe_start_distributor(t), do: t
+
+  @doc false
+  @spec handle_distributor_down(State.t(), reason :: term()) :: State.t()
+  def handle_distributor_down(t, reason) do
+    t = %{t | distributor: nil, distributor_monitor: nil}
+
+    case reason do
+      # Ceded: superseded at the lock or the epoch ended — a newer owner
+      # exists, recruiting another would just lose the race again.
+      :normal ->
+        t
+
+      _failure ->
+        schedule_distributor_retry(t)
+    end
+  end
+
+  defp schedule_distributor_retry(t) do
+    Process.send_after(self(), {:timeout, :start_distributor}, t.distributor_retry_ms)
+    t
   end
 
   @spec prune_service_directory(State.t(), RecoveryAttempt.t()) :: State.t()

--- a/lib/bedrock/control_plane/director/server.ex
+++ b/lib/bedrock/control_plane/director/server.ex
@@ -23,6 +23,7 @@ defmodule Bedrock.ControlPlane.Director.Server do
   alias Bedrock.ControlPlane.Config
   alias Bedrock.ControlPlane.Config.TransactionSystemLayout
   alias Bedrock.ControlPlane.Coordinator
+  alias Bedrock.ControlPlane.Director.Recovery
   alias Bedrock.ControlPlane.Director.State
 
   require Logger
@@ -91,6 +92,17 @@ defmodule Bedrock.ControlPlane.Director.Server do
     |> ping_all_coordinators()
     |> noreply()
   end
+
+  # The distributor is the one monitored process whose death is NOT
+  # epoch-fatal: it is a per-epoch singleton the director re-recruits
+  # (ceded :normal exits excepted). This clause must precede the
+  # component-failure catch-all.
+  @impl true
+  def handle_info({:DOWN, ref, :process, _pid, reason}, %{distributor_monitor: ref} = t) when ref != nil,
+    do: t |> Recovery.handle_distributor_down(reason) |> noreply()
+
+  @impl true
+  def handle_info({:timeout, :start_distributor}, t), do: t |> Recovery.maybe_start_distributor() |> noreply()
 
   @impl true
   def handle_info({:DOWN, _monitor_ref, :process, failed_pid, reason}, t) do

--- a/lib/bedrock/control_plane/director/state.ex
+++ b/lib/bedrock/control_plane/director/state.ex
@@ -12,6 +12,10 @@ defmodule Bedrock.ControlPlane.Director.State do
   @type timer_registry :: %{atom() => reference()}
 
   @type t :: %__MODULE__{
+          distributor: pid() | nil,
+          distributor_monitor: reference() | nil,
+          distributor_retry_ms: pos_integer(),
+          distributor_start_fn: (keyword() -> {:ok, pid()} | {:error, term()}) | nil,
           state: state(),
           epoch: Bedrock.epoch(),
           cluster: module(),
@@ -25,7 +29,11 @@ defmodule Bedrock.ControlPlane.Director.State do
           lock_token: binary(),
           recovery_attempt: Config.RecoveryAttempt.t() | nil
         }
-  defstruct state: :starting,
+  defstruct distributor: nil,
+            distributor_monitor: nil,
+            distributor_retry_ms: 1_000,
+            distributor_start_fn: nil,
+            state: :starting,
             epoch: nil,
             cluster: nil,
             config: nil,

--- a/lib/bedrock/control_plane/distributor/server.ex
+++ b/lib/bedrock/control_plane/distributor/server.ex
@@ -1,0 +1,107 @@
+defmodule Bedrock.ControlPlane.Distributor.Server do
+  @moduledoc false
+  use GenServer
+
+  alias Bedrock.ControlPlane.Distributor.State
+  alias Bedrock.ControlPlane.Distributor.Transactions
+
+  require Logger
+
+  # FDB's MOVEKEYS_LOCK_POLLING_DELAY: a superseded distributor exits
+  # within seconds even when idle, instead of waiting to lose a commit.
+  @poll_interval_ms 5_000
+
+  @spec child_spec(keyword()) :: Supervisor.child_spec()
+  def child_spec(opts) do
+    %{
+      id: __MODULE__,
+      start: {__MODULE__, :start, [opts]},
+      restart: :temporary
+    }
+  end
+
+  @doc """
+  Starts an unlinked distributor: the director supervises by monitor
+  (ceded `:normal` exits are not re-recruited; failures are), and the
+  distributor watches the director back — a per-epoch singleton dies
+  with its epoch.
+  """
+  @spec start(keyword()) :: {:ok, pid()} | {:error, term()}
+  def start(opts) do
+    GenServer.start(__MODULE__, opts, name: Keyword.get(opts, :otp_name))
+  end
+
+  @impl true
+  def init(opts) do
+    cluster = Keyword.fetch!(opts, :cluster)
+    epoch = Keyword.fetch!(opts, :epoch)
+    director = Keyword.fetch!(opts, :director)
+
+    deps =
+      Keyword.get_lazy(opts, :deps, fn ->
+        Transactions.deps_for(
+          cluster,
+          epoch,
+          Keyword.fetch!(opts, :sequencer),
+          Keyword.fetch!(opts, :proxies)
+        )
+      end)
+
+    state = %State{
+      cluster: cluster,
+      epoch: epoch,
+      director: director,
+      director_monitor: Process.monitor(director),
+      deps: deps,
+      poll_interval_ms: Keyword.get(opts, :poll_interval_ms, @poll_interval_ms)
+    }
+
+    {:ok, state, {:continue, :take_lock}}
+  end
+
+  # Lock first, everything else second (FDB's DD startup order): a
+  # distributor that cannot own the fence must not exist. A commit abort
+  # means a newer owner won — cede (:normal, the director does not
+  # re-recruit); a transient failure stops :shutdown so the director's
+  # retry recruits a fresh instance.
+  @impl true
+  def handle_continue(:take_lock, %State{} = t) do
+    case Transactions.take_lock(t.deps) do
+      {:ok, lock} ->
+        Logger.info("Bedrock distributor (epoch #{t.epoch}): lock taken")
+        {:noreply, schedule_poll(%{t | lock: lock})}
+
+      {:error, :superseded} ->
+        Logger.info("Bedrock distributor (epoch #{t.epoch}): superseded at take; ceding")
+        {:stop, :normal, t}
+
+      {:error, reason} ->
+        {:stop, {:shutdown, {:lock_take_failed, reason}}, t}
+    end
+  end
+
+  # The poll-to-die loop: a read-only fence evaluation every poll
+  # interval. Supersession cedes; an unavailable read is not a verdict —
+  # the next tick retries.
+  @impl true
+  def handle_info(:poll_lock, %State{} = t) do
+    case Transactions.poll_verdict(t.lock, t.deps) do
+      :superseded ->
+        Logger.info("Bedrock distributor (epoch #{t.epoch}): lock superseded; ceding")
+        {:stop, :normal, t}
+
+      _ok_or_unavailable ->
+        {:noreply, schedule_poll(t)}
+    end
+  end
+
+  # A per-epoch singleton dies with its epoch: the director's death is a
+  # recovery in progress, and the next epoch's director recruits the
+  # next distributor.
+  def handle_info({:DOWN, ref, :process, _pid, _reason}, %State{director_monitor: ref} = t), do: {:stop, :normal, t}
+
+  defp schedule_poll(%State{} = t) do
+    Process.send_after(self(), :poll_lock, t.poll_interval_ms)
+    t
+  end
+end

--- a/lib/bedrock/control_plane/distributor/server.ex
+++ b/lib/bedrock/control_plane/distributor/server.ex
@@ -60,20 +60,18 @@ defmodule Bedrock.ControlPlane.Distributor.Server do
   end
 
   # Lock first, everything else second (FDB's DD startup order): a
-  # distributor that cannot own the fence must not exist. A commit abort
-  # means a newer owner won — cede (:normal, the director does not
-  # re-recruit); a transient failure stops :shutdown so the director's
-  # retry recruits a fresh instance.
+  # distributor that cannot own the fence must not exist. Take is
+  # last-take-wins and never a supersession verdict (Transactions
+  # retries aborts with fresh versions); any take failure stops
+  # :shutdown so the director's retry recruits a fresh instance.
+  # Supersession is delivered by the poll loop and, later, by the CHECK
+  # fence on mutating transactions.
   @impl true
   def handle_continue(:take_lock, %State{} = t) do
     case Transactions.take_lock(t.deps) do
       {:ok, lock} ->
         Logger.info("Bedrock distributor (epoch #{t.epoch}): lock taken")
         {:noreply, schedule_poll(%{t | lock: lock})}
-
-      {:error, :superseded} ->
-        Logger.info("Bedrock distributor (epoch #{t.epoch}): superseded at take; ceding")
-        {:stop, :normal, t}
 
       {:error, reason} ->
         {:stop, {:shutdown, {:lock_take_failed, reason}}, t}

--- a/lib/bedrock/control_plane/distributor/state.ex
+++ b/lib/bedrock/control_plane/distributor/state.ex
@@ -1,0 +1,26 @@
+defmodule Bedrock.ControlPlane.Distributor.State do
+  @moduledoc false
+
+  alias Bedrock.ControlPlane.Distributor.Lock
+  alias Bedrock.ControlPlane.Distributor.Transactions
+
+  @type t :: %__MODULE__{
+          cluster: module(),
+          epoch: Bedrock.epoch(),
+          director: pid(),
+          director_monitor: reference(),
+          deps: Transactions.deps(),
+          lock: Lock.t() | nil,
+          poll_interval_ms: pos_integer()
+        }
+  @enforce_keys [:cluster, :epoch, :director, :director_monitor, :deps]
+  defstruct [
+    :cluster,
+    :epoch,
+    :director,
+    :director_monitor,
+    :deps,
+    lock: nil,
+    poll_interval_ms: 5_000
+  ]
+end

--- a/lib/bedrock/control_plane/distributor/transactions.ex
+++ b/lib/bedrock/control_plane/distributor/transactions.ex
@@ -47,34 +47,61 @@ defmodule Bedrock.ControlPlane.Distributor.Transactions do
     %{
       epoch: epoch,
       proxies: proxies,
-      next_read_version_fn: fn -> Sequencer.next_read_version(sequencer, epoch) end,
+      # Every call is bounded: an alive-but-wedged callee must surface as
+      # a transient error the director's retry can recruit past — an
+      # unbounded call would wedge the distributor invisibly (the
+      # director sees a healthy monitored singleton forever).
+      next_read_version_fn: fn -> Sequencer.next_read_version(sequencer, epoch, timeout_in_ms: 5_000) end,
       get_fn: fn key, version ->
-        with {:ok, {_start, _end, _tag, {worker_id, node}}} <-
-               CommitProxy.fetch_routing(Enum.random(proxies), key) do
-          # The documented exception to no-atoms-on-decode: system-mode-
-          # gated writers, count bounded by cluster membership.
-          # credo:disable-for-next-line Credo.Check.Warning.UnsafeToAtom
-          Materializer.get({cluster.otp_name_for_worker(worker_id), String.to_atom(node)}, key, version)
+        case CommitProxy.fetch_routing(Enum.random(proxies), key) do
+          {:ok, {_start, _end, _tag, {worker_id, node}}} ->
+            # The documented exception to no-atoms-on-decode: system-
+            # mode-gated writers, count bounded by cluster membership.
+            # credo:disable-for-next-line Credo.Check.Warning.UnsafeToAtom
+            Materializer.get({cluster.otp_name_for_worker(worker_id), String.to_atom(node)}, key, version,
+              timeout: 5_000
+            )
+
+          # Routing's :not_found means UNROUTABLE — a different fact from
+          # a key that is readable-and-absent, which only the
+          # materializer may assert.
+          {:error, :not_found} ->
+            {:error, {:unroutable_system_key, key}}
+
+          {:error, reason} ->
+            {:error, reason}
         end
       end,
       commit_fn: fn proxy, commit_epoch, encoded, opts ->
-        CommitProxy.commit(proxy, commit_epoch, encoded, opts)
+        CommitProxy.commit(proxy, commit_epoch, encoded, Keyword.put(opts, :timeout_in_ms, 10_000))
       end
     }
   end
+
+  @take_attempts 3
 
   @doc """
   Takes the distributor lock: reads both lock keys at a pinned version
   (FDB's take reads both — the remembered write UID is the
   unobserved-take evidence), claims the owner key, and commits with read
-  conflicts on both keys at that version. `{:error, :superseded}` means
-  a newer owner won the race (commit abort); other errors are transient.
+  conflicts on both keys at that version.
+
+  An abort at TAKE time is not a verdict — FDB's `takeMoveKeysLock`
+  retries `not_committed`/`too_old` with a fresh read version, because
+  an abort here can also mean the read version fell below the
+  resolver's pruning floor. Take semantics are last-take-wins: the
+  re-take reads the interleaved winner as the new previous owner and
+  claims over it; supersession is delivered where it is authoritative —
+  by the CHECK fence on mutating transactions and the poll loop.
+  Exhausted retries surface as a transient commit failure for the
+  director's recruit-retry.
   """
   @spec take_lock(deps()) ::
           {:ok, Lock.t()}
-          | {:error, :superseded}
           | {:error, {:read_version_failed | :lock_read_failed | :lock_commit_failed, term()}}
-  def take_lock(deps) do
+  def take_lock(deps), do: take_lock(deps, @take_attempts)
+
+  defp take_lock(deps, attempts_left) do
     with {:ok, version} <- read_version(deps),
          {:ok, owner} <- read_lock_key(deps, SystemKeys.distributor_lock_owner(), version),
          {:ok, write} <- read_lock_key(deps, SystemKeys.distributor_lock_write(), version) do
@@ -82,7 +109,7 @@ defmodule Bedrock.ControlPlane.Distributor.Transactions do
 
       case commit_fenced(deps, version, mutations) do
         :ok -> {:ok, lock}
-        {:error, :aborted} -> {:error, :superseded}
+        {:error, :aborted} when attempts_left > 1 -> take_lock(deps, attempts_left - 1)
         {:error, reason} -> {:error, {:lock_commit_failed, reason}}
       end
     end

--- a/lib/bedrock/control_plane/distributor/transactions.ex
+++ b/lib/bedrock/control_plane/distributor/transactions.ex
@@ -1,0 +1,139 @@
+defmodule Bedrock.ControlPlane.Distributor.Transactions do
+  @moduledoc """
+  The distributor's fenced system transactions.
+
+  Every mutating commit is built the FDB way: read the lock state at a
+  pinned version, evaluate the `Lock` fence, and commit the fence's
+  mutations WITH read conflicts on the lock keys at that version — so a
+  concurrent take conflicts with this commit inside the pipeline itself.
+  A commit abort is therefore an authoritative supersession verdict (the
+  replacement for phase-a's director-side delta rejection); transient
+  read/commit failures are surfaced as themselves and are not verdicts.
+
+  Reads resolve through the same channel clients use: a commit proxy's
+  covering entry names the system-shard materializer, and the versioned
+  read happens there. The keyspace is the channel, for the distributor
+  too.
+  """
+
+  alias Bedrock.ControlPlane.Distributor.Lock
+  alias Bedrock.DataPlane.CommitProxy
+  alias Bedrock.DataPlane.Materializer
+  alias Bedrock.DataPlane.Sequencer
+  alias Bedrock.Internal.TransactionBuilder.Tx
+  alias Bedrock.SystemKeys
+
+  @typedoc """
+  The injectable dependency set. `deps_for/4` builds the production
+  wiring; tests script the three seams directly.
+  """
+  @type deps :: %{
+          required(:epoch) => Bedrock.epoch(),
+          required(:proxies) => [CommitProxy.ref()],
+          required(:next_read_version_fn) => (-> {:ok, Bedrock.version()} | {:error, term()}),
+          required(:get_fn) => (Bedrock.key(), Bedrock.version() ->
+                                  {:ok, binary()} | {:error, :not_found | term()} | {:failure, term(), term()}),
+          required(:commit_fn) => (CommitProxy.ref(), Bedrock.epoch(), binary(), keyword() ->
+                                     {:ok, Bedrock.version(), non_neg_integer()} | {:error, term()})
+        }
+
+  @doc """
+  Production dependencies: read versions from the epoch's sequencer,
+  reads resolved by-key through a commit proxy to the covering
+  materializer, commits through a random proxy.
+  """
+  @spec deps_for(module(), Bedrock.epoch(), Sequencer.ref(), [CommitProxy.ref()]) :: deps()
+  def deps_for(cluster, epoch, sequencer, proxies) do
+    %{
+      epoch: epoch,
+      proxies: proxies,
+      next_read_version_fn: fn -> Sequencer.next_read_version(sequencer, epoch) end,
+      get_fn: fn key, version ->
+        with {:ok, {_start, _end, _tag, {worker_id, node}}} <-
+               CommitProxy.fetch_routing(Enum.random(proxies), key) do
+          # The documented exception to no-atoms-on-decode: system-mode-
+          # gated writers, count bounded by cluster membership.
+          # credo:disable-for-next-line Credo.Check.Warning.UnsafeToAtom
+          Materializer.get({cluster.otp_name_for_worker(worker_id), String.to_atom(node)}, key, version)
+        end
+      end,
+      commit_fn: fn proxy, commit_epoch, encoded, opts ->
+        CommitProxy.commit(proxy, commit_epoch, encoded, opts)
+      end
+    }
+  end
+
+  @doc """
+  Takes the distributor lock: reads both lock keys at a pinned version
+  (FDB's take reads both — the remembered write UID is the
+  unobserved-take evidence), claims the owner key, and commits with read
+  conflicts on both keys at that version. `{:error, :superseded}` means
+  a newer owner won the race (commit abort); other errors are transient.
+  """
+  @spec take_lock(deps()) ::
+          {:ok, Lock.t()}
+          | {:error, :superseded}
+          | {:error, {:read_version_failed | :lock_read_failed | :lock_commit_failed, term()}}
+  def take_lock(deps) do
+    with {:ok, version} <- read_version(deps),
+         {:ok, owner} <- read_lock_key(deps, SystemKeys.distributor_lock_owner(), version),
+         {:ok, write} <- read_lock_key(deps, SystemKeys.distributor_lock_write(), version) do
+      {lock, mutations} = Lock.take(owner, write)
+
+      case commit_fenced(deps, version, mutations) do
+        :ok -> {:ok, lock}
+        {:error, :aborted} -> {:error, :superseded}
+        {:error, reason} -> {:error, {:lock_commit_failed, reason}}
+      end
+    end
+  end
+
+  @doc """
+  The read-only poll-to-die verdict: reads both lock keys at a fresh
+  version and mirrors `Lock.poll/3`. A failed read is `:unavailable` —
+  not a verdict; the poll loop simply tries again on its next tick.
+  """
+  @spec poll_verdict(Lock.t(), deps()) :: :ok | :superseded | :unavailable
+  def poll_verdict(lock, deps) do
+    with {:ok, version} <- read_version(deps),
+         {:ok, owner} <- read_lock_key(deps, SystemKeys.distributor_lock_owner(), version),
+         {:ok, write} <- read_lock_key(deps, SystemKeys.distributor_lock_write(), version) do
+      Lock.poll(lock, owner, write)
+    else
+      _transient -> :unavailable
+    end
+  end
+
+  defp read_version(%{next_read_version_fn: next_read_version_fn}) do
+    case next_read_version_fn.() do
+      {:ok, version} -> {:ok, version}
+      {:error, reason} -> {:error, {:read_version_failed, reason}}
+    end
+  end
+
+  # An absent key is protocol-meaningful nil (fresh cluster / stomped
+  # lock) and is passed through UNDECODED — see Lock.check/3's runner
+  # obligations.
+  defp read_lock_key(%{get_fn: get_fn}, key, version) do
+    case get_fn.(key, version) do
+      {:ok, value} -> {:ok, value}
+      {:error, :not_found} -> {:ok, nil}
+      {:error, reason} -> {:error, {:lock_read_failed, reason}}
+      {:failure, reason, _ref} -> {:error, {:lock_read_failed, reason}}
+    end
+  end
+
+  defp commit_fenced(%{proxies: proxies, epoch: epoch, commit_fn: commit_fn}, version, mutations) do
+    encoded =
+      Tx.new()
+      |> Tx.add_read_conflict_key(SystemKeys.distributor_lock_owner())
+      |> Tx.add_read_conflict_key(SystemKeys.distributor_lock_write())
+      |> then(&Enum.reduce(mutations, &1, fn {:set, key, value}, tx -> Tx.set(tx, key, value) end))
+      |> Tx.commit(version)
+
+    case commit_fn.(Enum.random(proxies), epoch, encoded, mode: :system) do
+      {:ok, _commit_version, _sequence} -> :ok
+      {:error, reason} -> {:error, reason}
+    end
+  end
+end

--- a/lib/bedrock/data_plane/commit_proxy.ex
+++ b/lib/bedrock/data_plane/commit_proxy.ex
@@ -105,15 +105,17 @@ defmodule Bedrock.DataPlane.CommitProxy do
           commit_proxy_ref :: ref(),
           epoch :: Bedrock.epoch(),
           transaction :: Transaction.encoded(),
-          opts :: [mode: :user | :system]
+          opts :: [mode: :user | :system, timeout_in_ms: Bedrock.timeout_in_ms()]
         ) ::
           {:ok, version :: Bedrock.version(), index :: non_neg_integer()}
           | {:error, :wrong_epoch | :locked | :aborted | :timeout | :unavailable}
           | {:error, {:key_out_of_range, Bedrock.key()}}
           | {:error, :invalid_transaction}
   def commit(commit_proxy, epoch, transaction, opts \\ []) do
+    timeout = Keyword.get(opts, :timeout_in_ms, :infinity)
+
     case Keyword.get(opts, :mode, :user) do
-      mode when mode in [:user, :system] -> call(commit_proxy, {:commit, epoch, transaction, mode}, :infinity)
+      mode when mode in [:user, :system] -> call(commit_proxy, {:commit, epoch, transaction, mode}, timeout)
       other -> raise ArgumentError, "invalid commit mode: #{inspect(other)}"
     end
   end

--- a/test/bedrock/control_plane/director/distributor_recruitment_test.exs
+++ b/test/bedrock/control_plane/director/distributor_recruitment_test.exs
@@ -1,0 +1,119 @@
+defmodule Bedrock.ControlPlane.Director.DistributorRecruitmentTest do
+  @moduledoc """
+  The director recruits the per-epoch Distributor singleton after
+  recovery accepts commits (FDB: CC recruits DD post-recovery), and
+  supervises by monitor: ceded exits are final for the epoch; failures
+  retry. The lock — not this supervision — fences a stale instance.
+  """
+  use ExUnit.Case, async: true
+
+  alias Bedrock.ControlPlane.Director.Recovery
+  alias Bedrock.ControlPlane.Director.State
+
+  defp running_state(overrides) do
+    struct!(
+      %State{
+        state: :running,
+        epoch: 5,
+        cluster: __MODULE__,
+        config: %{},
+        transaction_system_layout: %{
+          epoch: 5,
+          sequencer: self(),
+          proxies: [self()],
+          resolvers: [],
+          logs: %{}
+        },
+        distributor_retry_ms: 10
+      },
+      overrides
+    )
+  end
+
+  describe "maybe_start_distributor/1" do
+    test "recruits once the transaction system is running, and monitors" do
+      stub = spawn(fn -> Process.sleep(:infinity) end)
+      t = running_state(distributor_start_fn: fn _opts -> {:ok, stub} end)
+
+      t = Recovery.maybe_start_distributor(t)
+
+      assert t.distributor == stub
+      assert is_reference(t.distributor_monitor)
+    end
+
+    test "hands the distributor the epoch's wiring" do
+      test_pid = self()
+      stub = spawn(fn -> Process.sleep(:infinity) end)
+
+      t =
+        running_state(
+          distributor_start_fn: fn opts ->
+            send(test_pid, {:started_with, opts})
+            {:ok, stub}
+          end
+        )
+
+      Recovery.maybe_start_distributor(t)
+
+      assert_received {:started_with, opts}
+      assert opts[:epoch] == 5
+      assert opts[:proxies] == [self()]
+      assert opts[:director] == self()
+    end
+
+    test "leaves an existing distributor alone" do
+      existing = spawn(fn -> Process.sleep(:infinity) end)
+
+      t =
+        running_state(
+          distributor: existing,
+          distributor_start_fn: fn _ -> flunk("must not start a second distributor") end
+        )
+
+      assert Recovery.maybe_start_distributor(t).distributor == existing
+    end
+
+    test "does not recruit before the system is running" do
+      t =
+        running_state(
+          state: :recovering,
+          distributor_start_fn: fn _ -> flunk("must not recruit mid-recovery") end
+        )
+
+      assert Recovery.maybe_start_distributor(t).distributor == nil
+    end
+
+    test "a failed start schedules a retry" do
+      t = running_state(distributor_start_fn: fn _ -> {:error, :nope} end)
+
+      log =
+        ExUnit.CaptureLog.capture_log(fn ->
+          assert Recovery.maybe_start_distributor(t).distributor == nil
+          assert_receive {:timeout, :start_distributor}, 200
+        end)
+
+      assert log =~ "Distributor start failed"
+    end
+  end
+
+  describe "handle_distributor_down/2" do
+    test "a ceded (:normal) exit is final for the epoch — no re-recruit" do
+      t = running_state(distributor: self(), distributor_monitor: make_ref())
+
+      t = Recovery.handle_distributor_down(t, :normal)
+
+      assert t.distributor == nil
+      assert t.distributor_monitor == nil
+      refute_receive {:timeout, :start_distributor}, 50
+    end
+
+    test "a failure schedules a re-recruit — the director itself survives" do
+      t = running_state(distributor: self(), distributor_monitor: make_ref())
+
+      t = Recovery.handle_distributor_down(t, {:shutdown, {:lock_take_failed, :whatever}})
+
+      assert t.distributor == nil
+      assert_receive {:timeout, :start_distributor}, 200
+    end
+  end
+end

--- a/test/bedrock/control_plane/distributor/server_test.exs
+++ b/test/bedrock/control_plane/distributor/server_test.exs
@@ -1,0 +1,110 @@
+defmodule Bedrock.ControlPlane.Distributor.ServerTest do
+  @moduledoc """
+  The per-epoch distributor singleton: lock first, everything else
+  second; a superseded lock cedes (:normal, no re-recruit); transient
+  failures stop :shutdown so the director's retry recruits afresh; the
+  poll-to-die loop evaluates the fence read-only; the singleton dies
+  with its director.
+  """
+  use ExUnit.Case, async: true
+
+  alias Bedrock.ControlPlane.Distributor.Lock
+  alias Bedrock.ControlPlane.Distributor.Server
+  alias Bedrock.ControlPlane.Distributor.State
+  alias Bedrock.DataPlane.Version
+
+  defp scripted_deps(overrides) do
+    Map.merge(
+      %{
+        epoch: 3,
+        proxies: [:proxy],
+        next_read_version_fn: fn -> {:ok, Version.from_integer(1)} end,
+        get_fn: fn _key, _version -> {:error, :not_found} end,
+        commit_fn: fn _proxy, _epoch, _encoded, _opts -> {:ok, Version.from_integer(2), 0} end
+      },
+      overrides
+    )
+  end
+
+  defp state(deps_overrides, state_overrides \\ []) do
+    director = Keyword.get(state_overrides, :director, self())
+
+    struct!(
+      %State{
+        cluster: __MODULE__,
+        epoch: 3,
+        director: director,
+        director_monitor: Keyword.get(state_overrides, :director_monitor, make_ref()),
+        deps: scripted_deps(deps_overrides),
+        poll_interval_ms: 5
+      },
+      state_overrides
+    )
+  end
+
+  describe "taking the lock at startup" do
+    test "success installs the lock and arms the poll" do
+      assert {:noreply, %State{lock: %Lock{}} = t} = Server.handle_continue(:take_lock, state(%{}))
+      assert_receive :poll_lock, 100
+      assert t.lock.prev_owner == nil
+    end
+
+    test "a commit abort cedes — a newer owner won the race" do
+      deps = %{commit_fn: fn _p, _e, _t, _o -> {:error, :aborted} end}
+
+      assert {:stop, :normal, _t} = Server.handle_continue(:take_lock, state(deps))
+    end
+
+    test "a transient failure stops :shutdown so the director retries" do
+      deps = %{get_fn: fn _k, _v -> {:failure, :unavailable, :ref} end}
+
+      assert {:stop, {:shutdown, {:lock_take_failed, {:lock_read_failed, :unavailable}}}, _t} =
+               Server.handle_continue(:take_lock, state(deps))
+    end
+  end
+
+  describe "the poll-to-die loop" do
+    test "a superseding owner cedes" do
+      {lock, _} = Lock.take(nil, nil)
+      usurper = Lock.new_uid()
+
+      t = state(%{get_fn: fn _k, _v -> {:ok, usurper} end}, lock: lock)
+
+      assert {:stop, :normal, _t} = Server.handle_info(:poll_lock, t)
+    end
+
+    test "a healthy fence re-arms" do
+      {lock, _} = Lock.take(nil, nil)
+
+      t =
+        state(
+          %{
+            get_fn: fn key, _v ->
+              if String.ends_with?(key, "owner"), do: {:ok, lock.my_owner}, else: {:error, :not_found}
+            end
+          },
+          lock: lock
+        )
+
+      assert {:noreply, _t} = Server.handle_info(:poll_lock, t)
+      assert_receive :poll_lock, 100
+    end
+
+    test "an unavailable read is not a verdict — re-arm and retry" do
+      {lock, _} = Lock.take(nil, nil)
+      t = state(%{get_fn: fn _k, _v -> {:failure, :timeout, :ref} end}, lock: lock)
+
+      assert {:noreply, _t} = Server.handle_info(:poll_lock, t)
+      assert_receive :poll_lock, 100
+    end
+  end
+
+  describe "the singleton dies with its epoch" do
+    test "director DOWN cedes" do
+      ref = make_ref()
+      t = state(%{}, director_monitor: ref)
+
+      assert {:stop, :normal, _t} = Server.handle_info({:DOWN, ref, :process, self(), :shutdown}, t)
+    end
+  end
+end

--- a/test/bedrock/control_plane/distributor/server_test.exs
+++ b/test/bedrock/control_plane/distributor/server_test.exs
@@ -49,10 +49,11 @@ defmodule Bedrock.ControlPlane.Distributor.ServerTest do
       assert t.lock.prev_owner == nil
     end
 
-    test "a commit abort cedes — a newer owner won the race" do
+    test "exhausted take aborts stop :shutdown — the director recruits again; supersession is the poll's to deliver" do
       deps = %{commit_fn: fn _p, _e, _t, _o -> {:error, :aborted} end}
 
-      assert {:stop, :normal, _t} = Server.handle_continue(:take_lock, state(deps))
+      assert {:stop, {:shutdown, {:lock_take_failed, {:lock_commit_failed, :aborted}}}, _t} =
+               Server.handle_continue(:take_lock, state(deps))
     end
 
     test "a transient failure stops :shutdown so the director retries" do

--- a/test/bedrock/control_plane/distributor/transactions_test.exs
+++ b/test/bedrock/control_plane/distributor/transactions_test.exs
@@ -1,0 +1,131 @@
+defmodule Bedrock.ControlPlane.Distributor.TransactionsTest do
+  @moduledoc """
+  The distributor's fenced system transactions. Every mutating commit
+  carries read conflicts on the lock keys at the version the fence was
+  evaluated, so a concurrent take conflicts with it — ownership enforced
+  by the commit pipeline, not by supervision.
+  """
+  use ExUnit.Case, async: true
+
+  alias Bedrock.ControlPlane.Distributor.Lock
+  alias Bedrock.ControlPlane.Distributor.Transactions
+  alias Bedrock.DataPlane.Transaction
+  alias Bedrock.DataPlane.Version
+  alias Bedrock.SystemKeys
+
+  defp deps(overrides) do
+    v = Version.from_integer(100)
+
+    Map.merge(
+      %{
+        epoch: 7,
+        proxies: [:proxy_a],
+        next_read_version_fn: fn -> {:ok, v} end,
+        get_fn: fn _key, _version -> {:error, :not_found} end,
+        commit_fn: fn _proxy, _epoch, _encoded, _opts -> {:ok, v, 0} end
+      },
+      overrides
+    )
+  end
+
+  describe "take_lock/1" do
+    test "reads both keys, claims the owner, and fences the commit with read conflicts at the read version" do
+      test_pid = self()
+      v = Version.from_integer(42)
+
+      deps =
+        deps(%{
+          next_read_version_fn: fn -> {:ok, v} end,
+          get_fn: fn key, version ->
+            send(test_pid, {:read, key, version})
+            {:error, :not_found}
+          end,
+          commit_fn: fn proxy, epoch, encoded, opts ->
+            send(test_pid, {:committed, proxy, epoch, encoded, opts})
+            {:ok, v, 0}
+          end
+        })
+
+      assert {:ok, %Lock{prev_owner: nil, prev_write: nil} = lock} = Transactions.take_lock(deps)
+
+      owner_key = SystemKeys.distributor_lock_owner()
+      write_key = SystemKeys.distributor_lock_write()
+
+      # FDB's takeMoveKeysLock reads BOTH keys (the remembered write is
+      # the unobserved-take evidence), at the fence's read version.
+      assert_received {:read, ^owner_key, ^v}
+      assert_received {:read, ^write_key, ^v}
+
+      assert_received {:committed, :proxy_a, 7, encoded, opts}
+      assert Keyword.get(opts, :mode) == :system
+
+      # The claim itself.
+      assert {:ok, mutations} = Transaction.mutations(encoded)
+      assert Enum.to_list(mutations) == [{:set, owner_key, lock.my_owner}]
+
+      # The fence: read conflicts on both lock keys, so any interleaved
+      # take/check conflicts with this commit.
+      assert {:ok, {read_version, conflict_ranges}} = Transaction.read_conflicts(encoded)
+      assert read_version == v
+      covered = fn key -> Enum.any?(conflict_ranges, fn {s, e} -> key >= s and key < e end) end
+      assert covered.(owner_key)
+      assert covered.(write_key)
+    end
+
+    test "an existing owner's UIDs are remembered as the previous state" do
+      prev_owner = Lock.new_uid()
+      prev_write = Lock.new_uid()
+
+      deps =
+        deps(%{
+          get_fn: fn key, _version ->
+            cond do
+              key == SystemKeys.distributor_lock_owner() -> {:ok, prev_owner}
+              key == SystemKeys.distributor_lock_write() -> {:ok, prev_write}
+            end
+          end
+        })
+
+      assert {:ok, %Lock{prev_owner: ^prev_owner, prev_write: ^prev_write}} = Transactions.take_lock(deps)
+    end
+
+    test "a commit abort is supersession — a newer owner won the race" do
+      deps = deps(%{commit_fn: fn _proxy, _epoch, _encoded, _opts -> {:error, :aborted} end})
+
+      assert {:error, :superseded} = Transactions.take_lock(deps)
+    end
+
+    test "read and commit failures surface as themselves — transient, not verdicts" do
+      assert {:error, {:lock_read_failed, :unavailable}} =
+               Transactions.take_lock(deps(%{get_fn: fn _k, _v -> {:failure, :unavailable, :ref} end}))
+
+      assert {:error, {:lock_commit_failed, :timeout}} =
+               Transactions.take_lock(deps(%{commit_fn: fn _p, _e, _t, _o -> {:error, :timeout} end}))
+
+      assert {:error, {:read_version_failed, :unavailable}} =
+               Transactions.take_lock(deps(%{next_read_version_fn: fn -> {:error, :unavailable} end}))
+    end
+  end
+
+  describe "poll_verdict/2" do
+    test "reads both keys read-only and mirrors the Lock verdict" do
+      {lock, _mutations} = Lock.take(nil, nil)
+
+      assert Transactions.poll_verdict(lock, deps(%{get_fn: fn _k, _v -> {:error, :not_found} end})) == :ok
+
+      usurper = Lock.new_uid()
+
+      assert Transactions.poll_verdict(
+               lock,
+               deps(%{get_fn: fn _k, _v -> {:ok, usurper} end})
+             ) == :superseded
+    end
+
+    test "a failed poll read is not a verdict — retry on the next tick" do
+      {lock, _mutations} = Lock.take(nil, nil)
+
+      assert Transactions.poll_verdict(lock, deps(%{get_fn: fn _k, _v -> {:failure, :timeout, :ref} end})) ==
+               :unavailable
+    end
+  end
+end

--- a/test/bedrock/control_plane/distributor/transactions_test.exs
+++ b/test/bedrock/control_plane/distributor/transactions_test.exs
@@ -89,10 +89,56 @@ defmodule Bedrock.ControlPlane.Distributor.TransactionsTest do
       assert {:ok, %Lock{prev_owner: ^prev_owner, prev_write: ^prev_write}} = Transactions.take_lock(deps)
     end
 
-    test "a commit abort is supersession — a newer owner won the race" do
+    test "a commit abort re-takes with a fresh read version — take is last-take-wins, not a verdict" do
+      # An abort at take time can be a genuine race OR the read version
+      # falling below the resolver's pruning floor; only the CHECK fence
+      # and the poll deliver supersession. FDB's takeMoveKeysLock
+      # retries the same way.
+      test_pid = self()
+      counter = :counters.new(1, [])
+      winner = Lock.new_uid()
+
+      deps =
+        deps(%{
+          get_fn: fn key, _version ->
+            # The re-take observes the interleaved winner as previous.
+            if :counters.get(counter, 1) > 0 and String.ends_with?(key, "owner"),
+              do: {:ok, winner},
+              else: {:error, :not_found}
+          end,
+          commit_fn: fn _proxy, _epoch, encoded, _opts ->
+            send(test_pid, {:commit_attempt, encoded})
+
+            if :counters.get(counter, 1) == 0 do
+              :counters.add(counter, 1, 1)
+              {:error, :aborted}
+            else
+              {:ok, Version.from_integer(9), 0}
+            end
+          end
+        })
+
+      assert {:ok, %Lock{prev_owner: ^winner}} = Transactions.take_lock(deps)
+      assert_received {:commit_attempt, _first}
+      assert_received {:commit_attempt, _second}
+    end
+
+    test "exhausted take retries surface as a transient commit failure — the director recruits again" do
       deps = deps(%{commit_fn: fn _proxy, _epoch, _encoded, _opts -> {:error, :aborted} end})
 
-      assert {:error, :superseded} = Transactions.take_lock(deps)
+      assert {:error, {:lock_commit_failed, :aborted}} = Transactions.take_lock(deps)
+    end
+
+    test "a catching-up materializer's waitlist expiry is a transient read failure" do
+      deps = deps(%{get_fn: fn _k, _v -> {:error, :waiting_timeout} end})
+
+      assert {:error, {:lock_read_failed, :waiting_timeout}} = Transactions.take_lock(deps)
+    end
+
+    test "an unroutable system key is a read failure, never key-absence" do
+      deps = deps(%{get_fn: fn key, _v -> {:error, {:unroutable_system_key, key}} end})
+
+      assert {:error, {:lock_read_failed, {:unroutable_system_key, _key}}} = Transactions.take_lock(deps)
     end
 
     test "read and commit failures surface as themselves — transient, not verdicts" do


### PR DESCRIPTION
## Why

Phase 3 (first half) of the settled bedrock-q67.21 course. Before the distributor can sweep, publish placeholders, or heal, it must exist and own the fence — and FDB's DD startup order is deliberate: **lock first, snapshot second, work third**. This PR delivers exactly the singleton lifecycle and lock ownership; the placeholder and sweep publication follow as part 2.

## What

- **`Distributor.Transactions`** — the fenced-commit runner. `take_lock/1` reads both lock keys at a pinned sequencer version, claims the owner key, and commits `mode: :system` with **read conflicts on both keys at that version**: a concurrent take conflicts inside the commit pipeline itself. A commit abort is the authoritative supersession verdict — the structural replacement for phase-a's director-side delta rejection. Reads resolve the way clients do (proxy covering entry → system materializer; the keyspace is the channel for the distributor too), and both Lock runner obligations from the #186 audit are honored: absent keys pass through as protocol-meaningful nil, undecoded. `poll_verdict/2` is the read-only mirror; failed reads are `:unavailable`, never verdicts.
- **`Distributor.Server`** — unlinked + monitored per-epoch singleton: fenced take at startup (superseded → cede `:normal`; transient → `:shutdown` for the director's retry), the 5s poll-to-die loop (`MOVEKEYS_LOCK_POLLING_DELAY`), and death-with-director.
- **Director** — recruits after recovery accepts commits, with a **dedicated monitor clause preceding the epoch-fatal component-failure catch-all**: the distributor is the one monitored process whose death does not kill the epoch. Ceded exits are final; failures re-recruit on a timer. Injectable `distributor_start_fn` seam.

## How

TDD: the fenced-commit content is pinned (exact mutation set, conflict coverage of both keys, the read version, `mode: :system`), supersession-vs-transient classification, the server's verdict matrix, and the recruitment/ceded/retry behaviors from the phase-a spec.

Full suite (2635 tests), credo --strict, dialyzer green.