### PR TITLE
Idle spin-down: cold shards park; revival is demand-driven

### DIFF
--- a/lib/bedrock/control_plane/distributor/server.ex
+++ b/lib/bedrock/control_plane/distributor/server.ex
@@ -221,6 +221,14 @@ defmodule Bedrock.ControlPlane.Distributor.Server do
         Logger.warning("Bedrock distributor (epoch #{t.epoch}): materializer for tag #{tag} unreachable; verifying")
         {:noreply, schedule_reverify(t, tag)}
 
+      {:shutdown, :idle} ->
+        # A voluntary idle spin-down (bedrock-q67.21.5): the shard proved
+        # cold, so revival is demand-driven — swap the placeholder in but
+        # do NOT eagerly re-recruit; the next read parks and re-demands.
+        Logger.info("Bedrock distributor (epoch #{t.epoch}): tag #{tag} spun down idle; revival on demand")
+        Telemetry.emit_idle_spindown(t.cluster, tag)
+        park_tag(clear_unreachable(t, tag), tag)
+
       _dead ->
         Logger.warning("Bedrock distributor (epoch #{t.epoch}): materializer for tag #{tag} down (#{inspect(reason)})")
         heal_tag(clear_unreachable(t, tag), tag)
@@ -410,34 +418,46 @@ defmodule Bedrock.ControlPlane.Distributor.Server do
     end
   end
 
-  # The heal itself: make the gap keyspace-visible FIRST — publish the
-  # placeholder ref under the fence, so clients park instead of
-  # hammering the corpse and displaced-but-alive twins observe the
-  # change — then tell the placeholder the tag is uncovered (park, don't
-  # forward) and eagerly re-recruit. A superseded publish cedes: a newer
-  # owner heals, not us. On a transient publish failure the tag's LOCAL
-  # ref is dropped so a racing coverage_demand recruits instead of
-  # draining parked reads into the corpse; the keyspace still names the
-  # corpse but self-corrects at the recruit's publication.
+  # The heal itself is park + eager re-recruit; an idle spin-down parks
+  # WITHOUT the recruit (revival is demand-driven).
   defp heal_tag(%State{} = t, tag) do
+    case park_tag(t, tag) do
+      {:noreply, t2} -> {:noreply, maybe_recruit(t2, tag)}
+      stop -> stop
+    end
+  end
+
+  # The park: make the gap keyspace-visible FIRST — publish the
+  # placeholder ref under the fence, so clients park instead of
+  # hammering the departed worker and displaced-but-alive twins observe
+  # the change — then tell the placeholder the tag is uncovered (park,
+  # don't forward). A superseded publish cedes: a newer owner heals, not
+  # us. On a transient publish failure the tag's LOCAL ref is dropped so
+  # a racing coverage_demand recruits instead of draining parked reads
+  # into the departed worker; the keyspace still names it but
+  # self-corrects at the next publication.
+  defp park_tag(%State{} = t, tag) do
     Placeholder.notify_uncovered(t.placeholder, tag)
 
     case publish_placeholders(t, [tag]) do
       :ok ->
         refs = Map.put(t.snapshot.materializer_refs, tag, {@placeholder_worker_id, Atom.to_string(node())})
-        {:noreply, maybe_recruit(%{t | snapshot: %{t.snapshot | materializer_refs: refs}}, tag)}
+        {:noreply, %{t | snapshot: %{t.snapshot | materializer_refs: refs}}}
 
       {:error, :superseded} ->
-        Logger.info("Bedrock distributor (epoch #{t.epoch}): superseded healing tag #{tag}; ceding")
+        Logger.info(
+          "Bedrock distributor (epoch #{t.epoch}): superseded swapping the placeholder into tag #{tag}; ceding"
+        )
+
         {:stop, :normal, t}
 
       {:error, reason} ->
         Logger.warning(
-          "Bedrock distributor (epoch #{t.epoch}): healing publish for tag #{tag} failed: #{inspect(reason)}"
+          "Bedrock distributor (epoch #{t.epoch}): placeholder publish for tag #{tag} failed: #{inspect(reason)}"
         )
 
         refs = Map.delete(t.snapshot.materializer_refs, tag)
-        {:noreply, maybe_recruit(%{t | snapshot: %{t.snapshot | materializer_refs: refs}}, tag)}
+        {:noreply, %{t | snapshot: %{t.snapshot | materializer_refs: refs}}}
     end
   end
 

--- a/lib/bedrock/control_plane/distributor/telemetry.ex
+++ b/lib/bedrock/control_plane/distributor/telemetry.ex
@@ -46,6 +46,15 @@ defmodule Bedrock.ControlPlane.Distributor.Telemetry do
     )
   end
 
+  @spec emit_idle_spindown(module(), Bedrock.range_tag()) :: :ok
+  def emit_idle_spindown(cluster, tag) do
+    :telemetry.execute(
+      [:bedrock, :distributor, :idle_spindown],
+      %{count: 1},
+      %{cluster: cluster, tag: tag}
+    )
+  end
+
   @spec emit_placeholder_published(module(), [Bedrock.range_tag()]) :: :ok
   def emit_placeholder_published(cluster, tags) do
     :telemetry.execute(

--- a/lib/bedrock/data_plane/materializer/olivine/logic.ex
+++ b/lib/bedrock/data_plane/materializer/olivine/logic.ex
@@ -30,6 +30,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Logic do
   def startup(otp_name, foreman, id, path, opts \\ []) do
     cluster = Keyword.get(opts, :cluster)
     {shard_tag, shard_num} = normalize_shard(Keyword.get(opts, :shard_id))
+    idle_timeout = Keyword.get(opts, :idle_timeout, :infinity)
     snapshot = build_snapshot_handle(cluster, shard_tag)
 
     with :ok <- ensure_directory_exists(path),
@@ -46,7 +47,9 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Logic do
          foreman: foreman,
          database: database,
          index_manager: index_manager,
-         snapshot: snapshot
+         snapshot: snapshot,
+         idle_timeout: idle_timeout,
+         last_read_at: System.monotonic_time(:millisecond)
        }}
     end
   end
@@ -441,6 +444,38 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Logic do
       end)
 
     {:ok, task}
+  end
+
+  @doc """
+  Best-effort synchronous snapshot upload before an idle spin-down.
+
+  Unlike `maybe_upload_snapshot/4` this runs in the caller: the worker's
+  removal reclaims its working directory right after it exits, so a
+  fire-and-forget task would race the deletion of the very files it
+  reads. A no-op when no snapshot is configured; failures are logged and
+  swallowed (the shard remains rebuildable from earlier snapshots and
+  the logs).
+  """
+  @spec upload_snapshot_before_spindown(State.t()) :: :ok
+  def upload_snapshot_before_spindown(%State{snapshot: nil}), do: :ok
+
+  def upload_snapshot_before_spindown(%State{snapshot: snapshot} = t) do
+    {data_db, index_db} = t.database
+    version_int = t.database |> Database.durable_version() |> Version.to_integer()
+
+    with {:ok, data} <- File.read(to_string(data_db.file_name)),
+         {:ok, idx} <- File.read(to_string(index_db.file_name)),
+         :ok <- Snapshot.write(snapshot, version_int, [data, idx]) do
+      Logger.info("Snapshot uploaded to ObjectStorage before idle spin-down", version: version_int)
+    else
+      {:error, reason} ->
+        Logger.warning("Snapshot upload before idle spin-down failed",
+          version: version_int,
+          reason: inspect(reason)
+        )
+    end
+
+    :ok
   end
 
   @doc """

--- a/lib/bedrock/data_plane/materializer/olivine/server.ex
+++ b/lib/bedrock/data_plane/materializer/olivine/server.ex
@@ -15,8 +15,11 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Server do
   alias Bedrock.DataPlane.Materializer.Olivine.Logic
   alias Bedrock.DataPlane.Materializer.Olivine.Reading
   alias Bedrock.DataPlane.Materializer.Olivine.State
+  alias Bedrock.DataPlane.Materializer.Olivine.Telemetry, as: OlivineTelemetry
   alias Bedrock.DataPlane.Materializer.Telemetry
   alias Bedrock.Service.Foreman
+
+  require Logger
 
   # Transaction count limits for adaptive batching
   # Small batches for responsiveness during normal operation
@@ -36,17 +39,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Server do
     foreman = opts[:foreman] || raise "Missing :foreman option"
     id = opts[:id] || raise "Missing :id option"
     path = opts[:path] || raise "Missing :path option"
-    cluster = opts[:cluster]
-    params = opts[:params] || %{}
-    shard_id = params["shard_id"]
-
-    # Build startup opts only if cluster and shard_id are provided
-    startup_opts =
-      if cluster && shard_id do
-        [cluster: cluster, shard_id: shard_id]
-      else
-        []
-      end
+    startup_opts = startup_opts(opts[:cluster], opts[:params] || %{})
 
     %{
       id: {__MODULE__, id},
@@ -60,12 +53,35 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Server do
     }
   end
 
+  # Builds the opts handed to Logic.startup/5 from the worker's manifest
+  # params. shard_id is ALWAYS threaded through (it identifies the
+  # worker's shard assignment for info facts and re-adoption, and must
+  # never be gated on cluster presence); the ObjectStorage snapshot
+  # handle additionally requires a cluster, which Logic guards on. Idle
+  # spin-down is opt-in per worker (bedrock-q67.21.5): without an
+  # explicit positive idle_timeout the worker never spins down, which is
+  # what exempts the system shard (its bootstrap never sets the param).
+  @spec startup_opts(cluster :: module() | nil, params :: map()) :: keyword()
+  defp startup_opts(cluster, params) do
+    base = [cluster: cluster, shard_id: params["shard_id"]]
+
+    case params["idle_timeout"] do
+      idle_timeout when is_integer(idle_timeout) and idle_timeout > 0 ->
+        Keyword.put(base, :idle_timeout, idle_timeout)
+
+      _ ->
+        base
+    end
+  end
+
   @impl true
   def init(args), do: {:ok, args, {:continue, :finish_startup}}
 
   @impl true
 
   def handle_call({:get, key, version, opts}, from, %State{} = t) do
+    t = touch_read_activity(t)
+
     # Set operation context metadata for this request
     Telemetry.trace_metadata(%{operation: :get, key: key})
 
@@ -91,6 +107,8 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Server do
   end
 
   def handle_call({:get_range, start_key, end_key, version, opts}, from, %State{} = t) do
+    t = touch_read_activity(t)
+
     # Set operation context metadata for this request
     Telemetry.trace_metadata(%{operation: :get_range, key: {start_key, end_key}})
 
@@ -247,6 +265,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Server do
     case Logic.startup(otp_name, foreman, id, path, opts) do
       {:ok, state} ->
         Telemetry.trace_startup_complete()
+        schedule_idle_check(state)
         noreply(state, continue: :report_health_to_foreman)
 
       {:error, reason} ->
@@ -276,7 +295,28 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Server do
   defp max_version(version, nil), do: version
   defp max_version(a, b), do: max(a, b)
 
+  # Periodic idle check (bedrock-q67.21.5): only client reads count as
+  # activity - transaction application and pulls keep a shard fresh, not
+  # hot. When the read-inactivity window expires the worker best-effort
+  # uploads a snapshot (when configured), arranges for its foreman entry
+  # (and on-disk working directory) to be removed once it has exited,
+  # and stops with {:shutdown, :idle} so the distributor swaps the
+  # placeholder in WITHOUT eager re-recruitment: demand revives the
+  # shard on the next read.
   @impl true
+  def handle_info(:idle_check, %State{idle_timeout: :infinity} = t), do: noreply(t)
+
+  def handle_info(:idle_check, %State{} = t) do
+    idle_ms = System.monotonic_time(:millisecond) - t.last_read_at
+
+    if idle_ms >= t.idle_timeout do
+      initiate_idle_spindown(t, idle_ms)
+    else
+      schedule_idle_check(t)
+      noreply(t, continue: :maybe_process_transactions)
+    end
+  end
+
   # Discard transactions when locked
   def handle_info({:apply_transactions, _encoded_transactions}, %State{mode: :locked} = t), do: noreply(t)
 
@@ -333,7 +373,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Server do
       ) do
     # Atomic cutover to compacted files
     # Get file paths from old database
-    alias Bedrock.DataPlane.Materializer.Olivine.Telemetry, as: OlivineTelemetry
+    alias OlivineTelemetry, as: OlivineTelemetry
 
     # The cutover rewinds the index to the durable snapshot, so the
     # running puller's position (and any batch it has in flight) is
@@ -523,6 +563,63 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Server do
       {:error, :not_found} -> :displaced
       {:error, _not_a_verdict} -> :keep
     end
+  end
+
+  @spec touch_read_activity(State.t()) :: State.t()
+  defp touch_read_activity(%State{} = t), do: %{t | last_read_at: System.monotonic_time(:millisecond)}
+
+  # Checks run at a quarter of the timeout, so per-read cost stays a
+  # single timestamp write instead of per-request timer churn on the hot
+  # path.
+  @spec schedule_idle_check(State.t()) :: State.t()
+  defp schedule_idle_check(%State{idle_timeout: :infinity} = t), do: t
+
+  defp schedule_idle_check(%State{idle_timeout: idle_timeout} = t) do
+    Process.send_after(self(), :idle_check, max(div(idle_timeout, 4), 10))
+    t
+  end
+
+  @spec initiate_idle_spindown(State.t(), non_neg_integer()) :: {:stop, {:shutdown, :idle}, State.t()}
+  defp initiate_idle_spindown(%State{} = t, idle_ms) do
+    OlivineTelemetry.trace_idle_spindown(idle_ms,
+      n_keys: IndexManager.info(t.index_manager, :n_keys),
+      size_in_bytes: IndexManager.info(t.index_manager, :size_in_bytes)
+    )
+
+    Logic.upload_snapshot_before_spindown(t)
+    remove_worker_after_exit(t)
+    stop(t, {:shutdown, :idle})
+  end
+
+  # The foreman entry (and with it the on-disk working directory) is
+  # reclaimed by Foreman.remove_worker/3 - but only after this worker
+  # has actually exited, so the {:shutdown, :idle} exit reason reaches
+  # the distributor's monitor untainted by the supervisor's
+  # terminate_child. Calling the foreman inline would also deadlock: it
+  # calls back into this worker's supervisor.
+  @spec remove_worker_after_exit(State.t()) :: :ok
+  defp remove_worker_after_exit(%State{foreman: foreman, id: id}) do
+    worker = self()
+
+    spawn(fn ->
+      ref = Process.monitor(worker)
+
+      receive do
+        {:DOWN, ^ref, :process, ^worker, _reason} ->
+          try do
+            Foreman.remove_worker(foreman, id, timeout: 5_000)
+          catch
+            kind, reason ->
+              Logger.warning(
+                "Failed to remove idle materializer worker #{inspect(id)} from foreman: #{inspect({kind, reason})}"
+              )
+          end
+      after
+        30_000 -> :ok
+      end
+    end)
+
+    :ok
   end
 
   @impl true

--- a/lib/bedrock/data_plane/materializer/olivine/state.ex
+++ b/lib/bedrock/data_plane/materializer/olivine/state.ex
@@ -31,6 +31,8 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.State do
           snapshot: Snapshot.t() | nil,
           pull_sources: [{Log.id(), Log.ref()}] | nil,
           shard_num: non_neg_integer() | nil,
+          idle_timeout: pos_integer() | :infinity,
+          last_read_at: integer() | nil,
           known_committed_version: Bedrock.version() | nil,
           pending_ingest: GenServer.from() | nil
         }
@@ -53,6 +55,8 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.State do
             snapshot: nil,
             pull_sources: nil,
             shard_num: nil,
+            idle_timeout: :infinity,
+            last_read_at: nil,
             known_committed_version: nil,
             pending_ingest: nil
 

--- a/lib/bedrock/data_plane/materializer/olivine/telemetry.ex
+++ b/lib/bedrock/data_plane/materializer/olivine/telemetry.ex
@@ -50,6 +50,19 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Telemetry do
     Telemetry.emit_materializer_operation(:window_advanced, measurements, metadata)
   end
 
+  @spec trace_idle_spindown(non_neg_integer(), keyword()) :: :ok
+  def trace_idle_spindown(idle_duration_ms, opts \\ []) do
+    Telemetry.emit_materializer_operation(
+      :idle_spindown,
+      %{
+        idle_duration_ms: idle_duration_ms,
+        n_keys: Keyword.get(opts, :n_keys, 0),
+        size_in_bytes: Keyword.get(opts, :size_in_bytes, 0)
+      },
+      %{}
+    )
+  end
+
   @spec trace_compaction_started(Bedrock.version(), keyword()) :: :ok
   def trace_compaction_started(durable_version, opts \\ []) do
     measurements = %{

--- a/test/bedrock/control_plane/distributor/server_test.exs
+++ b/test/bedrock/control_plane/distributor/server_test.exs
@@ -690,6 +690,31 @@ defmodule Bedrock.ControlPlane.Distributor.ServerTest do
       end)
     end
 
+    test "an idle spin-down parks the tag WITHOUT re-recruiting — revival is demand-driven" do
+      test_pid = self()
+      ref = make_ref()
+      t = healing_state(test_pid, [])
+      t = %{t | assignment_monitors: %{ref => 7}}
+
+      log =
+        ExUnit.CaptureLog.capture_log(fn ->
+          assert {:noreply, t2} = Server.handle_info({:DOWN, ref, :process, self(), {:shutdown, :idle}}, t)
+
+          # The placeholder swap is published and the tag uncovered —
+          # exactly like a heal — but NO recruit task starts.
+          assert_received {:committed, _}
+          assert_receive {:placeholder_got, {:uncovered, 7}}
+          refute MapSet.member?(t2.recruiting, 7)
+          assert t2.snapshot.materializer_refs[7] == {Placeholder.worker_id(), Atom.to_string(node())}
+
+          # The next read's demand is what revives the shard.
+          assert {:noreply, t3} = Server.handle_cast({:coverage_demand, 7}, t2)
+          assert MapSet.member?(t3.recruiting, 7)
+        end)
+
+      assert log =~ "spun down idle"
+    end
+
     test "a :noconnection DOWN does not heal — the tag is verified, not stampeded" do
       test_pid = self()
       ref = make_ref()
@@ -816,7 +841,7 @@ defmodule Bedrock.ControlPlane.Distributor.ServerTest do
           refute_received {:placeholder_got, {:covered, 7, _}}
         end)
 
-      assert log =~ "healing publish for tag 7 failed"
+      assert log =~ "placeholder publish for tag 7 failed"
     end
 
     test "the startup sweep monitors live assignments but never the placeholder's own refs" do

--- a/test/bedrock/data_plane/materializer/olivine/idle_spindown_test.exs
+++ b/test/bedrock/data_plane/materializer/olivine/idle_spindown_test.exs
@@ -1,0 +1,206 @@
+defmodule Bedrock.DataPlane.Materializer.Olivine.IdleSpindownTest do
+  @moduledoc """
+  Idle spin-down (bedrock-q67.21.5): a worker opted in via the
+  "idle_timeout" manifest param exits {:shutdown, :idle} after a
+  read-inactivity window — only client reads count as activity — after
+  best-effort uploading a snapshot and arranging its own foreman
+  removal. Workers without the param never spin down (the system
+  shard's exemption).
+
+  Deterministic technique: :sys.replace_state/2 rewinds last_read_at,
+  then send(pid, :idle_check) drives the periodic check by hand. The
+  foreman is the test process, so the deferred remove_worker call is
+  assertable as a plain GenServer call message.
+  """
+  use ExUnit.Case, async: false
+
+  alias Bedrock.DataPlane.Materializer.Olivine
+  alias Bedrock.DataPlane.Version
+  alias Bedrock.ObjectStorage
+  alias Bedrock.ObjectStorage.Config, as: ObjectStorageConfig
+  alias Bedrock.ObjectStorage.Keys, as: ObjectStorageKeys
+  alias Bedrock.ObjectStorage.LocalFilesystem
+  alias Bedrock.ObjectStorage.Snapshot
+
+  defmodule TestCluster do
+    @moduledoc false
+    def name, do: "idle-spindown-test-cluster"
+  end
+
+  setup do
+    test_id = :erlang.unique_integer([:positive])
+    tmp_dir = Path.join(System.tmp_dir!(), "olivine_idle_#{test_id}")
+    File.rm_rf(tmp_dir)
+    File.mkdir_p!(tmp_dir)
+    on_exit(fn -> File.rm_rf(tmp_dir) end)
+    {:ok, tmp_dir: tmp_dir, test_id: test_id}
+  end
+
+  defp start_worker(tmp_dir, params, opts \\ []) do
+    worker_id = "idle_wkr_#{System.unique_integer([:positive])}"
+    otp_name = :"olivine_idle_#{System.unique_integer([:positive])}"
+
+    child_spec =
+      Olivine.child_spec(
+        Keyword.merge(
+          [otp_name: otp_name, foreman: self(), id: worker_id, path: tmp_dir, params: params],
+          opts
+        )
+      )
+
+    # Unlinked: the {:shutdown, :idle} exit is the observable under test
+    # and must reach the monitor, not tear the test down through a link.
+    {GenServer, :start_link, args} = child_spec.start
+    {:ok, pid} = apply(GenServer, :start, args)
+
+    receive do
+      {:"$gen_cast", {:worker_health, ^worker_id, {:ok, ^pid}}} -> :ok
+    after
+      5_000 -> flunk("no health report")
+    end
+
+    {pid, worker_id, otp_name}
+  end
+
+  defp rewind_idle_clock(pid, by_ms) do
+    :sys.replace_state(pid, fn t -> %{t | last_read_at: System.monotonic_time(:millisecond) - by_ms} end)
+  end
+
+  describe "idle expiry" do
+    test "with no reads the worker exits {:shutdown, :idle}, emits telemetry, and requests foreman removal",
+         %{tmp_dir: tmp_dir} do
+      handler_id = "idle-spindown-#{System.unique_integer([:positive])}"
+      test_pid = self()
+
+      :telemetry.attach(
+        handler_id,
+        [:bedrock, :materializer, :idle_spindown],
+        fn _event, measurements, _meta, _cfg -> send(test_pid, {:spindown_telemetry, measurements}) end,
+        nil
+      )
+
+      on_exit(fn -> :telemetry.detach(handler_id) end)
+
+      {pid, worker_id, _otp_name} = start_worker(tmp_dir, %{"idle_timeout" => 60_000})
+      ref = Process.monitor(pid)
+
+      rewind_idle_clock(pid, 120_000)
+      send(pid, :idle_check)
+
+      assert_receive {:DOWN, ^ref, :process, ^pid, {:shutdown, :idle}}, 5_000
+      assert_receive {:spindown_telemetry, %{idle_duration_ms: idle_ms}}
+      assert idle_ms >= 60_000
+
+      # The deferred self-removal calls the foreman only AFTER the exit.
+      assert_receive {:"$gen_call", from, {:remove_worker, ^worker_id}}, 5_000
+      GenServer.reply(from, :ok)
+    end
+
+    test "a real (short) idle_timeout expires on the periodic check without manual driving", %{tmp_dir: tmp_dir} do
+      {pid, _worker_id, _otp_name} = start_worker(tmp_dir, %{"idle_timeout" => 50})
+      ref = Process.monitor(pid)
+
+      assert_receive {:DOWN, ^ref, :process, ^pid, {:shutdown, :idle}}, 5_000
+    end
+  end
+
+  describe "activity tracking" do
+    test "a read resets the idle timer", %{tmp_dir: tmp_dir} do
+      {pid, _worker_id, _otp_name} = start_worker(tmp_dir, %{"idle_timeout" => 60_000})
+      ref = Process.monitor(pid)
+
+      rewind_idle_clock(pid, 120_000)
+
+      # The read touches last_read_at before the check runs; the reply
+      # itself (found or not) is irrelevant to the timer.
+      _ = GenServer.call(pid, {:get, "k", Version.from_integer(0), [timeout: 100]}, 500)
+      send(pid, :idle_check)
+
+      refute_receive {:DOWN, ^ref, :process, ^pid, _}, 200
+      assert Process.alive?(pid)
+    end
+
+    test "transaction application does NOT count as activity", %{tmp_dir: tmp_dir} do
+      {pid, _worker_id, _otp_name} = start_worker(tmp_dir, %{"idle_timeout" => 60_000})
+      ref = Process.monitor(pid)
+
+      rewind_idle_clock(pid, 120_000)
+      send(pid, {:apply_transactions, []})
+      send(pid, :idle_check)
+
+      assert_receive {:DOWN, ^ref, :process, ^pid, {:shutdown, :idle}}, 5_000
+    end
+  end
+
+  describe "snapshot upload on idle exit" do
+    test "a configured snapshot is uploaded before the worker stops", %{tmp_dir: tmp_dir, test_id: test_id} do
+      object_storage_root = Path.join(System.tmp_dir!(), "olivine_idle_objects_#{test_id}")
+      File.mkdir_p!(object_storage_root)
+      backend = ObjectStorage.backend(LocalFilesystem, root: object_storage_root)
+
+      old_config = Application.get_env(:bedrock, ObjectStorage)
+      Application.put_env(:bedrock, ObjectStorage, backend: backend)
+
+      on_exit(fn ->
+        if old_config,
+          do: Application.put_env(:bedrock, ObjectStorage, old_config),
+          else: Application.delete_env(:bedrock, ObjectStorage)
+
+        File.rm_rf(object_storage_root)
+      end)
+
+      {pid, worker_id, _otp_name} =
+        start_worker(tmp_dir, %{"idle_timeout" => 60_000, "shard_id" => 42}, cluster: TestCluster)
+
+      ref = Process.monitor(pid)
+      rewind_idle_clock(pid, 120_000)
+      send(pid, :idle_check)
+
+      assert_receive {:DOWN, ^ref, :process, ^pid, {:shutdown, :idle}}, 5_000
+
+      # The upload is synchronous and precedes the exit, so by the time
+      # the DOWN arrives the snapshot is discoverable.
+      # The worker never applied a transaction, so the bundle is small —
+      # what matters is that it EXISTS and is discoverable before the
+      # exit: it is the only durable artifact bridging spin-down to
+      # demand-driven revival.
+      snapshot = %Snapshot{} = snapshot_handle_for(42)
+      assert {:ok, _version, _data} = Snapshot.read_latest(snapshot)
+
+      assert_receive {:"$gen_call", from, {:remove_worker, ^worker_id}}, 5_000
+      GenServer.reply(from, :ok)
+    end
+  end
+
+  describe "re-adoption identity coexists with idle spin-down" do
+    test "a worker with shard_id, no cluster, and idle_timeout exposes :shard_id and still honors idle_check",
+         %{tmp_dir: tmp_dir} do
+      {pid, _worker_id, _otp_name} = start_worker(tmp_dir, %{"idle_timeout" => 60_000, "shard_id" => 42})
+
+      assert {:ok, %{shard_id: 42}} = GenServer.call(pid, {:info, [:shard_id]})
+
+      ref = Process.monitor(pid)
+      rewind_idle_clock(pid, 120_000)
+      send(pid, :idle_check)
+
+      assert_receive {:DOWN, ^ref, :process, ^pid, {:shutdown, :idle}}, 5_000
+    end
+  end
+
+  describe "exemption" do
+    test "a worker without an explicit idle_timeout never spins down", %{tmp_dir: tmp_dir} do
+      {pid, _worker_id, _otp_name} = start_worker(tmp_dir, %{"shard_id" => 42})
+      ref = Process.monitor(pid)
+
+      send(pid, :idle_check)
+
+      refute_receive {:DOWN, ^ref, :process, ^pid, _}, 200
+      assert Process.alive?(pid)
+    end
+  end
+
+  defp snapshot_handle_for(shard_num) do
+    tag = ObjectStorageKeys.shard_tag(shard_num)
+    Snapshot.new(ObjectStorageConfig.backend(), tag)
+  end
+end


### PR DESCRIPTION
Phase 5a of **bedrock-q67.21.5**, ported from phase-a (bedrock-q67.13).

## Worker side (olivine)

- An opt-in `"idle_timeout"` manifest param arms a periodic read-inactivity check (poll at a quarter of the timeout — one timestamp write per read, no hot-path timer churn).
- **Only client reads count as activity.** Pulls and transaction application keep a shard *fresh*, not *hot*.
- On expiry: synchronous snapshot upload (the only durable artifact bridging spin-down to demand-driven revival; fire-and-forget would race the working-directory deletion), then a deferred foreman self-removal that runs only AFTER the worker's own exit (inline would deadlock through the supervisor and rewrite the exit reason), then `{:shutdown, :idle}`.
- No param → never spins down: the system shard's exemption, since bootstrap never sets it.
- `child_spec` no longer gates `shard_id` on cluster presence — the shard identity must survive even when no ObjectStorage handle can be built (phase-a regression guard).

## Distributor side

- `{:shutdown, :idle}` at the assignment monitor **parks** the tag: placeholder published under the CHECK fence, tag uncovered at the placeholder — but **no eager re-recruit**. The shard proved cold; the next read's coverage demand revives it (recruitment restores from the uploaded snapshot and drinks the log suffix).
- `heal_tag` refactored to `park_tag` + recruit; death healing and idle parking share the publish/supersession/transient-failure semantics from #192, including the corpse-ref drop on transient publish failure.

## Tests

7 worker pins (expiry, telemetry, deferred foreman removal ordering, short-timeout end-to-end, read-resets-timer, apply-is-not-activity, synchronous snapshot-before-exit, shard_id-without-cluster, exemption) + a distributor pin (idle parks without recruiting; demand still recruits afterward).

Stacked on #192.