### PR TITLE
Death healing; recovery ceases data-tag creation

### DIFF
--- a/lib/bedrock/control_plane/director/recovery/materializer_bootstrap_phase.ex
+++ b/lib/bedrock/control_plane/director/recovery/materializer_bootstrap_phase.ex
@@ -83,10 +83,13 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhase do
     Logger.debug("Fresh cluster detected, using default shard layout")
 
     shard_layout = default_shard_layout()
-    shard_tags = extract_shard_tags(shard_layout)
 
-    # Create materializers for all shards in the layout
-    case create_materializers_for_shards(shard_tags, recovery_attempt, context) do
+    # Only the system shard is recovery's to create (stall-only-for-tag-0
+    # completed, bedrock-q67.21.4): data-tag gaps are left ABSENT — the
+    # distributor's sweep covers them with the placeholder and demand
+    # recruits real workers. Recovery no longer manufactures data-plane
+    # coverage it does not itself need.
+    case create_materializers_for_shards([RecoveryAttempt.system_shard_id()], recovery_attempt, context) do
       {:ok, shard_materializers, created_services} ->
         updated_attempt =
           recovery_attempt
@@ -357,6 +360,9 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhase do
           shard_tag
           |> start_materializer_for_shard(existing_by_shard, recovery_version, recovery_attempt, context)
           |> case do
+            {:ok, :absent, _created} ->
+              {:cont, {:ok, acc, services}}
+
             {:ok, assignment, created} ->
               {:cont, {:ok, Map.put(acc, shard_tag, assignment), Map.merge(services, created)}}
 
@@ -376,12 +382,14 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhase do
         end
 
       :error ->
-        Logger.info("Materializer for shard #{shard_tag} not found, creating new one")
-
-        with {:ok, assignment, {worker_id, descriptor}} <-
-               create_and_start_materializer(shard_tag, recovery_attempt, context) do
-          {:ok, assignment, %{worker_id => descriptor}}
-        end
+        # No survivor: the gap is the distributor's to heal, not
+        # recovery's to fill (stall-only-for-tag-0 completed,
+        # bedrock-q67.21.4). The slot stays ABSENT; the sweep covers it
+        # with the placeholder and demand recruits a real worker. The
+        # shard's durable history is safe regardless — chunks are
+        # shard-keyed, epoch-spanning, and never deleted.
+        Logger.info("Materializer for shard #{shard_tag} not found; leaving for the distributor to heal")
+        {:ok, :absent, %{}}
     end
   end
 

--- a/lib/bedrock/control_plane/distributor/server.ex
+++ b/lib/bedrock/control_plane/distributor/server.ex
@@ -14,6 +14,12 @@ defmodule Bedrock.ControlPlane.Distributor.Server do
 
   @placeholder_worker_id Placeholder.worker_id()
 
+  # Consecutive failed ping-verifications before unreachability is
+  # treated as death. With the default reverify interval this is ~6s of
+  # sustained unreachability — long enough to ride out a dist blip,
+  # short enough that a lost node heals promptly.
+  @max_unreachable_verifications 3
+
   # FDB's MOVEKEYS_LOCK_POLLING_DELAY: a superseded distributor exits
   # within seconds even when idle, instead of waiting to lose a commit.
   @poll_interval_ms 5_000
@@ -68,7 +74,8 @@ defmodule Bedrock.ControlPlane.Distributor.Server do
       poll_interval_ms: Keyword.get(opts, :poll_interval_ms, @poll_interval_ms),
       placeholder_start_fn: Keyword.get(opts, :placeholder_start_fn),
       recruitment_ctx: Keyword.get(opts, :recruitment_ctx),
-      backoff_ms: Keyword.get(opts, :backoff_ms, 5_000)
+      backoff_ms: Keyword.get(opts, :backoff_ms, 5_000),
+      reverify_interval_ms: Keyword.get(opts, :reverify_interval_ms, 2_000)
     }
 
     {:ok, state, {:continue, :take_lock}}
@@ -104,8 +111,12 @@ defmodule Bedrock.ControlPlane.Distributor.Server do
     with {:ok, snapshot} <- Transactions.read_snapshot(t.deps),
          {:ok, placeholder} <- start_placeholder(t, snapshot.shard_layout),
          t = %{t | placeholder: placeholder, snapshot: snapshot},
-         :ok <- publish_placeholders(t, uncovered_tags(snapshot)) do
-      {:noreply, monitor_assignments(t)}
+         uncovered = uncovered_tags(snapshot),
+         :ok <- publish_placeholders(t, uncovered) do
+      # Eager recruitment for the swept gaps erases first-touch latency:
+      # the sweep already knows every uncovered tag, and the in-flight
+      # dedupe and backoff machinery make eagerness free.
+      {:noreply, Enum.reduce(uncovered, monitor_assignments(t), &maybe_recruit(&2, &1))}
     else
       {:error, :superseded} ->
         Logger.info("Bedrock distributor (epoch #{t.epoch}): superseded at publish; ceding")
@@ -193,39 +204,43 @@ defmodule Bedrock.ControlPlane.Distributor.Server do
     end
   end
 
-  # Death healing (event-driven, FDB teamTracker-style): a monitored
-  # assignment died. First make the gap keyspace-visible — publish the
-  # placeholder ref under the fence, so clients park instead of
-  # hammering the corpse and displaced-but-alive twins observe the
-  # change — then tell the placeholder the tag is uncovered (park, don't
-  # forward) and eagerly re-recruit. A superseded publish cedes: a newer
-  # owner heals, not us.
+  # Death healing (event-driven, FDB teamTracker-style) — with FDB's
+  # distinction between connection state and failure: unreachable is NOT
+  # dead. A :noconnection DOWN fires for every remote assignment at once
+  # on any transient dist blip; healing eagerly on it would rip live
+  # workers out of the routing view and stampede recruitment (N blips →
+  # N+1 workers per shard). Instead: damp — ping-verify on a timer, heal
+  # only after the node stays unreachable across consecutive checks.
+  # Genuine death signals (:noproc, :killed, crashes) heal immediately.
   def handle_info({:DOWN, ref, :process, _pid, reason}, %State{} = t) when is_map_key(t.assignment_monitors, ref) do
     {tag, monitors} = Map.pop(t.assignment_monitors, ref)
     t = %{t | assignment_monitors: monitors}
 
-    Logger.warning("Bedrock distributor (epoch #{t.epoch}): materializer for tag #{tag} down (#{inspect(reason)})")
-    Placeholder.notify_uncovered(t.placeholder, tag)
+    case reason do
+      :noconnection ->
+        Logger.warning("Bedrock distributor (epoch #{t.epoch}): materializer for tag #{tag} unreachable; verifying")
+        {:noreply, schedule_reverify(t, tag)}
 
-    case publish_placeholders(t, [tag]) do
-      :ok ->
-        refs = Map.put(t.snapshot.materializer_refs, tag, {@placeholder_worker_id, Atom.to_string(node())})
-        {:noreply, maybe_recruit(%{t | snapshot: %{t.snapshot | materializer_refs: refs}}, tag)}
+      _dead ->
+        Logger.warning("Bedrock distributor (epoch #{t.epoch}): materializer for tag #{tag} down (#{inspect(reason)})")
+        heal_tag(clear_unreachable(t, tag), tag)
+    end
+  end
 
-      {:error, :superseded} ->
-        Logger.info("Bedrock distributor (epoch #{t.epoch}): superseded healing tag #{tag}; ceding")
-        {:stop, :normal, t}
+  # The reverify tick: reachable again means the worker was never
+  # observed dead — reset the count and re-arm the monitor (a genuinely
+  # dead worker on a reachable node yields an immediate :noproc DOWN and
+  # heals through the fast path above). Persistent unreachability
+  # escalates to a heal after @max_unreachable_verifications consecutive
+  # failed pings. A tag whose ref changed meanwhile has nothing left to
+  # verify.
+  def handle_info({:reverify_assignment, tag}, %State{} = t) do
+    case Map.get(t.snapshot.materializer_refs, tag) do
+      {worker_id, node_string} when worker_id != @placeholder_worker_id ->
+        reverify_assignment(t, tag, worker_id, node_string)
 
-      {:error, reason2} ->
-        # The gap stays; the corpse's clients fail :unavailable and the
-        # next demand or DOWN-less poll tick has another chance once the
-        # transient clears. Re-recruit anyway — publish retries on
-        # completion.
-        Logger.warning(
-          "Bedrock distributor (epoch #{t.epoch}): healing publish for tag #{tag} failed: #{inspect(reason2)}"
-        )
-
-        {:noreply, maybe_recruit(t, tag)}
+      _placeholder_or_absent ->
+        {:noreply, clear_unreachable(t, tag)}
     end
   end
 
@@ -371,6 +386,67 @@ defmodule Bedrock.ControlPlane.Distributor.Server do
   defp commit_definitely_not_landed?({:lock_read_failed, _}), do: true
   defp commit_definitely_not_landed?({:read_version_failed, _}), do: true
   defp commit_definitely_not_landed?(_ambiguous), do: false
+
+  defp reverify_assignment(%State{} = t, tag, worker_id, node_string) do
+    # credo:disable-for-next-line Credo.Check.Warning.UnsafeToAtom
+    node_atom = String.to_atom(node_string)
+
+    if node_atom == node() or Node.ping(node_atom) == :pong do
+      {:noreply,
+       t |> clear_unreachable(tag) |> monitor_assignment(tag, {t.cluster.otp_name_for_worker(worker_id), node_atom})}
+    else
+      count = Map.get(t.unreachable_counts, tag, 0) + 1
+      t = %{t | unreachable_counts: Map.put(t.unreachable_counts, tag, count)}
+
+      if count >= @max_unreachable_verifications do
+        Logger.warning(
+          "Bedrock distributor (epoch #{t.epoch}): tag #{tag} unreachable after #{count} verifications; healing"
+        )
+
+        heal_tag(clear_unreachable(t, tag), tag)
+      else
+        {:noreply, schedule_reverify(t, tag)}
+      end
+    end
+  end
+
+  # The heal itself: make the gap keyspace-visible FIRST — publish the
+  # placeholder ref under the fence, so clients park instead of
+  # hammering the corpse and displaced-but-alive twins observe the
+  # change — then tell the placeholder the tag is uncovered (park, don't
+  # forward) and eagerly re-recruit. A superseded publish cedes: a newer
+  # owner heals, not us. On a transient publish failure the tag's LOCAL
+  # ref is dropped so a racing coverage_demand recruits instead of
+  # draining parked reads into the corpse; the keyspace still names the
+  # corpse but self-corrects at the recruit's publication.
+  defp heal_tag(%State{} = t, tag) do
+    Placeholder.notify_uncovered(t.placeholder, tag)
+
+    case publish_placeholders(t, [tag]) do
+      :ok ->
+        refs = Map.put(t.snapshot.materializer_refs, tag, {@placeholder_worker_id, Atom.to_string(node())})
+        {:noreply, maybe_recruit(%{t | snapshot: %{t.snapshot | materializer_refs: refs}}, tag)}
+
+      {:error, :superseded} ->
+        Logger.info("Bedrock distributor (epoch #{t.epoch}): superseded healing tag #{tag}; ceding")
+        {:stop, :normal, t}
+
+      {:error, reason} ->
+        Logger.warning(
+          "Bedrock distributor (epoch #{t.epoch}): healing publish for tag #{tag} failed: #{inspect(reason)}"
+        )
+
+        refs = Map.delete(t.snapshot.materializer_refs, tag)
+        {:noreply, maybe_recruit(%{t | snapshot: %{t.snapshot | materializer_refs: refs}}, tag)}
+    end
+  end
+
+  defp clear_unreachable(%State{} = t, tag), do: %{t | unreachable_counts: Map.delete(t.unreachable_counts, tag)}
+
+  defp schedule_reverify(%State{} = t, tag) do
+    Process.send_after(self(), {:reverify_assignment, tag}, t.reverify_interval_ms)
+    t
+  end
 
   # Monitor every live (non-placeholder) assignment by its callable name
   # — monitors on {name, node} fire on death OR unreachability, either of

--- a/lib/bedrock/control_plane/distributor/server.ex
+++ b/lib/bedrock/control_plane/distributor/server.ex
@@ -105,7 +105,7 @@ defmodule Bedrock.ControlPlane.Distributor.Server do
          {:ok, placeholder} <- start_placeholder(t, snapshot.shard_layout),
          t = %{t | placeholder: placeholder, snapshot: snapshot},
          :ok <- publish_placeholders(t, uncovered_tags(snapshot)) do
-      {:noreply, t}
+      {:noreply, monitor_assignments(t)}
     else
       {:error, :superseded} ->
         Logger.info("Bedrock distributor (epoch #{t.epoch}): superseded at publish; ceding")
@@ -190,6 +190,42 @@ defmodule Bedrock.ControlPlane.Distributor.Server do
       handle_info({:recruitment_complete, tag, {:error, {:recruit_task_crashed, reason}}}, t)
     else
       {:noreply, t}
+    end
+  end
+
+  # Death healing (event-driven, FDB teamTracker-style): a monitored
+  # assignment died. First make the gap keyspace-visible — publish the
+  # placeholder ref under the fence, so clients park instead of
+  # hammering the corpse and displaced-but-alive twins observe the
+  # change — then tell the placeholder the tag is uncovered (park, don't
+  # forward) and eagerly re-recruit. A superseded publish cedes: a newer
+  # owner heals, not us.
+  def handle_info({:DOWN, ref, :process, _pid, reason}, %State{} = t) when is_map_key(t.assignment_monitors, ref) do
+    {tag, monitors} = Map.pop(t.assignment_monitors, ref)
+    t = %{t | assignment_monitors: monitors}
+
+    Logger.warning("Bedrock distributor (epoch #{t.epoch}): materializer for tag #{tag} down (#{inspect(reason)})")
+    Placeholder.notify_uncovered(t.placeholder, tag)
+
+    case publish_placeholders(t, [tag]) do
+      :ok ->
+        refs = Map.put(t.snapshot.materializer_refs, tag, {@placeholder_worker_id, Atom.to_string(node())})
+        {:noreply, maybe_recruit(%{t | snapshot: %{t.snapshot | materializer_refs: refs}}, tag)}
+
+      {:error, :superseded} ->
+        Logger.info("Bedrock distributor (epoch #{t.epoch}): superseded healing tag #{tag}; ceding")
+        {:stop, :normal, t}
+
+      {:error, reason2} ->
+        # The gap stays; the corpse's clients fail :unavailable and the
+        # next demand or DOWN-less poll tick has another chance once the
+        # transient clears. Re-recruit anyway — publish retries on
+        # completion.
+        Logger.warning(
+          "Bedrock distributor (epoch #{t.epoch}): healing publish for tag #{tag} failed: #{inspect(reason2)}"
+        )
+
+        {:noreply, maybe_recruit(t, tag)}
     end
   end
 
@@ -288,16 +324,21 @@ defmodule Bedrock.ControlPlane.Distributor.Server do
 
     case Transactions.commit_checked(t.lock, t.deps, [mutation]) do
       :ok ->
-        Placeholder.notify_covered(t.placeholder, tag, {t.cluster.otp_name_for_worker(worker_id), node})
+        callable = {t.cluster.otp_name_for_worker(worker_id), node}
+        Placeholder.notify_covered(t.placeholder, tag, callable)
 
         refs = Map.put(t.snapshot.materializer_refs, tag, {worker_id, node_string})
 
         {:noreply,
-         %{
-           t
-           | snapshot: %{t.snapshot | materializer_refs: refs},
-             pending_demands: MapSet.delete(t.pending_demands, tag)
-         }}
+         monitor_assignment(
+           %{
+             t
+             | snapshot: %{t.snapshot | materializer_refs: refs},
+               pending_demands: MapSet.delete(t.pending_demands, tag)
+           },
+           tag,
+           callable
+         )}
 
       {:error, :superseded} ->
         # The READ verdict refused before any commit was attempted: this
@@ -330,6 +371,29 @@ defmodule Bedrock.ControlPlane.Distributor.Server do
   defp commit_definitely_not_landed?({:lock_read_failed, _}), do: true
   defp commit_definitely_not_landed?({:read_version_failed, _}), do: true
   defp commit_definitely_not_landed?(_ambiguous), do: false
+
+  # Monitor every live (non-placeholder) assignment by its callable name
+  # — monitors on {name, node} fire on death OR unreachability, either of
+  # which is a coverage gap worth healing.
+  defp monitor_assignments(%State{} = t) do
+    Enum.reduce(t.snapshot.materializer_refs, t, fn
+      {_tag, {@placeholder_worker_id, _node}}, acc ->
+        acc
+
+      {tag, {worker_id, node}}, acc ->
+        # credo:disable-for-next-line Credo.Check.Warning.UnsafeToAtom
+        monitor_assignment(acc, tag, {acc.cluster.otp_name_for_worker(worker_id), String.to_atom(node)})
+    end)
+  end
+
+  defp monitor_assignment(%State{} = t, tag, {name, node_atom}) do
+    # A local name is monitored as a bare atom: the {name, node} form
+    # requires live distribution, which a single-node deployment
+    # legitimately runs without.
+    target = if node_atom == node(), do: name, else: {name, node_atom}
+    ref = Process.monitor(target)
+    %{t | assignment_monitors: Map.put(t.assignment_monitors, ref, tag)}
+  end
 
   defp start_backoff(%State{} = t, tag),
     do: %{t | backoff: Map.put(t.backoff, tag, System.monotonic_time(:millisecond) + t.backoff_ms)}

--- a/lib/bedrock/control_plane/distributor/state.ex
+++ b/lib/bedrock/control_plane/distributor/state.ex
@@ -24,6 +24,7 @@ defmodule Bedrock.ControlPlane.Distributor.State do
           recruitment_ctx: map() | nil,
           recruiting: MapSet.t(Bedrock.range_tag()),
           recruit_task_refs: %{reference() => Bedrock.range_tag()},
+          assignment_monitors: %{reference() => Bedrock.range_tag()},
           backoff: %{Bedrock.range_tag() => integer()},
           backoff_ms: pos_integer()
         }
@@ -43,6 +44,7 @@ defmodule Bedrock.ControlPlane.Distributor.State do
     recruitment_ctx: nil,
     recruiting: MapSet.new(),
     recruit_task_refs: %{},
+    assignment_monitors: %{},
     backoff: %{},
     backoff_ms: 5_000
   ]

--- a/lib/bedrock/control_plane/distributor/state.ex
+++ b/lib/bedrock/control_plane/distributor/state.ex
@@ -25,6 +25,8 @@ defmodule Bedrock.ControlPlane.Distributor.State do
           recruiting: MapSet.t(Bedrock.range_tag()),
           recruit_task_refs: %{reference() => Bedrock.range_tag()},
           assignment_monitors: %{reference() => Bedrock.range_tag()},
+          unreachable_counts: %{Bedrock.range_tag() => pos_integer()},
+          reverify_interval_ms: pos_integer(),
           backoff: %{Bedrock.range_tag() => integer()},
           backoff_ms: pos_integer()
         }
@@ -45,6 +47,8 @@ defmodule Bedrock.ControlPlane.Distributor.State do
     recruiting: MapSet.new(),
     recruit_task_refs: %{},
     assignment_monitors: %{},
+    unreachable_counts: %{},
+    reverify_interval_ms: 2_000,
     backoff: %{},
     backoff_ms: 5_000
   ]

--- a/test/bedrock/control_plane/director/recovery/materializer_bootstrap_phase_test.exs
+++ b/test/bedrock/control_plane/director/recovery/materializer_bootstrap_phase_test.exs
@@ -55,10 +55,13 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhaseTest 
           # Default layout has two shards: system and user
           assert map_size(updated_attempt.shard_layout) == 2
 
-          # Should have created materializers for both shards
-          assert map_size(updated_attempt.shard_materializers) == 2
+          # Only the system shard is recovery's to create: the data
+          # shard's slot stays ABSENT for the distributor to cover with
+          # the placeholder and heal by recruitment (stall-only-for-
+          # tag-0 completed).
+          assert map_size(updated_attempt.shard_materializers) == 1
           assert Map.has_key?(updated_attempt.shard_materializers, 0)
-          assert Map.has_key?(updated_attempt.shard_materializers, 1)
+          refute Map.has_key?(updated_attempt.shard_materializers, 1)
 
           assert {<<_::binary>>, node_string} =
                    updated_attempt.shard_materializers[RecoveryAttempt.system_shard_id()]
@@ -72,15 +75,14 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhaseTest 
             for {_id, %{kind: :materializer, status: {:up, pid}}} <- updated_attempt.transaction_services, do: pid
 
           assert system_materializer_pid in created_pids
-          assert user_materializer_pid in created_pids
+          refute user_materializer_pid in created_pids
         end)
 
       assert log =~ "Fresh cluster detected"
 
-      # Verify both shards were created
+      # Only the system shard's materializer was created.
       shards = created_shards |> :ets.lookup(:shard) |> Enum.map(fn {:shard, tag} -> tag end)
-      assert 0 in shards
-      assert 1 in shards
+      assert shards == [0]
 
       :ets.delete(created_shards)
     end
@@ -134,17 +136,20 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhaseTest 
       assert {<<_::binary>>, <<_::binary>>} =
                updated_attempt.shard_materializers[RecoveryAttempt.system_shard_id()]
 
-      # Replication spans all logs today, so every shard's replica set
-      # covers both — each seed carries {log_id, ref} pairs, never a
-      # cluster services map.
+      # Replication spans all logs today, so the system shard's replica
+      # set covers both — the seed carries {log_id, ref} pairs, never a
+      # cluster services map. (The data shard is not created; its seed
+      # is the distributor's, at recruitment.)
       expected = [{"log_1", log_1_pid}, {"log_2", log_2_pid}]
 
-      for pid <- [system_materializer_pid, user_materializer_pid] do
-        assert [{:unlock, ^pid, sources}] =
-                 unlocks |> :ets.lookup(:unlock) |> Enum.filter(&match?({:unlock, ^pid, _}, &1))
+      assert [{:unlock, ^system_materializer_pid, sources}] =
+               unlocks
+               |> :ets.lookup(:unlock)
+               |> Enum.filter(&match?({:unlock, ^system_materializer_pid, _}, &1))
 
-        assert Enum.sort(sources) == expected
-      end
+      assert Enum.sort(sources) == expected
+
+      assert [] = unlocks |> :ets.lookup(:unlock) |> Enum.filter(&match?({:unlock, ^user_materializer_pid, _}, &1))
 
       :ets.delete(unlocks)
     end

--- a/test/bedrock/control_plane/distributor/server_test.exs
+++ b/test/bedrock/control_plane/distributor/server_test.exs
@@ -164,7 +164,9 @@ defmodule Bedrock.ControlPlane.Distributor.ServerTest do
       test_pid = self()
 
       # Tag 0 is covered; tag 1 has no entry — the gap.
-      refs_entries = [{SystemKeys.materializer_key(0), Values.encode_materializer_ref("wkr_sys", "n@h")}]
+      refs_entries = [
+        {SystemKeys.materializer_key(0), Values.encode_materializer_ref("wkr_sys", Atom.to_string(node()))}
+      ]
 
       assert {:noreply, t} = Server.handle_continue(:startup_sweep, swept_state(refs_entries, test_pid))
       assert t.snapshot.shard_layout == %{"m" => {1, <<>>}, <<0xFF, 0xFF>> => {0, "m"}}
@@ -204,8 +206,8 @@ defmodule Bedrock.ControlPlane.Distributor.ServerTest do
       test_pid = self()
 
       refs_entries = [
-        {SystemKeys.materializer_key(0), Values.encode_materializer_ref("wkr_sys", "n@h")},
-        {SystemKeys.materializer_key(1), Values.encode_materializer_ref("wkr_a", "n@h")}
+        {SystemKeys.materializer_key(0), Values.encode_materializer_ref("wkr_sys", Atom.to_string(node()))},
+        {SystemKeys.materializer_key(1), Values.encode_materializer_ref("wkr_a", Atom.to_string(node()))}
       ]
 
       assert {:noreply, _t} = Server.handle_continue(:startup_sweep, swept_state(refs_entries, test_pid))
@@ -557,6 +559,118 @@ defmodule Bedrock.ControlPlane.Distributor.ServerTest do
       end)
 
       assert_received {:orphan_removed, "wkr_orphan"}
+    end
+  end
+
+  describe "death healing" do
+    alias Bedrock.SystemKeys, as: HealKeys
+    alias Bedrock.SystemKeys.Values, as: HealValues
+
+    defp healing_state(test_pid, overrides) do
+      {lock, _} = Lock.take(nil, nil)
+      Process.put(:my_owner, lock.my_owner)
+
+      deps = %{
+        get_fn: fn key, _v ->
+          if String.ends_with?(key, "owner"), do: {:ok, Process.get(:my_owner)}, else: {:error, :not_found}
+        end,
+        commit_fn: fn _p, _e, encoded, _o ->
+          send(test_pid, {:committed, encoded})
+          {:ok, Version.from_integer(9), 0}
+        end
+      }
+
+      placeholder =
+        spawn(fn ->
+          receive do
+            {:"$gen_cast", msg} -> send(test_pid, {:placeholder_got, msg})
+          end
+        end)
+
+      state(
+        deps,
+        Keyword.merge(
+          [
+            lock: lock,
+            placeholder: placeholder,
+            snapshot: %{
+              shard_layout: %{},
+              materializer_refs: %{7 => {"wkr_dead", Atom.to_string(node())}}
+            },
+            recruitment_ctx: %{
+              cluster: __MODULE__,
+              epoch: 3,
+              node_capabilities: %{materializer: [node()]},
+              logs: %{"log_1" => []},
+              log_refs: %{"log_1" => :ref},
+              create_worker_fn: fn _f, _i, _k, _o -> {:error, :scripted} end
+            }
+          ],
+          overrides
+        )
+      )
+    end
+
+    test "an assignment's death publishes the placeholder, uncovers the tag, and re-recruits" do
+      test_pid = self()
+      ref = make_ref()
+      t = healing_state(test_pid, [])
+      t = %{t | assignment_monitors: %{ref => 7}}
+
+      log =
+        ExUnit.CaptureLog.capture_log(fn ->
+          assert {:noreply, t2} = Server.handle_info({:DOWN, ref, :process, self(), :killed}, t)
+
+          # The gap became keyspace-visible first.
+          assert_received {:committed, encoded}
+          assert {:ok, mutations} = Transaction.mutations(encoded)
+
+          placeholder_ref = HealValues.encode_materializer_ref(Placeholder.worker_id(), Atom.to_string(node()))
+          assert {:set, HealKeys.materializer_key(7), placeholder_ref} in Enum.to_list(mutations)
+
+          # Park, don't forward; and the re-recruit is in flight. (The
+          # stub forwards a cast: wait, don't demand prior arrival.)
+          assert_receive {:placeholder_got, {:uncovered, 7}}
+          assert MapSet.member?(t2.recruiting, 7)
+          assert t2.snapshot.materializer_refs[7] == {Placeholder.worker_id(), Atom.to_string(node())}
+          assert t2.assignment_monitors == %{}
+        end)
+
+      assert log =~ "materializer for tag 7 down"
+    end
+
+    test "a superseded healing publish cedes — a newer owner heals, not us" do
+      test_pid = self()
+      ref = make_ref()
+
+      t = healing_state(test_pid, [])
+
+      superseding_deps =
+        Map.merge(t.deps, %{
+          get_fn: fn _k, _v -> {:ok, Lock.new_uid()} end,
+          commit_fn: fn _p, _e, _t, _o -> flunk("must not commit past a refused fence") end
+        })
+
+      t = %{t | deps: superseding_deps, assignment_monitors: %{ref => 7}}
+
+      ExUnit.CaptureLog.capture_log(fn ->
+        assert {:stop, :normal, _t} = Server.handle_info({:DOWN, ref, :process, self(), :killed}, t)
+      end)
+    end
+
+    test "the startup sweep monitors live assignments but never the placeholder's own refs" do
+      test_pid = self()
+      node_string = Atom.to_string(node())
+
+      refs_entries = [
+        {HealKeys.materializer_key(0), HealValues.encode_materializer_ref("wkr_sys", node_string)},
+        {HealKeys.materializer_key(1), HealValues.encode_materializer_ref(Placeholder.worker_id(), node_string)}
+      ]
+
+      assert {:noreply, t} = Server.handle_continue(:startup_sweep, swept_state(refs_entries, test_pid))
+
+      assert map_size(t.assignment_monitors) == 1
+      assert t.assignment_monitors |> Map.values() |> Enum.sort() == [0]
     end
   end
 end

--- a/test/bedrock/control_plane/distributor/server_test.exs
+++ b/test/bedrock/control_plane/distributor/server_test.exs
@@ -214,6 +214,34 @@ defmodule Bedrock.ControlPlane.Distributor.ServerTest do
       refute_received {:committed, _}
     end
 
+    test "the sweep recruits its uncovered tags eagerly — no first-touch wait for demand" do
+      test_pid = self()
+      {lock, _} = Lock.take(nil, nil)
+      Process.put(:my_owner, lock.my_owner)
+
+      refs_entries = [
+        {SystemKeys.materializer_key(0), Values.encode_materializer_ref("wkr_sys", Atom.to_string(node()))}
+      ]
+
+      t =
+        state(two_shard_snapshot_deps(refs_entries, test_pid),
+          lock: lock,
+          placeholder_start_fn: fn _opts -> {:ok, spawn(fn -> Process.sleep(:infinity) end)} end,
+          recruitment_ctx: %{
+            cluster: __MODULE__,
+            epoch: 3,
+            node_capabilities: %{materializer: [node()]},
+            logs: %{"log_1" => []},
+            log_refs: %{"log_1" => :ref},
+            create_worker_fn: fn _f, _i, _k, _o -> {:error, :scripted} end
+          }
+        )
+
+      assert {:noreply, t2} = Server.handle_continue(:startup_sweep, t)
+      assert MapSet.member?(t2.recruiting, 1)
+      refute MapSet.member?(t2.recruiting, 0)
+    end
+
     test "supersession at the publish cedes" do
       test_pid = self()
       {lock, _} = Lock.take(nil, nil)
@@ -403,6 +431,10 @@ defmodule Bedrock.ControlPlane.Distributor.ServerTest do
       assert_receive {:placeholder_got, {:covered, 9, {_otp, _node}}}
       assert t2.snapshot.materializer_refs[9] == {"wkr_new", Atom.to_string(node())}
       refute MapSet.member?(t2.recruiting, 9)
+
+      # The published assignment is monitored from this moment — healing
+      # coverage starts at publication, not at the next sweep.
+      assert Map.values(t2.assignment_monitors) == [9]
     end
 
     test "a superseded publish removes the orphan and cedes" do
@@ -656,6 +688,135 @@ defmodule Bedrock.ControlPlane.Distributor.ServerTest do
       ExUnit.CaptureLog.capture_log(fn ->
         assert {:stop, :normal, _t} = Server.handle_info({:DOWN, ref, :process, self(), :killed}, t)
       end)
+    end
+
+    test "a :noconnection DOWN does not heal — the tag is verified, not stampeded" do
+      test_pid = self()
+      ref = make_ref()
+      t = healing_state(test_pid, [])
+      t = %{t | assignment_monitors: %{ref => 7}, reverify_interval_ms: 5}
+
+      log =
+        ExUnit.CaptureLog.capture_log(fn ->
+          assert {:noreply, t2} = Server.handle_info({:DOWN, ref, :process, self(), :noconnection}, t)
+
+          # Nothing destructive happened: no publish, no uncover, no
+          # recruit — the (possibly live) worker keeps its assignment...
+          refute_received {:committed, _}
+          refute_received {:placeholder_got, _}
+          refute MapSet.member?(t2.recruiting, 7)
+          assert t2.snapshot.materializer_refs[7] == {"wkr_dead", Atom.to_string(node())}
+
+          # ...and verification is armed instead.
+          assert_receive {:reverify_assignment, 7}, 100
+        end)
+
+      assert log =~ "unreachable; verifying"
+    end
+
+    test "persistent unreachability escalates to a heal after consecutive failed verifications" do
+      test_pid = self()
+
+      t =
+        healing_state(test_pid,
+          snapshot: %{shard_layout: %{}, materializer_refs: %{7 => {"wkr_gone", "gone@nowhere"}}}
+        )
+
+      t = %{t | reverify_interval_ms: 5}
+
+      log =
+        ExUnit.CaptureLog.capture_log(fn ->
+          # Two failed pings only re-arm the verification timer...
+          assert {:noreply, t} = Server.handle_info({:reverify_assignment, 7}, t)
+          assert t.unreachable_counts[7] == 1
+          refute_received {:committed, _}
+          assert_receive {:reverify_assignment, 7}, 100
+
+          assert {:noreply, t} = Server.handle_info({:reverify_assignment, 7}, t)
+          assert t.unreachable_counts[7] == 2
+
+          # ...the third escalates: publish, uncover, re-recruit.
+          assert {:noreply, t3} = Server.handle_info({:reverify_assignment, 7}, t)
+          assert_received {:committed, _}
+          assert_receive {:placeholder_got, {:uncovered, 7}}
+          assert MapSet.member?(t3.recruiting, 7)
+          assert t3.unreachable_counts == %{}
+        end)
+
+      assert log =~ "unreachable after 3 verifications; healing"
+    end
+
+    test "a reachable node resets the count and re-arms the monitor; a re-assigned tag has nothing to verify" do
+      test_pid = self()
+
+      t =
+        healing_state(test_pid,
+          snapshot: %{shard_layout: %{}, materializer_refs: %{7 => {"wkr_alive", Atom.to_string(node())}}}
+        )
+
+      t = %{t | unreachable_counts: %{7 => 2}}
+
+      assert {:noreply, t2} = Server.handle_info({:reverify_assignment, 7}, t)
+      assert t2.unreachable_counts == %{}
+      assert Map.values(t2.assignment_monitors) == [7]
+      refute_received {:committed, _}
+
+      # A tag re-assigned to the placeholder meanwhile is already
+      # healing: verification just stands down.
+      t3 = %{
+        t
+        | snapshot: %{t.snapshot | materializer_refs: %{7 => {Placeholder.worker_id(), Atom.to_string(node())}}}
+      }
+
+      assert {:noreply, t4} = Server.handle_info({:reverify_assignment, 7}, t3)
+      assert t4.unreachable_counts == %{}
+      assert t4.assignment_monitors == %{}
+      refute_received {:committed, _}
+    end
+
+    test "a dead registered name heals through :noproc — monitor fires immediately, the heal chain runs" do
+      test_pid = self()
+      t = healing_state(test_pid, [])
+
+      # A monitor on a never-registered local name yields an instant
+      # :noproc DOWN — the exact signal a reachable node's dead worker
+      # produces at re-arm time.
+      ref = Process.monitor(otp_name_for_worker("wkr_dead"))
+      assert_receive {:DOWN, ^ref, :process, _, :noproc}
+
+      t = %{t | assignment_monitors: %{ref => 7}}
+
+      ExUnit.CaptureLog.capture_log(fn ->
+        assert {:noreply, t2} = Server.handle_info({:DOWN, ref, :process, nil, :noproc}, t)
+        assert_received {:committed, _}
+        assert_receive {:placeholder_got, {:uncovered, 7}}
+        assert MapSet.member?(t2.recruiting, 7)
+      end)
+    end
+
+    test "a transiently failed healing publish drops the corpse ref — demand recruits, never serves the corpse" do
+      test_pid = self()
+      ref = make_ref()
+      t = healing_state(test_pid, [])
+
+      failing_deps = Map.put(t.deps, :commit_fn, fn _p, _e, _t, _o -> {:error, :timeout} end)
+      t = %{t | deps: failing_deps, assignment_monitors: %{ref => 7}}
+
+      log =
+        ExUnit.CaptureLog.capture_log(fn ->
+          assert {:noreply, t2} = Server.handle_info({:DOWN, ref, :process, self(), :killed}, t)
+
+          # The corpse's ref left the local view even though the keyspace
+          # still names it: a racing demand falls to the recruit path
+          # instead of handing parked readers a dead callable.
+          refute Map.has_key?(t2.snapshot.materializer_refs, 7)
+
+          assert {:noreply, t3} = Server.handle_cast({:coverage_demand, 7}, t2)
+          assert MapSet.member?(t3.pending_demands, 7)
+          refute_received {:placeholder_got, {:covered, 7, _}}
+        end)
+
+      assert log =~ "healing publish for tag 7 failed"
     end
 
     test "the startup sweep monitors live assignments but never the placeholder's own refs" do


### PR DESCRIPTION
## Why

Phase 4 (second half) of bedrock-q67.21 — the settled endpoint of decision B: **stall-only-for-tag-0 completes**. Recovery stops manufacturing data-plane coverage it does not itself need, and the distributor becomes the healer of record for data tags.

## What

- **Bootstrap ceases data-tag creation**: fresh clusters create the system materializer only; a missing data-tag survivor leaves the slot ABSENT for the sweep + demand recruitment. Safe by the #191 audit's verified invariant: shard history lives in shard-keyed, epoch-spanning, never-deleted chunks — a later recruit re-serves everything.
- **Death healing** (event-driven, teamTracker-style): every live assignment is monitored by callable name (bare atoms locally — single-node runs without distribution; `{name, node}` remotely, firing on death or unreachability). On DOWN, ordering is deliberate: **publish the placeholder ref under the fence first** — the gap becomes keyspace-visible, clients park instead of hammering the corpse, and a displaced-but-alive twin observes the change — then uncover at the placeholder and eagerly re-recruit. Superseded healing publish cedes (a newer owner heals, not us); transient publish failure still re-recruits, with publication retried at completion.
- Recruited assignments are monitored on publish, closing the lifecycle loop.

This also begins reconciling the #191 ambiguous-commit residual: an ambiguous leftover whose commit actually landed is now monitored-on-startup next epoch and healed on death like any assignment.

## How

TDD: the DOWN flow's committed content and ordering (placeholder ref decoded from the fenced transaction), superseded-cede, startup monitors excluding the placeholder's own refs, and the re-pinned bootstrap contract (system-only creation; absent data slots; the data shard's pull-source seed is now the distributor's, at recruitment). One deflake caught by seed-sweeping before push (stub cast forwarding vs `assert_received`).

Full suite (2686 tests), credo --strict, dialyzer green.