### PR TITLE
Assignment verification: the committed family is the membership authority

### DIFF
--- a/lib/bedrock/control_plane/distributor/recruitment.ex
+++ b/lib/bedrock/control_plane/distributor/recruitment.ex
@@ -67,6 +67,32 @@ defmodule Bedrock.ControlPlane.Distributor.Recruitment do
   end
 
   @doc """
+  Adopts a family-named materializer into the current epoch: recruitment
+  minus creation. The worker already exists (the committed
+  `materializers/` family names it — the keyspace is the membership
+  authority) but was never locked into this epoch, typically because its
+  node missed recovery's roll call and rejoined later. It is locked at
+  the epoch and unlocked at the durable version IT reports, so it
+  resumes pulling from exactly where its own store left off.
+
+  Unlike a failed recruitment, a failed adoption never removes the
+  worker: it pre-exists this attempt and holds real state — enforced
+  structurally by there being no removal call on this path. The caller
+  heals the tag instead (placeholder + fresh recruit); the unadopted
+  worker later observes the new entry and retires itself in-band.
+  """
+  @spec adopt(Bedrock.range_tag(), Worker.id(), node(), context()) ::
+          {:ok, pid(), node(), Worker.id()} | {:error, term()}
+  def adopt(tag, worker_id, node, context) do
+    with {:ok, sources} <- pull_sources_for_shard(tag, context),
+         {:ok, pid, recovery_info} <-
+           lock_materializer({context.cluster.otp_name_for_worker(worker_id), node}, node, context),
+         :ok <- unlock_and_start_pulling(pid, node, recovery_info, sources, context) do
+      {:ok, pid, node, worker_id}
+    end
+  end
+
+  @doc """
   Best-effort removal of a worker left behind by a failed recruitment or
   an aborted publication. The worker never carried data a client could
   reach, so removal is safe; any failure to remove it is logged and

--- a/lib/bedrock/control_plane/distributor/server.ex
+++ b/lib/bedrock/control_plane/distributor/server.ex
@@ -7,6 +7,7 @@ defmodule Bedrock.ControlPlane.Distributor.Server do
   alias Bedrock.ControlPlane.Distributor.State
   alias Bedrock.ControlPlane.Distributor.Telemetry
   alias Bedrock.ControlPlane.Distributor.Transactions
+  alias Bedrock.DataPlane.Materializer
   alias Bedrock.SystemKeys
   alias Bedrock.SystemKeys.Values
 
@@ -19,6 +20,11 @@ defmodule Bedrock.ControlPlane.Distributor.Server do
   # sustained unreachability — long enough to ride out a dist blip,
   # short enough that a lost node heals promptly.
   @max_unreachable_verifications 3
+
+  # Deadline for the sweep's per-assignment epoch probe: placeholder
+  # coverage and monitors are already live, so verification is a pure
+  # membership check that must never wait on a wedged worker.
+  @verification_timeout_ms 2_000
 
   # FDB's MOVEKEYS_LOCK_POLLING_DELAY: a superseded distributor exits
   # within seconds even when idle, instead of waiting to lose a commit.
@@ -115,8 +121,11 @@ defmodule Bedrock.ControlPlane.Distributor.Server do
          :ok <- publish_placeholders(t, uncovered) do
       # Eager recruitment for the swept gaps erases first-touch latency:
       # the sweep already knows every uncovered tag, and the in-flight
-      # dedupe and backoff machinery make eagerness free.
-      {:noreply, Enum.reduce(uncovered, monitor_assignments(t), &maybe_recruit(&2, &1))}
+      # dedupe and backoff machinery make eagerness free. Named
+      # assignments get the complementary treatment: verification that
+      # each is actually IN this epoch (see verify_assignments/1).
+      t = Enum.reduce(uncovered, monitor_assignments(t), &maybe_recruit(&2, &1))
+      {:noreply, verify_assignments(t)}
     else
       {:error, :superseded} ->
         Logger.info("Bedrock distributor (epoch #{t.epoch}): superseded at publish; ceding")
@@ -160,12 +169,45 @@ defmodule Bedrock.ControlPlane.Distributor.Server do
 
     case result do
       {:ok, pid, node, worker_id} ->
-        publish_recruit(t, tag, pid, node, worker_id)
+        publish_assignment(t, tag, pid, node, worker_id, :created)
 
       {:error, reason} ->
         Logger.warning("Bedrock distributor (epoch #{t.epoch}): recruitment for tag #{tag} failed: #{inspect(reason)}")
         Placeholder.notify_coverage_failed(t.placeholder, tag, reason)
         {:noreply, start_backoff(t, tag)}
+    end
+  end
+
+  # Verification verdicts serialize back through the server. The
+  # reservation (the tag's membership in `recruiting`) is released
+  # first; then any verdict for a tag whose ref no longer names the
+  # probed worker is DROPPED — another mechanism (death healing, idle
+  # parking, a completed demand recruit) re-owned the tag while the
+  # probe was in flight, and a late-adopted worker is now an unnamed
+  # stray that retires itself at the next layout push.
+  def handle_info({:assignment_verified, tag, worker, verdict}, %State{} = t) do
+    t = %{t | recruiting: MapSet.delete(t.recruiting, tag)}
+
+    cond do
+      verdict == :current ->
+        {:noreply, t}
+
+      Map.get(t.snapshot.materializer_refs, tag) != worker ->
+        {:noreply, t}
+
+      match?({:adopted, _pid, _node, _worker_id}, verdict) ->
+        {:adopted, pid, node, worker_id} = verdict
+        publish_assignment(t, tag, pid, node, worker_id, :preexisting)
+
+      true ->
+        {:error, reason} = verdict
+
+        Logger.warning(
+          "Bedrock distributor (epoch #{t.epoch}): assignment for tag #{tag} failed verification " <>
+            "(#{inspect(reason)}); healing"
+        )
+
+        heal_tag(t, tag)
     end
   end
 
@@ -341,13 +383,19 @@ defmodule Bedrock.ControlPlane.Distributor.Server do
     %{t | recruiting: MapSet.put(t.recruiting, tag), recruit_task_refs: Map.put(t.recruit_task_refs, ref, tag)}
   end
 
-  defp publish_recruit(%State{} = t, tag, pid, node, worker_id) do
+  # Publishes an assignment under the CHECK fence. Provenance decides
+  # the failure policy: a :created recruit that was never fenced in is
+  # an orphan this distributor made and may remove (verdicts permitting)
+  # — a :preexisting adopted worker is NEVER removed (it holds real
+  # state and its entry already names it; only the fence confirmation
+  # was lost).
+  defp publish_assignment(%State{} = t, tag, pid, node, worker_id, provenance) do
     node_string = Atom.to_string(node)
     mutation = {:set, SystemKeys.materializer_key(tag), Values.encode_materializer_ref(worker_id, node_string)}
+    callable = {t.cluster.otp_name_for_worker(worker_id), node}
 
     case Transactions.commit_checked(t.lock, t.deps, [mutation]) do
       :ok ->
-        callable = {t.cluster.otp_name_for_worker(worker_id), node}
         Placeholder.notify_covered(t.placeholder, tag, callable)
 
         refs = Map.put(t.snapshot.materializer_refs, tag, {worker_id, node_string})
@@ -364,14 +412,14 @@ defmodule Bedrock.ControlPlane.Distributor.Server do
          )}
 
       {:error, :superseded} ->
-        # The READ verdict refused before any commit was attempted: this
-        # recruit was definitively never fenced into the family — remove
-        # the orphan and cede.
-        Recruitment.remove_orphaned_worker(worker_id, node, t.recruitment_ctx)
+        # The READ verdict refused before any commit was attempted: a
+        # :created recruit was definitively never fenced into the family
+        # — remove the orphan. Either way, cede.
+        if provenance == :created, do: Recruitment.remove_orphaned_worker(worker_id, node, t.recruitment_ctx)
         Logger.info("Bedrock distributor (epoch #{t.epoch}): superseded publishing tag #{tag}; ceding")
         {:stop, :normal, t}
 
-      {:error, reason} ->
+      {:error, reason} when provenance == :created ->
         # Removal is destruction and demands an unambiguous verdict. An
         # exhausted ABORT and a failed READ are definitive (nothing
         # committed): the worker is a true orphan. A commit TIMEOUT is
@@ -387,6 +435,16 @@ defmodule Bedrock.ControlPlane.Distributor.Server do
         Placeholder.notify_coverage_failed(t.placeholder, tag, reason)
         _ = pid
         {:noreply, start_backoff(t, tag)}
+
+      {:error, reason} ->
+        # :preexisting — the entry already names this worker and it is
+        # now serving; only the fence re-assertion was lost transiently.
+        # Monitor it and let the poll loop deliver any supersession.
+        Logger.warning(
+          "Bedrock distributor (epoch #{t.epoch}): adoption re-assert for tag #{tag} failed: #{inspect(reason)}"
+        )
+
+        {:noreply, monitor_assignment(t, tag, callable)}
     end
   end
 
@@ -489,6 +547,61 @@ defmodule Bedrock.ControlPlane.Distributor.Server do
   defp schedule_reverify(%State{} = t, tag) do
     Process.send_after(self(), {:reverify_assignment, tag}, t.reverify_interval_ms)
     t
+  end
+
+  # The membership check the committed family demands (FDB's DD verifies
+  # every serverList entry the same way; membership is never assumed
+  # from liveness): each named assignment is asked, bounded, which epoch
+  # it was last locked into. Current answers verify silently. A stale or
+  # never-locked answer means the epoch never embraced this worker — its
+  # node missed recovery's roll call — and it is ADOPTED: locked at the
+  # epoch, unlocked at its own durable version, its entry re-asserted
+  # under the fence. Anything else (wedged, dead, unreachable beyond the
+  # monitor's damping) is healed; the worker itself is never removed —
+  # it retires in-band when it observes the replacing entry. One shot,
+  # at the sweep; tags are reserved in `recruiting` while in flight so
+  # demand recruitment cannot double-cover.
+  defp verify_assignments(%State{recruitment_ctx: nil} = t), do: t
+
+  defp verify_assignments(%State{} = t) do
+    Enum.reduce(t.snapshot.materializer_refs, t, fn
+      {_tag, {@placeholder_worker_id, _node}}, acc -> acc
+      {tag, {worker_id, node_string}}, acc -> start_verification(acc, tag, worker_id, node_string)
+    end)
+  end
+
+  defp start_verification(%State{} = t, tag, worker_id, node_string) do
+    server = self()
+    ctx = t.recruitment_ctx
+    epoch = t.epoch
+    name = t.cluster.otp_name_for_worker(worker_id)
+    # credo:disable-for-next-line Credo.Check.Warning.UnsafeToAtom
+    node_atom = String.to_atom(node_string)
+    info_fn = Map.get(ctx, :info_fn, &Materializer.info/3)
+
+    {_pid, ref} =
+      spawn_monitor(fn ->
+        verdict =
+          try do
+            case info_fn.({name, node_atom}, [:epoch], timeout_in_ms: @verification_timeout_ms) do
+              {:ok, %{epoch: ^epoch}} -> :current
+              {:ok, %{epoch: _stale_or_nil}} -> Recruitment.adopt(tag, worker_id, node_atom, ctx)
+              {:error, reason} -> {:error, reason}
+            end
+          catch
+            kind, reason -> {:error, {kind, reason}}
+          end
+
+        verdict =
+          case verdict do
+            {:ok, pid, node, id} -> {:adopted, pid, node, id}
+            other -> other
+          end
+
+        send(server, {:assignment_verified, tag, {worker_id, node_string}, verdict})
+      end)
+
+    %{t | recruiting: MapSet.put(t.recruiting, tag), recruit_task_refs: Map.put(t.recruit_task_refs, ref, tag)}
   end
 
   # Monitor every live (non-placeholder) assignment by its callable name

--- a/lib/bedrock/control_plane/distributor/server.ex
+++ b/lib/bedrock/control_plane/distributor/server.ex
@@ -21,9 +21,11 @@ defmodule Bedrock.ControlPlane.Distributor.Server do
   # short enough that a lost node heals promptly.
   @max_unreachable_verifications 3
 
-  # Deadline for the sweep's per-assignment epoch probe: placeholder
-  # coverage and monitors are already live, so verification is a pure
-  # membership check that must never wait on a wedged worker.
+  # Deadline for the sweep's per-assignment epoch PROBE (the adopt that
+  # may follow carries its own 30s lock/unlock bounds — the tag's
+  # reservation is held for that long, deliberately). Monitors and
+  # placeholder coverage are already live, so the probe itself must
+  # never wait on a wedged worker.
   @verification_timeout_ms 2_000
 
   # FDB's MOVEKEYS_LOCK_POLLING_DELAY: a superseded distributor exits
@@ -180,24 +182,40 @@ defmodule Bedrock.ControlPlane.Distributor.Server do
 
   # Verification verdicts serialize back through the server. The
   # reservation (the tag's membership in `recruiting`) is released
-  # first; then any verdict for a tag whose ref no longer names the
-  # probed worker is DROPPED — another mechanism (death healing, idle
-  # parking, a completed demand recruit) re-owned the tag while the
-  # probe was in flight, and a late-adopted worker is now an unnamed
-  # stray that retires itself at the next layout push.
+  # first; then a verdict for a tag whose ref no longer names the probed
+  # worker belongs to a mechanism that re-owned the tag mid-probe (death
+  # healing, idle parking, a completed demand recruit) — a late-adopted
+  # worker is an unnamed stray that retires itself at the next layout
+  # push. One re-owned shape demands action: an ABSENT ref is a degraded
+  # park whose correcting recruit OUR reservation suppressed — without
+  # it the committed keyspace keeps naming a corpse no read can bypass,
+  # dark until the next recovery. A placeholder ref needs nothing
+  # (demand revives it); a foreign worker ref is already re-covered.
   def handle_info({:assignment_verified, tag, worker, verdict}, %State{} = t) do
     t = %{t | recruiting: MapSet.delete(t.recruiting, tag)}
 
     cond do
       verdict == :current ->
-        {:noreply, t}
+        {:noreply, clear_unreachable(t, tag)}
 
       Map.get(t.snapshot.materializer_refs, tag) != worker ->
-        {:noreply, t}
+        case Map.get(t.snapshot.materializer_refs, tag) do
+          nil -> {:noreply, maybe_recruit(t, tag)}
+          _placeholder_or_foreign -> {:noreply, t}
+        end
 
       match?({:adopted, _pid, _node, _worker_id}, verdict) ->
         {:adopted, pid, node, worker_id} = verdict
-        publish_assignment(t, tag, pid, node, worker_id, :preexisting)
+        publish_assignment(clear_unreachable(t, tag), tag, pid, node, worker_id, :preexisting)
+
+      match?({:error, reason} when reason in [:unavailable, :timeout], verdict) ->
+        # Unreachable-shaped: the same evidence a :noconnection DOWN
+        # carries, damped the same way — a dist blip at sweep time (the
+        # post-recovery moment nodes are still rejoining) must not heal
+        # every shard on the node at once. Escalates through the shared
+        # counter; the reverify tick re-runs verification on contact.
+        Logger.warning("Bedrock distributor (epoch #{t.epoch}): tag #{tag} unreachable during verification; damping")
+        escalate_unreachable(t, tag)
 
       true ->
         {:error, reason} = verdict
@@ -207,7 +225,7 @@ defmodule Bedrock.ControlPlane.Distributor.Server do
             "(#{inspect(reason)}); healing"
         )
 
-        heal_tag(t, tag)
+        heal_tag(clear_unreachable(t, tag), tag)
     end
   end
 
@@ -458,31 +476,46 @@ defmodule Bedrock.ControlPlane.Distributor.Server do
     node_atom = String.to_atom(node_string)
 
     if node_atom == node() or Node.ping(node_atom) == :pong do
-      # A worker that idle-spun-down DURING the blip re-monitors here and
-      # gets an immediate :noproc — healed eagerly, its {:shutdown, :idle}
-      # intent lost with the connection. Safe, mildly wasteful, and not
-      # worth persisting spin-down intent to avoid.
-      {:noreply,
-       t |> clear_unreachable(tag) |> monitor_assignment(tag, {t.cluster.otp_name_for_worker(worker_id), node_atom})}
+      # Contact restored: re-arm the monitor (a genuinely dead worker on
+      # a reachable node yields an immediate :noproc and heals through
+      # the fast path; one that idle-spun-down during the blip is healed
+      # the same way, its {:shutdown, :idle} intent lost — safe, mildly
+      # wasteful, not worth persisting intent to avoid). Reachability is
+      # not membership, though: verification re-runs, and ITS verdict —
+      # not the ping — clears the escalation counter, so a wedged-alive
+      # worker whose node pings fine still escalates to a heal.
+      t = monitor_assignment(t, tag, {t.cluster.otp_name_for_worker(worker_id), node_atom})
+      t = if t.recruitment_ctx, do: start_verification(t, tag, worker_id, node_string), else: clear_unreachable(t, tag)
+      {:noreply, t}
     else
-      count = Map.get(t.unreachable_counts, tag, 0) + 1
-      t = %{t | unreachable_counts: Map.put(t.unreachable_counts, tag, count)}
+      escalate_unreachable(t, tag)
+    end
+  end
 
-      if count >= @max_unreachable_verifications do
-        Logger.warning(
-          "Bedrock distributor (epoch #{t.epoch}): tag #{tag} unreachable after #{count} verifications; healing"
-        )
+  # The shared unreachability escalation: fed by failed pings AND
+  # unreachable-shaped verification verdicts. Heals only after
+  # @max_unreachable_verifications consecutive pieces of evidence.
+  defp escalate_unreachable(%State{} = t, tag) do
+    count = Map.get(t.unreachable_counts, tag, 0) + 1
+    t = %{t | unreachable_counts: Map.put(t.unreachable_counts, tag, count)}
 
-        heal_tag(clear_unreachable(t, tag), tag)
-      else
-        {:noreply, schedule_reverify(t, tag)}
-      end
+    if count >= @max_unreachable_verifications do
+      Logger.warning(
+        "Bedrock distributor (epoch #{t.epoch}): tag #{tag} unreachable after #{count} verifications; healing"
+      )
+
+      heal_tag(clear_unreachable(t, tag), tag)
+    else
+      {:noreply, schedule_reverify(t, tag)}
     end
   end
 
   # The heal is park + eager re-recruit — a degraded park (publish
   # failed) recruits too, since the recruit's own publication is what
-  # self-corrects the keyspace.
+  # self-corrects the keyspace. When the tag is under a verification
+  # reservation the recruit is deferred, not lost: the verdict handler
+  # re-issues it for a degraded park and leaves an intact park to
+  # demand-driven revival.
   defp heal_tag(%State{} = t, tag) do
     case park_tag(t, tag) do
       {:parked, t2} -> {:noreply, maybe_recruit(t2, tag)}
@@ -619,12 +652,18 @@ defmodule Bedrock.ControlPlane.Distributor.Server do
   end
 
   defp monitor_assignment(%State{} = t, tag, {name, node_atom}) do
-    # A local name is monitored as a bare atom: the {name, node} form
-    # requires live distribution, which a single-node deployment
-    # legitimately runs without.
-    target = if node_atom == node(), do: name, else: {name, node_atom}
-    ref = Process.monitor(target)
-    %{t | assignment_monitors: Map.put(t.assignment_monitors, ref, tag)}
+    if tag in Map.values(t.assignment_monitors) do
+      # Already armed (the sweep monitors before verification adopts):
+      # a second monitor would double every DOWN into a double heal.
+      t
+    else
+      # A local name is monitored as a bare atom: the {name, node} form
+      # requires live distribution, which a single-node deployment
+      # legitimately runs without.
+      target = if node_atom == node(), do: name, else: {name, node_atom}
+      ref = Process.monitor(target)
+      %{t | assignment_monitors: Map.put(t.assignment_monitors, ref, tag)}
+    end
   end
 
   defp start_backoff(%State{} = t, tag),

--- a/lib/bedrock/data_plane/materializer/olivine/logic.ex
+++ b/lib/bedrock/data_plane/materializer/olivine/logic.ex
@@ -253,6 +253,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Logic do
   defp supported_info, do: ~w[
       current_version
       durable_version
+      epoch
       oldest_durable_version
       id
       pid
@@ -274,6 +275,11 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Logic do
   # known-committed version and which therefore trails by design.
   defp gather_info(:current_version, t), do: t.index_manager.current_version
   defp gather_info(:shard_id, t), do: t.shard_num
+  # The epoch this worker was last locked into (nil: never locked). The
+  # distributor's assignment verification reads it to distinguish a
+  # worker that is IN the epoch from one the epoch never embraced — a
+  # node that missed recovery's roll call and rejoined later.
+  defp gather_info(:epoch, t), do: t.epoch
   defp gather_info(:id, t), do: t.id
   defp gather_info(:key_ranges, t), do: IndexManager.info(t.index_manager, :key_ranges)
   defp gather_info(:kind, _t), do: :materializer

--- a/lib/bedrock/data_plane/materializer/olivine/server.ex
+++ b/lib/bedrock/data_plane/materializer/olivine/server.ex
@@ -182,7 +182,23 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Server do
     end
   end
 
+  # The lock's taker is the unlock's only authority: adoption
+  # (bedrock-q67.21.5) means family-named workers can now be locked by
+  # racing epochs — an equal-or-newer lock replaces `director`, and a
+  # superseded locker's late unlock must not flip the worker to
+  # :running with the loser's pull sources mid-recovery. A worker with
+  # no lock owner has no authority to violate (static configurations
+  # unlock directly).
   @impl true
+  def handle_call(
+        {:unlock_after_recovery, _durable_version, _pull_sources},
+        {caller, _},
+        %State{director: director} = t
+      )
+      when director != nil and caller != director do
+    reply(t, {:error, :not_lock_owner})
+  end
+
   def handle_call({:unlock_after_recovery, durable_version, pull_sources}, {_director, _}, t) do
     {:ok, updated_state} = Logic.unlock_after_recovery(t, durable_version, pull_sources)
     # Service starts now: a worker that spent its whole idle window locked

--- a/test/bedrock/control_plane/distributor/recruitment_test.exs
+++ b/test/bedrock/control_plane/distributor/recruitment_test.exs
@@ -15,6 +15,7 @@ defmodule Bedrock.ControlPlane.Distributor.RecruitmentTest do
   defmodule TestCluster do
     @moduledoc false
     def otp_name(:foreman), do: :recruitment_test_foreman
+    def otp_name_for_worker(id), do: :"recruitment_test_worker_#{id}"
   end
 
   defp ctx(overrides) do
@@ -138,5 +139,56 @@ defmodule Bedrock.ControlPlane.Distributor.RecruitmentTest do
       })
 
     assert {:error, {:no_pull_sources, 7}} = Recruitment.recruit(7, ctx)
+  end
+
+  describe "adoption: recruitment minus creation, minus destruction" do
+    test "an adopt locks at the epoch and unlocks at the worker's OWN durable version with its replica set" do
+      test_pid = self()
+      own_durable = Version.from_integer(9)
+
+      ctx =
+        ctx(%{
+          lock_materializer_fn: fn worker, epoch ->
+            send(test_pid, {:locked, worker, epoch})
+            {:ok, test_pid, %{durable_version: own_durable}}
+          end,
+          unlock_materializer_fn: fn pid, version, sources ->
+            send(test_pid, {:unlocked, pid, version, sources})
+            :ok
+          end,
+          create_worker_fn: fn _f, _i, _k, _o -> flunk("adoption must never create a worker") end
+        })
+
+      assert {:ok, _pid, :node_b@host, "wkr_named"} = Recruitment.adopt(7, "wkr_named", :node_b@host, ctx)
+
+      # Locked by its callable name on ITS node — no node selection.
+      assert_received {:locked, {:recruitment_test_worker_wkr_named, :node_b@host}, 4}
+
+      # Unlocked at the version the worker itself reports: it resumes
+      # pulling from exactly where its own store left off.
+      assert_received {:unlocked, _pid, ^own_durable, [{"log_1", :ref_1} | _]}
+    end
+
+    test "a failed adoption never removes the worker — it pre-exists this attempt and holds real state" do
+      ctx =
+        ctx(%{
+          lock_materializer_fn: fn _worker, _epoch -> {:error, :wedged} end,
+          remove_worker_fn: fn _f, _i, _o -> flunk("a pre-existing worker must never be removed") end,
+          create_worker_fn: fn _f, _i, _k, _o -> flunk("adoption must never create a worker") end
+        })
+
+      assert {:error, {:materializer_lock_failed, :wedged, :node_b@host}} =
+               Recruitment.adopt(7, "wkr_named", :node_b@host, ctx)
+    end
+
+    test "an adopt with no pull sources fails loudly before touching the worker" do
+      ctx =
+        ctx(%{
+          log_refs: %{},
+          lock_materializer_fn: fn _w, _e -> flunk("must not lock a worker it cannot feed") end
+        })
+
+      assert {:error, {:no_pull_sources, 7}} = Recruitment.adopt(7, "wkr_named", :node_b@host, ctx)
+    end
   end
 end

--- a/test/bedrock/control_plane/distributor/server_test.exs
+++ b/test/bedrock/control_plane/distributor/server_test.exs
@@ -329,10 +329,12 @@ defmodule Bedrock.ControlPlane.Distributor.ServerTest do
                Server.handle_info({:assignment_verified, 1, worker, {:adopted, adopted, node(), "wkr_stale"}}, t2)
 
       # The adoption re-asserts the same entry under the fence (supersession
-      # check) and the assignment is monitored from this moment.
+      # check); the assignment stays monitored — and exactly ONCE: the
+      # sweep armed it, and publish must not double it (a doubled monitor
+      # doubles every DOWN into a double heal).
       assert_received {:committed, _}
       refute MapSet.member?(t3.recruiting, 1)
-      assert 1 in Map.values(t3.assignment_monitors)
+      assert Enum.count(Map.values(t3.assignment_monitors), &(&1 == 1)) == 1
       assert t3.snapshot.materializer_refs[1] == {"wkr_stale", node_string}
     end
 
@@ -347,17 +349,22 @@ defmodule Bedrock.ControlPlane.Distributor.ServerTest do
         {SystemKeys.materializer_key(1), Values.encode_materializer_ref("wkr_wedged", node_string)}
       ]
 
+      # A stale answer whose adoption then definitively fails: wedged
+      # mid-adopt, alive — heal, never remove.
       info_fn = fn
         {name, _node}, [:epoch], _opts ->
-          if name == otp_name_for_worker("wkr_wedged"), do: {:error, :timeout}, else: {:ok, %{epoch: 3}}
+          if name == otp_name_for_worker("wkr_wedged"), do: {:ok, %{epoch: 2}}, else: {:ok, %{epoch: 3}}
       end
 
       t = verified_sweep_state(refs_entries, test_pid, info_fn)
 
       ctx =
-        Map.put(t.recruitment_ctx, :remove_worker_fn, fn _f, _i, _o ->
-          flunk("a pre-existing worker must never be removed")
-        end)
+        Map.merge(t.recruitment_ctx, %{
+          lock_materializer_fn: fn _worker, _epoch -> {:error, :wedged_mid_lock} end,
+          remove_worker_fn: fn _f, _i, _o ->
+            flunk("a pre-existing worker must never be removed")
+          end
+        })
 
       t = %{t | recruitment_ctx: ctx}
 
@@ -365,8 +372,14 @@ defmodule Bedrock.ControlPlane.Distributor.ServerTest do
         ExUnit.CaptureLog.capture_log(fn ->
           assert {:noreply, t2} = Server.handle_continue(:startup_sweep, t)
 
-          assert_receive {:assignment_verified, 1, worker, {:error, :timeout}}
-          assert {:noreply, t3} = Server.handle_info({:assignment_verified, 1, worker, {:error, :timeout}}, t2)
+          assert_receive {:assignment_verified, 1, worker, {:error, {:materializer_lock_failed, :wedged_mid_lock, _}}}
+
+          assert {:noreply, t3} =
+                   Server.handle_info(
+                     {:assignment_verified, 1, worker,
+                      {:error, {:materializer_lock_failed, :wedged_mid_lock, :nonode@nohost}}},
+                     t2
+                   )
 
           # Healed: placeholder published over the wedged worker's entry,
           # replacement recruiting.
@@ -376,6 +389,187 @@ defmodule Bedrock.ControlPlane.Distributor.ServerTest do
         end)
 
       assert log =~ "failed verification"
+    end
+
+    test "DOWN-before-verdict: the heal's recruit is suppressed by the reservation and re-issued when the park degraded" do
+      test_pid = self()
+      node_string = Atom.to_string(node())
+      ref = make_ref()
+
+      refs_entries = [{SystemKeys.materializer_key(0), Values.encode_materializer_ref("wkr_dead", node_string)}]
+      t = verified_sweep_state(refs_entries, test_pid, fn _w, [:epoch], _o -> {:ok, %{epoch: 2}} end)
+
+      # Simulate the common order for a dead named worker: monitor and
+      # reservation armed by the sweep, then the :noproc DOWN lands while
+      # the probe is still in flight — with the publish failing (the
+      # degraded park deletes the local ref).
+      t = %{
+        t
+        | placeholder: spawn(fn -> Process.sleep(:infinity) end),
+          snapshot: %{shard_layout: %{}, materializer_refs: %{0 => {"wkr_dead", node_string}}},
+          recruiting: MapSet.new([0]),
+          assignment_monitors: %{ref => 0},
+          deps: Map.put(t.deps, :commit_fn, fn _p, _e, _t, _o -> {:error, :timeout} end)
+      }
+
+      log =
+        ExUnit.CaptureLog.capture_log(fn ->
+          assert {:noreply, t2} = Server.handle_info({:DOWN, ref, :process, self(), :noproc}, t)
+
+          # The reservation suppressed the heal's recruit and the park
+          # degraded: refs is now ABSENT for the tag.
+          refute Map.has_key?(t2.snapshot.materializer_refs, 0)
+          assert t2.recruiting == MapSet.new([0])
+
+          # The late verdict re-issues the suppressed recruit — without
+          # this the committed keyspace names a corpse until the next
+          # recovery.
+          assert {:noreply, t3} =
+                   Server.handle_info({:assignment_verified, 0, {"wkr_dead", node_string}, {:error, :noproc}}, t2)
+
+          assert MapSet.member?(t3.recruiting, 0)
+        end)
+
+      assert log =~ "placeholder publish"
+    end
+
+    test "unreachable-shaped probe verdicts damp instead of healing, and escalate to a heal" do
+      test_pid = self()
+      node_string = Atom.to_string(node())
+
+      refs_entries = [{SystemKeys.materializer_key(0), Values.encode_materializer_ref("wkr_far", node_string)}]
+      t = verified_sweep_state(refs_entries, test_pid, fn _w, [:epoch], _o -> {:ok, %{epoch: 3}} end)
+
+      t = %{
+        t
+        | placeholder: spawn(fn -> Process.sleep(:infinity) end),
+          snapshot: %{shard_layout: %{}, materializer_refs: %{0 => {"wkr_far", node_string}}},
+          reverify_interval_ms: 5
+      }
+
+      worker = {"wkr_far", node_string}
+
+      log =
+        ExUnit.CaptureLog.capture_log(fn ->
+          # Two unreachable-shaped verdicts: no heal, no commit — the
+          # damping counter climbs and the reverify tick re-arms.
+          assert {:noreply, t} = Server.handle_info({:assignment_verified, 0, worker, {:error, :unavailable}}, t)
+          assert t.unreachable_counts[0] == 1
+          refute_received {:committed, _}
+          assert_receive {:reverify_assignment, 0}, 100
+
+          assert {:noreply, t} = Server.handle_info({:assignment_verified, 0, worker, {:error, :timeout}}, t)
+          assert t.unreachable_counts[0] == 2
+          refute_received {:committed, _}
+
+          # The third escalates to the heal.
+          assert {:noreply, t} = Server.handle_info({:assignment_verified, 0, worker, {:error, :timeout}}, t)
+          assert_received {:committed, _}
+          assert t.unreachable_counts == %{}
+          assert MapSet.member?(t.recruiting, 0)
+        end)
+
+      assert log =~ "unreachable during verification; damping"
+    end
+
+    test "a :preexisting transient re-assert failure monitors without backoff and never removes" do
+      test_pid = self()
+      node_string = Atom.to_string(node())
+      adopted = spawn(fn -> Process.sleep(:infinity) end)
+
+      refs_entries = [{SystemKeys.materializer_key(0), Values.encode_materializer_ref("wkr_adopt", node_string)}]
+      t = verified_sweep_state(refs_entries, test_pid, fn _w, [:epoch], _o -> {:ok, %{epoch: 3}} end)
+
+      ctx =
+        Map.put(t.recruitment_ctx, :remove_worker_fn, fn _f, _i, _o ->
+          flunk("a pre-existing worker must never be removed")
+        end)
+
+      t = %{
+        t
+        | recruitment_ctx: ctx,
+          snapshot: %{shard_layout: %{}, materializer_refs: %{0 => {"wkr_adopt", node_string}}},
+          deps: Map.put(t.deps, :commit_fn, fn _p, _e, _t, _o -> {:error, :timeout} end)
+      }
+
+      log =
+        ExUnit.CaptureLog.capture_log(fn ->
+          assert {:noreply, t2} =
+                   Server.handle_info(
+                     {:assignment_verified, 0, {"wkr_adopt", node_string}, {:adopted, adopted, node(), "wkr_adopt"}},
+                     t
+                   )
+
+          # The entry already names the worker and it is serving: only
+          # the fence confirmation was lost. Monitor; no backoff.
+          assert 0 in Map.values(t2.assignment_monitors)
+          assert t2.backoff == %{}
+        end)
+
+      assert log =~ "adoption re-assert"
+    end
+
+    test "a superseded :preexisting re-assert cedes WITHOUT removing the worker" do
+      test_pid = self()
+      node_string = Atom.to_string(node())
+      adopted = spawn(fn -> Process.sleep(:infinity) end)
+
+      refs_entries = [{SystemKeys.materializer_key(0), Values.encode_materializer_ref("wkr_adopt", node_string)}]
+      t = verified_sweep_state(refs_entries, test_pid, fn _w, [:epoch], _o -> {:ok, %{epoch: 3}} end)
+
+      ctx =
+        Map.put(t.recruitment_ctx, :remove_worker_fn, fn _f, _i, _o ->
+          flunk("a pre-existing worker must never be removed, even ceding")
+        end)
+
+      superseding_deps =
+        Map.merge(t.deps, %{
+          get_fn: fn _k, _v -> {:ok, Lock.new_uid()} end,
+          commit_fn: fn _p, _e, _t, _o -> flunk("must not commit past a refused fence") end
+        })
+
+      t = %{
+        t
+        | recruitment_ctx: ctx,
+          deps: superseding_deps,
+          snapshot: %{shard_layout: %{}, materializer_refs: %{0 => {"wkr_adopt", node_string}}}
+      }
+
+      ExUnit.CaptureLog.capture_log(fn ->
+        assert {:stop, :normal, _t} =
+                 Server.handle_info(
+                   {:assignment_verified, 0, {"wkr_adopt", node_string}, {:adopted, adopted, node(), "wkr_adopt"}},
+                   t
+                 )
+      end)
+    end
+
+    test "a reachable reverify re-runs verification — reachability is not membership" do
+      test_pid = self()
+      node_string = Atom.to_string(node())
+
+      refs_entries = [{SystemKeys.materializer_key(0), Values.encode_materializer_ref("wkr_back", node_string)}]
+
+      t =
+        verified_sweep_state(refs_entries, test_pid, fn _w, [:epoch], _o ->
+          send(test_pid, :probed)
+          {:ok, %{epoch: 3}}
+        end)
+
+      t = %{
+        t
+        | snapshot: %{shard_layout: %{}, materializer_refs: %{0 => {"wkr_back", node_string}}},
+          unreachable_counts: %{0 => 1}
+      }
+
+      assert {:noreply, t2} = Server.handle_info({:reverify_assignment, 0}, t)
+
+      # Monitor re-armed AND a fresh probe launched; the count survives
+      # until the verdict clears it.
+      assert 0 in Map.values(t2.assignment_monitors)
+      assert t2.unreachable_counts == %{0 => 1}
+      assert_receive :probed
+      assert_receive {:assignment_verified, 0, _worker, :current}
     end
 
     test "a verification verdict for a tag another mechanism re-owned is dropped" do
@@ -985,7 +1179,7 @@ defmodule Bedrock.ControlPlane.Distributor.ServerTest do
       assert log =~ "unreachable after 3 verifications; healing"
     end
 
-    test "a reachable node resets the count and re-arms the monitor; a re-assigned tag has nothing to verify" do
+    test "a reachable node re-arms the monitor and re-verifies; the VERDICT clears the count, not the ping" do
       test_pid = self()
 
       t =
@@ -993,11 +1187,19 @@ defmodule Bedrock.ControlPlane.Distributor.ServerTest do
           snapshot: %{shard_layout: %{}, materializer_refs: %{7 => {"wkr_alive", Atom.to_string(node())}}}
         )
 
-      t = %{t | unreachable_counts: %{7 => 2}}
+      ctx = Map.put(t.recruitment_ctx, :info_fn, fn _w, [:epoch], _o -> {:ok, %{epoch: 3}} end)
+      t = %{t | recruitment_ctx: ctx, unreachable_counts: %{7 => 2}}
 
       assert {:noreply, t2} = Server.handle_info({:reverify_assignment, 7}, t)
-      assert t2.unreachable_counts == %{}
+
+      # Reachability alone is not membership: the count survives the
+      # pong; verification re-runs and its :current verdict clears it.
+      assert t2.unreachable_counts == %{7 => 2}
       assert Map.values(t2.assignment_monitors) == [7]
+
+      assert_receive {:assignment_verified, 7, worker, :current}
+      assert {:noreply, t2b} = Server.handle_info({:assignment_verified, 7, worker, :current}, t2)
+      assert t2b.unreachable_counts == %{}
       refute_received {:committed, _}
 
       # A tag re-assigned to the placeholder meanwhile is already

--- a/test/bedrock/control_plane/distributor/server_test.exs
+++ b/test/bedrock/control_plane/distributor/server_test.exs
@@ -233,13 +233,205 @@ defmodule Bedrock.ControlPlane.Distributor.ServerTest do
             node_capabilities: %{materializer: [node()]},
             logs: %{"log_1" => []},
             log_refs: %{"log_1" => :ref},
+            info_fn: fn _worker, [:epoch], _opts -> {:ok, %{epoch: 3}} end,
             create_worker_fn: fn _f, _i, _k, _o -> {:error, :scripted} end
           }
         )
 
       assert {:noreply, t2} = Server.handle_continue(:startup_sweep, t)
       assert MapSet.member?(t2.recruiting, 1)
-      refute MapSet.member?(t2.recruiting, 0)
+
+      # The covered tag is reserved only while its verification is in
+      # flight; a current-epoch answer releases it without recruiting.
+      assert_receive {:assignment_verified, 0, worker, :current}
+      assert {:noreply, t3} = Server.handle_info({:assignment_verified, 0, worker, :current}, t2)
+      refute MapSet.member?(t3.recruiting, 0)
+      assert MapSet.member?(t3.recruiting, 1)
+    end
+
+    test "the sweep verifies every named assignment is in the epoch: current answers verify silently" do
+      test_pid = self()
+      {lock, _} = Lock.take(nil, nil)
+      Process.put(:my_owner, lock.my_owner)
+
+      refs_entries = [
+        {SystemKeys.materializer_key(0), Values.encode_materializer_ref("wkr_sys", Atom.to_string(node()))},
+        {SystemKeys.materializer_key(1), Values.encode_materializer_ref("wkr_a", Atom.to_string(node()))}
+      ]
+
+      t = verified_sweep_state(refs_entries, test_pid, fn _worker, [:epoch], _opts -> {:ok, %{epoch: 3}} end)
+
+      assert {:noreply, t2} = Server.handle_continue(:startup_sweep, t)
+
+      # Both named tags are reserved while their verification is in flight...
+      assert MapSet.member?(t2.recruiting, 0) and MapSet.member?(t2.recruiting, 1)
+
+      # ...and a current-epoch answer releases the reservation with no
+      # publish, no adoption, no recruit.
+      assert_receive {:assignment_verified, 0, _worker, :current}
+      assert_receive {:assignment_verified, 1, _worker, verdict1}
+
+      assert {:noreply, t3} =
+               Server.handle_info({:assignment_verified, 0, {"wkr_sys", Atom.to_string(node())}, :current}, t2)
+
+      assert {:noreply, t4} =
+               Server.handle_info({:assignment_verified, 1, {"wkr_a", Atom.to_string(node())}, verdict1}, t3)
+
+      assert t4.recruiting == MapSet.new()
+      refute_received {:committed, _}
+    end
+
+    test "a stale-epoch assignment is adopted: locked, unlocked at its own version, re-asserted under the fence" do
+      test_pid = self()
+      {lock, _} = Lock.take(nil, nil)
+      Process.put(:my_owner, lock.my_owner)
+      node_string = Atom.to_string(node())
+
+      refs_entries = [
+        {SystemKeys.materializer_key(0), Values.encode_materializer_ref("wkr_sys", node_string)},
+        {SystemKeys.materializer_key(1), Values.encode_materializer_ref("wkr_stale", node_string)}
+      ]
+
+      adopted = spawn(fn -> Process.sleep(:infinity) end)
+
+      info_fn = fn
+        {name, _node}, [:epoch], _opts ->
+          if name == otp_name_for_worker("wkr_stale"), do: {:ok, %{epoch: 2}}, else: {:ok, %{epoch: 3}}
+      end
+
+      t = verified_sweep_state(refs_entries, test_pid, info_fn)
+
+      ctx =
+        Map.merge(t.recruitment_ctx, %{
+          lock_materializer_fn: fn worker, epoch ->
+            send(test_pid, {:adopt_locked, worker, epoch})
+            {:ok, adopted, %{durable_version: Version.from_integer(5)}}
+          end,
+          unlock_materializer_fn: fn _pid, version, _sources ->
+            send(test_pid, {:adopt_unlocked, version})
+            :ok
+          end
+        })
+
+      t = %{t | recruitment_ctx: ctx}
+
+      assert {:noreply, t2} = Server.handle_continue(:startup_sweep, t)
+
+      # The stale worker was locked into THIS epoch and unlocked at the
+      # version IT reported.
+      assert_receive {:adopt_locked, {_name, _node}, 3}
+      assert_receive {:adopt_unlocked, version}
+      assert version == Version.from_integer(5)
+
+      assert_receive {:assignment_verified, 1, worker, {:adopted, ^adopted, _node, "wkr_stale"}}
+
+      assert {:noreply, t3} =
+               Server.handle_info({:assignment_verified, 1, worker, {:adopted, adopted, node(), "wkr_stale"}}, t2)
+
+      # The adoption re-asserts the same entry under the fence (supersession
+      # check) and the assignment is monitored from this moment.
+      assert_received {:committed, _}
+      refute MapSet.member?(t3.recruiting, 1)
+      assert 1 in Map.values(t3.assignment_monitors)
+      assert t3.snapshot.materializer_refs[1] == {"wkr_stale", node_string}
+    end
+
+    test "an unadoptable named assignment is healed — parked and re-recruited, the worker never removed" do
+      test_pid = self()
+      {lock, _} = Lock.take(nil, nil)
+      Process.put(:my_owner, lock.my_owner)
+      node_string = Atom.to_string(node())
+
+      refs_entries = [
+        {SystemKeys.materializer_key(0), Values.encode_materializer_ref("wkr_sys", node_string)},
+        {SystemKeys.materializer_key(1), Values.encode_materializer_ref("wkr_wedged", node_string)}
+      ]
+
+      info_fn = fn
+        {name, _node}, [:epoch], _opts ->
+          if name == otp_name_for_worker("wkr_wedged"), do: {:error, :timeout}, else: {:ok, %{epoch: 3}}
+      end
+
+      t = verified_sweep_state(refs_entries, test_pid, info_fn)
+
+      ctx =
+        Map.put(t.recruitment_ctx, :remove_worker_fn, fn _f, _i, _o ->
+          flunk("a pre-existing worker must never be removed")
+        end)
+
+      t = %{t | recruitment_ctx: ctx}
+
+      log =
+        ExUnit.CaptureLog.capture_log(fn ->
+          assert {:noreply, t2} = Server.handle_continue(:startup_sweep, t)
+
+          assert_receive {:assignment_verified, 1, worker, {:error, :timeout}}
+          assert {:noreply, t3} = Server.handle_info({:assignment_verified, 1, worker, {:error, :timeout}}, t2)
+
+          # Healed: placeholder published over the wedged worker's entry,
+          # replacement recruiting.
+          assert_received {:committed, _}
+          assert t3.snapshot.materializer_refs[1] == {Placeholder.worker_id(), node_string}
+          assert MapSet.member?(t3.recruiting, 1)
+        end)
+
+      assert log =~ "failed verification"
+    end
+
+    test "a verification verdict for a tag another mechanism re-owned is dropped" do
+      test_pid = self()
+      {lock, _} = Lock.take(nil, nil)
+      Process.put(:my_owner, lock.my_owner)
+      node_string = Atom.to_string(node())
+
+      refs_entries = [
+        {SystemKeys.materializer_key(0), Values.encode_materializer_ref("wkr_sys", node_string)},
+        {SystemKeys.materializer_key(1), Values.encode_materializer_ref("wkr_gone", node_string)}
+      ]
+
+      t = verified_sweep_state(refs_entries, test_pid, fn _w, [:epoch], _o -> {:ok, %{epoch: 3}} end)
+      assert {:noreply, t2} = Server.handle_continue(:startup_sweep, t)
+
+      # Death healing re-owned tag 1 meanwhile: the ref now names the
+      # placeholder. A late error verdict must not double-heal...
+      healed_refs = Map.put(t2.snapshot.materializer_refs, 1, {Placeholder.worker_id(), node_string})
+      t2 = %{t2 | snapshot: %{t2.snapshot | materializer_refs: healed_refs}}
+
+      assert {:noreply, t3} =
+               Server.handle_info({:assignment_verified, 1, {"wkr_gone", node_string}, {:error, :noproc}}, t2)
+
+      refute MapSet.member?(t3.recruiting, 1)
+
+      # ...and a late adoption verdict must not clobber the new owner: the
+      # adopted worker is an unnamed stray now and self-retires in-band.
+      stray = spawn(fn -> Process.sleep(:infinity) end)
+
+      assert {:noreply, t4} =
+               Server.handle_info(
+                 {:assignment_verified, 1, {"wkr_gone", node_string}, {:adopted, stray, node(), "wkr_gone"}},
+                 t3
+               )
+
+      assert t4.snapshot.materializer_refs[1] == {Placeholder.worker_id(), node_string}
+    end
+
+    defp verified_sweep_state(refs_entries, test_pid, info_fn) do
+      {lock, _} = Lock.take(nil, nil)
+      Process.put(:my_owner, lock.my_owner)
+
+      state(two_shard_snapshot_deps(refs_entries, test_pid),
+        lock: lock,
+        placeholder_start_fn: fn _opts -> {:ok, spawn(fn -> Process.sleep(:infinity) end)} end,
+        recruitment_ctx: %{
+          cluster: __MODULE__,
+          epoch: 3,
+          node_capabilities: %{materializer: [node()]},
+          logs: %{"log_1" => []},
+          log_refs: %{"log_1" => :ref},
+          info_fn: info_fn,
+          create_worker_fn: fn _f, _i, _k, _o -> {:error, :scripted} end
+        }
+      )
     end
 
     test "supersession at the publish cedes" do

--- a/test/bedrock/data_plane/materializer/olivine/genserver_integration_test.exs
+++ b/test/bedrock/data_plane/materializer/olivine/genserver_integration_test.exs
@@ -703,4 +703,27 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.GenServerIntegrationTest do
       assert {:ok, :materializer} = GenServer.call(pid, {:info, :kind}, @timeout)
     end
   end
+
+  describe "unlock authority (assignment verification, bedrock-q67.21.5)" do
+    @tag :tmp_dir
+    test "only the locker may unlock: a foreign caller's unlock is refused", %{tmp_dir: tmp_dir} do
+      {_worker_id, _otp_name, pid} = setup_supervised_worker(tmp_dir, "unlock_auth")
+
+      # Lock from THIS process: we are the lock owner.
+      assert {:ok, ^pid, _info} = GenServer.call(pid, {:lock_for_recovery, 5}, @timeout)
+
+      # A different process's unlock — a superseded adopter's late call —
+      # must be refused, not flip the worker to :running with the
+      # loser's pull sources.
+      task =
+        Task.async(fn ->
+          GenServer.call(pid, {:unlock_after_recovery, Version.zero(), []}, @timeout)
+        end)
+
+      assert {:error, :not_lock_owner} = Task.await(task)
+
+      # The owner's unlock still works.
+      assert :ok = GenServer.call(pid, {:unlock_after_recovery, Version.zero(), []}, @timeout)
+    end
+  end
 end

--- a/test/bedrock/data_plane/materializer/olivine/logic_test.exs
+++ b/test/bedrock/data_plane/materializer/olivine/logic_test.exs
@@ -518,4 +518,18 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.LogicTest do
         await_snapshot(snapshot, attempts_left - 1)
     end
   end
+
+  describe "the :epoch info fact (assignment verification, bedrock-q67.21.5)" do
+    test "a never-locked worker reports nil; a locked worker reports its epoch", %{test_dir: test_dir} do
+      {:ok, state} = Logic.startup(:epoch_fact_test, self(), "epoch_wkr", test_dir)
+
+      assert {:ok, %{epoch: nil}} = Logic.info(state, [:epoch])
+
+      {:ok, locked} = Logic.lock_for_recovery(state, self(), 7)
+      assert {:ok, %{epoch: 7}} = Logic.info(locked, [:epoch])
+      assert :epoch in elem(Logic.info(locked, [:supported_info]), 1).supported_info
+
+      Logic.shutdown(locked)
+    end
+  end
 end


### PR DESCRIPTION
Closes the **bedrock-q67.21.5** re-adoption residue and **bedrock-q67.21.7** (alive-but-unadopted workers) with a single mechanism. Draft for review; stacked on #194.

## The FDB sanity check killed the original plan

The ticket sketched a phase-a-style port: hand the distributor a snapshot of the director's services map, interrogate every materializer for its `:shard_id` under a deadline, and adopt matches for uncovered tags. Checked against FDB and the current architecture, that mechanism is redundant twice over — and a side channel besides:

- **Recovery's locking phase already locks every advertised materializer**, and bootstrap adopts every locked survivor (`existing_materializers_by_shard` + `prefer_family_named`). A sweep over the same services map rediscovers only what bootstrap already found.
- **Unnamed strays already retire themselves**: `rejoin_verdict` → `:displaced` on the next layout push — FDB's undesired-data self-cleanup. Nothing to add.
- FDB's DD has no process-discovery RPC sweep. Membership rides the committed keyspace (`serverList`/`serverKeys`); DD *verifies* every listed server. Keyspace-is-the-channel says the same.

## What actually remains — and the collapse

The one real gap is a worker the committed `materializers/` family **names** but the epoch never **embraced**: its node missed recovery's roll call and rejoined later. The sweep monitors it, liveness looks fine — but it was never locked into the epoch, so the tag stays dark until the next recovery. That is precisely q67.21.7: *liveness is not adoption*. Candidates come from the family itself — no services snapshot, no `:shard_id` interrogation (the entry already binds worker→tag).

## Mechanism

At the startup sweep, each named non-placeholder assignment gets one bounded (2s) probe of its new `:epoch` info fact — the membership check, FDB-DD-style:

- **Current** → verified silently; the reservation releases.
- **Stale / never-locked** → **adopted**: `Recruitment.adopt/4` = recruitment minus creation — bounded lock at the epoch, unlock at the durable version the worker itself reports (it resumes exactly where its own store left off), entry re-asserted under the CHECK fence (supersession → cede), monitored.
- **Wedged / dead** → **healed** (placeholder + fresh recruit). The worker is *never* removed — structurally: `adopt` has no removal call, and `publish_assignment`'s failure policy is keyed by provenance (`:created` may remove orphans under the existing verdict rules; `:preexisting` never). The displaced worker observes the replacing entry and retires in-band.

One shot, at the sweep. Reservation rides the existing `recruiting` set so demand recruitment cannot double-cover; late verdicts for tags another mechanism re-owned (death healing, idle parking) are dropped, and a late-adopted stray self-retires.

## Tests (TDD)

Written first, 8 failing → green: the `:epoch` fact (nil until locked); adopt locks-at-epoch/unlocks-at-own-version/never-creates/never-removes/fails-loudly-without-sources; sweep pins for current-verifies-silently, stale-adopts-with-fenced-re-assert-and-monitor, unadoptable-heals-without-removal, and late-verdict-dropped-after-re-ownership. Full suite (2714), credo --strict, dialyzer, 3-seed sweep green.

## Tickets

bedrock-q67.21.7 closes on merge (description updated with the mechanism); q67.21.5's description records the collapse and its rationale.