### PR TITLE
Distributor placeholder + startup sweep: coverage gaps become keyspace-visible

### DIFF
--- a/lib/bedrock/control_plane/director/recovery/materializer_bootstrap_phase.ex
+++ b/lib/bedrock/control_plane/director/recovery/materializer_bootstrap_phase.ex
@@ -37,7 +37,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhase do
   alias Bedrock.DataPlane.ShardRouter
   alias Bedrock.Service.Foreman
   alias Bedrock.Service.Worker
-  alias Bedrock.SystemKeys.Values
+  alias Bedrock.SystemKeys.Reader
 
   require Logger
 
@@ -419,27 +419,16 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhase do
       Materializer.get_range(materializer_pid, start_key, range_end, read_version, limit: 1000)
     end
 
-    with {:ok, entries} <- page_entries(range_read_fn, prefix, :prior_refs_query_failed, []) do
+    with {:ok, entries} <- Reader.read_family(range_read_fn, prefix, :prior_refs_query_failed) do
       decode_prior_refs(entries)
     end
   end
 
   @doc false
-  # Public for tests: the default in-recovery reader is injected away in
-  # unit tests, so the decode contract is pinned directly.
   @spec decode_prior_refs([{Bedrock.key(), binary()}]) ::
           {:ok, %{Bedrock.range_tag() => {Worker.id(), String.t()}}}
           | {:error, {:invalid_materializer_entry, Bedrock.key()}}
-  def decode_prior_refs(entries) do
-    Enum.reduce_while(entries, {:ok, %{}}, fn {key, value}, {:ok, acc} ->
-      with {:materializer_key, tag} <- Bedrock.SystemKeys.parse_key(key),
-           {:ok, ref} <- Values.decode_materializer_ref(value) do
-        {:cont, {:ok, Map.put(acc, tag, ref)}}
-      else
-        _ -> {:halt, {:error, {:invalid_materializer_entry, key}}}
-      end
-    end)
-  end
+  defdelegate decode_prior_refs(entries), to: Reader, as: :decode_materializer_refs
 
   # Find a node that can host materializers
   defp find_materializer_capable_node(%{node_capabilities: caps}) do
@@ -596,115 +585,16 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhase do
   end
 
   @doc false
-  # Pages a system-family range read to exhaustion, resuming each page
-  # immediately after the last returned key. Any failure mid-continuation
-  # fails the whole read: partial success would BE the silent truncation
-  # this exists to preclude. An empty page claiming more is a broken read
-  # contract and is surfaced as an error rather than looped on.
-  @spec read_all_shard_entries((Bedrock.key() ->
-                                  {:ok, {[{Bedrock.key(), binary()}], more :: boolean()}}
-                                  | {:error, term()}
-                                  | {:failure, term(), term()})) ::
+  # Delegates to the shared reader (Bedrock.SystemKeys.Reader): one
+  # pager, one decode home, so recovery and the Distributor cannot
+  # disagree about the families.
+  @spec read_all_shard_entries(Reader.range_read_fn()) ::
           {:ok, [{Bedrock.key(), binary()}]} | {:error, {:shard_layout_query_failed, term()}}
   def read_all_shard_entries(range_read_fn),
-    do: page_entries(range_read_fn, Bedrock.SystemKeys.shard_keys_prefix(), :shard_layout_query_failed, [])
-
-  defp page_entries(range_read_fn, start_key, error_tag, pages) do
-    case range_read_fn.(start_key) do
-      {:ok, {entries, false}} ->
-        {:ok, [entries | pages] |> Enum.reverse() |> Enum.concat()}
-
-      {:ok, {[], true}} ->
-        {:error, {error_tag, :empty_continuation_page}}
-
-      {:ok, {entries, true}} ->
-        {last_key, _value} = List.last(entries)
-        page_entries(range_read_fn, Bedrock.Key.key_after(last_key), error_tag, [entries | pages])
-
-      {:error, reason} ->
-        {:error, {error_tag, reason}}
-
-      {:failure, reason, _ref} ->
-        {:error, {error_tag, reason}}
-    end
-  end
+    do: Reader.read_family(range_read_fn, Bedrock.SystemKeys.shard_keys_prefix(), :shard_layout_query_failed)
 
   @doc false
-  # Key format: \xff/system/shard_keys/<end_key>; value: {tag, start_key}
-  # (see Bedrock.SystemKeys.Values). The value CARRIES the start key and
-  # this reader consumes it — the same meaning RoutingData.apply_mutation
-  # gives it; two readers of one family must not disagree about what the
-  # value means. Adjacency reconstruction (each shard starts where the
-  # previous ends) survives only for legacy term_to_binary snapshots
-  # that predate carried start keys. Recovery no longer rewrites the
-  # family (read-and-heal, bedrock-q67.21.2), so a legacy family stays
-  # legacy — encoding-uniform, which the any-legacy-falls-back-whole
-  # rule covers — until bedrock-q67.20.7 retires the fallback with an
-  # explicit one-time migration.
   @spec shard_layout_from_entries([{Bedrock.key(), binary()}]) ::
           {:ok, RecoveryAttempt.shard_layout()} | {:error, {:invalid_shard_value, Bedrock.key()}}
-  def shard_layout_from_entries(entries) do
-    entries
-    |> Enum.reduce_while({:ok, []}, fn {key, value}, {:ok, acc} ->
-      case decode_shard_entry(value) do
-        {:ok, decoded} -> {:cont, {:ok, [{extract_end_key_from_shard_key(key), decoded} | acc]}}
-        {:error, _} -> {:halt, {:error, {:invalid_shard_value, key}}}
-      end
-    end)
-    |> case do
-      {:ok, decoded_by_end_key} -> {:ok, build_shard_layout(decoded_by_end_key)}
-      error -> error
-    end
-  end
-
-  defp build_shard_layout(decoded_by_end_key) do
-    if Enum.any?(decoded_by_end_key, &match?({_end_key, {:legacy, _tag}}, &1)) do
-      rebuild_start_keys_by_adjacency(decoded_by_end_key)
-    else
-      Map.new(decoded_by_end_key, fn {end_key, {tag, start_key}} -> {end_key, {tag, start_key}} end)
-    end
-  end
-
-  defp rebuild_start_keys_by_adjacency(decoded_by_end_key) do
-    decoded_by_end_key
-    |> Enum.sort_by(fn {end_key, _decoded} -> end_key end)
-    |> Enum.map_reduce(<<>>, fn {end_key, decoded}, start_key ->
-      tag =
-        case decoded do
-          {:legacy, tag} -> tag
-          {tag, _carried_start} -> tag
-        end
-
-      {{end_key, {tag, start_key}}, end_key}
-    end)
-    |> elem(0)
-    |> Map.new()
-  end
-
-  defp extract_end_key_from_shard_key(key) do
-    prefix = Bedrock.SystemKeys.shard_keys_prefix()
-    prefix_len = byte_size(prefix)
-    binary_part(key, prefix_len, byte_size(key) - prefix_len)
-  end
-
-  defp decode_shard_entry(value) do
-    case Values.decode_shard_key_entry(value) do
-      {:ok, {tag, start_key}} -> {:ok, {tag, start_key}}
-      {:error, _} -> decode_legacy_shard_tag(value)
-    end
-  end
-
-  # Clusters created before Bedrock.SystemKeys.Values wrote shard_key
-  # values with term_to_binary. Recovery no longer rewrites the family,
-  # so these values persist AS-IS until bedrock-q67.20.7's explicit
-  # migration retires them along with this fallback.
-  defp decode_legacy_shard_tag(value) do
-    case :erlang.binary_to_term(value, [:safe]) do
-      tag when is_integer(tag) -> {:ok, {:legacy, tag}}
-      {tag, _start_key} when is_integer(tag) -> {:ok, {:legacy, tag}}
-      _ -> {:error, :invalid_encoding}
-    end
-  rescue
-    ArgumentError -> {:error, :invalid_encoding}
-  end
+  defdelegate shard_layout_from_entries(entries), to: Reader
 end

--- a/lib/bedrock/control_plane/distributor/placeholder.ex
+++ b/lib/bedrock/control_plane/distributor/placeholder.ex
@@ -1,0 +1,65 @@
+defmodule Bedrock.ControlPlane.Distributor.Placeholder do
+  @moduledoc """
+  The coverage placeholder: a process that speaks the materializer read
+  API and parks reads for uncovered shard tags, bounded by
+  `min(caller timeout, hold_ms)`, shedding `{:error, :unavailable}` —
+  which clients already classify as retryable — when coverage does not
+  arrive in time.
+
+  Addressing is the settled option 2 (bedrock-q67.21): the placeholder
+  IS a materializer ref. The distributor publishes
+  `materializers/<tag> = {placeholder_worker_id, distributor_node}` for
+  uncovered tags, and the placeholder registers under
+  `cluster.otp_name_for_worker(placeholder_worker_id)` — so proxies and
+  clients need no special case at all; coverage gaps are visible in the
+  keyspace like any other assignment. A corollary: a restarted
+  placeholder re-registers the same name on the same node, so restarts
+  need no republication.
+
+  When the distributor delivers `{:covered, tag, ref}` the tag's parked
+  requests drain by re-issue; `{:coverage_failed, tag, reason}` sheds.
+  """
+
+  use Bedrock.Internal.GenServerApi, for: __MODULE__.Server
+
+  @type ref :: pid() | atom() | {atom(), node()}
+
+  @default_hold_ms 2_000
+
+  # The stable worker id the keyspace names for uncovered tags. Worker
+  # OTP names are deterministic in the id, so the callable ref is
+  # derivable everywhere from the committed {worker_id, node} pair.
+  @worker_id "distributor-placeholder"
+
+  @doc "The reserved worker id placeholder entries carry in the keyspace."
+  @spec worker_id() :: String.t()
+  def worker_id, do: @worker_id
+
+  @doc "The default maximum time a request may be parked awaiting coverage."
+  @spec default_hold_ms() :: pos_integer()
+  def default_hold_ms, do: @default_hold_ms
+
+  @doc """
+  Notifies the placeholder that a shard tag is now covered by a live
+  materializer. Parked requests for the tag are drained by re-issuing
+  them against the materializer; subsequent requests forward to it.
+  """
+  @spec notify_covered(ref(), Bedrock.range_tag(), materializer :: ref()) :: :ok
+  def notify_covered(placeholder, tag, materializer), do: cast(placeholder, {:covered, tag, materializer})
+
+  @doc """
+  Notifies the placeholder that a shard tag's materializer has died and
+  the tag is uncovered again: subsequent requests park and re-demand
+  coverage instead of forwarding to the dead ref.
+  """
+  @spec notify_uncovered(ref(), Bedrock.range_tag()) :: :ok
+  def notify_uncovered(placeholder, tag), do: cast(placeholder, {:uncovered, tag})
+
+  @doc """
+  Notifies the placeholder that recruitment for a shard tag failed:
+  parked requests shed `{:error, :unavailable}` and the demand dedupe
+  clears so a later request re-triggers recruitment.
+  """
+  @spec notify_coverage_failed(ref(), Bedrock.range_tag(), reason :: term()) :: :ok
+  def notify_coverage_failed(placeholder, tag, reason), do: cast(placeholder, {:coverage_failed, tag, reason})
+end

--- a/lib/bedrock/control_plane/distributor/placeholder.ex
+++ b/lib/bedrock/control_plane/distributor/placeholder.ex
@@ -6,6 +6,17 @@ defmodule Bedrock.ControlPlane.Distributor.Placeholder do
   which clients already classify as retryable — when coverage does not
   arrive in time.
 
+  An honest note on what parking buys whom: the transaction builder
+  passes its fetch timeout (50ms) as the caller timeout, so for repo
+  traffic the effective park is ~50ms per attempt and the caller's own
+  clock usually expires first — the REPO's retry-with-backoff loop does
+  the actual waiting, and this process serves as a crash-absorbing,
+  demand-signaling stall (no noproc storms, gaps visible in the
+  keyspace, demand deduped per tag). The full `hold_ms` park is
+  reachable only by direct materializer callers with generous or absent
+  timeouts. Parked entries self-expire; replies to dead callers are
+  no-ops.
+
   Addressing is the settled option 2 (bedrock-q67.21): the placeholder
   IS a materializer ref. The distributor publishes
   `materializers/<tag> = {placeholder_worker_id, distributor_node}` for

--- a/lib/bedrock/control_plane/distributor/placeholder/server.ex
+++ b/lib/bedrock/control_plane/distributor/placeholder/server.ex
@@ -1,0 +1,193 @@
+defmodule Bedrock.ControlPlane.Distributor.Placeholder.Server do
+  @moduledoc """
+  GenServer implementation of the coverage placeholder.
+
+  Accepts the exact read-path call shapes real materializer servers
+  handle — `{:get, key_or_selector, version, opts}` and
+  `{:get_range, start, end, version, opts}` — and either forwards them
+  to a live materializer (when one is known for the shard tag) or parks
+  them in a deadline-bounded waiting list while signaling coverage
+  demand to the distributor.
+
+  Deadline expiry is timer-driven: every mutation of the waiting list
+  reschedules a `Process.send_after/3` for the earliest deadline, and
+  expired entries shed `{:error, :unavailable}` — retryable and
+  routing-invalidating at the client, which is exactly right for a key
+  whose coverage has not arrived.
+  """
+
+  use GenServer
+
+  import Bedrock.ControlPlane.Distributor.Telemetry,
+    only: [
+      emit_placeholder_parked: 2,
+      emit_placeholder_forwarded: 2,
+      emit_placeholder_shed: 4,
+      emit_placeholder_drained: 3
+    ]
+
+  import Bedrock.Internal.GenServer.Replies
+
+  alias Bedrock.ControlPlane.Distributor.Placeholder
+  alias Bedrock.ControlPlane.Distributor.Placeholder.State
+  alias Bedrock.DataPlane.Materializer
+  alias Bedrock.Internal.WaitingList
+  alias Bedrock.KeySelector
+
+  @doc false
+  @spec child_spec(
+          opts :: [
+            cluster: module(),
+            distributor: pid(),
+            shard_layout: %{Bedrock.key() => {Bedrock.range_tag(), Bedrock.key()}},
+            hold_ms: pos_integer(),
+            otp_name: atom()
+          ]
+        ) :: Supervisor.child_spec()
+  def child_spec(opts) do
+    cluster = opts[:cluster] || raise "Missing :cluster option"
+    distributor = opts[:distributor] || raise "Missing :distributor option"
+    shard_layout = opts[:shard_layout] || %{}
+    hold_ms = opts[:hold_ms] || Placeholder.default_hold_ms()
+
+    start_opts =
+      case opts[:otp_name] do
+        nil -> []
+        otp_name -> [name: otp_name]
+      end
+
+    %{
+      id: {__MODULE__, cluster},
+      start: {GenServer, :start_link, [__MODULE__, {cluster, distributor, shard_layout, hold_ms}, start_opts]},
+      restart: :temporary
+    }
+  end
+
+  @impl true
+  def init({cluster, distributor, shard_layout, hold_ms}) do
+    {:ok, %State{cluster: cluster, distributor: distributor, shard_layout: shard_layout, hold_ms: hold_ms}}
+  end
+
+  @impl true
+  def handle_call({:get, key_or_selector, _version, opts} = request, from, %State{} = t),
+    do: handle_read(t, racing_key(key_or_selector), request, opts, from)
+
+  def handle_call({:get_range, start_key_or_selector, _end, _version, opts} = request, from, %State{} = t),
+    do: handle_read(t, racing_key(start_key_or_selector), request, opts, from)
+
+  @impl true
+  def handle_cast({:covered, tag, materializer}, %State{} = t) do
+    {waiting, entries} = WaitingList.remove_all(t.waiting, tag)
+
+    Enum.each(entries, fn {_deadline, reply_fn, request} ->
+      {:ok, _pid} = Task.start(fn -> reply_fn.(reissue(materializer, request)) end)
+    end)
+
+    emit_placeholder_drained(t.cluster, tag, length(entries))
+
+    t = %{
+      t
+      | waiting: waiting,
+        covered: Map.put(t.covered, tag, materializer),
+        demanded: MapSet.delete(t.demanded, tag)
+    }
+
+    t |> reschedule_expiry() |> noreply()
+  end
+
+  def handle_cast({:uncovered, tag}, %State{} = t),
+    do: noreply(%{t | covered: Map.delete(t.covered, tag), demanded: MapSet.delete(t.demanded, tag)})
+
+  def handle_cast({:coverage_failed, tag, reason}, %State{} = t) do
+    {waiting, entries} = WaitingList.remove_all(t.waiting, tag)
+    WaitingList.reply_to_expired(entries, {:error, :unavailable})
+
+    emit_placeholder_shed(t.cluster, tag, length(entries), reason)
+
+    t = %{t | waiting: waiting, demanded: MapSet.delete(t.demanded, tag)}
+    t |> reschedule_expiry() |> noreply()
+  end
+
+  @impl true
+  def handle_info(:expire_waiting, %State{} = t) do
+    {waiting, expired} = WaitingList.expire(t.waiting)
+    WaitingList.reply_to_expired(expired, {:error, :unavailable})
+
+    if expired != [], do: emit_placeholder_shed(t.cluster, nil, length(expired), :deadline_expired)
+
+    # This message may be stale — a mutation since the timer fired may
+    # have re-armed `expiry_timer`. Rescheduling cancels rather than
+    # leaking a duplicate timer; expiry itself is idempotent.
+    %{t | waiting: waiting} |> reschedule_expiry() |> noreply()
+  end
+
+  def handle_info(_message, %State{} = t), do: noreply(t)
+
+  # Read handling
+
+  defp handle_read(%State{} = t, key, request, opts, from) do
+    case State.resolve_tag(t, key) do
+      {:ok, tag} ->
+        case Map.fetch(t.covered, tag) do
+          {:ok, materializer} -> forward(t, tag, materializer, request, from)
+          :error -> park(t, tag, request, opts, from)
+        end
+
+      {:error, :no_shard} ->
+        reply(t, {:error, :unavailable})
+    end
+  end
+
+  defp forward(%State{} = t, tag, materializer, request, from) do
+    emit_placeholder_forwarded(t.cluster, tag)
+
+    {:ok, _pid} = Task.start(fn -> GenServer.reply(from, reissue(materializer, request)) end)
+
+    noreply(t)
+  end
+
+  defp park(%State{} = t, tag, request, opts, from) do
+    budget_ms = State.parking_budget_ms(t, opts[:timeout])
+    reply_fn = fn result -> GenServer.reply(from, result) end
+    {waiting, _next_timeout} = WaitingList.insert(t.waiting, tag, request, reply_fn, budget_ms)
+
+    emit_placeholder_parked(t.cluster, tag)
+
+    t
+    |> struct!(waiting: waiting)
+    |> signal_demand(tag)
+    |> reschedule_expiry()
+    |> noreply()
+  end
+
+  defp signal_demand(%State{} = t, tag) do
+    if MapSet.member?(t.demanded, tag) do
+      t
+    else
+      GenServer.cast(t.distributor, {:coverage_demand, tag})
+      %{t | demanded: MapSet.put(t.demanded, tag)}
+    end
+  end
+
+  # Re-issue a parked or forwarded request against a live materializer,
+  # using the same client API the original caller used.
+  defp reissue(materializer, {:get, key_or_selector, version, opts}),
+    do: Materializer.get(materializer, key_or_selector, version, opts)
+
+  defp reissue(materializer, {:get_range, start_sel, end_sel, version, opts}),
+    do: Materializer.get_range(materializer, start_sel, end_sel, version, opts)
+
+  defp racing_key(%KeySelector{key: key}), do: key
+  defp racing_key(key) when is_binary(key), do: key
+
+  # A single timer armed for the earliest deadline across the waiting
+  # list, rescheduled on every mutation.
+  defp reschedule_expiry(%State{} = t) do
+    if t.expiry_timer, do: Process.cancel_timer(t.expiry_timer)
+
+    case WaitingList.next_timeout(t.waiting) do
+      :infinity -> %{t | expiry_timer: nil}
+      timeout_ms -> %{t | expiry_timer: Process.send_after(self(), :expire_waiting, timeout_ms)}
+    end
+  end
+end

--- a/lib/bedrock/control_plane/distributor/placeholder/server.ex
+++ b/lib/bedrock/control_plane/distributor/placeholder/server.ex
@@ -75,6 +75,15 @@ defmodule Bedrock.ControlPlane.Distributor.Placeholder.Server do
   def handle_call({:get_range, start_key_or_selector, _end, _version, opts} = request, from, %State{} = t),
     do: handle_read(t, racing_key(start_key_or_selector), request, opts, from)
 
+  # The placeholder is a wire boundary: real workers also speak
+  # lock/info/recovery shapes, and a future or operational caller
+  # reaching this ref with one must get a refusal, not a
+  # FunctionClauseError that kills every parked request. (Recovery never
+  # targets placeholder refs — locking draws from the old TSL and
+  # re-adoption filters by locked recovery info — so this clause serves
+  # foreign callers, not a precluded internal path.)
+  def handle_call(_unsupported, _from, %State{} = t), do: reply(t, {:error, :unsupported})
+
   @impl true
   def handle_cast({:covered, tag, materializer}, %State{} = t) do
     {waiting, entries} = WaitingList.remove_all(t.waiting, tag)

--- a/lib/bedrock/control_plane/distributor/placeholder/state.ex
+++ b/lib/bedrock/control_plane/distributor/placeholder/state.ex
@@ -1,0 +1,56 @@
+defmodule Bedrock.ControlPlane.Distributor.Placeholder.State do
+  @moduledoc false
+
+  alias Bedrock.ControlPlane.Distributor.Placeholder
+  alias Bedrock.Internal.WaitingList
+
+  @unbounded_end_key <<0xFF, 0xFF>>
+
+  @type t :: %__MODULE__{
+          cluster: module(),
+          distributor: pid(),
+          shard_layout: %{Bedrock.key() => {Bedrock.range_tag(), Bedrock.key()}},
+          hold_ms: pos_integer(),
+          waiting: WaitingList.t(),
+          covered: %{Bedrock.range_tag() => Placeholder.ref()},
+          demanded: MapSet.t(Bedrock.range_tag()),
+          expiry_timer: reference() | nil
+        }
+  defstruct cluster: nil,
+            distributor: nil,
+            shard_layout: %{},
+            hold_ms: 2_000,
+            waiting: %{},
+            covered: %{},
+            demanded: MapSet.new(),
+            expiry_timer: nil
+
+  @doc """
+  Resolves the shard tag responsible for a key from the placeholder's
+  copy of the shard layout (`%{end_key => {tag, start_key}}`), read from
+  the committed keyspace. The end key `<<0xFF, 0xFF>>` is the unbounded
+  sentinel, matching `LayoutIndex` semantics.
+  """
+  @spec resolve_tag(t(), Bedrock.key()) :: {:ok, Bedrock.range_tag()} | {:error, :no_shard}
+  def resolve_tag(%__MODULE__{shard_layout: shard_layout}, key) do
+    shard_layout
+    |> Enum.find(fn {end_key, {_tag, start_key}} ->
+      start_key <= key and (key < end_key or end_key == @unbounded_end_key)
+    end)
+    |> case do
+      {_end_key, {tag, _start_key}} -> {:ok, tag}
+      nil -> {:error, :no_shard}
+    end
+  end
+
+  @doc """
+  The parking budget for a request: the minimum of the caller-supplied
+  timeout (when finite) and the configured `hold_ms` — the placeholder
+  never holds a caller past its own deadline.
+  """
+  @spec parking_budget_ms(t(), caller_timeout :: timeout() | nil) :: non_neg_integer()
+  def parking_budget_ms(%__MODULE__{hold_ms: hold_ms}, caller_timeout)
+      when is_integer(caller_timeout) and caller_timeout >= 0, do: min(caller_timeout, hold_ms)
+
+  def parking_budget_ms(%__MODULE__{hold_ms: hold_ms}, _caller_timeout), do: hold_ms
+end

--- a/lib/bedrock/control_plane/distributor/server.ex
+++ b/lib/bedrock/control_plane/distributor/server.ex
@@ -2,10 +2,16 @@ defmodule Bedrock.ControlPlane.Distributor.Server do
   @moduledoc false
   use GenServer
 
+  alias Bedrock.ControlPlane.Distributor.Placeholder
   alias Bedrock.ControlPlane.Distributor.State
+  alias Bedrock.ControlPlane.Distributor.Telemetry
   alias Bedrock.ControlPlane.Distributor.Transactions
+  alias Bedrock.SystemKeys
+  alias Bedrock.SystemKeys.Values
 
   require Logger
+
+  @placeholder_worker_id Placeholder.worker_id()
 
   # FDB's MOVEKEYS_LOCK_POLLING_DELAY: a superseded distributor exits
   # within seconds even when idle, instead of waiting to lose a commit.
@@ -47,13 +53,19 @@ defmodule Bedrock.ControlPlane.Distributor.Server do
         )
       end)
 
+    # The placeholder dies with the distributor and vice versa: they are
+    # one coverage story, and the linked pair keeps the registered name
+    # and the demand channel consistent.
+    Process.flag(:trap_exit, true)
+
     state = %State{
       cluster: cluster,
       epoch: epoch,
       director: director,
       director_monitor: Process.monitor(director),
       deps: deps,
-      poll_interval_ms: Keyword.get(opts, :poll_interval_ms, @poll_interval_ms)
+      poll_interval_ms: Keyword.get(opts, :poll_interval_ms, @poll_interval_ms),
+      placeholder_start_fn: Keyword.get(opts, :placeholder_start_fn)
     }
 
     {:ok, state, {:continue, :take_lock}}
@@ -71,10 +83,51 @@ defmodule Bedrock.ControlPlane.Distributor.Server do
     case Transactions.take_lock(t.deps) do
       {:ok, lock} ->
         Logger.info("Bedrock distributor (epoch #{t.epoch}): lock taken")
-        {:noreply, schedule_poll(%{t | lock: lock})}
+        {:noreply, schedule_poll(%{t | lock: lock}), {:continue, :startup_sweep}}
 
       {:error, reason} ->
         {:stop, {:shutdown, {:lock_take_failed, reason}}, t}
+    end
+  end
+
+  # Lock, then snapshot, then work (FDB's DD startup order): read both
+  # durable families at one pinned version, start the placeholder over
+  # the read layout, and publish placeholder refs for every uncovered
+  # tag in ONE check-fenced commit — coverage gaps become visible in the
+  # keyspace, addressed to a ref that parks reads instead of failing
+  # them. Supersession at the publish cedes; transient failures stop
+  # :shutdown for the director's retry.
+  def handle_continue(:startup_sweep, %State{} = t) do
+    with {:ok, snapshot} <- Transactions.read_snapshot(t.deps),
+         {:ok, placeholder} <- start_placeholder(t, snapshot.shard_layout),
+         t = %{t | placeholder: placeholder, snapshot: snapshot},
+         :ok <- publish_placeholders(t, uncovered_tags(snapshot)) do
+      {:noreply, t}
+    else
+      {:error, :superseded} ->
+        Logger.info("Bedrock distributor (epoch #{t.epoch}): superseded at publish; ceding")
+        {:stop, :normal, t}
+
+      {:error, reason} ->
+        {:stop, {:shutdown, {:startup_sweep_failed, reason}}, t}
+    end
+  end
+
+  # Coverage demand from the placeholder: if the snapshot already names
+  # a live assignment (a race between park and publish), hand the
+  # placeholder the covered ref so it drains; otherwise record the
+  # pending demand — recruitment consumes it (bedrock-q67.21.4).
+  @impl true
+  def handle_cast({:coverage_demand, tag}, %State{} = t) do
+    Telemetry.emit_coverage_demand(t.cluster, tag)
+
+    case Map.fetch(t.snapshot.materializer_refs, tag) do
+      {:ok, {worker_id, node}} when worker_id != @placeholder_worker_id ->
+        Placeholder.notify_covered(t.placeholder, tag, callable_ref(t.cluster, worker_id, node))
+        {:noreply, t}
+
+      _uncovered_or_placeholder ->
+        {:noreply, %{t | pending_demands: MapSet.put(t.pending_demands, tag)}}
     end
   end
 
@@ -97,6 +150,68 @@ defmodule Bedrock.ControlPlane.Distributor.Server do
   # recovery in progress, and the next epoch's director recruits the
   # next distributor.
   def handle_info({:DOWN, ref, :process, _pid, _reason}, %State{director_monitor: ref} = t), do: {:stop, :normal, t}
+
+  # A crashed placeholder restarts under the SAME registered name on the
+  # same node, so the committed placeholder refs stay valid — no
+  # republication (the option-2 addressing dividend). Parked requests
+  # died with it; their callers time out and retry, which re-parks.
+  def handle_info({:EXIT, pid, reason}, %State{placeholder: pid} = t) do
+    Logger.warning("Bedrock distributor (epoch #{t.epoch}): placeholder exited #{inspect(reason)}; restarting")
+
+    case start_placeholder(t, t.snapshot.shard_layout) do
+      {:ok, placeholder} -> {:noreply, %{t | placeholder: placeholder}}
+      {:error, reason2} -> {:stop, {:shutdown, {:placeholder_restart_failed, reason2}}, t}
+    end
+  end
+
+  def handle_info({:EXIT, _pid, _reason}, %State{} = t), do: {:noreply, t}
+
+  defp uncovered_tags(%{shard_layout: shard_layout, materializer_refs: refs}) do
+    shard_layout
+    |> Map.values()
+    |> Enum.map(fn {tag, _start_key} -> tag end)
+    |> Enum.uniq()
+    |> Enum.reject(&Map.has_key?(refs, &1))
+  end
+
+  defp publish_placeholders(_t, []), do: :ok
+
+  defp publish_placeholders(%State{} = t, tags) do
+    node_string = Atom.to_string(node())
+
+    mutations =
+      Enum.map(tags, fn tag ->
+        {:set, SystemKeys.materializer_key(tag), Values.encode_materializer_ref(@placeholder_worker_id, node_string)}
+      end)
+
+    with :ok <- Transactions.commit_checked(t.lock, t.deps, mutations) do
+      Telemetry.emit_placeholder_published(t.cluster, tags)
+      :ok
+    end
+  end
+
+  defp start_placeholder(%State{} = t, shard_layout) do
+    start_fn = t.placeholder_start_fn || (&default_start_placeholder/1)
+
+    start_fn.(
+      cluster: t.cluster,
+      distributor: self(),
+      shard_layout: shard_layout,
+      otp_name: t.cluster.otp_name_for_worker(@placeholder_worker_id)
+    )
+  end
+
+  defp default_start_placeholder(opts) do
+    %{start: {m, f, a}} = Placeholder.Server.child_spec(opts)
+    apply(m, f, a)
+  end
+
+  defp callable_ref(cluster, worker_id, node) do
+    # The documented exception to no-atoms-on-decode: system-mode-gated
+    # writers, count bounded by cluster membership.
+    # credo:disable-for-next-line Credo.Check.Warning.UnsafeToAtom
+    {cluster.otp_name_for_worker(worker_id), String.to_atom(node)}
+  end
 
   defp schedule_poll(%State{} = t) do
     Process.send_after(self(), :poll_lock, t.poll_interval_ms)

--- a/lib/bedrock/control_plane/distributor/server.ex
+++ b/lib/bedrock/control_plane/distributor/server.ex
@@ -166,6 +166,14 @@ defmodule Bedrock.ControlPlane.Distributor.Server do
 
   def handle_info({:EXIT, _pid, _reason}, %State{} = t), do: {:noreply, t}
 
+  # An existing placeholder ref counts as covered-enough to skip
+  # republication. That rests on two invariants: the distributor runs on
+  # the director's node (a restarted placeholder re-registers the same
+  # name on the node the committed refs already name), and every
+  # recovery's bootstrap re-assigns all layout tags, so placeholder refs
+  # never survive a recovery as stale foreign-node entries. If the
+  # distributor ever detaches from the director's node, this rejection
+  # must compare the ref's node too.
   defp uncovered_tags(%{shard_layout: shard_layout, materializer_refs: refs}) do
     shard_layout
     |> Map.values()

--- a/lib/bedrock/control_plane/distributor/state.ex
+++ b/lib/bedrock/control_plane/distributor/state.ex
@@ -11,7 +11,16 @@ defmodule Bedrock.ControlPlane.Distributor.State do
           director_monitor: reference(),
           deps: Transactions.deps(),
           lock: Lock.t() | nil,
-          poll_interval_ms: pos_integer()
+          poll_interval_ms: pos_integer(),
+          placeholder: pid() | nil,
+          placeholder_start_fn: (keyword() -> {:ok, pid()} | {:error, term()}) | nil,
+          snapshot:
+            %{
+              shard_layout: %{Bedrock.key() => {Bedrock.range_tag(), Bedrock.key()}},
+              materializer_refs: %{Bedrock.range_tag() => {String.t(), String.t()}}
+            }
+            | nil,
+          pending_demands: MapSet.t(Bedrock.range_tag())
         }
   @enforce_keys [:cluster, :epoch, :director, :director_monitor, :deps]
   defstruct [
@@ -21,6 +30,10 @@ defmodule Bedrock.ControlPlane.Distributor.State do
     :director_monitor,
     :deps,
     lock: nil,
-    poll_interval_ms: 5_000
+    poll_interval_ms: 5_000,
+    placeholder: nil,
+    placeholder_start_fn: nil,
+    snapshot: nil,
+    pending_demands: MapSet.new()
   ]
 end

--- a/lib/bedrock/control_plane/distributor/telemetry.ex
+++ b/lib/bedrock/control_plane/distributor/telemetry.ex
@@ -1,0 +1,57 @@
+defmodule Bedrock.ControlPlane.Distributor.Telemetry do
+  @moduledoc false
+
+  @spec emit_placeholder_parked(module(), Bedrock.range_tag()) :: :ok
+  def emit_placeholder_parked(cluster, tag) do
+    :telemetry.execute(
+      [:bedrock, :distributor, :placeholder, :parked],
+      %{count: 1},
+      %{cluster: cluster, tag: tag}
+    )
+  end
+
+  @spec emit_placeholder_forwarded(module(), Bedrock.range_tag()) :: :ok
+  def emit_placeholder_forwarded(cluster, tag) do
+    :telemetry.execute(
+      [:bedrock, :distributor, :placeholder, :forwarded],
+      %{count: 1},
+      %{cluster: cluster, tag: tag}
+    )
+  end
+
+  @spec emit_placeholder_drained(module(), Bedrock.range_tag(), count :: non_neg_integer()) :: :ok
+  def emit_placeholder_drained(cluster, tag, count) do
+    :telemetry.execute(
+      [:bedrock, :distributor, :placeholder, :drained],
+      %{count: count},
+      %{cluster: cluster, tag: tag}
+    )
+  end
+
+  @spec emit_placeholder_shed(module(), Bedrock.range_tag() | nil, count :: non_neg_integer(), reason :: term()) :: :ok
+  def emit_placeholder_shed(cluster, tag, count, reason) do
+    :telemetry.execute(
+      [:bedrock, :distributor, :placeholder, :shed],
+      %{count: count},
+      %{cluster: cluster, tag: tag, reason: reason}
+    )
+  end
+
+  @spec emit_coverage_demand(module(), Bedrock.range_tag()) :: :ok
+  def emit_coverage_demand(cluster, tag) do
+    :telemetry.execute(
+      [:bedrock, :distributor, :coverage_demand],
+      %{count: 1},
+      %{cluster: cluster, tag: tag}
+    )
+  end
+
+  @spec emit_placeholder_published(module(), [Bedrock.range_tag()]) :: :ok
+  def emit_placeholder_published(cluster, tags) do
+    :telemetry.execute(
+      [:bedrock, :distributor, :placeholder, :published],
+      %{count: length(tags)},
+      %{cluster: cluster, tags: tags}
+    )
+  end
+end

--- a/lib/bedrock/control_plane/distributor/transactions.ex
+++ b/lib/bedrock/control_plane/distributor/transactions.ex
@@ -22,6 +22,9 @@ defmodule Bedrock.ControlPlane.Distributor.Transactions do
   alias Bedrock.DataPlane.Sequencer
   alias Bedrock.Internal.TransactionBuilder.Tx
   alias Bedrock.SystemKeys
+  alias Bedrock.SystemKeys.Reader
+
+  @take_attempts 3
 
   @typedoc """
   The injectable dependency set. `deps_for/4` builds the production
@@ -34,7 +37,11 @@ defmodule Bedrock.ControlPlane.Distributor.Transactions do
           required(:get_fn) => (Bedrock.key(), Bedrock.version() ->
                                   {:ok, binary()} | {:error, :not_found | term()} | {:failure, term(), term()}),
           required(:commit_fn) => (CommitProxy.ref(), Bedrock.epoch(), binary(), keyword() ->
-                                     {:ok, Bedrock.version(), non_neg_integer()} | {:error, term()})
+                                     {:ok, Bedrock.version(), non_neg_integer()} | {:error, term()}),
+          required(:get_range_fn) => (Bedrock.key(), Bedrock.key(), Bedrock.version() ->
+                                        {:ok, {[{Bedrock.key(), binary()}], boolean()}}
+                                        | {:error, term()}
+                                        | {:failure, term(), term()})
         }
 
   @doc """
@@ -74,11 +81,111 @@ defmodule Bedrock.ControlPlane.Distributor.Transactions do
       end,
       commit_fn: fn proxy, commit_epoch, encoded, opts ->
         CommitProxy.commit(proxy, commit_epoch, encoded, Keyword.put(opts, :timeout_in_ms, 10_000))
+      end,
+      get_range_fn: fn start_key, end_key, version ->
+        case CommitProxy.fetch_routing(Enum.random(proxies), start_key) do
+          {:ok, {_s, _e, _tag, {worker_id, node}}} ->
+            # credo:disable-for-next-line Credo.Check.Warning.UnsafeToAtom
+            Materializer.get_range(
+              {cluster.otp_name_for_worker(worker_id), String.to_atom(node)},
+              start_key,
+              end_key,
+              version,
+              limit: 1000,
+              timeout: 5_000
+            )
+
+          {:error, :not_found} ->
+            {:error, {:unroutable_system_key, start_key}}
+
+          {:error, reason} ->
+            {:error, reason}
+        end
       end
     }
   end
 
-  @take_attempts 3
+  @doc """
+  Reads the distributor's snapshot of the durable mapping families —
+  shard layout and materializer refs — at one pinned version (a
+  single-version multi-page read cannot tear: the families are written
+  transactionally). Read AFTER the lock is taken, under FDB's
+  lock-first-snapshot-second startup order.
+  """
+  @spec read_snapshot(deps()) ::
+          {:ok,
+           %{
+             shard_layout: %{Bedrock.key() => {Bedrock.range_tag(), Bedrock.key()}},
+             materializer_refs: %{Bedrock.range_tag() => {String.t(), String.t()}}
+           }}
+          | {:error, term()}
+  def read_snapshot(deps) do
+    shard_prefix = SystemKeys.shard_keys_prefix()
+    {_s1, shard_end} = Bedrock.KeyRange.from_prefix(shard_prefix)
+    refs_prefix = SystemKeys.materializers_prefix()
+    {_s2, refs_end} = Bedrock.KeyRange.from_prefix(refs_prefix)
+
+    with {:ok, version} <- read_version(deps),
+         {:ok, shard_entries} <-
+           Reader.read_family(&deps.get_range_fn.(&1, shard_end, version), shard_prefix, :snapshot_read_failed),
+         {:ok, ref_entries} <-
+           Reader.read_family(&deps.get_range_fn.(&1, refs_end, version), refs_prefix, :snapshot_read_failed),
+         {:ok, shard_layout} <- Reader.shard_layout_from_entries(shard_entries),
+         {:ok, refs} <- Reader.decode_materializer_refs(ref_entries) do
+      {:ok, %{shard_layout: shard_layout, materializer_refs: refs}}
+    end
+  end
+
+  @doc """
+  A CHECK-fenced mutating commit, honoring the Lock runner obligations:
+  the owner key is read (and read-conflicted) always; the write key is
+  read only when the owner is not ours — an unconditional write-key
+  read would make every pair of concurrent same-owner distributor
+  transactions mutually conflict and serialize.
+
+  Verdict semantics mirror FDB exactly: supersession is the READ
+  verdict (`Lock.check`'s refusal — FDB's `movekeys_conflict`), and it
+  is authoritative. A commit ABORT is not: it retries with a fresh read
+  version (re-evaluating the fence, so a genuine usurper is caught by
+  the read on the retry); exhausted retries surface as a transient
+  commit failure.
+  """
+  @spec commit_checked(Lock.t(), deps(), [Lock.mutation() | {:set, Bedrock.key(), binary()}]) ::
+          :ok
+          | {:error, :superseded}
+          | {:error, {:read_version_failed | :lock_read_failed | :lock_commit_failed, term()}}
+  def commit_checked(lock, deps, payload_mutations), do: commit_checked(lock, deps, payload_mutations, @take_attempts)
+
+  defp commit_checked(lock, deps, payload_mutations, attempts_left) do
+    with {:ok, version} <- read_version(deps),
+         {:ok, owner} <- read_lock_key(deps, SystemKeys.distributor_lock_owner(), version),
+         {:ok, write, write_read?} <- maybe_read_write_key(lock, deps, owner, version),
+         {:ok, fence_mutations} <- Lock.check(lock, owner, write) do
+      conflict_keys =
+        if write_read?,
+          do: [SystemKeys.distributor_lock_owner(), SystemKeys.distributor_lock_write()],
+          else: [SystemKeys.distributor_lock_owner()]
+
+      case commit_with_conflicts(deps, version, conflict_keys, fence_mutations ++ payload_mutations) do
+        :ok ->
+          :ok
+
+        {:error, :aborted} when attempts_left > 1 ->
+          commit_checked(lock, deps, payload_mutations, attempts_left - 1)
+
+        {:error, reason} ->
+          {:error, {:lock_commit_failed, reason}}
+      end
+    end
+  end
+
+  defp maybe_read_write_key(%Lock{my_owner: mine}, _deps, mine, _version), do: {:ok, nil, false}
+
+  defp maybe_read_write_key(_lock, deps, _other_owner, version) do
+    with {:ok, write} <- read_lock_key(deps, SystemKeys.distributor_lock_write(), version) do
+      {:ok, write, true}
+    end
+  end
 
   @doc """
   Takes the distributor lock: reads both lock keys at a pinned version
@@ -150,11 +257,19 @@ defmodule Bedrock.ControlPlane.Distributor.Transactions do
     end
   end
 
-  defp commit_fenced(%{proxies: proxies, epoch: epoch, commit_fn: commit_fn}, version, mutations) do
+  defp commit_fenced(deps, version, mutations) do
+    commit_with_conflicts(
+      deps,
+      version,
+      [SystemKeys.distributor_lock_owner(), SystemKeys.distributor_lock_write()],
+      mutations
+    )
+  end
+
+  defp commit_with_conflicts(%{proxies: proxies, epoch: epoch, commit_fn: commit_fn}, version, conflict_keys, mutations) do
     encoded =
       Tx.new()
-      |> Tx.add_read_conflict_key(SystemKeys.distributor_lock_owner())
-      |> Tx.add_read_conflict_key(SystemKeys.distributor_lock_write())
+      |> then(&Enum.reduce(conflict_keys, &1, fn key, tx -> Tx.add_read_conflict_key(tx, key) end))
       |> then(&Enum.reduce(mutations, &1, fn {:set, key, value}, tx -> Tx.set(tx, key, value) end))
       |> Tx.commit(version)
 

--- a/lib/bedrock/internal/waiting_list.ex
+++ b/lib/bedrock/internal/waiting_list.ex
@@ -11,7 +11,10 @@ defmodule Bedrock.Internal.WaitingList do
 
   alias Bedrock.Internal.Time
 
-  @type version :: Bedrock.version()
+  # The waiting key: version binaries for the resolver/long-pull users,
+  # shard tags for the distributor's placeholder — the structure is a
+  # generically keyed deadline map.
+  @type version :: Bedrock.version() | Bedrock.range_tag()
   @type reply_fn :: (any() -> :ok)
   @type timeout_ms :: non_neg_integer()
 

--- a/lib/bedrock/system_keys/reader.ex
+++ b/lib/bedrock/system_keys/reader.ex
@@ -1,0 +1,148 @@
+defmodule Bedrock.SystemKeys.Reader do
+  @moduledoc """
+  The shared readers for the durable `\\xFF/system` mapping families:
+  paged range reads and the family decoders. Recovery's materializer
+  bootstrap and the Distributor both read the same families the same
+  way — one reader, so two consumers cannot disagree about what the
+  bytes mean.
+
+  Paging resumes each page immediately after the last returned key and
+  drains the continuation to exhaustion: a truncated boundary map is not
+  a degraded layout, it is a wrong one. Any failure mid-continuation
+  fails the whole read — partial success would BE the silent truncation
+  this exists to preclude — and an empty page claiming more is a broken
+  read contract, surfaced rather than looped on.
+  """
+
+  alias Bedrock.SystemKeys
+  alias Bedrock.SystemKeys.Values
+
+  @type range_read_fn ::
+          (Bedrock.key() ->
+             {:ok, {[{Bedrock.key(), binary()}], more :: boolean()}}
+             | {:error, term()}
+             | {:failure, term(), term()})
+
+  @doc "Reads a system family's entries to exhaustion, starting at `prefix`."
+  @spec read_family(range_read_fn(), prefix :: Bedrock.key(), error_tag :: atom()) ::
+          {:ok, [{Bedrock.key(), binary()}]} | {:error, {atom(), term()}}
+  def read_family(range_read_fn, prefix, error_tag), do: page_entries(range_read_fn, prefix, error_tag, [])
+
+  defp page_entries(range_read_fn, start_key, error_tag, pages) do
+    case range_read_fn.(start_key) do
+      {:ok, {entries, false}} ->
+        {:ok, [entries | pages] |> Enum.reverse() |> Enum.concat()}
+
+      {:ok, {[], true}} ->
+        {:error, {error_tag, :empty_continuation_page}}
+
+      {:ok, {entries, true}} ->
+        {last_key, _value} = List.last(entries)
+        page_entries(range_read_fn, Bedrock.Key.key_after(last_key), error_tag, [entries | pages])
+
+      {:error, reason} ->
+        {:error, {error_tag, reason}}
+
+      {:failure, reason, _ref} ->
+        {:error, {error_tag, reason}}
+    end
+  end
+
+  @doc """
+  Decodes `materializers/<tag>` entries into `%{tag => {worker_id,
+  node}}`. Foreign or undecodable entries fail the whole decode.
+  """
+  @spec decode_materializer_refs([{Bedrock.key(), binary()}]) ::
+          {:ok, %{Bedrock.range_tag() => {Bedrock.Service.Worker.id(), String.t()}}}
+          | {:error, {:invalid_materializer_entry, Bedrock.key()}}
+  def decode_materializer_refs(entries) do
+    Enum.reduce_while(entries, {:ok, %{}}, fn {key, value}, {:ok, acc} ->
+      with {:materializer_key, tag} <- SystemKeys.parse_key(key),
+           {:ok, ref} <- Values.decode_materializer_ref(value) do
+        {:cont, {:ok, Map.put(acc, tag, ref)}}
+      else
+        _ -> {:halt, {:error, {:invalid_materializer_entry, key}}}
+      end
+    end)
+  end
+
+  @doc """
+  Decodes `shard_keys/<end_key>` entries into the boundary map
+  `%{end_key => {tag, start_key}}`, consuming the carried start key
+  verbatim — the same meaning `RoutingData.apply_mutation` gives the
+  value; two readers of one family must not disagree. Adjacency
+  reconstruction (each shard starts where the previous ends) survives
+  only for legacy term_to_binary snapshots that predate carried start
+  keys; recovery no longer rewrites the family (read-and-heal,
+  bedrock-q67.21.2), so a legacy family stays legacy — encoding-uniform,
+  covered by the any-legacy-falls-back-whole rule — until
+  bedrock-q67.20.7 retires the fallback with an explicit migration.
+  """
+  @spec shard_layout_from_entries([{Bedrock.key(), binary()}]) ::
+          {:ok, %{Bedrock.key() => {Bedrock.range_tag(), Bedrock.key()}}}
+          | {:error, {:invalid_shard_value, Bedrock.key()}}
+  def shard_layout_from_entries(entries) do
+    entries
+    |> Enum.reduce_while({:ok, []}, fn {key, value}, {:ok, acc} ->
+      case decode_shard_entry(value) do
+        {:ok, decoded} -> {:cont, {:ok, [{extract_end_key(key), decoded} | acc]}}
+        {:error, _} -> {:halt, {:error, {:invalid_shard_value, key}}}
+      end
+    end)
+    |> case do
+      {:ok, decoded_by_end_key} -> {:ok, build_shard_layout(decoded_by_end_key)}
+      error -> error
+    end
+  end
+
+  defp build_shard_layout(decoded_by_end_key) do
+    if Enum.any?(decoded_by_end_key, &match?({_end_key, {:legacy, _tag}}, &1)) do
+      rebuild_start_keys_by_adjacency(decoded_by_end_key)
+    else
+      Map.new(decoded_by_end_key, fn {end_key, {tag, start_key}} -> {end_key, {tag, start_key}} end)
+    end
+  end
+
+  defp rebuild_start_keys_by_adjacency(decoded_by_end_key) do
+    decoded_by_end_key
+    |> Enum.sort_by(fn {end_key, _decoded} -> end_key end)
+    |> Enum.map_reduce(<<>>, fn {end_key, decoded}, start_key ->
+      tag =
+        case decoded do
+          {:legacy, tag} -> tag
+          {tag, _carried_start} -> tag
+        end
+
+      {{end_key, {tag, start_key}}, end_key}
+    end)
+    |> elem(0)
+    |> Map.new()
+  end
+
+  defp extract_end_key(key) do
+    prefix = SystemKeys.shard_keys_prefix()
+    prefix_len = byte_size(prefix)
+    binary_part(key, prefix_len, byte_size(key) - prefix_len)
+  end
+
+  defp decode_shard_entry(value) do
+    case Values.decode_shard_key_entry(value) do
+      {:ok, {tag, start_key}} -> {:ok, {tag, start_key}}
+      {:error, _} -> decode_legacy_shard_tag(value)
+    end
+  end
+
+  # Clusters created before Bedrock.SystemKeys.Values wrote shard_key
+  # values with term_to_binary. Recovery no longer rewrites the family,
+  # so these values persist AS-IS until bedrock-q67.20.7's explicit
+  # migration retires them along with this fallback.
+  defp decode_legacy_shard_tag(value) do
+    case :erlang.binary_to_term(value, [:safe]) do
+      tag when is_integer(tag) -> {:ok, {:legacy, tag}}
+      {tag, _start_key} when is_integer(tag) -> {:ok, {:legacy, tag}}
+      _ -> {:error, :invalid_encoding}
+    end
+  rescue
+    ArgumentError -> {:error, :invalid_encoding}
+  end
+end

--- a/test/bedrock/control_plane/distributor/placeholder_test.exs
+++ b/test/bedrock/control_plane/distributor/placeholder_test.exs
@@ -253,4 +253,21 @@ defmodule Bedrock.ControlPlane.Distributor.PlaceholderTest do
       refute_receive {:"$gen_cast", {:coverage_demand, _tag}}, 50
     end
   end
+
+  describe "the wire boundary" do
+    test "a non-read worker-protocol shape is refused, never a crash that sheds parked calls" do
+      # hold_ms below the caller timeout so the shed (not the caller's
+      # own clock) delivers the reply — the audit-documented reality is
+      # that equal clocks race and the caller usually wins.
+      placeholder = start_placeholder(hold_ms: 50)
+      parked = async_get(placeholder, "apple", timeout: 500)
+
+      assert GenServer.call(placeholder, {:lock_for_recovery, 3}) == {:error, :unsupported}
+      assert GenServer.call(placeholder, {:info, [:kind]}) == {:error, :unsupported}
+
+      # The parked request is untouched by the refusals; it sheds only on
+      # its own deadline.
+      assert {:error, :unavailable} = Task.await(parked)
+    end
+  end
 end

--- a/test/bedrock/control_plane/distributor/placeholder_test.exs
+++ b/test/bedrock/control_plane/distributor/placeholder_test.exs
@@ -1,0 +1,256 @@
+defmodule Bedrock.ControlPlane.Distributor.PlaceholderTest do
+  use ExUnit.Case, async: true
+
+  alias Bedrock.ControlPlane.Distributor.Placeholder
+  alias Bedrock.DataPlane.Materializer
+  alias Bedrock.DataPlane.Version
+  alias Bedrock.KeySelector
+  alias Bedrock.Test.ControlPlane.StubMaterializer
+
+  defmodule TestCluster do
+    @moduledoc false
+  end
+
+  # Layout: tag 1 covers [<<>>, "m"), tag 2 covers ["m", <<0xFF, 0xFF>>).
+  @shard_layout %{
+    "m" => {1, <<>>},
+    <<0xFF, 0xFF>> => {2, "m"}
+  }
+
+  @version Version.from_integer(1)
+
+  defp start_placeholder(opts \\ []) do
+    start_supervised!(
+      Placeholder.Server.child_spec(
+        cluster: TestCluster,
+        distributor: Keyword.get(opts, :distributor, self()),
+        shard_layout: Keyword.get(opts, :shard_layout, @shard_layout),
+        hold_ms: Keyword.get(opts, :hold_ms, 2_000)
+      )
+    )
+  end
+
+  defp start_stub(kvs) do
+    start_supervised!(%{
+      id: {StubMaterializer, System.unique_integer([:positive])},
+      start: {StubMaterializer, :start_link, [kvs]}
+    })
+  end
+
+  defp async_get(placeholder, key, opts \\ []),
+    do: Task.async(fn -> Materializer.get(placeholder, key, @version, opts) end)
+
+  defp attach_telemetry(test_pid) do
+    handler_id = "placeholder-test-#{System.unique_integer([:positive])}"
+
+    :telemetry.attach_many(
+      handler_id,
+      [
+        [:bedrock, :distributor, :placeholder, :parked],
+        [:bedrock, :distributor, :placeholder, :forwarded],
+        [:bedrock, :distributor, :placeholder, :drained],
+        [:bedrock, :distributor, :placeholder, :shed]
+      ],
+      fn event, measurements, metadata, _config ->
+        send(test_pid, {:telemetry, event, measurements, metadata})
+      end,
+      nil
+    )
+
+    on_exit(fn -> :telemetry.detach(handler_id) end)
+  end
+
+  describe "park then cover" do
+    test "parked get is drained with the real value once coverage arrives" do
+      attach_telemetry(self())
+      placeholder = start_placeholder()
+      stub = start_stub(%{"apple" => "red"})
+
+      task = async_get(placeholder, "apple", timeout: 5_000)
+
+      assert_receive {:"$gen_cast", {:coverage_demand, 1}}
+      assert_receive {:telemetry, [:bedrock, :distributor, :placeholder, :parked], %{count: 1}, %{tag: 1}}
+
+      :ok = Placeholder.notify_covered(placeholder, 1, stub)
+
+      assert {:ok, "red"} = Task.await(task, 5_000)
+      assert_receive {:telemetry, [:bedrock, :distributor, :placeholder, :drained], %{count: 1}, %{tag: 1}}
+    end
+
+    test "parked key-selector get is drained with the resolved key-value" do
+      placeholder = start_placeholder()
+      stub = start_stub(%{"apple" => "red"})
+
+      selector = KeySelector.first_greater_or_equal("apple")
+      task = Task.async(fn -> Materializer.get(placeholder, selector, @version, timeout: 5_000) end)
+
+      assert_receive {:"$gen_cast", {:coverage_demand, 1}}
+      :ok = Placeholder.notify_covered(placeholder, 1, stub)
+
+      assert {:ok, {"apple", "red"}} = Task.await(task, 5_000)
+    end
+
+    test "parked get_range is drained with the shard's key-values" do
+      placeholder = start_placeholder()
+      stub = start_stub(%{"apple" => "red", "banana" => "yellow", "zebra" => "striped"})
+
+      task = Task.async(fn -> Materializer.get_range(placeholder, "a", "c", @version, timeout: 5_000) end)
+
+      assert_receive {:"$gen_cast", {:coverage_demand, 1}}
+      :ok = Placeholder.notify_covered(placeholder, 1, stub)
+
+      assert {:ok, {[{"apple", "red"}, {"banana", "yellow"}], false}} = Task.await(task, 5_000)
+    end
+
+    test "draining multiple parked requests replies to every waiter" do
+      placeholder = start_placeholder()
+      stub = start_stub(%{"apple" => "red", "cherry" => "dark red"})
+
+      task_a = async_get(placeholder, "apple", timeout: 5_000)
+      task_b = async_get(placeholder, "cherry", timeout: 5_000)
+
+      assert_receive {:"$gen_cast", {:coverage_demand, 1}}
+      :ok = Placeholder.notify_covered(placeholder, 1, stub)
+
+      assert {:ok, "red"} = Task.await(task_a, 1_000)
+      assert {:ok, "dark red"} = Task.await(task_b, 1_000)
+    end
+  end
+
+  describe "deadline expiry" do
+    test "parked request is shed with :unavailable when hold_ms expires" do
+      attach_telemetry(self())
+      placeholder = start_placeholder(hold_ms: 30)
+
+      task = async_get(placeholder, "apple", timeout: 5_000)
+
+      assert {:error, :unavailable} = Task.await(task, 5_000)
+
+      assert_receive {:telemetry, [:bedrock, :distributor, :placeholder, :shed], %{count: 1},
+                      %{reason: :deadline_expired}}
+    end
+
+    test "caller-supplied timeout below hold_ms bounds the parking budget" do
+      placeholder = start_placeholder(hold_ms: 5_000)
+
+      # Call directly with a generous GenServer timeout so the placeholder's
+      # budget (opts[:timeout] = 30ms) is what trips, not the client call.
+      task =
+        Task.async(fn ->
+          GenServer.call(placeholder, {:get, "apple", @version, [timeout: 30]}, 1_000)
+        end)
+
+      assert {:error, :unavailable} = Task.await(task, 5_000)
+    end
+
+    test "expiry only sheds entries past their deadline" do
+      placeholder = start_placeholder(hold_ms: 5_000)
+      stub = start_stub(%{"apple" => "red"})
+
+      short_task =
+        Task.async(fn ->
+          GenServer.call(placeholder, {:get, "apple", @version, [timeout: 30]}, 1_000)
+        end)
+
+      long_task = async_get(placeholder, "apple", timeout: 5_000)
+
+      assert {:error, :unavailable} = Task.await(short_task, 1_000)
+
+      # The longer-deadline waiter is still parked and drains on coverage.
+      :ok = Placeholder.notify_covered(placeholder, 1, stub)
+      assert {:ok, "red"} = Task.await(long_task, 1_000)
+    end
+  end
+
+  describe "forwarding" do
+    test "requests for a covered tag are forwarded without parking" do
+      attach_telemetry(self())
+      placeholder = start_placeholder()
+      stub = start_stub(%{"apple" => "red"})
+
+      :ok = Placeholder.notify_covered(placeholder, 1, stub)
+
+      assert {:ok, "red"} = Materializer.get(placeholder, "apple", @version, timeout: 5_000)
+      assert_receive {:telemetry, [:bedrock, :distributor, :placeholder, :forwarded], %{count: 1}, %{tag: 1}}
+      refute_receive {:"$gen_cast", {:coverage_demand, _tag}}, 50
+    end
+
+    test "forwarding is per-tag: uncovered tags still park" do
+      placeholder = start_placeholder()
+      stub = start_stub(%{"apple" => "red"})
+
+      :ok = Placeholder.notify_covered(placeholder, 1, stub)
+
+      task = async_get(placeholder, "pear", timeout: 5_000)
+      assert_receive {:"$gen_cast", {:coverage_demand, 2}}
+
+      :ok = Placeholder.notify_covered(placeholder, 2, start_stub(%{"pear" => "green"}))
+      assert {:ok, "green"} = Task.await(task, 5_000)
+    end
+  end
+
+  describe "demand dedupe" do
+    test "at most one coverage demand per tag until covered" do
+      placeholder = start_placeholder()
+
+      task_a = async_get(placeholder, "apple", timeout: 5_000)
+      task_b = async_get(placeholder, "banana", timeout: 5_000)
+
+      assert_receive {:"$gen_cast", {:coverage_demand, 1}}
+      refute_receive {:"$gen_cast", {:coverage_demand, 1}}, 50
+
+      stub = start_stub(%{"apple" => "red", "banana" => "yellow"})
+      :ok = Placeholder.notify_covered(placeholder, 1, stub)
+      assert {:ok, "red"} = Task.await(task_a, 1_000)
+      assert {:ok, "yellow"} = Task.await(task_b, 1_000)
+    end
+
+    test "distinct tags each signal their own demand" do
+      placeholder = start_placeholder(hold_ms: 30)
+
+      task_a = async_get(placeholder, "apple", timeout: 5_000)
+      task_b = async_get(placeholder, "pear", timeout: 5_000)
+
+      assert_receive {:"$gen_cast", {:coverage_demand, 1}}
+      assert_receive {:"$gen_cast", {:coverage_demand, 2}}
+
+      assert {:error, :unavailable} = Task.await(task_a, 1_000)
+      assert {:error, :unavailable} = Task.await(task_b, 1_000)
+    end
+  end
+
+  describe "coverage failure" do
+    test "sheds parked requests with :unavailable and re-arms the demand" do
+      attach_telemetry(self())
+      placeholder = start_placeholder()
+
+      task = async_get(placeholder, "apple", timeout: 5_000)
+      # Generous budget: the default 100ms flakes under full-suite load.
+      assert_receive {:"$gen_cast", {:coverage_demand, 1}}, 1_000
+
+      :ok = Placeholder.notify_coverage_failed(placeholder, 1, :no_capacity)
+
+      assert {:error, :unavailable} = Task.await(task, 5_000)
+
+      assert_receive {:telemetry, [:bedrock, :distributor, :placeholder, :shed], %{count: 1},
+                      %{tag: 1, reason: :no_capacity}}
+
+      # Dedupe was cleared: a later request re-triggers the demand.
+      retry_task = async_get(placeholder, "apple", timeout: 5_000)
+      assert_receive {:"$gen_cast", {:coverage_demand, 1}}
+
+      stub = start_stub(%{"apple" => "red"})
+      :ok = Placeholder.notify_covered(placeholder, 1, stub)
+      assert {:ok, "red"} = Task.await(retry_task, 1_000)
+    end
+  end
+
+  describe "layout misses" do
+    test "keys outside every shard are refused with :unavailable" do
+      placeholder = start_placeholder(shard_layout: %{"m" => {1, "a"}})
+
+      assert {:error, :unavailable} = GenServer.call(placeholder, {:get, "zebra", @version, []}, 1_000)
+      refute_receive {:"$gen_cast", {:coverage_demand, _tag}}, 50
+    end
+  end
+end

--- a/test/bedrock/control_plane/distributor/server_test.exs
+++ b/test/bedrock/control_plane/distributor/server_test.exs
@@ -9,9 +9,15 @@ defmodule Bedrock.ControlPlane.Distributor.ServerTest do
   use ExUnit.Case, async: true
 
   alias Bedrock.ControlPlane.Distributor.Lock
+  alias Bedrock.ControlPlane.Distributor.Placeholder
   alias Bedrock.ControlPlane.Distributor.Server
   alias Bedrock.ControlPlane.Distributor.State
+  alias Bedrock.DataPlane.Transaction
   alias Bedrock.DataPlane.Version
+
+  # The test module doubles as the cluster: the placeholder registers
+  # under otp_name_for_worker(placeholder_worker_id).
+  def otp_name_for_worker(id), do: :"distributor_server_test_worker_#{id}"
 
   defp scripted_deps(overrides) do
     Map.merge(
@@ -20,7 +26,8 @@ defmodule Bedrock.ControlPlane.Distributor.ServerTest do
         proxies: [:proxy],
         next_read_version_fn: fn -> {:ok, Version.from_integer(1)} end,
         get_fn: fn _key, _version -> {:error, :not_found} end,
-        commit_fn: fn _proxy, _epoch, _encoded, _opts -> {:ok, Version.from_integer(2), 0} end
+        commit_fn: fn _proxy, _epoch, _encoded, _opts -> {:ok, Version.from_integer(2), 0} end,
+        get_range_fn: fn _start, _end, _version -> {:ok, {[], false}} end
       },
       overrides
     )
@@ -43,8 +50,10 @@ defmodule Bedrock.ControlPlane.Distributor.ServerTest do
   end
 
   describe "taking the lock at startup" do
-    test "success installs the lock and arms the poll" do
-      assert {:noreply, %State{lock: %Lock{}} = t} = Server.handle_continue(:take_lock, state(%{}))
+    test "success installs the lock, arms the poll, and continues into the startup sweep" do
+      assert {:noreply, %State{lock: %Lock{}} = t, {:continue, :startup_sweep}} =
+               Server.handle_continue(:take_lock, state(%{}))
+
       assert_receive :poll_lock, 100
       assert t.lock.prev_owner == nil
     end
@@ -106,6 +115,176 @@ defmodule Bedrock.ControlPlane.Distributor.ServerTest do
       t = state(%{}, director_monitor: ref)
 
       assert {:stop, :normal, _t} = Server.handle_info({:DOWN, ref, :process, self(), :shutdown}, t)
+    end
+  end
+
+  describe "the startup sweep" do
+    alias Bedrock.SystemKeys
+    alias Bedrock.SystemKeys.Values
+
+    defp two_shard_snapshot_deps(refs_entries, test_pid) do
+      shard_entries = [
+        {SystemKeys.shard_key("m"), Values.encode_shard_key_entry(1, <<>>)},
+        {SystemKeys.shard_key(<<0xFF, 0xFF>>), Values.encode_shard_key_entry(0, "m")}
+      ]
+
+      %{
+        get_range_fn: fn start_key, _end, _version ->
+          cond do
+            String.starts_with?(start_key, SystemKeys.shard_keys_prefix()) -> {:ok, {shard_entries, false}}
+            String.starts_with?(start_key, SystemKeys.materializers_prefix()) -> {:ok, {refs_entries, false}}
+          end
+        end,
+        commit_fn: fn _p, _e, encoded, _o ->
+          send(test_pid, {:committed, encoded})
+          {:ok, Version.from_integer(9), 0}
+        end,
+        get_fn: fn key, _v ->
+          # commit_checked's fence read: we are the steady-state owner.
+          if String.ends_with?(key, "owner"), do: {:ok, Process.get(:my_owner)}, else: {:error, :not_found}
+        end
+      }
+    end
+
+    defp swept_state(refs_entries, test_pid) do
+      {lock, _} = Lock.take(nil, nil)
+      Process.put(:my_owner, lock.my_owner)
+
+      state(two_shard_snapshot_deps(refs_entries, test_pid),
+        lock: lock,
+        placeholder_start_fn: fn opts ->
+          send(test_pid, {:placeholder_started, opts})
+          {:ok, spawn(fn -> Process.sleep(:infinity) end)}
+        end
+      )
+    end
+
+    test "publishes placeholder refs for every uncovered tag in one fenced commit" do
+      test_pid = self()
+
+      # Tag 0 is covered; tag 1 has no entry — the gap.
+      refs_entries = [{SystemKeys.materializer_key(0), Values.encode_materializer_ref("wkr_sys", "n@h")}]
+
+      assert {:noreply, t} = Server.handle_continue(:startup_sweep, swept_state(refs_entries, test_pid))
+      assert t.snapshot.shard_layout == %{"m" => {1, <<>>}, <<0xFF, 0xFF>> => {0, "m"}}
+
+      assert_received {:placeholder_started, opts}
+      assert opts[:shard_layout] == t.snapshot.shard_layout
+
+      assert_received {:committed, encoded}
+      assert {:ok, mutations} = Transaction.mutations(encoded)
+
+      placeholder_sets =
+        for {:set, key, value} <- Enum.to_list(mutations),
+            String.starts_with?(key, SystemKeys.materializers_prefix()),
+            do: {key, Values.decode_materializer_ref(value)}
+
+      node_string = Atom.to_string(node())
+
+      assert placeholder_sets == [
+               {SystemKeys.materializer_key(1), {:ok, {Placeholder.worker_id(), node_string}}}
+             ]
+    end
+
+    test "full coverage publishes nothing" do
+      test_pid = self()
+
+      refs_entries = [
+        {SystemKeys.materializer_key(0), Values.encode_materializer_ref("wkr_sys", "n@h")},
+        {SystemKeys.materializer_key(1), Values.encode_materializer_ref("wkr_a", "n@h")}
+      ]
+
+      assert {:noreply, _t} = Server.handle_continue(:startup_sweep, swept_state(refs_entries, test_pid))
+      refute_received {:committed, _}
+    end
+
+    test "supersession at the publish cedes" do
+      test_pid = self()
+      {lock, _} = Lock.take(nil, nil)
+
+      deps =
+        Map.merge(two_shard_snapshot_deps([], test_pid), %{
+          # A usurper owns the lock: the fence read refuses.
+          get_fn: fn _k, _v -> {:ok, Lock.new_uid()} end,
+          commit_fn: fn _p, _e, _t, _o -> flunk("must not commit past a refused fence") end
+        })
+
+      t =
+        state(deps,
+          lock: lock,
+          placeholder_start_fn: fn _opts -> {:ok, spawn(fn -> Process.sleep(:infinity) end)} end
+        )
+
+      assert {:stop, :normal, _t} = Server.handle_continue(:startup_sweep, t)
+    end
+  end
+
+  describe "coverage demand" do
+    test "an already-covered tag hands the placeholder the callable ref" do
+      test_pid = self()
+
+      placeholder =
+        spawn(fn ->
+          receive do
+            {:"$gen_cast", msg} -> send(test_pid, {:placeholder_got, msg})
+          end
+        end)
+
+      t =
+        state(%{},
+          placeholder: placeholder,
+          snapshot: %{shard_layout: %{}, materializer_refs: %{7 => {"wkr_a", Atom.to_string(node())}}}
+        )
+
+      assert {:noreply, _t} = Server.handle_cast({:coverage_demand, 7}, t)
+      assert_receive {:placeholder_got, {:covered, 7, {_otp_name, _node}}}
+    end
+
+    test "an uncovered tag is recorded as pending demand for recruitment" do
+      t = state(%{}, snapshot: %{shard_layout: %{}, materializer_refs: %{}})
+
+      assert {:noreply, t} = Server.handle_cast({:coverage_demand, 9}, t)
+      assert MapSet.member?(t.pending_demands, 9)
+    end
+
+    test "a placeholder-covered tag is still pending — the placeholder is not coverage" do
+      t =
+        state(%{},
+          snapshot: %{
+            shard_layout: %{},
+            materializer_refs: %{9 => {Placeholder.worker_id(), Atom.to_string(node())}}
+          }
+        )
+
+      assert {:noreply, t} = Server.handle_cast({:coverage_demand, 9}, t)
+      assert MapSet.member?(t.pending_demands, 9)
+    end
+  end
+
+  describe "placeholder lifecycle" do
+    test "a crashed placeholder restarts under the same name — no republication needed" do
+      test_pid = self()
+      dead = spawn(fn -> :ok end)
+      fresh = spawn(fn -> Process.sleep(:infinity) end)
+
+      t =
+        state(%{},
+          placeholder: dead,
+          snapshot: %{shard_layout: %{"m" => {1, <<>>}}, materializer_refs: %{}},
+          placeholder_start_fn: fn opts ->
+            send(test_pid, {:restarted_with, opts[:shard_layout]})
+            {:ok, fresh}
+          end
+        )
+
+      log =
+        ExUnit.CaptureLog.capture_log(fn ->
+          assert {:noreply, t2} = Server.handle_info({:EXIT, dead, :boom}, t)
+          assert t2.placeholder == fresh
+        end)
+
+      assert log =~ "placeholder exited"
+      assert_received {:restarted_with, %{"m" => {1, <<>>}}}
     end
   end
 end

--- a/test/bedrock/control_plane/distributor/server_test.exs
+++ b/test/bedrock/control_plane/distributor/server_test.exs
@@ -186,6 +186,19 @@ defmodule Bedrock.ControlPlane.Distributor.ServerTest do
              ]
     end
 
+    test "pre-existing placeholder refs are not republished — same name, same node, still valid" do
+      test_pid = self()
+      node_string = Atom.to_string(node())
+
+      refs_entries = [
+        {SystemKeys.materializer_key(0), Values.encode_materializer_ref("wkr_sys", node_string)},
+        {SystemKeys.materializer_key(1), Values.encode_materializer_ref(Placeholder.worker_id(), node_string)}
+      ]
+
+      assert {:noreply, _t} = Server.handle_continue(:startup_sweep, swept_state(refs_entries, test_pid))
+      refute_received {:committed, _}
+    end
+
     test "full coverage publishes nothing" do
       test_pid = self()
 
@@ -262,6 +275,22 @@ defmodule Bedrock.ControlPlane.Distributor.ServerTest do
   end
 
   describe "placeholder lifecycle" do
+    test "a failed placeholder restart stops :shutdown for the director's retry" do
+      dead = spawn(fn -> :ok end)
+
+      t =
+        state(%{},
+          placeholder: dead,
+          snapshot: %{shard_layout: %{}, materializer_refs: %{}},
+          placeholder_start_fn: fn _opts -> {:error, :nope} end
+        )
+
+      ExUnit.CaptureLog.capture_log(fn ->
+        assert {:stop, {:shutdown, {:placeholder_restart_failed, :nope}}, _t} =
+                 Server.handle_info({:EXIT, dead, :boom}, t)
+      end)
+    end
+
     test "a crashed placeholder restarts under the same name — no republication needed" do
       test_pid = self()
       dead = spawn(fn -> :ok end)

--- a/test/bedrock/control_plane/distributor/transactions_test.exs
+++ b/test/bedrock/control_plane/distributor/transactions_test.exs
@@ -266,6 +266,22 @@ defmodule Bedrock.ControlPlane.Distributor.TransactionsTest do
     end
   end
 
+  describe "commit_checked/3 exhaustion" do
+    test "persistent same-owner aborts exhaust into a transient commit failure" do
+      {lock, _} = Lock.take(nil, nil)
+
+      deps =
+        deps(%{
+          get_fn: fn key, _v ->
+            if String.ends_with?(key, "owner"), do: {:ok, lock.my_owner}, else: {:error, :not_found}
+          end,
+          commit_fn: fn _p, _e, _t, _o -> {:error, :aborted} end
+        })
+
+      assert {:error, {:lock_commit_failed, :aborted}} = Transactions.commit_checked(lock, deps, [])
+    end
+  end
+
   describe "read_snapshot/1" do
     test "reads both families at one pinned version and decodes them" do
       alias Bedrock.SystemKeys.Values, as: V

--- a/test/bedrock/control_plane/distributor/transactions_test.exs
+++ b/test/bedrock/control_plane/distributor/transactions_test.exs
@@ -22,7 +22,8 @@ defmodule Bedrock.ControlPlane.Distributor.TransactionsTest do
         proxies: [:proxy_a],
         next_read_version_fn: fn -> {:ok, v} end,
         get_fn: fn _key, _version -> {:error, :not_found} end,
-        commit_fn: fn _proxy, _epoch, _encoded, _opts -> {:ok, v, 0} end
+        commit_fn: fn _proxy, _epoch, _encoded, _opts -> {:ok, v, 0} end,
+        get_range_fn: fn _start, _end, _version -> {:ok, {[], false}} end
       },
       overrides
     )
@@ -150,6 +151,150 @@ defmodule Bedrock.ControlPlane.Distributor.TransactionsTest do
 
       assert {:error, {:read_version_failed, :unavailable}} =
                Transactions.take_lock(deps(%{next_read_version_fn: fn -> {:error, :unavailable} end}))
+    end
+  end
+
+  describe "commit_checked/3" do
+    defp taken_lock do
+      {lock, _mutations} = Lock.take(nil, nil)
+      lock
+    end
+
+    test "steady state: reads the owner only, conflicts on the owner only, touches write + payload" do
+      test_pid = self()
+      lock = taken_lock()
+
+      deps =
+        deps(%{
+          get_fn: fn key, _v ->
+            send(test_pid, {:read, key})
+            if String.ends_with?(key, "owner"), do: {:ok, lock.my_owner}, else: {:error, :not_found}
+          end,
+          commit_fn: fn _p, _e, encoded, _o ->
+            send(test_pid, {:committed, encoded})
+            {:ok, Version.from_integer(5), 0}
+          end
+        })
+
+      payload = {:set, SystemKeys.materializer_key(7), "payload"}
+      assert :ok = Transactions.commit_checked(lock, deps, [payload])
+
+      owner_key = SystemKeys.distributor_lock_owner()
+      write_key = SystemKeys.distributor_lock_write()
+
+      # The runner obligation: the write key is NOT read in the
+      # steady-state branch — an unconditional read would serialize all
+      # concurrent same-owner distributor transactions.
+      assert_received {:read, ^owner_key}
+      refute_received {:read, ^write_key}
+
+      assert_received {:committed, encoded}
+      assert {:ok, {_v, conflict_ranges}} = Transaction.read_conflicts(encoded)
+      covered = fn key -> Enum.any?(conflict_ranges, fn {s, e} -> key >= s and key < e end) end
+      assert covered.(owner_key)
+      refute covered.(write_key)
+
+      assert {:ok, mutations} = Transaction.mutations(encoded)
+      mutations = Enum.to_list(mutations)
+      assert {:set, SystemKeys.materializer_key(7), "payload"} in mutations
+      assert Enum.any?(mutations, &match?({:set, ^write_key, _fresh}, &1))
+    end
+
+    test "supersession is the READ verdict and is authoritative — no commit is attempted" do
+      lock = taken_lock()
+      usurper = Lock.new_uid()
+
+      deps =
+        deps(%{
+          get_fn: fn _k, _v -> {:ok, usurper} end,
+          commit_fn: fn _p, _e, _t, _o -> flunk("a superseded fence must not commit") end
+        })
+
+      assert {:error, :superseded} = Transactions.commit_checked(lock, deps, [])
+    end
+
+    test "a commit abort retries with a fresh fence read — a usurper appearing mid-retry is caught by the read" do
+      lock = taken_lock()
+      usurper = Lock.new_uid()
+      counter = :counters.new(1, [])
+
+      deps =
+        deps(%{
+          get_fn: fn key, _v ->
+            if String.ends_with?(key, "owner") do
+              # First evaluation: still ours. After the abort: usurped.
+              if :counters.get(counter, 1) == 0, do: {:ok, lock.my_owner}, else: {:ok, usurper}
+            else
+              {:error, :not_found}
+            end
+          end,
+          commit_fn: fn _p, _e, _t, _o ->
+            :counters.add(counter, 1, 1)
+            {:error, :aborted}
+          end
+        })
+
+      assert {:error, :superseded} = Transactions.commit_checked(lock, deps, [])
+    end
+
+    test "the previous-owner branch reads and conflicts on both keys" do
+      test_pid = self()
+      prev_owner = Lock.new_uid()
+      prev_write = Lock.new_uid()
+      {lock, _} = Lock.take(prev_owner, prev_write)
+
+      deps =
+        deps(%{
+          get_fn: fn key, _v ->
+            send(test_pid, {:read, key})
+            if String.ends_with?(key, "owner"), do: {:ok, prev_owner}, else: {:ok, prev_write}
+          end,
+          commit_fn: fn _p, _e, encoded, _o ->
+            send(test_pid, {:committed, encoded})
+            {:ok, Version.from_integer(5), 0}
+          end
+        })
+
+      assert :ok = Transactions.commit_checked(lock, deps, [])
+
+      write_key = SystemKeys.distributor_lock_write()
+      assert_received {:read, ^write_key}
+
+      assert_received {:committed, encoded}
+      assert {:ok, {_v, conflict_ranges}} = Transaction.read_conflicts(encoded)
+      assert Enum.any?(conflict_ranges, fn {s, e} -> write_key >= s and write_key < e end)
+    end
+  end
+
+  describe "read_snapshot/1" do
+    test "reads both families at one pinned version and decodes them" do
+      alias Bedrock.SystemKeys.Values, as: V
+
+      test_pid = self()
+      v = Version.from_integer(77)
+
+      shard_entries = [{SystemKeys.shard_key(<<0xFF, 0xFF>>), V.encode_shard_key_entry(0, <<>>)}]
+      ref_entries = [{SystemKeys.materializer_key(0), V.encode_materializer_ref("wkr", "n@h")}]
+
+      deps =
+        deps(%{
+          next_read_version_fn: fn -> {:ok, v} end,
+          get_range_fn: fn start_key, _end_key, version ->
+            send(test_pid, {:range_read, start_key, version})
+
+            cond do
+              String.starts_with?(start_key, SystemKeys.shard_keys_prefix()) -> {:ok, {shard_entries, false}}
+              String.starts_with?(start_key, SystemKeys.materializers_prefix()) -> {:ok, {ref_entries, false}}
+            end
+          end
+        })
+
+      assert {:ok, %{shard_layout: layout, materializer_refs: refs}} = Transactions.read_snapshot(deps)
+      assert layout == %{<<0xFF, 0xFF>> => {0, <<>>}}
+      assert refs == %{0 => {"wkr", "n@h"}}
+
+      assert_received {:range_read, _shard_start, ^v}
+      assert_received {:range_read, _refs_start, ^v}
     end
   end
 

--- a/test/support/control_plane/stub_materializer.ex
+++ b/test/support/control_plane/stub_materializer.ex
@@ -1,0 +1,91 @@
+defmodule Bedrock.Test.ControlPlane.StubMaterializer do
+  @moduledoc """
+  A stub materializer GenServer that implements the real read API call
+  shapes handled by the olivine/basalt materializer servers:
+
+    * `{:get, key | KeySelector.t(), version, opts}`
+    * `{:get_range, start_key | KeySelector.t(), end_key | KeySelector.t(), version, opts}`
+
+  Serves from a static key-value map, ignoring versions.
+
+  Also speaks the recovery worker protocol (`{:lock_for_recovery, epoch}`
+  and `{:unlock_after_recovery, durable_version, tsl}`) so recruitment
+  tests can stub only the foreman worker-creation boundary while keeping
+  the real epoch lock/unlock calls, and answers `{:info, fact_names}` with
+  the `:shard_id` / `:durable_version` it was started with (so re-adoption
+  tests can exercise the real identity-query path). Lock/unlock/info
+  activity is reported to an optional observer pid as
+  `{:stub_materializer, event}` messages.
+  """
+  use GenServer
+
+  alias Bedrock.DataPlane.Version
+  alias Bedrock.KeySelector
+
+  @spec start_link(%{Bedrock.key() => Bedrock.value()}, opts :: keyword()) :: GenServer.on_start()
+  def start_link(kvs, opts \\ []) do
+    {observer, opts} = Keyword.pop(opts, :observer)
+    {shard_id, opts} = Keyword.pop(opts, :shard_id)
+    {durable_version, opts} = Keyword.pop(opts, :durable_version, Version.zero())
+    GenServer.start_link(__MODULE__, {kvs, observer, shard_id, durable_version}, opts)
+  end
+
+  @impl true
+  def init({kvs, observer, shard_id, durable_version}),
+    do: {:ok, %{kvs: kvs, observer: observer, shard_id: shard_id, durable_version: durable_version}}
+
+  def init({kvs, observer}), do: {:ok, %{kvs: kvs, observer: observer, shard_id: nil, durable_version: Version.zero()}}
+  def init(kvs), do: {:ok, %{kvs: kvs, observer: nil, shard_id: nil, durable_version: Version.zero()}}
+
+  @impl true
+  def handle_call({:get, %KeySelector{key: key}, _version, _opts}, _from, %{kvs: kvs} = state) do
+    case Map.fetch(kvs, key) do
+      {:ok, value} -> {:reply, {:ok, {key, value}}, state}
+      :error -> {:reply, {:ok, nil}, state}
+    end
+  end
+
+  def handle_call({:get, key, _version, _opts}, _from, %{kvs: kvs} = state) when is_binary(key),
+    do: {:reply, {:ok, Map.get(kvs, key)}, state}
+
+  def handle_call({:get_range, start_key, end_key, _version, _opts}, _from, %{kvs: kvs} = state)
+      when is_binary(start_key) and is_binary(end_key) do
+    results =
+      kvs
+      |> Enum.filter(fn {key, _value} -> key >= start_key and key < end_key end)
+      |> Enum.sort()
+
+    {:reply, {:ok, {results, false}}, state}
+  end
+
+  def handle_call({:lock_for_recovery, epoch}, _from, state) do
+    notify(state, {:locked_for_recovery, self(), epoch})
+
+    recovery_info = %{
+      kind: :materializer,
+      durable_version: state.durable_version,
+      oldest_durable_version: Version.zero()
+    }
+
+    {:reply, {:ok, self(), recovery_info}, state}
+  end
+
+  def handle_call({:info, fact_names}, _from, state) when is_list(fact_names) do
+    notify(state, {:info, self(), fact_names})
+    {:reply, {:ok, Map.new(fact_names, &{&1, gather_info(&1, state)})}, state}
+  end
+
+  def handle_call({:unlock_after_recovery, durable_version, tsl}, _from, state) do
+    notify(state, {:unlocked_after_recovery, self(), durable_version, tsl})
+    {:reply, :ok, state}
+  end
+
+  defp notify(%{observer: nil}, _event), do: :ok
+  defp notify(%{observer: observer}, event), do: send(observer, {:stub_materializer, event})
+
+  defp gather_info(:kind, _state), do: :materializer
+  defp gather_info(:pid, _state), do: self()
+  defp gather_info(:shard_id, state), do: state.shard_id
+  defp gather_info(:durable_version, state), do: state.durable_version
+  defp gather_info(_unsupported, _state), do: {:error, :unsupported_info}
+end


### PR DESCRIPTION
## Why

Phase 3 (second half) of bedrock-q67.21. Uncovered shard tags today fail reads as unroutable; the phase-a design parks them briefly and sheds `:unavailable` — bounded degradation instead of hard failure — but its publication mechanism (a placeholder **pid** in a TSL slot) died with the TSL. The settled option-2 addressing makes the placeholder an ordinary materializer ref, so the keyspace remains the whole story.

## What

- **Placeholder** (ported from phase-a as the behavior spec — its 13 tests pass verbatim): speaks the exact materializer read API; parks with `min(caller timeout, hold_ms)` budgets; sheds `{:error, :unavailable}` (retryable + routing-invalidating at the client — exactly right for an uncovered key); per-tag demand dedupe; drain-by-reissue on covered.
- **Option-2 addressing**: the sweep publishes `materializers/<tag> = {"distributor-placeholder", node}` for every uncovered tag in **one check-fenced commit**; the placeholder registers under `otp_name_for_worker(placeholder_worker_id)`. No proxy or client changes anywhere. Dividend: restarts re-register the same name — no republication.
- **`Transactions.commit_checked`** — the first CHECK-fenced mutating commit, honoring both Lock runner obligations (write key read + conflicted **only** in the previous-owner branch — concurrent same-owner transactions never serialize on the lock). Verdict semantics mirror FDB exactly: supersession is the **read** verdict (authoritative, `movekeys_conflict`); a commit **abort** retries with a fresh fence read, and a usurper appearing mid-retry is caught by the read.
- **`Transactions.read_snapshot`** — both durable families at one pinned version (lock-first-snapshot-second).
- **`Bedrock.SystemKeys.Reader`** — the pager + family decoders extracted to one shared home; bootstrap delegates. One reader, so recovery and the distributor cannot disagree about the bytes.
- **Demand channel**: covered tags hand the placeholder the callable ref (park-vs-publish races drain); uncovered — including placeholder-covered, which is *not* coverage — record pending demand for recruitment (q67.21.4).

## How

TDD on every new contract: the fence-obligation pins (owner-only reads + conflicts in steady state; both in the previous-owner branch), read-verdict-authoritative vs abort-retries (including the usurper-mid-retry case), sweep content decoded from the committed transaction, demand routing matrix, no-republication restart. `WaitingList`'s key type widens to version-or-tag (phase-a parity).

Full suite (2663 tests), credo --strict, dialyzer green.