### PR TITLE
Materializer membership becomes a set: materializers/<tag>/<worker_id>

### DIFF
--- a/lib/bedrock/control_plane/config/recovery_attempt.ex
+++ b/lib/bedrock/control_plane/config/recovery_attempt.ex
@@ -81,9 +81,9 @@ defmodule Bedrock.ControlPlane.Config.RecoveryAttempt do
           transaction_services: %{Worker.id() => ServiceDescriptor.t()},
           service_pids: %{Worker.id() => pid()},
           transaction_system_layout: TransactionSystemLayout.t() | nil,
-          shard_materializers: %{Bedrock.range_tag() => {Worker.id(), node_name :: String.t()}},
+          shard_materializers: %{Bedrock.range_tag() => %{Worker.id() => node_name :: String.t()}},
           seeded_layout?: boolean(),
-          prior_materializer_refs: %{Bedrock.range_tag() => {Worker.id(), String.t()}} | nil,
+          prior_materializer_refs: %{Bedrock.range_tag() => %{Worker.id() => String.t()}} | nil,
           lock_failed_service_ids: MapSet.t(Worker.id()),
           shard_layout: shard_layout() | nil
         }

--- a/lib/bedrock/control_plane/director/recovery.ex
+++ b/lib/bedrock/control_plane/director/recovery.ex
@@ -186,7 +186,8 @@ defmodule Bedrock.ControlPlane.Director.Recovery do
     log_ids = completed_attempt.logs |> Map.keys() |> MapSet.new()
 
     materializer_ids =
-      for {_tag, {worker_id, _node}} <- completed_attempt.shard_materializers,
+      for {_tag, members} <- completed_attempt.shard_materializers,
+          {worker_id, _node} <- members,
           into: MapSet.new(),
           do: worker_id
 

--- a/lib/bedrock/control_plane/director/recovery/materializer_bootstrap_phase.ex
+++ b/lib/bedrock/control_plane/director/recovery/materializer_bootstrap_phase.ex
@@ -113,18 +113,21 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhase do
   # The one projection, at the one boundary it belongs: the phase
   # orchestrates with live pids (lock, unlock, catchup), but the attempt
   # carries the refs exactly as every reader consumes them — the
-  # keyspace-value shape {worker_id, node}, both strings. The persistence
-  # writer and the routing-snapshot seed embed this map verbatim, so the
-  # seed and the keyspace are the same map read twice; ghost pruning
-  # takes its worker ids from it directly. A pid is phase-local
+  # family's MEMBER shape, %{worker_id => node}, all strings. The
+  # persistence writer and the routing-snapshot seed embed this map
+  # verbatim, so the seed and the keyspace are the same map read twice;
+  # ghost pruning takes its worker ids from it directly. Recovery adopts
+  # exactly one member per tag (see prefer_family_named/3), so the map
+  # it builds is a singleton per tag — but it is member-SHAPED, because
+  # the family is a set and every reader treats it as one. A pid is phase-local
   # orchestration state, not a fact any reader needs — a future consumer
   # that wants one should ask where it lives (the directory, or the
   # worker), not have it carried speculatively.
   @spec to_materializer_refs(%{Bedrock.range_tag() => {Worker.id(), node(), pid()}}) ::
-          %{Bedrock.range_tag() => {Worker.id(), String.t()}}
+          %{Bedrock.range_tag() => %{Worker.id() => String.t()}}
   defp to_materializer_refs(shard_materializers) do
     Map.new(shard_materializers, fn {tag, {worker_id, node, _pid}} ->
-      {tag, {worker_id, Atom.to_string(node)}}
+      {tag, %{worker_id => Atom.to_string(node)}}
     end)
   end
 
@@ -399,14 +402,24 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhase do
   # most-advanced-durable contest, which remains the fallback for tags
   # the family does not name — and for tag 0, whose selection happens
   # before the family can be read (the family lives IN the system shard).
+  # Recovery adopts exactly ONE member per tag. The family may name
+  # several (the distributor can place replicas), but recovery's job is
+  # to get each shard served, not to re-establish every replica; the
+  # members it does not adopt keep their committed keys and the
+  # distributor's sweep verifies and adopts them into this epoch. The
+  # pick is the LOWEST worker id — the same deterministic rule
+  # RoutingData.pick_member/1 uses, so the member recovery unlocks is
+  # the member clients are routed to, with no window where the pick
+  # names a materializer still locked at the prior epoch.
   defp prefer_family_named(existing_by_shard, prior_refs, recovery_attempt) do
     named =
       for {tag, members} <- prior_refs,
-          {worker_id, _node} <- members,
+          {worker_id, _node} <- Enum.sort(members),
           match?(%{shard_id: ^tag}, Map.get(recovery_attempt.materializer_recovery_info_by_id, worker_id)),
           %{status: {:up, ref}} <- [Map.get(recovery_attempt.transaction_services, worker_id)],
-          into: %{},
-          do: {tag, {worker_id, {:materializer, ref}}}
+          reduce: %{} do
+        acc -> Map.put_new(acc, tag, {worker_id, {:materializer, ref}})
+      end
 
     Map.merge(existing_by_shard, named)
   end
@@ -435,7 +448,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhase do
 
   @doc false
   @spec decode_prior_refs([{Bedrock.key(), binary()}]) ::
-          {:ok, %{Bedrock.range_tag() => {Worker.id(), String.t()}}}
+          {:ok, %{Bedrock.range_tag() => %{Worker.id() => String.t()}}}
           | {:error, {:invalid_materializer_entry, Bedrock.key()}}
   defdelegate decode_prior_refs(entries), to: Reader, as: :decode_materializer_members
 

--- a/lib/bedrock/control_plane/director/recovery/materializer_bootstrap_phase.ex
+++ b/lib/bedrock/control_plane/director/recovery/materializer_bootstrap_phase.ex
@@ -401,7 +401,8 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhase do
   # before the family can be read (the family lives IN the system shard).
   defp prefer_family_named(existing_by_shard, prior_refs, recovery_attempt) do
     named =
-      for {tag, {worker_id, _node}} <- prior_refs,
+      for {tag, members} <- prior_refs,
+          {worker_id, _node} <- members,
           match?(%{shard_id: ^tag}, Map.get(recovery_attempt.materializer_recovery_info_by_id, worker_id)),
           %{status: {:up, ref}} <- [Map.get(recovery_attempt.transaction_services, worker_id)],
           into: %{},
@@ -436,7 +437,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhase do
   @spec decode_prior_refs([{Bedrock.key(), binary()}]) ::
           {:ok, %{Bedrock.range_tag() => {Worker.id(), String.t()}}}
           | {:error, {:invalid_materializer_entry, Bedrock.key()}}
-  defdelegate decode_prior_refs(entries), to: Reader, as: :decode_materializer_refs
+  defdelegate decode_prior_refs(entries), to: Reader, as: :decode_materializer_members
 
   # Find a node that can host materializers
   defp find_materializer_capable_node(%{node_capabilities: caps}) do

--- a/lib/bedrock/control_plane/director/recovery/persistence_phase.ex
+++ b/lib/bedrock/control_plane/director/recovery/persistence_phase.ex
@@ -240,10 +240,17 @@ defmodule Bedrock.ControlPlane.Director.Recovery.PersistencePhase do
       materializers ->
         prior = Map.get(recovery_attempt, :prior_materializer_refs) || %{}
 
-        materializers
-        |> Enum.reject(fn {tag, ref} -> Map.get(prior, tag) == ref end)
-        |> Enum.reduce(tx, fn {tag, {worker_id, node}}, tx ->
-          Tx.set(tx, SystemKeys.materializer_key(tag), Values.encode_materializer_ref(worker_id, node))
+        # Recovery writes the members it decided on and nothing else: an
+        # entry already naming this worker on this node is left alone,
+        # and members recovery never touched (other replicas of the same
+        # shard) keep their keys — the family is a set, so writing one
+        # member never implies removing another.
+        Enum.reduce(materializers, tx, fn {tag, {worker_id, node}}, tx ->
+          if prior |> Map.get(tag, %{}) |> Map.get(worker_id) == node do
+            tx
+          else
+            Tx.set(tx, SystemKeys.materializer_key(tag, worker_id), Values.encode_materializer_node(node))
+          end
         end)
     end
   end

--- a/lib/bedrock/control_plane/director/recovery/persistence_phase.ex
+++ b/lib/bedrock/control_plane/director/recovery/persistence_phase.ex
@@ -217,14 +217,14 @@ defmodule Bedrock.ControlPlane.Director.Recovery.PersistencePhase do
     build_materializer_keys(tx, recovery_attempt)
   end
 
-  # Creates materializer_key(tag) -> {worker_id, node} entries as a DIFF
+  # Creates materializer_key(tag, worker_id) -> node entries as a DIFF
   # against the prior family (read by bootstrap): only assignments this
   # recovery changed are written; unchanged entries are left in place,
   # and entries for tags outside this layout are not recovery's to clean
   # — read-and-heal means stale reconciliation belongs to the
   # distributor (bedrock-q67.21.4). A nil prior means the family was not
   # read (fresh cluster, legacy path): every assignment writes, the safe
-  # direction. The attempt carries refs in the keyspace-value shape, so
+  # direction. The attempt carries refs in the family's member shape, so
   # keyspace and routing-snapshot seed remain one map read twice. Gated
   # on the same INPUT as before: shard_materializers absent/empty means
   # shard management is not active.
@@ -245,13 +245,14 @@ defmodule Bedrock.ControlPlane.Director.Recovery.PersistencePhase do
         # and members recovery never touched (other replicas of the same
         # shard) keep their keys — the family is a set, so writing one
         # member never implies removing another.
-        Enum.reduce(materializers, tx, fn {tag, {worker_id, node}}, tx ->
-          if prior |> Map.get(tag, %{}) |> Map.get(worker_id) == node do
-            tx
-          else
-            Tx.set(tx, SystemKeys.materializer_key(tag, worker_id), Values.encode_materializer_node(node))
-          end
-        end)
+        for {tag, members} <- materializers, {worker_id, node} <- members, reduce: tx do
+          tx ->
+            if prior |> Map.get(tag, %{}) |> Map.get(worker_id) == node do
+              tx
+            else
+              Tx.set(tx, SystemKeys.materializer_key(tag, worker_id), Values.encode_materializer_node(node))
+            end
+        end
     end
   end
 

--- a/lib/bedrock/control_plane/distributor/placeholder.ex
+++ b/lib/bedrock/control_plane/distributor/placeholder.ex
@@ -40,7 +40,9 @@ defmodule Bedrock.ControlPlane.Distributor.Placeholder do
   # The stable worker id the keyspace names for uncovered tags. Worker
   # OTP names are deterministic in the id, so the callable ref is
   # derivable everywhere from the committed {worker_id, node} pair.
-  @worker_id "distributor-placeholder"
+  # One source of truth: routing reads this convention too, so it lives
+  # with the family's semantics rather than behind the control plane.
+  @worker_id Bedrock.SystemKeys.placeholder_worker_id()
 
   @doc "The reserved worker id placeholder entries carry in the keyspace."
   @spec worker_id() :: String.t()

--- a/lib/bedrock/control_plane/distributor/placeholder.ex
+++ b/lib/bedrock/control_plane/distributor/placeholder.ex
@@ -18,8 +18,9 @@ defmodule Bedrock.ControlPlane.Distributor.Placeholder do
   no-ops.
 
   Addressing is the settled option 2 (bedrock-q67.21): the placeholder
-  IS a materializer ref. The distributor publishes
-  `materializers/<tag> = {placeholder_worker_id, distributor_node}` for
+  IS a materializer ref — an ordinary MEMBER of the shard's set, one
+  that parks rather than serves. The distributor publishes
+  `materializers/<tag>/<placeholder_worker_id> = distributor_node` for
   uncovered tags, and the placeholder registers under
   `cluster.otp_name_for_worker(placeholder_worker_id)` — so proxies and
   clients need no special case at all; coverage gaps are visible in the

--- a/lib/bedrock/control_plane/distributor/server.ex
+++ b/lib/bedrock/control_plane/distributor/server.ex
@@ -7,6 +7,7 @@ defmodule Bedrock.ControlPlane.Distributor.Server do
   alias Bedrock.ControlPlane.Distributor.State
   alias Bedrock.ControlPlane.Distributor.Telemetry
   alias Bedrock.ControlPlane.Distributor.Transactions
+  alias Bedrock.DataPlane.CommitProxy.RoutingData
   alias Bedrock.DataPlane.Materializer
   alias Bedrock.SystemKeys
   alias Bedrock.SystemKeys.Values
@@ -22,8 +23,7 @@ defmodule Bedrock.ControlPlane.Distributor.Server do
   @max_unreachable_verifications 3
 
   # Deadline for the sweep's per-assignment epoch PROBE (the adopt that
-  # may follow carries its own 30s lock/unlock bounds — the tag's
-  # reservation is held for that long, deliberately). Monitors and
+  # may follow carries its own 30s lock/unlock bounds). Monitors and
   # placeholder coverage are already live, so the probe itself must
   # never wait on a wedged worker.
   @verification_timeout_ms 2_000
@@ -120,7 +120,7 @@ defmodule Bedrock.ControlPlane.Distributor.Server do
          {:ok, placeholder} <- start_placeholder(t, snapshot.shard_layout),
          t = %{t | placeholder: placeholder, snapshot: snapshot},
          uncovered = uncovered_tags(snapshot),
-         :ok <- publish_placeholders(t, uncovered) do
+         {:ok, t} <- publish_placeholders(t, uncovered) do
       # Eager recruitment for the swept gaps erases first-touch latency:
       # the sweep already knows every uncovered tag, and the in-flight
       # dedupe and backoff machinery make eagerness free. Named
@@ -147,12 +147,12 @@ defmodule Bedrock.ControlPlane.Distributor.Server do
   def handle_cast({:coverage_demand, tag}, %State{} = t) do
     Telemetry.emit_coverage_demand(t.cluster, tag)
 
-    case t |> real_members(tag) |> Enum.min(fn -> nil end) do
-      {worker_id, node} ->
+    case t |> coverage_members(tag) |> RoutingData.pick_member() do
+      {:ok, {worker_id, node}} ->
         Placeholder.notify_covered(t.placeholder, tag, callable_ref(t.cluster, worker_id, node))
         {:noreply, t}
 
-      nil ->
+      :error ->
         {:noreply, t |> Map.update!(:pending_demands, &MapSet.put(&1, tag)) |> maybe_recruit(tag)}
     end
   end
@@ -263,10 +263,15 @@ defmodule Bedrock.ControlPlane.Distributor.Server do
 
   # A retirement whose commit failed transiently: retry until the
   # keyspace stops naming a worker that is gone.
+  # ...unless the member was legitimately re-published in the meantime
+  # (an adoption verdict for a worker that turned out to be alive and
+  # this epoch's). "Still a member" alone cannot tell that apart from
+  # "never retired", so the pending entry is the token: publishing
+  # clears it, and a retry without one is stale.
   def handle_info({:retire_member, tag, worker_id}, %State{} = t) do
-    if Map.has_key?(real_members(t, tag), worker_id),
-      do: retire_member(t, tag, worker_id),
-      else: {:noreply, t}
+    if Map.has_key?(real_members(t, tag), worker_id) and Map.has_key?(t.pending_retires, {tag, worker_id}),
+      do: retire_member(%{t | pending_retires: Map.delete(t.pending_retires, {tag, worker_id})}, tag, worker_id),
+      else: {:noreply, %{t | pending_retires: Map.delete(t.pending_retires, {tag, worker_id})}}
   end
 
   # Death healing (event-driven, FDB teamTracker-style) — with FDB's
@@ -338,35 +343,57 @@ defmodule Bedrock.ControlPlane.Distributor.Server do
     |> Map.values()
     |> Enum.map(fn {tag, _start_key} -> tag end)
     |> Enum.uniq()
-    |> Enum.reject(fn tag -> refs |> Map.get(tag, %{}) |> Map.delete(@placeholder_worker_id) != %{} end)
+    |> Enum.filter(fn tag -> refs |> Map.get(tag, %{}) |> Map.delete(@placeholder_worker_id) == %{} end)
   end
 
-  defp publish_placeholders(_t, []), do: :ok
+  defp publish_placeholders(%State{} = t, []), do: {:ok, t}
 
   defp publish_placeholders(%State{} = t, tags) do
-    # A tag already carrying the placeholder needs no write: the entry is
-    # the same name on the same node, and re-setting it would be a commit
-    # that changes nothing.
-    case Enum.reject(tags, &Map.has_key?(members(t, &1), @placeholder_worker_id)) do
+    # A tag already carrying OUR placeholder needs no write: same name,
+    # same node, so re-setting it would be a commit that changes
+    # nothing. A placeholder naming a different node is a prior epoch's
+    # leak — it parks nothing we can reach, so it must be overwritten,
+    # not trusted.
+    case Enum.reject(tags, &placeholder_here?(t, &1)) do
       [] ->
-        :ok
+        {:ok, t}
 
       missing ->
         with :ok <- Transactions.commit_checked(t.lock, t.deps, Enum.map(missing, &placeholder_mutation/1)) do
           Telemetry.emit_placeholder_published(t.cluster, missing)
-          :ok
+          # Record what we just committed: every later placeholder
+          # decision reads this view, and a view that omits a committed
+          # placeholder omits its clear when a real member lands.
+          {:ok, Enum.reduce(missing, t, &put_member(&2, &1, @placeholder_worker_id, our_node_string()))}
         end
     end
   end
 
+  # Coverage the placeholder can actually provide: the entry must name
+  # this distributor's own node, because a parked read is held by the
+  # local placeholder process. A placeholder key naming a dead node
+  # routes clients at nothing.
+  defp placeholder_here?(%State{} = t, tag), do: Map.get(members(t, tag), @placeholder_worker_id) == our_node_string()
+
+  defp our_node_string, do: Atom.to_string(node())
+
   defp placeholder_mutation(tag) do
-    {:set, SystemKeys.materializer_key(tag, @placeholder_worker_id),
-     Values.encode_materializer_node(Atom.to_string(node()))}
+    {:set, SystemKeys.materializer_key(tag, @placeholder_worker_id), Values.encode_materializer_node(our_node_string())}
   end
 
   defp members(%State{} = t, tag), do: Map.get(t.snapshot.materializer_refs, tag, %{})
 
   defp real_members(%State{} = t, tag), do: t |> members(tag) |> Map.delete(@placeholder_worker_id)
+
+  # Members that can actually serve a read: a member whose retirement is
+  # awaiting a retry is still committed (the keyspace names it, honestly)
+  # but it is known-gone, so draining parked reads into it would undo the
+  # park for nothing.
+  defp coverage_members(%State{} = t, tag) do
+    t
+    |> real_members(tag)
+    |> Map.reject(fn {worker_id, _node} -> Map.has_key?(t.pending_retires, {tag, worker_id}) end)
+  end
 
   defp put_member(%State{} = t, tag, worker_id, node_string) do
     refs =
@@ -452,6 +479,9 @@ defmodule Bedrock.ControlPlane.Distributor.Server do
          t
          |> put_member(tag, worker_id, node_string)
          |> drop_member(tag, @placeholder_worker_id)
+         # This member is legitimately in the set again; any retirement
+         # still awaiting a retry is now stale and must not fire.
+         |> cancel_retire(tag, worker_id)
          |> Map.update!(:pending_demands, &MapSet.delete(&1, tag))
          |> monitor_assignment(tag, worker_id, callable)}
 
@@ -493,7 +523,7 @@ defmodule Bedrock.ControlPlane.Distributor.Server do
   end
 
   defp placeholder_retirement(%State{} = t, tag) do
-    if t |> members(tag) |> Map.has_key?(@placeholder_worker_id),
+    if Map.has_key?(members(t, tag), @placeholder_worker_id),
       do: [{:clear, SystemKeys.materializer_key(tag, @placeholder_worker_id)}],
       else: []
   end
@@ -549,10 +579,19 @@ defmodule Bedrock.ControlPlane.Distributor.Server do
 
   # A heal is retirement plus an eager replacement; an idle spin-down is
   # retirement alone (the shard proved cold — the next read revives it).
+  # Healing is retire-then-recruit, guarded on membership: a signal for
+  # a member the committed set no longer names is STALE (some other
+  # mechanism already retired it), and healing it would recruit a
+  # replica nothing asked for — unboundedly, since every redundant
+  # member is itself monitored.
   defp heal_member(%State{} = t, tag, worker_id) do
-    case retire_member(t, tag, worker_id) do
-      {:noreply, t2} -> {:noreply, maybe_recruit(t2, tag)}
-      {:stop, _reason, _t} = stop -> stop
+    if Map.has_key?(real_members(t, tag), worker_id) do
+      case retire_member(t, tag, worker_id) do
+        {:noreply, t2} -> {:noreply, maybe_recruit(t2, tag)}
+        {:stop, _reason, _t} = stop -> stop
+      end
+    else
+      {:noreply, t}
     end
   end
 
@@ -564,23 +603,28 @@ defmodule Bedrock.ControlPlane.Distributor.Server do
   # A superseded commit cedes. A transient failure keeps the local view
   # honest (the keyspace still names the departed worker) and schedules
   # a retry: nothing else would revisit this tag, and an uncleared
-  # corpse can be handed to clients by the deterministic pick.
+  # corpse can be handed to clients by the deterministic pick. Until
+  # that retry resolves, the member is listed in `pending_retires` — it
+  # is still committed, but it is not coverage, so the demand path skips
+  # it and a legitimate re-publication cancels the retry.
   defp retire_member(%State{} = t, tag, worker_id) do
     remaining = t |> real_members(tag) |> Map.delete(worker_id)
     parking? = remaining == %{}
 
-    if parking?, do: Placeholder.notify_uncovered(t.placeholder, tag)
+    if parking?,
+      do: Placeholder.notify_uncovered(t.placeholder, tag),
+      else: notify_covered_pick(t, tag, remaining)
 
     mutations =
       [{:clear, SystemKeys.materializer_key(tag, worker_id)}] ++
-        if parking? and not Map.has_key?(members(t, tag), @placeholder_worker_id),
+        if parking? and not placeholder_here?(t, tag),
           do: [placeholder_mutation(tag)],
           else: []
 
     case Transactions.commit_checked(t.lock, t.deps, mutations) do
       :ok ->
-        t = drop_member(t, tag, worker_id)
-        t = if parking?, do: put_member(t, tag, @placeholder_worker_id, Atom.to_string(node())), else: t
+        t = t |> drop_member(tag, worker_id) |> demonitor_member(tag, worker_id) |> cancel_retire(tag, worker_id)
+        t = if parking?, do: put_member(t, tag, @placeholder_worker_id, our_node_string()), else: t
         {:noreply, t}
 
       {:error, :superseded} ->
@@ -593,9 +637,49 @@ defmodule Bedrock.ControlPlane.Distributor.Server do
             "#{inspect(reason)}; retrying"
         )
 
-        Process.send_after(self(), {:retire_member, tag, worker_id}, t.backoff_ms)
-        {:noreply, t}
+        timer = Process.send_after(self(), {:retire_member, tag, worker_id}, t.backoff_ms)
+        {:noreply, %{t | pending_retires: Map.put(t.pending_retires, {tag, worker_id}, timer)}}
     end
+  end
+
+  # A partial retirement leaves the shard covered, but the placeholder
+  # may still be forwarding to the member that just left (an earlier
+  # notify_covered named it). Point it at the survivor the client-facing
+  # pick would choose.
+  defp notify_covered_pick(%State{} = t, tag, remaining) do
+    case RoutingData.pick_member(remaining) do
+      {:ok, {worker_id, node_string}} ->
+        Placeholder.notify_covered(t.placeholder, tag, callable_ref(t.cluster, worker_id, node_string))
+
+      :error ->
+        :ok
+    end
+  end
+
+  # Retirement disarms the member's monitor: an armed monitor for a
+  # member no longer in the set turns that member's eventual death into
+  # a heal, and a heal into a redundant replica.
+  defp demonitor_member(%State{} = t, tag, worker_id) do
+    case Enum.find(t.assignment_monitors, fn {_ref, member} -> member == {tag, worker_id} end) do
+      {ref, _member} ->
+        Process.demonitor(ref, [:flush])
+        %{t | assignment_monitors: Map.delete(t.assignment_monitors, ref)}
+
+      nil ->
+        t
+    end
+  end
+
+  defp cancel_retire(%State{} = t, tag, worker_id) do
+    case Map.pop(t.pending_retires, {tag, worker_id}) do
+      {nil, _} -> t
+      {timer, rest} -> cancel_timer(t, timer, rest)
+    end
+  end
+
+  defp cancel_timer(%State{} = t, timer, rest) do
+    Process.cancel_timer(timer)
+    %{t | pending_retires: rest}
   end
 
   defp clear_unreachable(%State{} = t, tag, worker_id),
@@ -616,8 +700,9 @@ defmodule Bedrock.ControlPlane.Distributor.Server do
   # under the fence. Anything else (wedged, dead, unreachable beyond the
   # monitor's damping) is healed; the worker itself is never removed —
   # it retires in-band when it observes the replacing entry. One shot,
-  # at the sweep; tags are reserved in `recruiting` while in flight so
-  # demand recruitment cannot double-cover.
+  # at the sweep. Nothing is reserved while a probe runs: membership is
+  # a set, so a concurrent recruit costs a redundant worker, never a
+  # lost heal.
   defp verify_assignments(%State{recruitment_ctx: nil} = t), do: t
 
   defp verify_assignments(%State{} = t) do

--- a/lib/bedrock/control_plane/distributor/server.ex
+++ b/lib/bedrock/control_plane/distributor/server.ex
@@ -147,12 +147,12 @@ defmodule Bedrock.ControlPlane.Distributor.Server do
   def handle_cast({:coverage_demand, tag}, %State{} = t) do
     Telemetry.emit_coverage_demand(t.cluster, tag)
 
-    case Map.fetch(t.snapshot.materializer_refs, tag) do
-      {:ok, {worker_id, node}} when worker_id != @placeholder_worker_id ->
+    case t |> real_members(tag) |> Enum.min(fn -> nil end) do
+      {worker_id, node} ->
         Placeholder.notify_covered(t.placeholder, tag, callable_ref(t.cluster, worker_id, node))
         {:noreply, t}
 
-      _uncovered_or_placeholder ->
+      nil ->
         {:noreply, t |> Map.update!(:pending_demands, &MapSet.put(&1, tag)) |> maybe_recruit(tag)}
     end
   end
@@ -180,33 +180,24 @@ defmodule Bedrock.ControlPlane.Distributor.Server do
     end
   end
 
-  # Verification verdicts serialize back through the server. The
-  # reservation (the tag's membership in `recruiting`) is released
-  # first; then a verdict for a tag whose ref no longer names the probed
-  # worker belongs to a mechanism that re-owned the tag mid-probe (death
-  # healing, idle parking, a completed demand recruit) — a late-adopted
-  # worker is an unnamed stray that retires itself at the next layout
-  # push. One re-owned shape demands action: an ABSENT ref is a degraded
-  # park whose correcting recruit OUR reservation suppressed — without
-  # it the committed keyspace keeps naming a corpse no read can bypass,
-  # dark until the next recovery. A placeholder ref needs nothing
-  # (demand revives it); a foreign worker ref is already re-covered.
-  def handle_info({:assignment_verified, tag, worker, verdict}, %State{} = t) do
-    t = %{t | recruiting: MapSet.delete(t.recruiting, tag)}
-
+  # Verification verdicts serialize back through the server. A verdict
+  # for a worker the committed set no longer contains is DROPPED: some
+  # other mechanism (death healing, idle retirement, a newer owner)
+  # already removed it, and a late-adopted stray retires itself in-band.
+  # Nothing is reserved while a probe is in flight — with set-valued
+  # membership an extra materializer is legal, so the only cost of a
+  # concurrent recruit is a redundant worker, never a lost heal.
+  def handle_info({:assignment_verified, tag, worker_id, verdict}, %State{} = t) do
     cond do
-      verdict == :current ->
-        {:noreply, clear_unreachable(t, tag)}
+      not Map.has_key?(real_members(t, tag), worker_id) ->
+        {:noreply, clear_unreachable(t, tag, worker_id)}
 
-      Map.get(t.snapshot.materializer_refs, tag) != worker ->
-        case Map.get(t.snapshot.materializer_refs, tag) do
-          nil -> {:noreply, maybe_recruit(t, tag)}
-          _placeholder_or_foreign -> {:noreply, t}
-        end
+      verdict == :current ->
+        {:noreply, clear_unreachable(t, tag, worker_id)}
 
       match?({:adopted, _pid, _node, _worker_id}, verdict) ->
-        {:adopted, pid, node, worker_id} = verdict
-        publish_assignment(clear_unreachable(t, tag), tag, pid, node, worker_id, :preexisting)
+        {:adopted, pid, node, adopted_id} = verdict
+        publish_assignment(clear_unreachable(t, tag, worker_id), tag, pid, node, adopted_id, :preexisting)
 
       match?({:error, reason} when reason in [:unavailable, :timeout], verdict) ->
         # Unreachable-shaped: the same evidence a :noconnection DOWN
@@ -215,17 +206,17 @@ defmodule Bedrock.ControlPlane.Distributor.Server do
         # every shard on the node at once. Escalates through the shared
         # counter; the reverify tick re-runs verification on contact.
         Logger.warning("Bedrock distributor (epoch #{t.epoch}): tag #{tag} unreachable during verification; damping")
-        escalate_unreachable(t, tag)
+        escalate_unreachable(t, tag, worker_id)
 
       true ->
         {:error, reason} = verdict
 
         Logger.warning(
-          "Bedrock distributor (epoch #{t.epoch}): assignment for tag #{tag} failed verification " <>
+          "Bedrock distributor (epoch #{t.epoch}): materializer #{worker_id} for tag #{tag} failed verification " <>
             "(#{inspect(reason)}); healing"
         )
 
-        heal_tag(clear_unreachable(t, tag), tag)
+        heal_member(clear_unreachable(t, tag, worker_id), tag, worker_id)
     end
   end
 
@@ -264,6 +255,20 @@ defmodule Bedrock.ControlPlane.Distributor.Server do
     end
   end
 
+  # A verification task that died without reporting leaves nothing to
+  # clean but its ref: the member keeps its entry, its monitor, and its
+  # place in the set, and the next epoch's sweep verifies it again.
+  def handle_info({:DOWN, ref, :process, _pid, _reason}, %State{} = t) when is_map_key(t.verification_task_refs, ref),
+    do: {:noreply, %{t | verification_task_refs: Map.delete(t.verification_task_refs, ref)}}
+
+  # A retirement whose commit failed transiently: retry until the
+  # keyspace stops naming a worker that is gone.
+  def handle_info({:retire_member, tag, worker_id}, %State{} = t) do
+    if Map.has_key?(real_members(t, tag), worker_id),
+      do: retire_member(t, tag, worker_id),
+      else: {:noreply, t}
+  end
+
   # Death healing (event-driven, FDB teamTracker-style) — with FDB's
   # distinction between connection state and failure: unreachable is NOT
   # dead. A :noconnection DOWN fires for every remote assignment at once
@@ -273,25 +278,25 @@ defmodule Bedrock.ControlPlane.Distributor.Server do
   # only after the node stays unreachable across consecutive checks.
   # Genuine death signals (:noproc, :killed, crashes) heal immediately.
   def handle_info({:DOWN, ref, :process, _pid, reason}, %State{} = t) when is_map_key(t.assignment_monitors, ref) do
-    {tag, monitors} = Map.pop(t.assignment_monitors, ref)
+    {{tag, worker_id}, monitors} = Map.pop(t.assignment_monitors, ref)
     t = %{t | assignment_monitors: monitors}
 
     case reason do
       :noconnection ->
-        Logger.warning("Bedrock distributor (epoch #{t.epoch}): materializer for tag #{tag} unreachable; verifying")
-        {:noreply, schedule_reverify(t, tag)}
+        Logger.warning("Bedrock distributor (epoch #{t.epoch}): materializer #{worker_id} unreachable; verifying")
+        {:noreply, schedule_reverify(t, tag, worker_id)}
 
       {:shutdown, :idle} ->
         # A voluntary idle spin-down (bedrock-q67.21.5): the shard proved
-        # cold, so revival is demand-driven — swap the placeholder in but
-        # do NOT eagerly re-recruit; the next read parks and re-demands.
-        Logger.info("Bedrock distributor (epoch #{t.epoch}): tag #{tag} spun down idle; revival on demand")
+        # cold, so revival is demand-driven — retire the member but do
+        # NOT eagerly re-recruit; the next read parks and re-demands.
+        Logger.info("Bedrock distributor (epoch #{t.epoch}): #{worker_id} spun down idle; revival on demand")
         Telemetry.emit_idle_spindown(t.cluster, tag)
-        idle_tag(clear_unreachable(t, tag), tag)
+        retire_member(clear_unreachable(t, tag, worker_id), tag, worker_id)
 
       _dead ->
-        Logger.warning("Bedrock distributor (epoch #{t.epoch}): materializer for tag #{tag} down (#{inspect(reason)})")
-        heal_tag(clear_unreachable(t, tag), tag)
+        Logger.warning("Bedrock distributor (epoch #{t.epoch}): materializer #{worker_id} down (#{inspect(reason)})")
+        heal_member(clear_unreachable(t, tag, worker_id), tag, worker_id)
     end
   end
 
@@ -302,13 +307,10 @@ defmodule Bedrock.ControlPlane.Distributor.Server do
   # escalates to a heal after @max_unreachable_verifications consecutive
   # failed pings. A tag whose ref changed meanwhile has nothing left to
   # verify.
-  def handle_info({:reverify_assignment, tag}, %State{} = t) do
-    case Map.get(t.snapshot.materializer_refs, tag) do
-      {worker_id, node_string} when worker_id != @placeholder_worker_id ->
-        reverify_assignment(t, tag, worker_id, node_string)
-
-      _placeholder_or_absent ->
-        {:noreply, clear_unreachable(t, tag)}
+  def handle_info({:reverify_assignment, tag, worker_id}, %State{} = t) do
+    case t |> real_members(tag) |> Map.fetch(worker_id) do
+      {:ok, node_string} -> reverify_assignment(t, tag, worker_id, node_string)
+      :error -> {:noreply, clear_unreachable(t, tag, worker_id)}
     end
   end
 
@@ -327,36 +329,60 @@ defmodule Bedrock.ControlPlane.Distributor.Server do
 
   def handle_info({:EXIT, _pid, _reason}, %State{} = t), do: {:noreply, t}
 
-  # An existing placeholder ref counts as covered-enough to skip
-  # republication. That rests on two invariants: the distributor runs on
-  # the director's node (a restarted placeholder re-registers the same
-  # name on the node the committed refs already name), and every
-  # recovery's bootstrap re-assigns all layout tags, so placeholder refs
-  # never survive a recovery as stale foreign-node entries. If the
-  # distributor ever detaches from the director's node, this rejection
-  # must compare the ref's node too.
+  # Uncovered means the tag's committed member set holds no REAL worker.
+  # The placeholder is an ordinary member of that set — it parks reads
+  # rather than serving them — so its presence is not coverage, and
+  # adding it never displaces a live worker.
   defp uncovered_tags(%{shard_layout: shard_layout, materializer_refs: refs}) do
     shard_layout
     |> Map.values()
     |> Enum.map(fn {tag, _start_key} -> tag end)
     |> Enum.uniq()
-    |> Enum.reject(&Map.has_key?(refs, &1))
+    |> Enum.reject(fn tag -> refs |> Map.get(tag, %{}) |> Map.delete(@placeholder_worker_id) != %{} end)
   end
 
   defp publish_placeholders(_t, []), do: :ok
 
   defp publish_placeholders(%State{} = t, tags) do
-    node_string = Atom.to_string(node())
+    # A tag already carrying the placeholder needs no write: the entry is
+    # the same name on the same node, and re-setting it would be a commit
+    # that changes nothing.
+    case Enum.reject(tags, &Map.has_key?(members(t, &1), @placeholder_worker_id)) do
+      [] ->
+        :ok
 
-    mutations =
-      Enum.map(tags, fn tag ->
-        {:set, SystemKeys.materializer_key(tag), Values.encode_materializer_ref(@placeholder_worker_id, node_string)}
-      end)
-
-    with :ok <- Transactions.commit_checked(t.lock, t.deps, mutations) do
-      Telemetry.emit_placeholder_published(t.cluster, tags)
-      :ok
+      missing ->
+        with :ok <- Transactions.commit_checked(t.lock, t.deps, Enum.map(missing, &placeholder_mutation/1)) do
+          Telemetry.emit_placeholder_published(t.cluster, missing)
+          :ok
+        end
     end
+  end
+
+  defp placeholder_mutation(tag) do
+    {:set, SystemKeys.materializer_key(tag, @placeholder_worker_id),
+     Values.encode_materializer_node(Atom.to_string(node()))}
+  end
+
+  defp members(%State{} = t, tag), do: Map.get(t.snapshot.materializer_refs, tag, %{})
+
+  defp real_members(%State{} = t, tag), do: t |> members(tag) |> Map.delete(@placeholder_worker_id)
+
+  defp put_member(%State{} = t, tag, worker_id, node_string) do
+    refs =
+      Map.update(t.snapshot.materializer_refs, tag, %{worker_id => node_string}, &Map.put(&1, worker_id, node_string))
+
+    %{t | snapshot: %{t.snapshot | materializer_refs: refs}}
+  end
+
+  defp drop_member(%State{} = t, tag, worker_id) do
+    refs =
+      case t |> members(tag) |> Map.delete(worker_id) do
+        empty when empty == %{} -> Map.delete(t.snapshot.materializer_refs, tag)
+        remaining -> Map.put(t.snapshot.materializer_refs, tag, remaining)
+      end
+
+    %{t | snapshot: %{t.snapshot | materializer_refs: refs}}
   end
 
   defp start_placeholder(%State{} = t, shard_layout) do
@@ -409,25 +435,25 @@ defmodule Bedrock.ControlPlane.Distributor.Server do
   # was lost).
   defp publish_assignment(%State{} = t, tag, pid, node, worker_id, provenance) do
     node_string = Atom.to_string(node)
-    mutation = {:set, SystemKeys.materializer_key(tag), Values.encode_materializer_ref(worker_id, node_string)}
     callable = {t.cluster.otp_name_for_worker(worker_id), node}
 
-    case Transactions.commit_checked(t.lock, t.deps, [mutation]) do
+    # Adding a real member retires the tag's placeholder in the same
+    # fenced commit: parking exists only while nothing serves, and one
+    # transaction means no window where both or neither is true.
+    mutations =
+      [{:set, SystemKeys.materializer_key(tag, worker_id), Values.encode_materializer_node(node_string)}] ++
+        placeholder_retirement(t, tag)
+
+    case Transactions.commit_checked(t.lock, t.deps, mutations) do
       :ok ->
         Placeholder.notify_covered(t.placeholder, tag, callable)
 
-        refs = Map.put(t.snapshot.materializer_refs, tag, {worker_id, node_string})
-
         {:noreply,
-         monitor_assignment(
-           %{
-             t
-             | snapshot: %{t.snapshot | materializer_refs: refs},
-               pending_demands: MapSet.delete(t.pending_demands, tag)
-           },
-           tag,
-           callable
-         )}
+         t
+         |> put_member(tag, worker_id, node_string)
+         |> drop_member(tag, @placeholder_worker_id)
+         |> Map.update!(:pending_demands, &MapSet.delete(&1, tag))
+         |> monitor_assignment(tag, worker_id, callable)}
 
       {:error, :superseded} ->
         # The READ verdict refused before any commit was attempted: a
@@ -462,8 +488,14 @@ defmodule Bedrock.ControlPlane.Distributor.Server do
           "Bedrock distributor (epoch #{t.epoch}): adoption re-assert for tag #{tag} failed: #{inspect(reason)}"
         )
 
-        {:noreply, monitor_assignment(t, tag, callable)}
+        {:noreply, monitor_assignment(t, tag, worker_id, callable)}
     end
+  end
+
+  defp placeholder_retirement(%State{} = t, tag) do
+    if t |> members(tag) |> Map.has_key?(@placeholder_worker_id),
+      do: [{:clear, SystemKeys.materializer_key(tag, @placeholder_worker_id)}],
+      else: []
   end
 
   defp commit_definitely_not_landed?({:lock_commit_failed, :aborted}), do: true
@@ -484,101 +516,93 @@ defmodule Bedrock.ControlPlane.Distributor.Server do
       # not membership, though: verification re-runs, and ITS verdict —
       # not the ping — clears the escalation counter, so a wedged-alive
       # worker whose node pings fine still escalates to a heal.
-      t = monitor_assignment(t, tag, {t.cluster.otp_name_for_worker(worker_id), node_atom})
-      t = if t.recruitment_ctx, do: start_verification(t, tag, worker_id, node_string), else: clear_unreachable(t, tag)
+      t = monitor_assignment(t, tag, worker_id, {t.cluster.otp_name_for_worker(worker_id), node_atom})
+
+      t =
+        if t.recruitment_ctx,
+          do: start_verification(t, tag, worker_id, node_string),
+          else: clear_unreachable(t, tag, worker_id)
+
       {:noreply, t}
     else
-      escalate_unreachable(t, tag)
+      escalate_unreachable(t, tag, worker_id)
     end
   end
 
   # The shared unreachability escalation: fed by failed pings AND
   # unreachable-shaped verification verdicts. Heals only after
   # @max_unreachable_verifications consecutive pieces of evidence.
-  defp escalate_unreachable(%State{} = t, tag) do
-    count = Map.get(t.unreachable_counts, tag, 0) + 1
-    t = %{t | unreachable_counts: Map.put(t.unreachable_counts, tag, count)}
+  defp escalate_unreachable(%State{} = t, tag, worker_id) do
+    count = Map.get(t.unreachable_counts, {tag, worker_id}, 0) + 1
+    t = %{t | unreachable_counts: Map.put(t.unreachable_counts, {tag, worker_id}, count)}
 
     if count >= @max_unreachable_verifications do
       Logger.warning(
-        "Bedrock distributor (epoch #{t.epoch}): tag #{tag} unreachable after #{count} verifications; healing"
+        "Bedrock distributor (epoch #{t.epoch}): #{worker_id} unreachable after #{count} verifications; healing"
       )
 
-      heal_tag(clear_unreachable(t, tag), tag)
+      heal_member(clear_unreachable(t, tag, worker_id), tag, worker_id)
     else
-      {:noreply, schedule_reverify(t, tag)}
+      {:noreply, schedule_reverify(t, tag, worker_id)}
     end
   end
 
-  # The heal is park + eager re-recruit — a degraded park (publish
-  # failed) recruits too, since the recruit's own publication is what
-  # self-corrects the keyspace. When the tag is under a verification
-  # reservation the recruit is deferred, not lost: the verdict handler
-  # re-issues it for a degraded park and leaves an intact park to
-  # demand-driven revival.
-  defp heal_tag(%State{} = t, tag) do
-    case park_tag(t, tag) do
-      {:parked, t2} -> {:noreply, maybe_recruit(t2, tag)}
-      {:degraded, t2} -> {:noreply, maybe_recruit(t2, tag)}
+  # A heal is retirement plus an eager replacement; an idle spin-down is
+  # retirement alone (the shard proved cold — the next read revives it).
+  defp heal_member(%State{} = t, tag, worker_id) do
+    case retire_member(t, tag, worker_id) do
+      {:noreply, t2} -> {:noreply, maybe_recruit(t2, tag)}
       {:stop, _reason, _t} = stop -> stop
     end
   end
 
-  # An idle spin-down parks WITHOUT the recruit (revival is
-  # demand-driven) — but ONLY when the park actually published. A
-  # degraded park left the committed keyspace naming the departed
-  # worker: clients keep routing to the corpse, no read ever reaches
-  # the placeholder, and coverage_demand can never fire — the tag would
-  # stay dark until the next recovery. The recruit's publication is the
-  # only self-correction available, so a degraded idle park falls back
-  # to the heal path.
-  defp idle_tag(%State{} = t, tag) do
-    case park_tag(t, tag) do
-      {:parked, t2} -> {:noreply, t2}
-      {:degraded, t2} -> {:noreply, maybe_recruit(t2, tag)}
-      {:stop, _reason, _t} = stop -> stop
-    end
-  end
+  # Retirement is a CLEAR of the departing member's own key — the family
+  # names members individually, so removing one never touches another
+  # and never has to overwrite a live twin's entry. When the clear would
+  # leave the tag with no real member, the same fenced commit adds the
+  # placeholder, so a shard is never briefly unroutable between the two.
+  # A superseded commit cedes. A transient failure keeps the local view
+  # honest (the keyspace still names the departed worker) and schedules
+  # a retry: nothing else would revisit this tag, and an uncleared
+  # corpse can be handed to clients by the deterministic pick.
+  defp retire_member(%State{} = t, tag, worker_id) do
+    remaining = t |> real_members(tag) |> Map.delete(worker_id)
+    parking? = remaining == %{}
 
-  # The park: make the gap keyspace-visible FIRST — publish the
-  # placeholder ref under the fence, so clients park instead of
-  # hammering the departed worker and displaced-but-alive twins observe
-  # the change — then tell the placeholder the tag is uncovered (park,
-  # don't forward). A superseded publish cedes: a newer owner heals, not
-  # us. A transient publish failure returns :degraded with the tag's
-  # LOCAL ref dropped, so a racing coverage_demand recruits instead of
-  # draining parked reads into the departed worker; the keyspace still
-  # names it, and every caller must arrange a correcting publication
-  # (both current callers recruit, whose publish self-corrects).
-  defp park_tag(%State{} = t, tag) do
-    Placeholder.notify_uncovered(t.placeholder, tag)
+    if parking?, do: Placeholder.notify_uncovered(t.placeholder, tag)
 
-    case publish_placeholders(t, [tag]) do
+    mutations =
+      [{:clear, SystemKeys.materializer_key(tag, worker_id)}] ++
+        if parking? and not Map.has_key?(members(t, tag), @placeholder_worker_id),
+          do: [placeholder_mutation(tag)],
+          else: []
+
+    case Transactions.commit_checked(t.lock, t.deps, mutations) do
       :ok ->
-        refs = Map.put(t.snapshot.materializer_refs, tag, {@placeholder_worker_id, Atom.to_string(node())})
-        {:parked, %{t | snapshot: %{t.snapshot | materializer_refs: refs}}}
+        t = drop_member(t, tag, worker_id)
+        t = if parking?, do: put_member(t, tag, @placeholder_worker_id, Atom.to_string(node())), else: t
+        {:noreply, t}
 
       {:error, :superseded} ->
-        Logger.info(
-          "Bedrock distributor (epoch #{t.epoch}): superseded swapping the placeholder into tag #{tag}; ceding"
-        )
-
+        Logger.info("Bedrock distributor (epoch #{t.epoch}): superseded retiring #{worker_id} for tag #{tag}; ceding")
         {:stop, :normal, t}
 
       {:error, reason} ->
         Logger.warning(
-          "Bedrock distributor (epoch #{t.epoch}): placeholder publish for tag #{tag} failed: #{inspect(reason)}"
+          "Bedrock distributor (epoch #{t.epoch}): retiring #{worker_id} for tag #{tag} failed: " <>
+            "#{inspect(reason)}; retrying"
         )
 
-        refs = Map.delete(t.snapshot.materializer_refs, tag)
-        {:degraded, %{t | snapshot: %{t.snapshot | materializer_refs: refs}}}
+        Process.send_after(self(), {:retire_member, tag, worker_id}, t.backoff_ms)
+        {:noreply, t}
     end
   end
 
-  defp clear_unreachable(%State{} = t, tag), do: %{t | unreachable_counts: Map.delete(t.unreachable_counts, tag)}
+  defp clear_unreachable(%State{} = t, tag, worker_id),
+    do: %{t | unreachable_counts: Map.delete(t.unreachable_counts, {tag, worker_id})}
 
-  defp schedule_reverify(%State{} = t, tag) do
-    Process.send_after(self(), {:reverify_assignment, tag}, t.reverify_interval_ms)
+  defp schedule_reverify(%State{} = t, tag, worker_id) do
+    Process.send_after(self(), {:reverify_assignment, tag, worker_id}, t.reverify_interval_ms)
     t
   end
 
@@ -597,10 +621,17 @@ defmodule Bedrock.ControlPlane.Distributor.Server do
   defp verify_assignments(%State{recruitment_ctx: nil} = t), do: t
 
   defp verify_assignments(%State{} = t) do
-    Enum.reduce(t.snapshot.materializer_refs, t, fn
-      {_tag, {@placeholder_worker_id, _node}}, acc -> acc
-      {tag, {worker_id, node_string}}, acc -> start_verification(acc, tag, worker_id, node_string)
+    Enum.reduce(each_real_member(t), t, fn {tag, worker_id, node_string}, acc ->
+      start_verification(acc, tag, worker_id, node_string)
     end)
+  end
+
+  # Every committed member of every tag except the placeholders, which
+  # this distributor owns directly and never verifies or monitors.
+  defp each_real_member(%State{} = t) do
+    for {tag, members} <- t.snapshot.materializer_refs,
+        {worker_id, node_string} <- Map.delete(members, @placeholder_worker_id),
+        do: {tag, worker_id, node_string}
   end
 
   defp start_verification(%State{} = t, tag, worker_id, node_string) do
@@ -631,28 +662,27 @@ defmodule Bedrock.ControlPlane.Distributor.Server do
             other -> other
           end
 
-        send(server, {:assignment_verified, tag, {worker_id, node_string}, verdict})
+        send(server, {:assignment_verified, tag, worker_id, verdict})
       end)
 
-    %{t | recruiting: MapSet.put(t.recruiting, tag), recruit_task_refs: Map.put(t.recruit_task_refs, ref, tag)}
+    # Verification reserves nothing: with set-valued membership a
+    # concurrent recruit costs a redundant worker, never a lost heal.
+    # The task is still monitored so a crash cannot leak silently.
+    %{t | verification_task_refs: Map.put(t.verification_task_refs, ref, {tag, worker_id})}
   end
 
   # Monitor every live (non-placeholder) assignment by its callable name
   # — monitors on {name, node} fire on death OR unreachability, either of
   # which is a coverage gap worth healing.
   defp monitor_assignments(%State{} = t) do
-    Enum.reduce(t.snapshot.materializer_refs, t, fn
-      {_tag, {@placeholder_worker_id, _node}}, acc ->
-        acc
-
-      {tag, {worker_id, node}}, acc ->
-        # credo:disable-for-next-line Credo.Check.Warning.UnsafeToAtom
-        monitor_assignment(acc, tag, {acc.cluster.otp_name_for_worker(worker_id), String.to_atom(node)})
+    Enum.reduce(each_real_member(t), t, fn {tag, worker_id, node}, acc ->
+      # credo:disable-for-next-line Credo.Check.Warning.UnsafeToAtom
+      monitor_assignment(acc, tag, worker_id, {acc.cluster.otp_name_for_worker(worker_id), String.to_atom(node)})
     end)
   end
 
-  defp monitor_assignment(%State{} = t, tag, {name, node_atom}) do
-    if tag in Map.values(t.assignment_monitors) do
+  defp monitor_assignment(%State{} = t, tag, worker_id, {name, node_atom}) do
+    if {tag, worker_id} in Map.values(t.assignment_monitors) do
       # Already armed (the sweep monitors before verification adopts):
       # a second monitor would double every DOWN into a double heal.
       t
@@ -662,7 +692,7 @@ defmodule Bedrock.ControlPlane.Distributor.Server do
       # legitimately runs without.
       target = if node_atom == node(), do: name, else: {name, node_atom}
       ref = Process.monitor(target)
-      %{t | assignment_monitors: Map.put(t.assignment_monitors, ref, tag)}
+      %{t | assignment_monitors: Map.put(t.assignment_monitors, ref, {tag, worker_id})}
     end
   end
 

--- a/lib/bedrock/control_plane/distributor/state.ex
+++ b/lib/bedrock/control_plane/distributor/state.ex
@@ -3,6 +3,7 @@ defmodule Bedrock.ControlPlane.Distributor.State do
 
   alias Bedrock.ControlPlane.Distributor.Lock
   alias Bedrock.ControlPlane.Distributor.Transactions
+  alias Bedrock.Service.Worker
 
   @type t :: %__MODULE__{
           cluster: module(),
@@ -17,15 +18,16 @@ defmodule Bedrock.ControlPlane.Distributor.State do
           snapshot:
             %{
               shard_layout: %{Bedrock.key() => {Bedrock.range_tag(), Bedrock.key()}},
-              materializer_refs: %{Bedrock.range_tag() => {String.t(), String.t()}}
+              materializer_refs: %{Bedrock.range_tag() => %{String.t() => String.t()}}
             }
             | nil,
           pending_demands: MapSet.t(Bedrock.range_tag()),
           recruitment_ctx: map() | nil,
           recruiting: MapSet.t(Bedrock.range_tag()),
           recruit_task_refs: %{reference() => Bedrock.range_tag()},
-          assignment_monitors: %{reference() => Bedrock.range_tag()},
-          unreachable_counts: %{Bedrock.range_tag() => pos_integer()},
+          verification_task_refs: %{reference() => {Bedrock.range_tag(), Worker.id()}},
+          assignment_monitors: %{reference() => {Bedrock.range_tag(), Worker.id()}},
+          unreachable_counts: %{{Bedrock.range_tag(), Worker.id()} => pos_integer()},
           reverify_interval_ms: pos_integer(),
           backoff: %{Bedrock.range_tag() => integer()},
           backoff_ms: pos_integer()
@@ -46,6 +48,7 @@ defmodule Bedrock.ControlPlane.Distributor.State do
     recruitment_ctx: nil,
     recruiting: MapSet.new(),
     recruit_task_refs: %{},
+    verification_task_refs: %{},
     assignment_monitors: %{},
     unreachable_counts: %{},
     reverify_interval_ms: 2_000,

--- a/lib/bedrock/control_plane/distributor/state.ex
+++ b/lib/bedrock/control_plane/distributor/state.ex
@@ -28,6 +28,7 @@ defmodule Bedrock.ControlPlane.Distributor.State do
           verification_task_refs: %{reference() => {Bedrock.range_tag(), Worker.id()}},
           assignment_monitors: %{reference() => {Bedrock.range_tag(), Worker.id()}},
           unreachable_counts: %{{Bedrock.range_tag(), Worker.id()} => pos_integer()},
+          pending_retires: %{{Bedrock.range_tag(), Worker.id()} => reference()},
           reverify_interval_ms: pos_integer(),
           backoff: %{Bedrock.range_tag() => integer()},
           backoff_ms: pos_integer()
@@ -51,6 +52,7 @@ defmodule Bedrock.ControlPlane.Distributor.State do
     verification_task_refs: %{},
     assignment_monitors: %{},
     unreachable_counts: %{},
+    pending_retires: %{},
     reverify_interval_ms: 2_000,
     backoff: %{},
     backoff_ms: 5_000

--- a/lib/bedrock/control_plane/distributor/transactions.ex
+++ b/lib/bedrock/control_plane/distributor/transactions.ex
@@ -116,7 +116,7 @@ defmodule Bedrock.ControlPlane.Distributor.Transactions do
           {:ok,
            %{
              shard_layout: %{Bedrock.key() => {Bedrock.range_tag(), Bedrock.key()}},
-             materializer_refs: %{Bedrock.range_tag() => {String.t(), String.t()}}
+             materializer_refs: %{Bedrock.range_tag() => %{String.t() => String.t()}}
            }}
           | {:error, term()}
   def read_snapshot(deps) do
@@ -131,7 +131,7 @@ defmodule Bedrock.ControlPlane.Distributor.Transactions do
          {:ok, ref_entries} <-
            Reader.read_family(&deps.get_range_fn.(&1, refs_end, version), refs_prefix, :snapshot_read_failed),
          {:ok, shard_layout} <- Reader.shard_layout_from_entries(shard_entries),
-         {:ok, refs} <- Reader.decode_materializer_refs(ref_entries) do
+         {:ok, refs} <- Reader.decode_materializer_members(ref_entries) do
       {:ok, %{shard_layout: shard_layout, materializer_refs: refs}}
     end
   end
@@ -150,7 +150,7 @@ defmodule Bedrock.ControlPlane.Distributor.Transactions do
   the read on the retry); exhausted retries surface as a transient
   commit failure.
   """
-  @spec commit_checked(Lock.t(), deps(), [Lock.mutation() | {:set, Bedrock.key(), binary()}]) ::
+  @spec commit_checked(Lock.t(), deps(), [Lock.mutation() | {:set, Bedrock.key(), binary()} | {:clear, Bedrock.key()}]) ::
           :ok
           | {:error, :superseded}
           | {:error, {:read_version_failed | :lock_read_failed | :lock_commit_failed, term()}}
@@ -270,7 +270,12 @@ defmodule Bedrock.ControlPlane.Distributor.Transactions do
     encoded =
       Tx.new()
       |> then(&Enum.reduce(conflict_keys, &1, fn key, tx -> Tx.add_read_conflict_key(tx, key) end))
-      |> then(&Enum.reduce(mutations, &1, fn {:set, key, value}, tx -> Tx.set(tx, key, value) end))
+      |> then(
+        &Enum.reduce(mutations, &1, fn
+          {:set, key, value}, tx -> Tx.set(tx, key, value)
+          {:clear, key}, tx -> Tx.clear(tx, key)
+        end)
+      )
       |> Tx.commit(version)
 
     case commit_fn.(Enum.random(proxies), epoch, encoded, mode: :system) do

--- a/lib/bedrock/data_plane/commit_proxy.ex
+++ b/lib/bedrock/data_plane/commit_proxy.ex
@@ -79,15 +79,15 @@ defmodule Bedrock.DataPlane.CommitProxy do
   the tag. A locked proxy replies `{:error, :locked}`; callers treat that
   (and unavailability) as "ask again later", never as displacement.
   """
-  @spec resolve_materializer(
-          commit_proxy_ref :: ref(),
+  @spec materializer_members(
+          commit_proxy :: ref(),
           tag :: non_neg_integer(),
           opts :: [timeout_in_ms: Bedrock.timeout_in_ms()]
         ) ::
-          {:ok, {worker_id :: String.t(), node :: String.t()}}
-          | {:error, :not_found | :locked | :timeout | :unavailable}
-  def resolve_materializer(commit_proxy, tag, opts \\ []),
-    do: call(commit_proxy, {:resolve_materializer, tag}, opts[:timeout_in_ms] || 5_000)
+          {:ok, %{Bedrock.Service.Worker.id() => String.t()}}
+          | {:error, :not_found | :locked | :unavailable | :timeout}
+  def materializer_members(commit_proxy, tag, opts \\ []),
+    do: call(commit_proxy, {:materializer_members, tag}, opts[:timeout_in_ms] || 5_000)
 
   @doc """
   Submits a transaction for commit.

--- a/lib/bedrock/data_plane/commit_proxy/routing_data.ex
+++ b/lib/bedrock/data_plane/commit_proxy/routing_data.ex
@@ -41,14 +41,20 @@ defmodule Bedrock.DataPlane.CommitProxy.RoutingData do
 
   @type shard_tree :: :gb_trees.tree(Bedrock.key(), {tag :: term(), start_key :: Bedrock.key()})
 
-  @typedoc "A materializer ref as committed to the keyspace: worker id and node, both strings."
+  @typedoc "A materializer ref handed to a client: worker id and node, both strings."
   @type materializer_ref :: {worker_id :: String.t(), node :: String.t()}
+
+  @typedoc """
+  One shard's committed members: worker id to node. A set, because a
+  shard may be served by more than one materializer (bedrock-q67.21.9).
+  """
+  @type members :: %{Bedrock.Service.Worker.id() => String.t()}
 
   @type t :: %__MODULE__{
           shards: shard_tree(),
           log_map: %{non_neg_integer() => Log.id()},
           log_services: %{Log.id() => {atom(), node()} | pid()},
-          materializers: %{Bedrock.range_tag() => materializer_ref()},
+          materializers: %{Bedrock.range_tag() => members()},
           replication_factor: pos_integer()
         }
 
@@ -57,7 +63,7 @@ defmodule Bedrock.DataPlane.CommitProxy.RoutingData do
   and nodes. `from_snapshot/1` turns it into runnable routing data.
   """
   @type snapshot :: %{
-          optional(:materializers) => %{Bedrock.range_tag() => materializer_ref()},
+          optional(:materializers) => %{Bedrock.range_tag() => members()},
           shard_layout: %{Bedrock.key() => {tag :: term(), start_key :: Bedrock.key()}},
           log_map: %{non_neg_integer() => Log.id()},
           log_services: %{Log.id() => {atom(), node()} | pid()},
@@ -74,19 +80,22 @@ defmodule Bedrock.DataPlane.CommitProxy.RoutingData do
           {start_key :: Bedrock.key(), end_key :: Bedrock.key(), tag :: term(), materializer_ref()}
 
   @doc """
-  The committed materializer assignment for a shard tag, or
-  `{:error, :not_found}` when the keyspace names none.
+  A shard tag's committed members, or `{:error, :not_found}` when the
+  keyspace names none.
 
   This answers a worker's rejoin validation (FDB's storage-server rejoin
-  through the proxy's txnStateStore: absence means `worker_removed`) from
-  the same routing view that serves clients — one authority, two readers.
+  through the proxy's txnStateStore: absence from the set means
+  `worker_removed`) from the same routing view that serves clients — one
+  authority, two readers asking different questions. The worker asks
+  MEMBERSHIP, not resolution: with several members per shard, the ref a
+  client happens to be routed to says nothing about whether any other
+  member still belongs.
   """
-  @spec resolve_materializer(t(), non_neg_integer()) ::
-          {:ok, {worker_id :: String.t(), node :: String.t()}} | {:error, :not_found}
-  def resolve_materializer(%__MODULE__{materializers: materializers}, tag) do
+  @spec materializer_members(t(), non_neg_integer()) :: {:ok, members()} | {:error, :not_found}
+  def materializer_members(%__MODULE__{materializers: materializers}, tag) do
     case Map.fetch(materializers, tag) do
-      {:ok, ref} -> {:ok, ref}
-      :error -> {:error, :not_found}
+      {:ok, members} when members != %{} -> {:ok, members}
+      _ -> {:error, :not_found}
     end
   end
 
@@ -105,10 +114,26 @@ defmodule Bedrock.DataPlane.CommitProxy.RoutingData do
   @spec covering_entry(t(), Bedrock.key()) :: {:ok, covering_entry()} | {:error, :not_found}
   def covering_entry(%__MODULE__{shards: shards, materializers: materializers}, key) do
     with {end_key, {tag, start_key}} <- ShardRouter.ceiling_entry(shards, key),
-         {:ok, ref} <- Map.fetch(materializers, tag) do
+         {:ok, ref} <- pick_member(Map.get(materializers, tag, %{})) do
       {:ok, {start_key, end_key, tag, ref}}
     else
       _ -> {:error, :not_found}
+    end
+  end
+
+  # The client-facing pick among a shard's members: real coverage beats
+  # the placeholder (which only parks), and the choice is deterministic
+  # so every proxy answers alike and a client's retry lands consistently.
+  # Load- and locality-aware selection is bedrock-q67.46's to add here.
+  @spec pick_member(members()) :: {:ok, materializer_ref()} | :error
+  defp pick_member(members) when map_size(members) == 0, do: :error
+
+  defp pick_member(members) do
+    placeholder = SystemKeys.placeholder_worker_id()
+
+    case members |> Map.delete(placeholder) |> Enum.min(fn -> nil end) do
+      nil -> {:ok, {placeholder, Map.fetch!(members, placeholder)}}
+      {worker_id, node} -> {:ok, {worker_id, node}}
     end
   end
 
@@ -223,10 +248,10 @@ defmodule Bedrock.DataPlane.CommitProxy.RoutingData do
         # mid-epoch (bedrock-q67.21).
         routing_data
 
-      {:materializer_key, tag} ->
-        # Undecodable values are ignored, keeping the last good ref.
-        case Values.decode_materializer_ref(value) do
-          {:ok, ref} -> %{routing_data | materializers: Map.put(routing_data.materializers, tag, ref)}
+      {:materializer_key, tag, worker_id} ->
+        # Undecodable values are ignored, keeping the last good member set.
+        case Values.decode_materializer_node(value) do
+          {:ok, node} -> put_member(routing_data, tag, worker_id, node)
           {:error, _} -> routing_data
         end
 
@@ -244,8 +269,8 @@ defmodule Bedrock.DataPlane.CommitProxy.RoutingData do
         # Epoch-constant; see the set clause.
         routing_data
 
-      {:materializer_key, tag} ->
-        %{routing_data | materializers: Map.delete(routing_data.materializers, tag)}
+      {:materializer_key, tag, worker_id} ->
+        drop_member(routing_data, tag, worker_id)
 
       _ ->
         routing_data
@@ -276,12 +301,33 @@ defmodule Bedrock.DataPlane.CommitProxy.RoutingData do
     %{routing_data | shards: cleared}
   end
 
+  # A tag's entry is the member set itself; an emptied set is dropped, so
+  # "no members" and "no tag" are the same absence and coverage never
+  # hinges on which one a caller happens to observe.
+  defp put_member(%__MODULE__{materializers: materializers} = routing_data, tag, worker_id, node) do
+    members = materializers |> Map.get(tag, %{}) |> Map.put(worker_id, node)
+    %{routing_data | materializers: Map.put(materializers, tag, members)}
+  end
+
+  defp drop_member(%__MODULE__{materializers: materializers} = routing_data, tag, worker_id) do
+    case materializers |> Map.get(tag, %{}) |> Map.delete(worker_id) do
+      empty when empty == %{} -> %{routing_data | materializers: Map.delete(materializers, tag)}
+      members -> %{routing_data | materializers: Map.put(materializers, tag, members)}
+    end
+  end
+
   defp clear_materializers_in_range(%__MODULE__{materializers: materializers} = routing_data, start_key, end_key) do
     kept =
-      Map.reject(materializers, fn {tag, _ref} ->
-        full_key = SystemKeys.materializer_key(tag)
-        full_key >= start_key and full_key < end_key
+      materializers
+      |> Enum.map(fn {tag, members} ->
+        {tag,
+         Map.reject(members, fn {worker_id, _node} ->
+           full_key = SystemKeys.materializer_key(tag, worker_id)
+           full_key >= start_key and full_key < end_key
+         end)}
       end)
+      |> Enum.reject(fn {_tag, members} -> members == %{} end)
+      |> Map.new()
 
     %{routing_data | materializers: kept}
   end

--- a/lib/bedrock/data_plane/commit_proxy/routing_data.ex
+++ b/lib/bedrock/data_plane/commit_proxy/routing_data.ex
@@ -7,9 +7,10 @@ defmodule Bedrock.DataPlane.CommitProxy.RoutingData do
     ceiling search (`end_key` is the shard's exclusive upper bound)
   - `log_map` - Map of index → log_id for golden ratio routing
   - `log_services` - Map of log_id → pid or {otp_name, node} for contacting logs
-  - `materializers` - Map of tag → `{worker_id, node}` (strings, as committed
-    to the `materializers/` keyspace family) for the client-facing routing
-    projection; clients derive the callable ref
+  - `materializers` - Map of tag → `%{worker_id => node}` (strings, as
+    committed to the `materializers/` keyspace family): a shard's MEMBER
+    SET, from which `covering_entry/2` picks the client-facing ref;
+    clients derive the callable ref from that pick
   - `replication_factor` - Number of logs per mutation
 
   The value is a plain immutable term: the commit proxy server is its only
@@ -121,14 +122,21 @@ defmodule Bedrock.DataPlane.CommitProxy.RoutingData do
     end
   end
 
-  # The client-facing pick among a shard's members: real coverage beats
-  # the placeholder (which only parks), and the choice is deterministic
-  # so every proxy answers alike and a client's retry lands consistently.
-  # Load- and locality-aware selection is bedrock-q67.46's to add here.
-  @spec pick_member(members()) :: {:ok, materializer_ref()} | :error
-  defp pick_member(members) when map_size(members) == 0, do: :error
+  @doc """
+  The client-facing pick among a shard's members: real coverage beats
+  the placeholder (which only parks), and the choice is deterministic
+  so every proxy answers alike and a client's retry lands consistently.
 
-  defp pick_member(members) do
+  THE one pick. The distributor points the placeholder at a shard's
+  members through this same function, so the member recovery unlocks,
+  the member clients are routed to, and the member parked reads drain
+  into cannot disagree. Load- and locality-aware selection is
+  bedrock-q67.46's to add here, once.
+  """
+  @spec pick_member(members()) :: {:ok, materializer_ref()} | :error
+  def pick_member(members) when map_size(members) == 0, do: :error
+
+  def pick_member(members) do
     placeholder = SystemKeys.placeholder_worker_id()
 
     case members |> Map.delete(placeholder) |> Enum.min(fn -> nil end) do

--- a/lib/bedrock/data_plane/commit_proxy/server.ex
+++ b/lib/bedrock/data_plane/commit_proxy/server.ex
@@ -228,12 +228,12 @@ defmodule Bedrock.DataPlane.CommitProxy.Server do
   # proxy's txnStateStore): one tag-keyed lookup in the live routing view.
   # Same cadence rule as :fetch_routing — the reply must not swallow an
   # open batch's pending timeout.
-  def handle_call({:resolve_materializer, tag}, from, %{mode: :running} = t) do
-    GenServer.reply(from, RoutingData.resolve_materializer(t.routing_data, tag))
+  def handle_call({:materializer_members, tag}, from, %{mode: :running} = t) do
+    GenServer.reply(from, RoutingData.materializer_members(t.routing_data, tag))
     noreply_resuming_cadence(t)
   end
 
-  def handle_call({:resolve_materializer, _tag}, _from, %{mode: :locked} = t), do: reply(t, {:error, :locked})
+  def handle_call({:materializer_members, _tag}, _from, %{mode: :locked} = t), do: reply(t, {:error, :locked})
 
   defp accept_commit(transaction, commit_mode, from, t) do
     case start_batch_if_needed(t) do

--- a/lib/bedrock/data_plane/materializer/olivine/server.ex
+++ b/lib/bedrock/data_plane/materializer/olivine/server.ex
@@ -583,9 +583,12 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Server do
   defp rejoin_verdict(_t, []), do: :keep
 
   defp rejoin_verdict(%State{} = t, proxies) do
-    case CommitProxy.resolve_materializer(Enum.random(proxies), t.shard_num) do
-      {:ok, {worker_id, _node}} when worker_id == t.id -> :keep
-      {:ok, {_other_worker, _node}} -> :displaced
+    # Membership, not resolution: a shard may have several materializers,
+    # so the question is whether the committed set still contains ME —
+    # another member's presence is not my displacement (FDB's
+    # matchesThisServer, asked of the set).
+    case CommitProxy.materializer_members(Enum.random(proxies), t.shard_num) do
+      {:ok, members} -> if Map.has_key?(members, t.id), do: :keep, else: :displaced
       {:error, :not_found} -> :displaced
       {:error, _not_a_verdict} -> :keep
     end

--- a/lib/bedrock/system_keys.ex
+++ b/lib/bedrock/system_keys.ex
@@ -67,7 +67,14 @@ defmodule Bedrock.SystemKeys do
   def materializer_key(tag, worker_id) when is_integer(tag) and is_binary(worker_id),
     do: "#{@system_prefix}/materializers/#{tag}/#{worker_id}"
 
-  @doc "Prefix covering one tag's members"
+  @doc """
+  Prefix covering one tag's members.
+
+  The family's standard triple mirrors FDB's (`SystemData.cpp`):
+  `materializers_prefix/0` is `serverKeysRange`, `materializer_key/2` is
+  `serverKeysKey`, and this is `serverKeysPrefixFor` — the scan that
+  answers "who serves this shard" without decoding the whole family.
+  """
   @spec materializer_tag_prefix(Bedrock.range_tag()) :: Bedrock.key()
   def materializer_tag_prefix(tag) when is_integer(tag), do: "#{@system_prefix}/materializers/#{tag}/"
 

--- a/lib/bedrock/system_keys.ex
+++ b/lib/bedrock/system_keys.ex
@@ -4,7 +4,7 @@ defmodule Bedrock.SystemKeys do
 
   Every key defined here has a named purpose: `shard_keys/<end_key>` feeds
   each commit proxy's routing view (through resolver metadata windows) and
-  the next recovery's materializer bootstrap; `materializers/<tag>` refs
+  the next recovery's materializer bootstrap; `materializers/<tag>/<worker_id>` entries
   feed the client-facing routing projection served by commit proxies
   (FDB's `serverList/` analogue - interfaces ride the keyspace) and answer
   worker rejoin validation. `layout/logs/<log_id>` keys have no code
@@ -23,6 +23,8 @@ defmodule Bedrock.SystemKeys do
   families return here when their readers do (config authority with
   bedrock-q67.25).
   """
+
+  alias Bedrock.Service.Worker
 
   @system_prefix "\xff/system"
 
@@ -50,13 +52,38 @@ defmodule Bedrock.SystemKeys do
   @spec layout_logs_prefix() :: Bedrock.key()
   def layout_logs_prefix, do: "#{@system_prefix}/layout/logs/"
 
-  @doc "Materializer ref entry: `materializers/<tag>` -> `{worker_id, node}` strings"
-  @spec materializer_key(Bedrock.range_tag()) :: Bedrock.key()
-  def materializer_key(tag) when is_integer(tag), do: "#{@system_prefix}/materializers/#{tag}"
+  @doc """
+  Membership entry: `materializers/<tag>/<worker_id>` -> node string.
 
-  @doc "Prefix covering every materializer ref entry"
+  Tag-major with the worker id IN the key, so one family answers both
+  questions FDB needs two for: a prefix scan over a tag gives the shard's
+  members (FDB's range-major `keyServers/<range>` -> team), and each
+  member is individually addressable for removal (FDB's server-major
+  `serverKeys/<server>/<range>`). A worker owns exactly one shard and
+  notices broadcast on the shard's tag, so no per-worker index is needed.
+  Membership is expressed by key PRESENCE; removal is a clear.
+  """
+  @spec materializer_key(Bedrock.range_tag(), Worker.id()) :: Bedrock.key()
+  def materializer_key(tag, worker_id) when is_integer(tag) and is_binary(worker_id),
+    do: "#{@system_prefix}/materializers/#{tag}/#{worker_id}"
+
+  @doc "Prefix covering one tag's members"
+  @spec materializer_tag_prefix(Bedrock.range_tag()) :: Bedrock.key()
+  def materializer_tag_prefix(tag) when is_integer(tag), do: "#{@system_prefix}/materializers/#{tag}/"
+
+  @doc "Prefix covering every materializer membership entry"
   @spec materializers_prefix() :: Bedrock.key()
   def materializers_prefix, do: "#{@system_prefix}/materializers/"
+
+  @doc """
+  The reserved worker id the distributor's placeholder registers under.
+
+  A keyspace-level convention, not a distributor detail: routing reads it
+  to prefer real coverage over parking, so it belongs where the family's
+  semantics are defined rather than behind a control-plane module.
+  """
+  @spec placeholder_worker_id() :: Worker.id()
+  def placeholder_worker_id, do: "distributor-placeholder"
 
   @doc """
   Parses a system key into its family. Unknown system keys parse as
@@ -65,7 +92,7 @@ defmodule Bedrock.SystemKeys do
   @spec parse_key(Bedrock.key()) ::
           {:layout_log, String.t()}
           | {:shard_key, Bedrock.key()}
-          | {:materializer_key, Bedrock.range_tag()}
+          | {:materializer_key, Bedrock.range_tag(), Worker.id()}
           | {:distributor_lock, :owner | :write}
           | :unknown
           | :error
@@ -75,8 +102,10 @@ defmodule Bedrock.SystemKeys do
   def parse_key(<<@system_prefix, "/shard_keys/", rest::binary>>), do: {:shard_key, rest}
 
   def parse_key(<<@system_prefix, "/materializers/", rest::binary>>) do
-    case Integer.parse(rest) do
-      {tag, ""} -> {:materializer_key, tag}
+    with [tag_string, worker_id] when worker_id != "" <- String.split(rest, "/", parts: 2),
+         {tag, ""} <- Integer.parse(tag_string) do
+      {:materializer_key, tag, worker_id}
+    else
       _ -> :unknown
     end
   end

--- a/lib/bedrock/system_keys/reader.ex
+++ b/lib/bedrock/system_keys/reader.ex
@@ -49,17 +49,19 @@ defmodule Bedrock.SystemKeys.Reader do
   end
 
   @doc """
-  Decodes `materializers/<tag>` entries into `%{tag => {worker_id,
-  node}}`. Foreign or undecodable entries fail the whole decode.
+  Decodes `materializers/<tag>/<worker_id>` entries into the membership
+  map `%{tag => %{worker_id => node}}` - a shard's members are a set, and
+  absence of a key is absence of a member. Foreign or undecodable entries
+  fail the whole decode.
   """
-  @spec decode_materializer_refs([{Bedrock.key(), binary()}]) ::
-          {:ok, %{Bedrock.range_tag() => {Bedrock.Service.Worker.id(), String.t()}}}
+  @spec decode_materializer_members([{Bedrock.key(), binary()}]) ::
+          {:ok, %{Bedrock.range_tag() => %{Bedrock.Service.Worker.id() => String.t()}}}
           | {:error, {:invalid_materializer_entry, Bedrock.key()}}
-  def decode_materializer_refs(entries) do
+  def decode_materializer_members(entries) do
     Enum.reduce_while(entries, {:ok, %{}}, fn {key, value}, {:ok, acc} ->
-      with {:materializer_key, tag} <- SystemKeys.parse_key(key),
-           {:ok, ref} <- Values.decode_materializer_ref(value) do
-        {:cont, {:ok, Map.put(acc, tag, ref)}}
+      with {:materializer_key, tag, worker_id} <- SystemKeys.parse_key(key),
+           {:ok, node} <- Values.decode_materializer_node(value) do
+        {:cont, {:ok, Map.update(acc, tag, %{worker_id => node}, &Map.put(&1, worker_id, node))}}
       else
         _ -> {:halt, {:error, {:invalid_materializer_entry, key}}}
       end

--- a/lib/bedrock/system_keys/reader.ex
+++ b/lib/bedrock/system_keys/reader.ex
@@ -53,6 +53,13 @@ defmodule Bedrock.SystemKeys.Reader do
   map `%{tag => %{worker_id => node}}` - a shard's members are a set, and
   absence of a key is absence of a member. Foreign or undecodable entries
   fail the whole decode.
+
+  This is deliberately the loud edge of the format change: a keyspace
+  still holding single-valued `materializers/<tag>` entries fails here
+  rather than being read as an empty family. An empty family reads as
+  "no shard has any member", which would silently re-recruit every
+  shard and orphan the live ones — a wrong answer is worse than a
+  failed recovery that names the offending key.
   """
   @spec decode_materializer_members([{Bedrock.key(), binary()}]) ::
           {:ok, %{Bedrock.range_tag() => %{Bedrock.Service.Worker.id() => String.t()}}}

--- a/lib/bedrock/system_keys/values.ex
+++ b/lib/bedrock/system_keys/values.ex
@@ -42,16 +42,17 @@ defmodule Bedrock.SystemKeys.Values do
     do: TupleEncoding.pack({tag, start_key})
 
   @doc """
-  Encodes a materializer ref: `{worker_id, node}`, both strings.
+  Encodes a materializer membership value: the member's node, a string.
 
-  Refs are string-encoded on purpose - never atoms or pids - so decoding
-  durable bytes never creates atoms. The worker's OTP name is derivable
-  from the id (`cluster.otp_name_for_worker/1`); conversion to a callable
-  ref happens at the consumer.
+  The worker id lives in the key (`materializers/<tag>/<worker_id>`), so
+  the value carries only what a consumer cannot derive: the node. Both
+  halves are string-encoded on purpose - never atoms or pids - so
+  decoding durable bytes never creates atoms. The worker's OTP name is
+  derivable from the id (`cluster.otp_name_for_worker/1`); conversion to
+  a callable ref happens at the consumer.
   """
-  @spec encode_materializer_ref(String.t(), String.t()) :: binary()
-  def encode_materializer_ref(worker_id, node) when is_binary(worker_id) and is_binary(node),
-    do: TupleEncoding.pack({worker_id, node})
+  @spec encode_materializer_node(String.t()) :: binary()
+  def encode_materializer_node(node) when is_binary(node), do: TupleEncoding.pack(node)
 
   @doc "Decodes a list of integer range tags."
   @spec decode_tag_list(binary()) :: {:ok, [Bedrock.range_tag()]} | decode_error()
@@ -62,10 +63,9 @@ defmodule Bedrock.SystemKeys.Values do
   def decode_shard_key_entry(binary),
     do: safe_unpack(binary, &match?({tag, start_key} when is_integer(tag) and is_binary(start_key), &1))
 
-  @doc "Decodes a materializer ref to `{:ok, {worker_id, node}}` (strings)."
-  @spec decode_materializer_ref(binary()) :: {:ok, {String.t(), String.t()}} | decode_error()
-  def decode_materializer_ref(binary),
-    do: safe_unpack(binary, &match?({worker_id, node} when is_binary(worker_id) and is_binary(node), &1))
+  @doc "Decodes a materializer membership value to `{:ok, node}` (string)."
+  @spec decode_materializer_node(binary()) :: {:ok, String.t()} | decode_error()
+  def decode_materializer_node(binary), do: safe_unpack(binary, &is_binary/1)
 
   @doc """
   Decodes a value given its parsed system key (from
@@ -75,7 +75,7 @@ defmodule Bedrock.SystemKeys.Values do
   def decode_for({:distributor_lock, _which}, value), do: decode_lock_uid(value)
   def decode_for({:shard_key, _end_key}, value), do: decode_shard_key_entry(value)
   def decode_for({:layout_log, _log_id}, value), do: decode_tag_list(value)
-  def decode_for({:materializer_key, _tag}, value), do: decode_materializer_ref(value)
+  def decode_for({:materializer_key, _tag, _worker_id}, value), do: decode_materializer_node(value)
   def decode_for(_unknown, _value), do: {:error, :unknown_family}
 
   defp safe_unpack(binary, valid?) when is_binary(binary) do

--- a/test/bedrock/control_plane/director/recovery/materializer_bootstrap_phase_test.exs
+++ b/test/bedrock/control_plane/director/recovery/materializer_bootstrap_phase_test.exs
@@ -63,8 +63,8 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhaseTest 
           assert Map.has_key?(updated_attempt.shard_materializers, 0)
           refute Map.has_key?(updated_attempt.shard_materializers, 1)
 
-          assert {<<_::binary>>, node_string} =
-                   updated_attempt.shard_materializers[RecoveryAttempt.system_shard_id()]
+          assert [{<<_::binary>>, node_string}] =
+                   Map.to_list(updated_attempt.shard_materializers[RecoveryAttempt.system_shard_id()])
 
           assert node_string == Atom.to_string(node())
 
@@ -133,8 +133,8 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhaseTest 
       assert {updated_attempt, CommitProxyStartupPhase} =
                MaterializerBootstrapPhase.execute(recovery_attempt, context)
 
-      assert {<<_::binary>>, <<_::binary>>} =
-               updated_attempt.shard_materializers[RecoveryAttempt.system_shard_id()]
+      assert [{<<_::binary>>, <<_::binary>>}] =
+               Map.to_list(updated_attempt.shard_materializers[RecoveryAttempt.system_shard_id()])
 
       # Replication spans all logs today, so the system shard's replica
       # set covers both — the seed carries {log_id, ref} pairs, never a
@@ -236,12 +236,12 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhaseTest 
                    MaterializerBootstrapPhase.execute(recovery_attempt, context)
 
           # The system-shard survivor answers the layout query...
-          assert {"mat_sys", _node} = updated_attempt.shard_materializers[RecoveryAttempt.system_shard_id()]
+          assert %{"mat_sys" => _node} = updated_attempt.shard_materializers[RecoveryAttempt.system_shard_id()]
           assert updated_attempt.shard_layout
 
           # ...and every shard in the layout gets its surviving
           # materializer — nothing newly created, nothing orphaned.
-          assert %{0 => {"mat_sys", _}, 1 => {"mat_user", _}} = updated_attempt.shard_materializers
+          assert %{0 => %{"mat_sys" => _}, 1 => %{"mat_user" => _}} = updated_attempt.shard_materializers
 
           assert map_size(updated_attempt.shard_materializers) == 2
         end)
@@ -295,8 +295,8 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhaseTest 
         assert {updated_attempt, CommitProxyStartupPhase} =
                  MaterializerBootstrapPhase.execute(recovery_attempt, context)
 
-        assert {"mat_real", _node} = updated_attempt.shard_materializers[RecoveryAttempt.system_shard_id()]
-        assert %{0 => {"mat_real", _}} = updated_attempt.shard_materializers
+        assert %{"mat_real" => _node} = updated_attempt.shard_materializers[RecoveryAttempt.system_shard_id()]
+        assert %{0 => %{"mat_real" => _}} = updated_attempt.shard_materializers
         assert map_size(updated_attempt.shard_materializers) == 1
       end)
     end
@@ -340,7 +340,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhaseTest 
           assert {updated_attempt, CommitProxyStartupPhase} =
                    MaterializerBootstrapPhase.execute(recovery_attempt, context)
 
-          assert {<<_::binary>>, <<_::binary>>} = updated_attempt.shard_materializers[0]
+          assert [{<<_::binary>>, <<_::binary>>}] = Map.to_list(updated_attempt.shard_materializers[0])
           assert updated_attempt.shard_layout
 
           # The creation is recorded: the layout will reference it, so
@@ -620,7 +620,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhaseTest 
         assert {updated_attempt, CommitProxyStartupPhase} =
                  MaterializerBootstrapPhase.execute(recovery_attempt, context)
 
-        assert {"mat_named", _node} = updated_attempt.shard_materializers[1]
+        assert %{"mat_named" => _node} = updated_attempt.shard_materializers[1]
         assert updated_attempt.prior_materializer_refs == %{1 => %{"mat_named" => Atom.to_string(node())}}
         refute updated_attempt.seeded_layout?
       end)
@@ -647,7 +647,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhaseTest 
 
         # "mat_gone" was not locked this epoch: the most-advanced
         # claimant wins as before.
-        assert {"mat_stray", _node} = updated_attempt.shard_materializers[1]
+        assert %{"mat_stray" => _node} = updated_attempt.shard_materializers[1]
       end)
     end
 

--- a/test/bedrock/control_plane/director/recovery/materializer_bootstrap_phase_test.exs
+++ b/test/bedrock/control_plane/director/recovery/materializer_bootstrap_phase_test.exs
@@ -610,7 +610,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhaseTest 
       context =
         existing_context(recovery_version, %{
           read_prior_refs_fn: fn _pid, _version ->
-            {:ok, %{1 => {"mat_named", Atom.to_string(node())}}}
+            {:ok, %{1 => %{"mat_named" => Atom.to_string(node())}}}
           end
         })
 
@@ -621,7 +621,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhaseTest 
                  MaterializerBootstrapPhase.execute(recovery_attempt, context)
 
         assert {"mat_named", _node} = updated_attempt.shard_materializers[1]
-        assert updated_attempt.prior_materializer_refs == %{1 => {"mat_named", Atom.to_string(node())}}
+        assert updated_attempt.prior_materializer_refs == %{1 => %{"mat_named" => Atom.to_string(node())}}
         refute updated_attempt.seeded_layout?
       end)
     end
@@ -635,7 +635,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhaseTest 
       context =
         existing_context(recovery_version, %{
           read_prior_refs_fn: fn _pid, _version ->
-            {:ok, %{1 => {"mat_gone", Atom.to_string(node())}}}
+            {:ok, %{1 => %{"mat_gone" => Atom.to_string(node())}}}
           end
         })
 
@@ -702,13 +702,16 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhaseTest 
     alias Bedrock.SystemKeys, as: SK
     alias Bedrock.SystemKeys.Values, as: V
 
-    test "decodes tag-keyed refs and rejects foreign or undecodable entries" do
+    test "decodes members into per-tag sets and rejects foreign or undecodable entries" do
       entries = [
-        {SK.materializer_key(0), V.encode_materializer_ref("wkr_sys", "n@h")},
-        {SK.materializer_key(7), V.encode_materializer_ref("wkr_a", "n@h")}
+        {SK.materializer_key(0, "wkr_sys"), V.encode_materializer_node("n@h")},
+        {SK.materializer_key(7, "wkr_a"), V.encode_materializer_node("n@h")},
+        {SK.materializer_key(7, "wkr_b"), V.encode_materializer_node("n2@h")}
       ]
 
-      assert {:ok, %{0 => {"wkr_sys", "n@h"}, 7 => {"wkr_a", "n@h"}}} =
+      # A tag's members are a set: two entries under tag 7 are two
+      # members, not a last-writer-wins overwrite.
+      assert {:ok, %{0 => %{"wkr_sys" => "n@h"}, 7 => %{"wkr_a" => "n@h", "wkr_b" => "n2@h"}}} =
                MaterializerBootstrapPhase.decode_prior_refs(entries)
 
       bad_key = SK.shard_key("m")
@@ -716,7 +719,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhaseTest 
       assert {:error, {:invalid_materializer_entry, ^bad_key}} =
                MaterializerBootstrapPhase.decode_prior_refs([{bad_key, "x"}])
 
-      garbage = SK.materializer_key(1)
+      garbage = SK.materializer_key(1, "wkr_a")
 
       assert {:error, {:invalid_materializer_entry, ^garbage}} =
                MaterializerBootstrapPhase.decode_prior_refs([{garbage, <<0xEE>>}])

--- a/test/bedrock/control_plane/director/recovery/persistence_phase_test.exs
+++ b/test/bedrock/control_plane/director/recovery/persistence_phase_test.exs
@@ -110,11 +110,12 @@ defmodule Bedrock.ControlPlane.Director.Recovery.PersistencePhaseTest do
 
       assert decoded[{:layout_log, "log_1"}] == [1, 2]
 
-      # Materializer refs: worker id + node as strings (FDB serverList
-      # analogue), projected from the carried shard_materializers refs.
+      # Membership: the worker id is in the KEY and the value carries the
+      # node (FDB serverKeys analogue), projected from the carried
+      # shard_materializers refs.
       node_string = Atom.to_string(node())
-      assert decoded[{:materializer_key, 0}] == {"wkr_sys", node_string}
-      assert decoded[{:materializer_key, 1}] == {"wkr_user", node_string}
+      assert decoded[{:materializer_key, 0, "wkr_sys"}] == node_string
+      assert decoded[{:materializer_key, 1, "wkr_user"}] == node_string
     end
 
     test "materializer family is skipped entirely when shard_materializers is absent" do
@@ -148,7 +149,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery.PersistencePhaseTest do
 
       for tag <- [0, 1] do
         assert Enum.any?(mutations, fn
-                 {:set, key, _} -> key == SystemKeys.materializer_key(tag)
+                 {:set, key, _} -> String.starts_with?(key, SystemKeys.materializer_tag_prefix(tag))
                  _ -> false
                end)
       end
@@ -294,16 +295,17 @@ defmodule Bedrock.ControlPlane.Director.Recovery.PersistencePhaseTest do
       # left alone — read-and-heal means stale entries are the
       # distributor's to reconcile, never recovery's to erase.
       prior = %{
-        0 => {"wkr_sys", node_string()},
-        1 => {"wkr_departed", node_string()},
-        9 => {"wkr_stray", node_string()}
+        0 => %{"wkr_sys" => node_string()},
+        1 => %{"wkr_departed" => node_string()},
+        9 => %{"wkr_stray" => node_string()}
       }
 
       recovery_attempt = Map.put(base_recovery_attempt(), :prior_materializer_refs, prior)
 
       stale_store =
-        Map.new(prior, fn {tag, {id, node}} ->
-          {SystemKeys.materializer_key(tag), Values.encode_materializer_ref(id, node)}
+        Map.new(prior, fn {tag, members} ->
+          [{id, node}] = Map.to_list(members)
+          {SystemKeys.materializer_key(tag, id), Values.encode_materializer_node(node)}
         end)
 
       mutations = captured_system_mutations(recovery_attempt)
@@ -314,15 +316,19 @@ defmodule Bedrock.ControlPlane.Director.Recovery.PersistencePhaseTest do
             String.starts_with?(key, SystemKeys.materializers_prefix()),
             do: {key, value}
 
+      # tag 1's member changed, so its NEW member's key is written; the
+      # departed member's key is left alone — recovery writes what it
+      # decided and never removes members it did not place (a set may
+      # legitimately hold replicas recovery knows nothing about).
       assert materializer_sets == [
-               {SystemKeys.materializer_key(1), Values.encode_materializer_ref("wkr_user", node_string())}
+               {SystemKeys.materializer_key(1, "wkr_user"), Values.encode_materializer_node(node_string())}
              ]
 
-      assert {:ok, {"wkr_sys", _}} =
-               Values.decode_materializer_ref(Map.fetch!(store, SystemKeys.materializer_key(0)))
+      assert {:ok, _node} =
+               Values.decode_materializer_node(Map.fetch!(store, SystemKeys.materializer_key(0, "wkr_sys")))
 
-      assert {:ok, {"wkr_stray", _}} =
-               Values.decode_materializer_ref(Map.fetch!(store, SystemKeys.materializer_key(9)))
+      assert {:ok, _node} =
+               Values.decode_materializer_node(Map.fetch!(store, SystemKeys.materializer_key(9, "wkr_stray")))
     end
 
     test "cleared prefix ranges do not cover any other system-key family" do

--- a/test/bedrock/control_plane/director/recovery/persistence_phase_test.exs
+++ b/test/bedrock/control_plane/director/recovery/persistence_phase_test.exs
@@ -43,7 +43,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery.PersistencePhaseTest do
       <<0xFF>> => {1, <<>>},
       <<0xFF, 0xFF>> => {0, <<0xFF>>}
     })
-    |> Map.put(:shard_materializers, %{0 => {"wkr_sys", node_string()}, 1 => {"wkr_user", node_string()}})
+    |> Map.put(:shard_materializers, %{0 => %{"wkr_sys" => node_string()}, 1 => %{"wkr_user" => node_string()}})
     |> Map.put(:seeded_layout?, true)
     |> Map.put(:prior_materializer_refs, %{})
     |> Map.put(:transaction_system_layout, mock_transaction_system_layout())

--- a/test/bedrock/control_plane/director/recovery/topology_phase_test.exs
+++ b/test/bedrock/control_plane/director/recovery/topology_phase_test.exs
@@ -4,6 +4,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery.TopologyPhaseTest do
   import Bedrock.Test.ControlPlane.RecoveryTestSupport
 
   alias Bedrock.ControlPlane.Director.Recovery.TopologyPhase
+  alias Bedrock.DataPlane.CommitProxy.RoutingData
 
   # Helper functions for common test setup
   defp base_recovery_attempt do
@@ -98,7 +99,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery.TopologyPhaseTest do
           "log_1" => %{status: {:up, self()}, kind: :log, last_seen: {:log_1, :node1}},
           "wkr_sys" => %{status: {:up, mat_sys}, kind: :materializer, last_seen: {:wkr_sys_name, node()}}
         })
-        |> Map.put(:shard_materializers, %{0 => {"wkr_sys", Atom.to_string(node())}})
+        |> Map.put(:shard_materializers, %{0 => %{"wkr_sys" => Atom.to_string(node())}})
 
       context =
         recovery_context()
@@ -112,11 +113,23 @@ defmodule Bedrock.ControlPlane.Director.Recovery.TopologyPhaseTest do
 
       assert_received {:routing_snapshot, snapshot}
 
-      # Refs are the same plain strings the persistence phase commits to the
+      # Refs are the same member maps the persistence phase commits to the
       # materializers/ family - the seed and the keyspace cannot disagree
-      # because both are derived from the same layout.
+      # because both are derived from the same layout. The seed must be
+      # member-shaped: RoutingData consumes it verbatim, so any other
+      # shape crashes the proxy on the first read after recovery.
       node_string = Atom.to_string(node())
-      assert snapshot.materializers == %{0 => {"wkr_sys", node_string}}
+      assert snapshot.materializers == %{0 => %{"wkr_sys" => node_string}}
+
+      # Cross the seam for real: the seed must survive the routing
+      # constructor and answer the reads a proxy actually performs.
+      routing =
+        snapshot
+        |> RoutingData.from_snapshot()
+        |> RoutingData.insert_shard("z", 0, "")
+
+      assert {:ok, %{"wkr_sys" => ^node_string}} = RoutingData.materializer_members(routing, 0)
+      assert {:ok, {"", "z", 0, {"wkr_sys", ^node_string}}} = RoutingData.covering_entry(routing, "a")
     end
 
     test "fails when commit proxy unlocking fails" do

--- a/test/bedrock/control_plane/director/recovery_test.exs
+++ b/test/bedrock/control_plane/director/recovery_test.exs
@@ -180,7 +180,7 @@ defmodule Bedrock.ControlPlane.Director.RecoveryTest do
 
       completed = %{
         logs: %{"live_log" => []},
-        shard_materializers: %{0 => {"live_mat", Atom.to_string(node())}},
+        shard_materializers: %{0 => %{"live_mat" => Atom.to_string(node())}},
         transaction_services: %{
           "live_log" => %{kind: :log, status: {:up, self()}},
           "live_mat" => %{kind: :materializer, status: {:up, live_mat_pid}}
@@ -217,7 +217,7 @@ defmodule Bedrock.ControlPlane.Director.RecoveryTest do
 
       completed = %{
         logs: %{},
-        shard_materializers: %{0 => {"assigned_mat", Atom.to_string(node())}},
+        shard_materializers: %{0 => %{"assigned_mat" => Atom.to_string(node())}},
         transaction_services: %{}
       }
 
@@ -235,7 +235,7 @@ defmodule Bedrock.ControlPlane.Director.RecoveryTest do
 
       completed = %{
         logs: %{},
-        shard_materializers: %{0 => {"active_mat", Atom.to_string(node())}},
+        shard_materializers: %{0 => %{"active_mat" => Atom.to_string(node())}},
         transaction_services: %{
           "active_mat" => %{kind: :materializer, status: {:up, active_pid}},
           "inactive_mat" => %{kind: :materializer, status: {:up, inactive_pid}}

--- a/test/bedrock/control_plane/distributor/lock_fence_resolver_test.exs
+++ b/test/bedrock/control_plane/distributor/lock_fence_resolver_test.exs
@@ -67,7 +67,7 @@ defmodule Bedrock.ControlPlane.Distributor.LockFenceResolverTest do
           end
       }
 
-      :ok = Transactions.commit_checked(lock, deps, [{:set, SystemKeys.materializer_key(1), "payload"}])
+      :ok = Transactions.commit_checked(lock, deps, [{:set, SystemKeys.materializer_key(1, "wkr_a"), "payload"}])
     end
 
     take = fn deps -> {:ok, _} = Transactions.take_lock(deps) end
@@ -97,7 +97,7 @@ defmodule Bedrock.ControlPlane.Distributor.LockFenceResolverTest do
           end
       }
 
-      :ok = Transactions.commit_checked(lock, deps, [{:set, SystemKeys.materializer_key(1), "payload"}])
+      :ok = Transactions.commit_checked(lock, deps, [{:set, SystemKeys.materializer_key(1, "wkr_a"), "payload"}])
     end
 
     encoded = encoded_fenced(check)
@@ -119,7 +119,7 @@ defmodule Bedrock.ControlPlane.Distributor.LockFenceResolverTest do
           end
       }
 
-      :ok = Transactions.commit_checked(lock, deps, [{:set, SystemKeys.materializer_key(1), "payload"}])
+      :ok = Transactions.commit_checked(lock, deps, [{:set, SystemKeys.materializer_key(1, "wkr_a"), "payload"}])
     end
 
     first = encoded_fenced(check)

--- a/test/bedrock/control_plane/distributor/server_test.exs
+++ b/test/bedrock/control_plane/distributor/server_test.exs
@@ -165,7 +165,7 @@ defmodule Bedrock.ControlPlane.Distributor.ServerTest do
 
       # Tag 0 is covered; tag 1 has no entry — the gap.
       refs_entries = [
-        {SystemKeys.materializer_key(0), Values.encode_materializer_ref("wkr_sys", Atom.to_string(node()))}
+        {SystemKeys.materializer_key(0, "wkr_sys"), Values.encode_materializer_node(Atom.to_string(node()))}
       ]
 
       assert {:noreply, t} = Server.handle_continue(:startup_sweep, swept_state(refs_entries, test_pid))
@@ -180,12 +180,12 @@ defmodule Bedrock.ControlPlane.Distributor.ServerTest do
       placeholder_sets =
         for {:set, key, value} <- Enum.to_list(mutations),
             String.starts_with?(key, SystemKeys.materializers_prefix()),
-            do: {key, Values.decode_materializer_ref(value)}
+            do: {key, Values.decode_materializer_node(value)}
 
       node_string = Atom.to_string(node())
 
       assert placeholder_sets == [
-               {SystemKeys.materializer_key(1), {:ok, {Placeholder.worker_id(), node_string}}}
+               {SystemKeys.materializer_key(1, Placeholder.worker_id()), {:ok, node_string}}
              ]
     end
 
@@ -194,8 +194,8 @@ defmodule Bedrock.ControlPlane.Distributor.ServerTest do
       node_string = Atom.to_string(node())
 
       refs_entries = [
-        {SystemKeys.materializer_key(0), Values.encode_materializer_ref("wkr_sys", node_string)},
-        {SystemKeys.materializer_key(1), Values.encode_materializer_ref(Placeholder.worker_id(), node_string)}
+        {SystemKeys.materializer_key(0, "wkr_sys"), Values.encode_materializer_node(node_string)},
+        {SystemKeys.materializer_key(1, Placeholder.worker_id()), Values.encode_materializer_node(node_string)}
       ]
 
       assert {:noreply, _t} = Server.handle_continue(:startup_sweep, swept_state(refs_entries, test_pid))
@@ -206,8 +206,8 @@ defmodule Bedrock.ControlPlane.Distributor.ServerTest do
       test_pid = self()
 
       refs_entries = [
-        {SystemKeys.materializer_key(0), Values.encode_materializer_ref("wkr_sys", Atom.to_string(node()))},
-        {SystemKeys.materializer_key(1), Values.encode_materializer_ref("wkr_a", Atom.to_string(node()))}
+        {SystemKeys.materializer_key(0, "wkr_sys"), Values.encode_materializer_node(Atom.to_string(node()))},
+        {SystemKeys.materializer_key(1, "wkr_a"), Values.encode_materializer_node(Atom.to_string(node()))}
       ]
 
       assert {:noreply, _t} = Server.handle_continue(:startup_sweep, swept_state(refs_entries, test_pid))
@@ -220,7 +220,7 @@ defmodule Bedrock.ControlPlane.Distributor.ServerTest do
       Process.put(:my_owner, lock.my_owner)
 
       refs_entries = [
-        {SystemKeys.materializer_key(0), Values.encode_materializer_ref("wkr_sys", Atom.to_string(node()))}
+        {SystemKeys.materializer_key(0, "wkr_sys"), Values.encode_materializer_node(Atom.to_string(node()))}
       ]
 
       t =
@@ -243,8 +243,8 @@ defmodule Bedrock.ControlPlane.Distributor.ServerTest do
 
       # The covered tag is reserved only while its verification is in
       # flight; a current-epoch answer releases it without recruiting.
-      assert_receive {:assignment_verified, 0, worker, :current}
-      assert {:noreply, t3} = Server.handle_info({:assignment_verified, 0, worker, :current}, t2)
+      assert_receive {:assignment_verified, 0, "wkr_sys", :current}
+      assert {:noreply, t3} = Server.handle_info({:assignment_verified, 0, "wkr_sys", :current}, t2)
       refute MapSet.member?(t3.recruiting, 0)
       assert MapSet.member?(t3.recruiting, 1)
     end
@@ -255,20 +255,21 @@ defmodule Bedrock.ControlPlane.Distributor.ServerTest do
       Process.put(:my_owner, lock.my_owner)
 
       refs_entries = [
-        {SystemKeys.materializer_key(0), Values.encode_materializer_ref("wkr_sys", Atom.to_string(node()))},
-        {SystemKeys.materializer_key(1), Values.encode_materializer_ref("wkr_a", Atom.to_string(node()))}
+        {SystemKeys.materializer_key(0, "wkr_sys"), Values.encode_materializer_node(Atom.to_string(node()))},
+        {SystemKeys.materializer_key(1, "wkr_a"), Values.encode_materializer_node(Atom.to_string(node()))}
       ]
 
       t = verified_sweep_state(refs_entries, test_pid, fn _worker, [:epoch], _opts -> {:ok, %{epoch: 3}} end)
 
       assert {:noreply, t2} = Server.handle_continue(:startup_sweep, t)
 
-      # Both named tags are reserved while their verification is in flight...
-      assert MapSet.member?(t2.recruiting, 0) and MapSet.member?(t2.recruiting, 1)
+      # Verification reserves nothing — with set-valued membership an
+      # extra materializer is legal, so a concurrent recruit costs a
+      # redundant worker, never a lost heal.
+      refute MapSet.member?(t2.recruiting, 0)
 
-      # ...and a current-epoch answer releases the reservation with no
-      # publish, no adoption, no recruit.
-      assert_receive {:assignment_verified, 0, _worker, :current}
+      # A current-epoch answer means no publish, no adoption, no recruit.
+      assert_receive {:assignment_verified, 0, "wkr_sys", :current}
       assert_receive {:assignment_verified, 1, _worker, verdict1}
 
       assert {:noreply, t3} =
@@ -288,8 +289,8 @@ defmodule Bedrock.ControlPlane.Distributor.ServerTest do
       node_string = Atom.to_string(node())
 
       refs_entries = [
-        {SystemKeys.materializer_key(0), Values.encode_materializer_ref("wkr_sys", node_string)},
-        {SystemKeys.materializer_key(1), Values.encode_materializer_ref("wkr_stale", node_string)}
+        {SystemKeys.materializer_key(0, "wkr_sys"), Values.encode_materializer_node(node_string)},
+        {SystemKeys.materializer_key(1, "wkr_stale"), Values.encode_materializer_node(node_string)}
       ]
 
       adopted = spawn(fn -> Process.sleep(:infinity) end)
@@ -334,8 +335,8 @@ defmodule Bedrock.ControlPlane.Distributor.ServerTest do
       # doubles every DOWN into a double heal).
       assert_received {:committed, _}
       refute MapSet.member?(t3.recruiting, 1)
-      assert Enum.count(Map.values(t3.assignment_monitors), &(&1 == 1)) == 1
-      assert t3.snapshot.materializer_refs[1] == {"wkr_stale", node_string}
+      assert Enum.count(Map.values(t3.assignment_monitors), &match?({1, _}, &1)) == 1
+      assert t3.snapshot.materializer_refs[1] == %{"wkr_stale" => node_string}
     end
 
     test "an unadoptable named assignment is healed — parked and re-recruited, the worker never removed" do
@@ -345,8 +346,8 @@ defmodule Bedrock.ControlPlane.Distributor.ServerTest do
       node_string = Atom.to_string(node())
 
       refs_entries = [
-        {SystemKeys.materializer_key(0), Values.encode_materializer_ref("wkr_sys", node_string)},
-        {SystemKeys.materializer_key(1), Values.encode_materializer_ref("wkr_wedged", node_string)}
+        {SystemKeys.materializer_key(0, "wkr_sys"), Values.encode_materializer_node(node_string)},
+        {SystemKeys.materializer_key(1, "wkr_wedged"), Values.encode_materializer_node(node_string)}
       ]
 
       # A stale answer whose adoption then definitively fails: wedged
@@ -384,82 +385,40 @@ defmodule Bedrock.ControlPlane.Distributor.ServerTest do
           # Healed: placeholder published over the wedged worker's entry,
           # replacement recruiting.
           assert_received {:committed, _}
-          assert t3.snapshot.materializer_refs[1] == {Placeholder.worker_id(), node_string}
+          assert t3.snapshot.materializer_refs[1] == %{Placeholder.worker_id() => node_string}
           assert MapSet.member?(t3.recruiting, 1)
         end)
 
       assert log =~ "failed verification"
     end
 
-    test "DOWN-before-verdict: the heal's recruit is suppressed by the reservation and re-issued when the park degraded" do
-      test_pid = self()
-      node_string = Atom.to_string(node())
-      ref = make_ref()
-
-      refs_entries = [{SystemKeys.materializer_key(0), Values.encode_materializer_ref("wkr_dead", node_string)}]
-      t = verified_sweep_state(refs_entries, test_pid, fn _w, [:epoch], _o -> {:ok, %{epoch: 2}} end)
-
-      # Simulate the common order for a dead named worker: monitor and
-      # reservation armed by the sweep, then the :noproc DOWN lands while
-      # the probe is still in flight — with the publish failing (the
-      # degraded park deletes the local ref).
-      t = %{
-        t
-        | placeholder: spawn(fn -> Process.sleep(:infinity) end),
-          snapshot: %{shard_layout: %{}, materializer_refs: %{0 => {"wkr_dead", node_string}}},
-          recruiting: MapSet.new([0]),
-          assignment_monitors: %{ref => 0},
-          deps: Map.put(t.deps, :commit_fn, fn _p, _e, _t, _o -> {:error, :timeout} end)
-      }
-
-      log =
-        ExUnit.CaptureLog.capture_log(fn ->
-          assert {:noreply, t2} = Server.handle_info({:DOWN, ref, :process, self(), :noproc}, t)
-
-          # The reservation suppressed the heal's recruit and the park
-          # degraded: refs is now ABSENT for the tag.
-          refute Map.has_key?(t2.snapshot.materializer_refs, 0)
-          assert t2.recruiting == MapSet.new([0])
-
-          # The late verdict re-issues the suppressed recruit — without
-          # this the committed keyspace names a corpse until the next
-          # recovery.
-          assert {:noreply, t3} =
-                   Server.handle_info({:assignment_verified, 0, {"wkr_dead", node_string}, {:error, :noproc}}, t2)
-
-          assert MapSet.member?(t3.recruiting, 0)
-        end)
-
-      assert log =~ "placeholder publish"
-    end
-
     test "unreachable-shaped probe verdicts damp instead of healing, and escalate to a heal" do
       test_pid = self()
       node_string = Atom.to_string(node())
 
-      refs_entries = [{SystemKeys.materializer_key(0), Values.encode_materializer_ref("wkr_far", node_string)}]
+      refs_entries = [{SystemKeys.materializer_key(0, "wkr_far"), Values.encode_materializer_node(node_string)}]
       t = verified_sweep_state(refs_entries, test_pid, fn _w, [:epoch], _o -> {:ok, %{epoch: 3}} end)
 
       t = %{
         t
         | placeholder: spawn(fn -> Process.sleep(:infinity) end),
-          snapshot: %{shard_layout: %{}, materializer_refs: %{0 => {"wkr_far", node_string}}},
+          snapshot: %{shard_layout: %{}, materializer_refs: %{0 => %{"wkr_far" => node_string}}},
           reverify_interval_ms: 5
       }
 
-      worker = {"wkr_far", node_string}
+      worker = "wkr_far"
 
       log =
         ExUnit.CaptureLog.capture_log(fn ->
           # Two unreachable-shaped verdicts: no heal, no commit — the
           # damping counter climbs and the reverify tick re-arms.
           assert {:noreply, t} = Server.handle_info({:assignment_verified, 0, worker, {:error, :unavailable}}, t)
-          assert t.unreachable_counts[0] == 1
+          assert t.unreachable_counts[{0, "wkr_far"}] == 1
           refute_received {:committed, _}
-          assert_receive {:reverify_assignment, 0}, 100
+          assert_receive {:reverify_assignment, 0, "wkr_far"}, 100
 
           assert {:noreply, t} = Server.handle_info({:assignment_verified, 0, worker, {:error, :timeout}}, t)
-          assert t.unreachable_counts[0] == 2
+          assert t.unreachable_counts[{0, "wkr_far"}] == 2
           refute_received {:committed, _}
 
           # The third escalates to the heal.
@@ -477,7 +436,7 @@ defmodule Bedrock.ControlPlane.Distributor.ServerTest do
       node_string = Atom.to_string(node())
       adopted = spawn(fn -> Process.sleep(:infinity) end)
 
-      refs_entries = [{SystemKeys.materializer_key(0), Values.encode_materializer_ref("wkr_adopt", node_string)}]
+      refs_entries = [{SystemKeys.materializer_key(0, "wkr_adopt"), Values.encode_materializer_node(node_string)}]
       t = verified_sweep_state(refs_entries, test_pid, fn _w, [:epoch], _o -> {:ok, %{epoch: 3}} end)
 
       ctx =
@@ -488,7 +447,7 @@ defmodule Bedrock.ControlPlane.Distributor.ServerTest do
       t = %{
         t
         | recruitment_ctx: ctx,
-          snapshot: %{shard_layout: %{}, materializer_refs: %{0 => {"wkr_adopt", node_string}}},
+          snapshot: %{shard_layout: %{}, materializer_refs: %{0 => %{"wkr_adopt" => node_string}}},
           deps: Map.put(t.deps, :commit_fn, fn _p, _e, _t, _o -> {:error, :timeout} end)
       }
 
@@ -496,13 +455,13 @@ defmodule Bedrock.ControlPlane.Distributor.ServerTest do
         ExUnit.CaptureLog.capture_log(fn ->
           assert {:noreply, t2} =
                    Server.handle_info(
-                     {:assignment_verified, 0, {"wkr_adopt", node_string}, {:adopted, adopted, node(), "wkr_adopt"}},
+                     {:assignment_verified, 0, "wkr_adopt", {:adopted, adopted, node(), "wkr_adopt"}},
                      t
                    )
 
           # The entry already names the worker and it is serving: only
           # the fence confirmation was lost. Monitor; no backoff.
-          assert 0 in Map.values(t2.assignment_monitors)
+          assert {0, "wkr_adopt"} in Map.values(t2.assignment_monitors)
           assert t2.backoff == %{}
         end)
 
@@ -514,7 +473,7 @@ defmodule Bedrock.ControlPlane.Distributor.ServerTest do
       node_string = Atom.to_string(node())
       adopted = spawn(fn -> Process.sleep(:infinity) end)
 
-      refs_entries = [{SystemKeys.materializer_key(0), Values.encode_materializer_ref("wkr_adopt", node_string)}]
+      refs_entries = [{SystemKeys.materializer_key(0, "wkr_adopt"), Values.encode_materializer_node(node_string)}]
       t = verified_sweep_state(refs_entries, test_pid, fn _w, [:epoch], _o -> {:ok, %{epoch: 3}} end)
 
       ctx =
@@ -532,13 +491,13 @@ defmodule Bedrock.ControlPlane.Distributor.ServerTest do
         t
         | recruitment_ctx: ctx,
           deps: superseding_deps,
-          snapshot: %{shard_layout: %{}, materializer_refs: %{0 => {"wkr_adopt", node_string}}}
+          snapshot: %{shard_layout: %{}, materializer_refs: %{0 => %{"wkr_adopt" => node_string}}}
       }
 
       ExUnit.CaptureLog.capture_log(fn ->
         assert {:stop, :normal, _t} =
                  Server.handle_info(
-                   {:assignment_verified, 0, {"wkr_adopt", node_string}, {:adopted, adopted, node(), "wkr_adopt"}},
+                   {:assignment_verified, 0, "wkr_adopt", {:adopted, adopted, node(), "wkr_adopt"}},
                    t
                  )
       end)
@@ -548,7 +507,7 @@ defmodule Bedrock.ControlPlane.Distributor.ServerTest do
       test_pid = self()
       node_string = Atom.to_string(node())
 
-      refs_entries = [{SystemKeys.materializer_key(0), Values.encode_materializer_ref("wkr_back", node_string)}]
+      refs_entries = [{SystemKeys.materializer_key(0, "wkr_back"), Values.encode_materializer_node(node_string)}]
 
       t =
         verified_sweep_state(refs_entries, test_pid, fn _w, [:epoch], _o ->
@@ -558,18 +517,18 @@ defmodule Bedrock.ControlPlane.Distributor.ServerTest do
 
       t = %{
         t
-        | snapshot: %{shard_layout: %{}, materializer_refs: %{0 => {"wkr_back", node_string}}},
-          unreachable_counts: %{0 => 1}
+        | snapshot: %{shard_layout: %{}, materializer_refs: %{0 => %{"wkr_back" => node_string}}},
+          unreachable_counts: %{{0, "wkr_back"} => 1}
       }
 
-      assert {:noreply, t2} = Server.handle_info({:reverify_assignment, 0}, t)
+      assert {:noreply, t2} = Server.handle_info({:reverify_assignment, 0, "wkr_back"}, t)
 
       # Monitor re-armed AND a fresh probe launched; the count survives
       # until the verdict clears it.
-      assert 0 in Map.values(t2.assignment_monitors)
-      assert t2.unreachable_counts == %{0 => 1}
+      assert {0, "wkr_back"} in Map.values(t2.assignment_monitors)
+      assert t2.unreachable_counts == %{{0, "wkr_back"} => 1}
       assert_receive :probed
-      assert_receive {:assignment_verified, 0, _worker, :current}
+      assert_receive {:assignment_verified, 0, "wkr_back", :current}
     end
 
     test "a verification verdict for a tag another mechanism re-owned is dropped" do
@@ -579,8 +538,8 @@ defmodule Bedrock.ControlPlane.Distributor.ServerTest do
       node_string = Atom.to_string(node())
 
       refs_entries = [
-        {SystemKeys.materializer_key(0), Values.encode_materializer_ref("wkr_sys", node_string)},
-        {SystemKeys.materializer_key(1), Values.encode_materializer_ref("wkr_gone", node_string)}
+        {SystemKeys.materializer_key(0, "wkr_sys"), Values.encode_materializer_node(node_string)},
+        {SystemKeys.materializer_key(1, "wkr_gone"), Values.encode_materializer_node(node_string)}
       ]
 
       t = verified_sweep_state(refs_entries, test_pid, fn _w, [:epoch], _o -> {:ok, %{epoch: 3}} end)
@@ -588,11 +547,11 @@ defmodule Bedrock.ControlPlane.Distributor.ServerTest do
 
       # Death healing re-owned tag 1 meanwhile: the ref now names the
       # placeholder. A late error verdict must not double-heal...
-      healed_refs = Map.put(t2.snapshot.materializer_refs, 1, {Placeholder.worker_id(), node_string})
+      healed_refs = Map.put(t2.snapshot.materializer_refs, 1, %{Placeholder.worker_id() => node_string})
       t2 = %{t2 | snapshot: %{t2.snapshot | materializer_refs: healed_refs}}
 
       assert {:noreply, t3} =
-               Server.handle_info({:assignment_verified, 1, {"wkr_gone", node_string}, {:error, :noproc}}, t2)
+               Server.handle_info({:assignment_verified, 1, "wkr_gone", {:error, :noproc}}, t2)
 
       refute MapSet.member?(t3.recruiting, 1)
 
@@ -602,11 +561,11 @@ defmodule Bedrock.ControlPlane.Distributor.ServerTest do
 
       assert {:noreply, t4} =
                Server.handle_info(
-                 {:assignment_verified, 1, {"wkr_gone", node_string}, {:adopted, stray, node(), "wkr_gone"}},
+                 {:assignment_verified, 1, "wkr_gone", {:adopted, stray, node(), "wkr_gone"}},
                  t3
                )
 
-      assert t4.snapshot.materializer_refs[1] == {Placeholder.worker_id(), node_string}
+      assert t4.snapshot.materializer_refs[1] == %{Placeholder.worker_id() => node_string}
     end
 
     defp verified_sweep_state(refs_entries, test_pid, info_fn) do
@@ -663,7 +622,7 @@ defmodule Bedrock.ControlPlane.Distributor.ServerTest do
       t =
         state(%{},
           placeholder: placeholder,
-          snapshot: %{shard_layout: %{}, materializer_refs: %{7 => {"wkr_a", Atom.to_string(node())}}}
+          snapshot: %{shard_layout: %{}, materializer_refs: %{7 => %{"wkr_a" => Atom.to_string(node())}}}
         )
 
       assert {:noreply, _t} = Server.handle_cast({:coverage_demand, 7}, t)
@@ -682,7 +641,7 @@ defmodule Bedrock.ControlPlane.Distributor.ServerTest do
         state(%{},
           snapshot: %{
             shard_layout: %{},
-            materializer_refs: %{9 => {Placeholder.worker_id(), Atom.to_string(node())}}
+            materializer_refs: %{9 => %{Placeholder.worker_id() => Atom.to_string(node())}}
           }
         )
 
@@ -810,17 +769,17 @@ defmodule Bedrock.ControlPlane.Distributor.ServerTest do
       assert {:ok, mutations} = Transaction.mutations(encoded)
 
       assert Enum.any?(Enum.to_list(mutations), fn
-               {:set, key, _} -> key == Bedrock.SystemKeys.materializer_key(9)
+               {:set, key, _} -> key == Bedrock.SystemKeys.materializer_key(9, "wkr_new")
                _ -> false
              end)
 
       assert_receive {:placeholder_got, {:covered, 9, {_otp, _node}}}
-      assert t2.snapshot.materializer_refs[9] == {"wkr_new", Atom.to_string(node())}
+      assert t2.snapshot.materializer_refs[9] == %{"wkr_new" => Atom.to_string(node())}
       refute MapSet.member?(t2.recruiting, 9)
 
       # The published assignment is monitored from this moment — healing
       # coverage starts at publication, not at the next sweep.
-      assert Map.values(t2.assignment_monitors) == [9]
+      assert Map.values(t2.assignment_monitors) == [{9, "wkr_new"}]
     end
 
     test "a superseded publish removes the orphan and cedes" do
@@ -1013,7 +972,7 @@ defmodule Bedrock.ControlPlane.Distributor.ServerTest do
             placeholder: placeholder,
             snapshot: %{
               shard_layout: %{},
-              materializer_refs: %{7 => {"wkr_dead", Atom.to_string(node())}}
+              materializer_refs: %{7 => %{"wkr_dead" => Atom.to_string(node())}}
             },
             recruitment_ctx: %{
               cluster: __MODULE__,
@@ -1033,7 +992,7 @@ defmodule Bedrock.ControlPlane.Distributor.ServerTest do
       test_pid = self()
       ref = make_ref()
       t = healing_state(test_pid, [])
-      t = %{t | assignment_monitors: %{ref => 7}}
+      t = %{t | assignment_monitors: %{ref => {7, "wkr_dead"}}}
 
       log =
         ExUnit.CaptureLog.capture_log(fn ->
@@ -1043,18 +1002,21 @@ defmodule Bedrock.ControlPlane.Distributor.ServerTest do
           assert_received {:committed, encoded}
           assert {:ok, mutations} = Transaction.mutations(encoded)
 
-          placeholder_ref = HealValues.encode_materializer_ref(Placeholder.worker_id(), Atom.to_string(node()))
-          assert {:set, HealKeys.materializer_key(7), placeholder_ref} in Enum.to_list(mutations)
+          placeholder_ref = HealValues.encode_materializer_node(Atom.to_string(node()))
+
+          assert {:set, HealKeys.materializer_key(7, Placeholder.worker_id()), placeholder_ref} in Enum.to_list(
+                   mutations
+                 )
 
           # Park, don't forward; and the re-recruit is in flight. (The
           # stub forwards a cast: wait, don't demand prior arrival.)
           assert_receive {:placeholder_got, {:uncovered, 7}}
           assert MapSet.member?(t2.recruiting, 7)
-          assert t2.snapshot.materializer_refs[7] == {Placeholder.worker_id(), Atom.to_string(node())}
+          assert t2.snapshot.materializer_refs[7] == %{Placeholder.worker_id() => Atom.to_string(node())}
           assert t2.assignment_monitors == %{}
         end)
 
-      assert log =~ "materializer for tag 7 down"
+      assert log =~ "materializer wkr_dead down"
     end
 
     test "a superseded healing publish cedes — a newer owner heals, not us" do
@@ -1069,7 +1031,7 @@ defmodule Bedrock.ControlPlane.Distributor.ServerTest do
           commit_fn: fn _p, _e, _t, _o -> flunk("must not commit past a refused fence") end
         })
 
-      t = %{t | deps: superseding_deps, assignment_monitors: %{ref => 7}}
+      t = %{t | deps: superseding_deps, assignment_monitors: %{ref => {7, "wkr_dead"}}}
 
       ExUnit.CaptureLog.capture_log(fn ->
         assert {:stop, :normal, _t} = Server.handle_info({:DOWN, ref, :process, self(), :killed}, t)
@@ -1080,7 +1042,7 @@ defmodule Bedrock.ControlPlane.Distributor.ServerTest do
       test_pid = self()
       ref = make_ref()
       t = healing_state(test_pid, [])
-      t = %{t | assignment_monitors: %{ref => 7}}
+      t = %{t | assignment_monitors: %{ref => {7, "wkr_dead"}}}
 
       log =
         ExUnit.CaptureLog.capture_log(fn ->
@@ -1091,7 +1053,7 @@ defmodule Bedrock.ControlPlane.Distributor.ServerTest do
           assert_received {:committed, _}
           assert_receive {:placeholder_got, {:uncovered, 7}}
           refute MapSet.member?(t2.recruiting, 7)
-          assert t2.snapshot.materializer_refs[7] == {Placeholder.worker_id(), Atom.to_string(node())}
+          assert t2.snapshot.materializer_refs[7] == %{Placeholder.worker_id() => Atom.to_string(node())}
 
           # The next read's demand is what revives the shard.
           assert {:noreply, t3} = Server.handle_cast({:coverage_demand, 7}, t2)
@@ -1101,33 +1063,71 @@ defmodule Bedrock.ControlPlane.Distributor.ServerTest do
       assert log =~ "spun down idle"
     end
 
-    test "a degraded idle park falls back to healing — the keyspace still names the corpse and only a recruit corrects it" do
+    test "a transient retirement failure keeps the view honest and retries — the keyspace never keeps a corpse" do
       test_pid = self()
       ref = make_ref()
       t = healing_state(test_pid, [])
 
-      failing_deps = Map.put(t.deps, :commit_fn, fn _p, _e, _t, _o -> {:error, :timeout} end)
-      t = %{t | deps: failing_deps, assignment_monitors: %{ref => 7}}
+      good_deps = t.deps
+      failing = Map.put(good_deps, :commit_fn, fn _p, _e, _t, _o -> {:error, :timeout} end)
+      t = %{t | deps: failing, assignment_monitors: %{ref => {7, "wkr_dead"}}, backoff_ms: 5}
 
       log =
         ExUnit.CaptureLog.capture_log(fn ->
-          assert {:noreply, t2} = Server.handle_info({:DOWN, ref, :process, self(), {:shutdown, :idle}}, t)
+          assert {:noreply, t2} = Server.handle_info({:DOWN, ref, :process, self(), :killed}, t)
 
-          # The publish failed: clients keep routing to the departed
-          # worker via the keyspace, so no demand can ever fire — the
-          # recruit (whose own publication self-corrects) must start.
-          refute Map.has_key?(t2.snapshot.materializer_refs, 7)
-          assert MapSet.member?(t2.recruiting, 7)
+          # The clear did not land, so the local view still names the
+          # worker the keyspace still names — lying to ourselves would
+          # only hide the corpse from the retry.
+          assert t2.snapshot.materializer_refs[7] == %{"wkr_dead" => Atom.to_string(node())}
+          assert_receive {:retire_member, 7, "wkr_dead"}, 200
+
+          # The retry re-attempts the same retirement; once it commits,
+          # the member is gone and the placeholder covers the gap.
+          t3 = %{t2 | deps: good_deps}
+          assert {:noreply, t4} = Server.handle_info({:retire_member, 7, "wkr_dead"}, t3)
+          assert t4.snapshot.materializer_refs[7] == %{Placeholder.worker_id() => Atom.to_string(node())}
         end)
 
-      assert log =~ "placeholder publish for tag 7 failed"
+      assert log =~ "retiring wkr_dead"
+    end
+
+    test "a retirement retry for a member already gone is a no-op" do
+      test_pid = self()
+      t = healing_state(test_pid, snapshot: %{shard_layout: %{}, materializer_refs: %{}})
+
+      assert {:noreply, _t} = Server.handle_info({:retire_member, 7, "wkr_dead"}, t)
+      refute_received {:committed, _}
+    end
+
+    test "verification reserves nothing: a death during a probe heals immediately" do
+      test_pid = self()
+      ref = make_ref()
+      t = healing_state(test_pid, [])
+
+      # A probe is in flight for the same tag (its task ref is tracked,
+      # but nothing about the tag is reserved).
+      t = %{
+        t
+        | assignment_monitors: %{ref => {7, "wkr_dead"}},
+          verification_task_refs: %{make_ref() => {7, "wkr_dead"}}
+      }
+
+      ExUnit.CaptureLog.capture_log(fn ->
+        assert {:noreply, t2} = Server.handle_info({:DOWN, ref, :process, self(), :noproc}, t)
+
+        # Healed AND recruiting — under the old tag-wide reservation the
+        # recruit was silently suppressed here (PR #195 audit F1).
+        assert_received {:committed, _}
+        assert MapSet.member?(t2.recruiting, 7)
+      end)
     end
 
     test "a :noconnection DOWN does not heal — the tag is verified, not stampeded" do
       test_pid = self()
       ref = make_ref()
       t = healing_state(test_pid, [])
-      t = %{t | assignment_monitors: %{ref => 7}, reverify_interval_ms: 5}
+      t = %{t | assignment_monitors: %{ref => {7, "wkr_dead"}}, reverify_interval_ms: 5}
 
       log =
         ExUnit.CaptureLog.capture_log(fn ->
@@ -1138,10 +1138,10 @@ defmodule Bedrock.ControlPlane.Distributor.ServerTest do
           refute_received {:committed, _}
           refute_received {:placeholder_got, _}
           refute MapSet.member?(t2.recruiting, 7)
-          assert t2.snapshot.materializer_refs[7] == {"wkr_dead", Atom.to_string(node())}
+          assert t2.snapshot.materializer_refs[7] == %{"wkr_dead" => Atom.to_string(node())}
 
           # ...and verification is armed instead.
-          assert_receive {:reverify_assignment, 7}, 100
+          assert_receive {:reverify_assignment, 7, "wkr_dead"}, 100
         end)
 
       assert log =~ "unreachable; verifying"
@@ -1152,7 +1152,7 @@ defmodule Bedrock.ControlPlane.Distributor.ServerTest do
 
       t =
         healing_state(test_pid,
-          snapshot: %{shard_layout: %{}, materializer_refs: %{7 => {"wkr_gone", "gone@nowhere"}}}
+          snapshot: %{shard_layout: %{}, materializer_refs: %{7 => %{"wkr_gone" => "gone@nowhere"}}}
         )
 
       t = %{t | reverify_interval_ms: 5}
@@ -1160,16 +1160,16 @@ defmodule Bedrock.ControlPlane.Distributor.ServerTest do
       log =
         ExUnit.CaptureLog.capture_log(fn ->
           # Two failed pings only re-arm the verification timer...
-          assert {:noreply, t} = Server.handle_info({:reverify_assignment, 7}, t)
-          assert t.unreachable_counts[7] == 1
+          assert {:noreply, t} = Server.handle_info({:reverify_assignment, 7, "wkr_gone"}, t)
+          assert t.unreachable_counts[{7, "wkr_gone"}] == 1
           refute_received {:committed, _}
-          assert_receive {:reverify_assignment, 7}, 100
+          assert_receive {:reverify_assignment, 7, "wkr_gone"}, 100
 
-          assert {:noreply, t} = Server.handle_info({:reverify_assignment, 7}, t)
-          assert t.unreachable_counts[7] == 2
+          assert {:noreply, t} = Server.handle_info({:reverify_assignment, 7, "wkr_gone"}, t)
+          assert t.unreachable_counts[{7, "wkr_gone"}] == 2
 
-          # ...the third escalates: publish, uncover, re-recruit.
-          assert {:noreply, t3} = Server.handle_info({:reverify_assignment, 7}, t)
+          # ...the third escalates: retire the member, park, re-recruit.
+          assert {:noreply, t3} = Server.handle_info({:reverify_assignment, 7, "wkr_gone"}, t)
           assert_received {:committed, _}
           assert_receive {:placeholder_got, {:uncovered, 7}}
           assert MapSet.member?(t3.recruiting, 7)
@@ -1184,18 +1184,18 @@ defmodule Bedrock.ControlPlane.Distributor.ServerTest do
 
       t =
         healing_state(test_pid,
-          snapshot: %{shard_layout: %{}, materializer_refs: %{7 => {"wkr_alive", Atom.to_string(node())}}}
+          snapshot: %{shard_layout: %{}, materializer_refs: %{7 => %{"wkr_alive" => Atom.to_string(node())}}}
         )
 
       ctx = Map.put(t.recruitment_ctx, :info_fn, fn _w, [:epoch], _o -> {:ok, %{epoch: 3}} end)
-      t = %{t | recruitment_ctx: ctx, unreachable_counts: %{7 => 2}}
+      t = %{t | recruitment_ctx: ctx, unreachable_counts: %{{7, "wkr_alive"} => 2}}
 
-      assert {:noreply, t2} = Server.handle_info({:reverify_assignment, 7}, t)
+      assert {:noreply, t2} = Server.handle_info({:reverify_assignment, 7, "wkr_alive"}, t)
 
       # Reachability alone is not membership: the count survives the
       # pong; verification re-runs and its :current verdict clears it.
-      assert t2.unreachable_counts == %{7 => 2}
-      assert Map.values(t2.assignment_monitors) == [7]
+      assert t2.unreachable_counts == %{{7, "wkr_alive"} => 2}
+      assert Map.values(t2.assignment_monitors) == [{7, "wkr_alive"}]
 
       assert_receive {:assignment_verified, 7, worker, :current}
       assert {:noreply, t2b} = Server.handle_info({:assignment_verified, 7, worker, :current}, t2)
@@ -1206,10 +1206,10 @@ defmodule Bedrock.ControlPlane.Distributor.ServerTest do
       # healing: verification just stands down.
       t3 = %{
         t
-        | snapshot: %{t.snapshot | materializer_refs: %{7 => {Placeholder.worker_id(), Atom.to_string(node())}}}
+        | snapshot: %{t.snapshot | materializer_refs: %{7 => %{Placeholder.worker_id() => Atom.to_string(node())}}}
       }
 
-      assert {:noreply, t4} = Server.handle_info({:reverify_assignment, 7}, t3)
+      assert {:noreply, t4} = Server.handle_info({:reverify_assignment, 7, "wkr_alive"}, t3)
       assert t4.unreachable_counts == %{}
       assert t4.assignment_monitors == %{}
       refute_received {:committed, _}
@@ -1225,7 +1225,7 @@ defmodule Bedrock.ControlPlane.Distributor.ServerTest do
       ref = Process.monitor(otp_name_for_worker("wkr_dead"))
       assert_receive {:DOWN, ^ref, :process, _, :noproc}
 
-      t = %{t | assignment_monitors: %{ref => 7}}
+      t = %{t | assignment_monitors: %{ref => {7, "wkr_dead"}}}
 
       ExUnit.CaptureLog.capture_log(fn ->
         assert {:noreply, t2} = Server.handle_info({:DOWN, ref, :process, nil, :noproc}, t)
@@ -1235,44 +1235,19 @@ defmodule Bedrock.ControlPlane.Distributor.ServerTest do
       end)
     end
 
-    test "a transiently failed healing publish drops the corpse ref — demand recruits, never serves the corpse" do
-      test_pid = self()
-      ref = make_ref()
-      t = healing_state(test_pid, [])
-
-      failing_deps = Map.put(t.deps, :commit_fn, fn _p, _e, _t, _o -> {:error, :timeout} end)
-      t = %{t | deps: failing_deps, assignment_monitors: %{ref => 7}}
-
-      log =
-        ExUnit.CaptureLog.capture_log(fn ->
-          assert {:noreply, t2} = Server.handle_info({:DOWN, ref, :process, self(), :killed}, t)
-
-          # The corpse's ref left the local view even though the keyspace
-          # still names it: a racing demand falls to the recruit path
-          # instead of handing parked readers a dead callable.
-          refute Map.has_key?(t2.snapshot.materializer_refs, 7)
-
-          assert {:noreply, t3} = Server.handle_cast({:coverage_demand, 7}, t2)
-          assert MapSet.member?(t3.pending_demands, 7)
-          refute_received {:placeholder_got, {:covered, 7, _}}
-        end)
-
-      assert log =~ "placeholder publish for tag 7 failed"
-    end
-
     test "the startup sweep monitors live assignments but never the placeholder's own refs" do
       test_pid = self()
       node_string = Atom.to_string(node())
 
       refs_entries = [
-        {HealKeys.materializer_key(0), HealValues.encode_materializer_ref("wkr_sys", node_string)},
-        {HealKeys.materializer_key(1), HealValues.encode_materializer_ref(Placeholder.worker_id(), node_string)}
+        {HealKeys.materializer_key(0, "wkr_sys"), HealValues.encode_materializer_node(node_string)},
+        {HealKeys.materializer_key(1, Placeholder.worker_id()), HealValues.encode_materializer_node(node_string)}
       ]
 
       assert {:noreply, t} = Server.handle_continue(:startup_sweep, swept_state(refs_entries, test_pid))
 
       assert map_size(t.assignment_monitors) == 1
-      assert t.assignment_monitors |> Map.values() |> Enum.sort() == [0]
+      assert t.assignment_monitors |> Map.values() |> Enum.sort() == [{0, "wkr_sys"}]
     end
   end
 end

--- a/test/bedrock/control_plane/distributor/server_test.exs
+++ b/test/bedrock/control_plane/distributor/server_test.exs
@@ -187,6 +187,50 @@ defmodule Bedrock.ControlPlane.Distributor.ServerTest do
       assert placeholder_sets == [
                {SystemKeys.materializer_key(1, Placeholder.worker_id()), {:ok, node_string}}
              ]
+
+      # The local view must record what the commit just wrote. Every
+      # later placeholder decision reads this map; a stale view omits
+      # the clear when a real member lands and leaks the key forever.
+      assert t.snapshot.materializer_refs[1] == %{Placeholder.worker_id() => node_string}
+    end
+
+    test "publishing a real member clears the placeholder the sweep committed" do
+      test_pid = self()
+      node_string = Atom.to_string(node())
+
+      refs_entries = [
+        {SystemKeys.materializer_key(0, "wkr_sys"), Values.encode_materializer_node(node_string)}
+      ]
+
+      assert {:noreply, t} = Server.handle_continue(:startup_sweep, swept_state(refs_entries, test_pid))
+
+      # Drain the sweep's own commit; the recruit for tag 1 is next.
+      assert_received {:committed, _}
+
+      assert {:noreply, t2} =
+               Server.handle_info({:recruitment_complete, 1, {:ok, self(), node(), "wkr_new"}}, %{
+                 t
+                 | recruiting: MapSet.new([1])
+               })
+
+      assert_received {:committed, encoded}
+      assert {:ok, mutations} = Transaction.mutations(encoded)
+      mutations = Enum.to_list(mutations)
+
+      assert Enum.any?(mutations, fn
+               {:set, key, _} -> key == SystemKeys.materializer_key(1, "wkr_new")
+               _ -> false
+             end)
+
+      # The placeholder key must be cleared in the SAME commit — the set
+      # format makes this mandatory, where the old single-key format got
+      # it for free by overwriting.
+      assert Enum.any?(mutations, fn
+               {:clear, key} -> key == SystemKeys.materializer_key(1, Placeholder.worker_id())
+               _ -> false
+             end)
+
+      assert t2.snapshot.materializer_refs[1] == %{"wkr_new" => node_string}
     end
 
     test "pre-existing placeholder refs are not republished — same name, same node, still valid" do
@@ -1090,6 +1134,212 @@ defmodule Bedrock.ControlPlane.Distributor.ServerTest do
         end)
 
       assert log =~ "retiring wkr_dead"
+    end
+
+    test "a placeholder left by a PRIOR epoch's node is replaced, not trusted" do
+      test_pid = self()
+      ref = make_ref()
+
+      # A previous distributor on a now-dead node leaked its placeholder
+      # key. Presence alone must not count as coverage: parking against
+      # a dead node fails reads instead of holding them, and no local
+      # placeholder ever hears the demand.
+      t =
+        test_pid
+        |> healing_state(
+          snapshot: %{
+            shard_layout: %{},
+            materializer_refs: %{
+              7 => %{"wkr_dead" => Atom.to_string(node()), Placeholder.worker_id() => "gone@elsewhere"}
+            }
+          }
+        )
+        |> Map.put(:assignment_monitors, %{ref => {7, "wkr_dead"}})
+
+      ExUnit.CaptureLog.capture_log(fn ->
+        assert {:noreply, t2} = Server.handle_info({:DOWN, ref, :process, self(), :killed}, t)
+
+        assert_received {:committed, encoded}
+        assert {:ok, mutations} = Transaction.mutations(encoded)
+
+        assert Enum.any?(Enum.to_list(mutations), fn
+                 {:set, key, value} ->
+                   key == HealKeys.materializer_key(7, Placeholder.worker_id()) and
+                     HealValues.decode_materializer_node(value) == {:ok, Atom.to_string(node())}
+
+                 _ ->
+                   false
+               end)
+
+        assert t2.snapshot.materializer_refs[7] == %{Placeholder.worker_id() => Atom.to_string(node())}
+      end)
+    end
+
+    # A placeholder stub that keeps relaying every cast, so a test can
+    # observe more than one notification.
+    defp relaying_placeholder(test_pid) do
+      spawn(fn ->
+        relay = fn relay ->
+          receive do
+            {:"$gen_cast", msg} ->
+              send(test_pid, {:placeholder_got, msg})
+              relay.(relay)
+          end
+        end
+
+        relay.(relay)
+      end)
+    end
+
+    test "retiring one of several members leaves the tag covered and points the placeholder at the survivor" do
+      test_pid = self()
+      ref = make_ref()
+      node_string = Atom.to_string(node())
+
+      t =
+        test_pid
+        |> healing_state(
+          snapshot: %{
+            shard_layout: %{},
+            materializer_refs: %{7 => %{"wkr_dead" => node_string, "wkr_live" => node_string}}
+          },
+          placeholder: relaying_placeholder(test_pid)
+        )
+        |> Map.put(:assignment_monitors, %{ref => {7, "wkr_dead"}})
+
+      ExUnit.CaptureLog.capture_log(fn ->
+        assert {:noreply, t2} = Server.handle_info({:DOWN, ref, :process, self(), :killed}, t)
+
+        assert_received {:committed, encoded}
+        assert {:ok, mutations} = Transaction.mutations(encoded)
+        mutations = Enum.to_list(mutations)
+
+        # The survivor still covers the shard, so no placeholder is added.
+        refute Enum.any?(mutations, fn
+                 {:set, key, _} -> key == HealKeys.materializer_key(7, Placeholder.worker_id())
+                 _ -> false
+               end)
+
+        assert Enum.any?(mutations, fn
+                 {:clear, key} -> key == HealKeys.materializer_key(7, "wkr_dead")
+                 _ -> false
+               end)
+
+        # The placeholder must learn the survivor: it may still be
+        # forwarding to the corpse from an earlier notify_covered.
+        assert_receive {:placeholder_got, {:covered, 7, _survivor_ref}}
+        refute_received {:placeholder_got, {:uncovered, 7}}
+
+        assert t2.snapshot.materializer_refs[7] == %{"wkr_live" => node_string}
+      end)
+    end
+
+    test "retiring a member disarms its monitor — a later death cannot re-heal a tag that already healed" do
+      test_pid = self()
+      ref = make_ref()
+      node_string = Atom.to_string(node())
+
+      t =
+        test_pid
+        |> healing_state(
+          snapshot: %{
+            shard_layout: %{},
+            materializer_refs: %{7 => %{"wkr_dead" => node_string, "wkr_live" => node_string}}
+          },
+          placeholder: relaying_placeholder(test_pid)
+        )
+        |> Map.put(:assignment_monitors, %{ref => {7, "wkr_dead"}})
+
+      ExUnit.CaptureLog.capture_log(fn ->
+        # Retire via a verification failure: this path does NOT pop the
+        # monitor the way a DOWN does, so a stale monitor would survive.
+        assert {:noreply, t2} =
+                 Server.handle_info({:assignment_verified, 7, "wkr_dead", {:error, :wrong_epoch}}, t)
+
+        assert_received {:committed, _}
+        refute Map.has_key?(t2.snapshot.materializer_refs[7], "wkr_dead")
+
+        # The monitor for the retired member must be gone; otherwise its
+        # eventual death recruits a redundant replica, unboundedly.
+        refute Enum.any?(t2.assignment_monitors, fn {_ref, member} -> member == {7, "wkr_dead"} end)
+      end)
+    end
+
+    test "a stale DOWN for an already-retired member is ignored, not healed into a redundant replica" do
+      test_pid = self()
+      ref = make_ref()
+
+      # The member is no longer in the committed set; the monitor is a
+      # leftover. Healing here would recruit a replica nothing asked for.
+      t =
+        test_pid
+        |> healing_state(
+          snapshot: %{shard_layout: %{}, materializer_refs: %{7 => %{"wkr_live" => Atom.to_string(node())}}}
+        )
+        |> Map.put(:assignment_monitors, %{ref => {7, "wkr_gone"}})
+
+      ExUnit.CaptureLog.capture_log(fn ->
+        assert {:noreply, t2} = Server.handle_info({:DOWN, ref, :process, self(), :killed}, t)
+
+        refute_received {:committed, _}
+        refute MapSet.member?(t2.recruiting, 7)
+      end)
+    end
+
+    test "a pending retirement is cancelled when the member is legitimately re-published" do
+      test_pid = self()
+      ref = make_ref()
+      node_string = Atom.to_string(node())
+
+      t = healing_state(test_pid, [])
+      good_deps = t.deps
+      failing = Map.put(good_deps, :commit_fn, fn _p, _e, _t, _o -> {:error, :timeout} end)
+      t = Map.merge(t, %{deps: failing, assignment_monitors: %{ref => {7, "wkr_dead"}}, backoff_ms: 5})
+
+      ExUnit.CaptureLog.capture_log(fn ->
+        # The retirement commit fails transiently and schedules a retry.
+        assert {:noreply, t2} = Server.handle_info({:DOWN, ref, :process, self(), :killed}, t)
+        assert_receive {:retire_member, 7, "wkr_dead"}, 200
+
+        # ...but the worker turns out to be alive and IS this epoch's:
+        # the verification probe adopts it and re-publishes its key.
+        t3 = %{t2 | deps: good_deps}
+
+        assert {:noreply, t4} =
+                 Server.handle_info(
+                   {:assignment_verified, 7, "wkr_dead", {:adopted, self(), node(), "wkr_dead"}},
+                   t3
+                 )
+
+        # The stale retry must not retire the freshly adopted worker.
+        assert {:noreply, t5} = Server.handle_info({:retire_member, 7, "wkr_dead"}, t4)
+        assert t5.snapshot.materializer_refs[7] == %{"wkr_dead" => node_string}
+      end)
+    end
+
+    test "a member awaiting retirement is never handed to the placeholder as coverage" do
+      test_pid = self()
+      ref = make_ref()
+
+      t = healing_state(test_pid, placeholder: relaying_placeholder(test_pid))
+
+      t =
+        Map.merge(t, %{
+          deps: Map.put(t.deps, :commit_fn, fn _p, _e, _t, _o -> {:error, :timeout} end),
+          assignment_monitors: %{ref => {7, "wkr_dead"}},
+          backoff_ms: 50
+        })
+
+      ExUnit.CaptureLog.capture_log(fn ->
+        assert {:noreply, t2} = Server.handle_info({:DOWN, ref, :process, self(), :killed}, t)
+
+        # The local view still names the corpse (honest: so does the
+        # keyspace). A demand must NOT drain parked reads into it.
+        assert {:noreply, t3} = Server.handle_cast({:coverage_demand, 7}, t2)
+
+        refute_received {:placeholder_got, {:covered, 7, _}}
+        assert MapSet.member?(t3.recruiting, 7)
+      end)
     end
 
     test "a retirement retry for a member already gone is a no-op" do

--- a/test/bedrock/control_plane/distributor/transactions_test.exs
+++ b/test/bedrock/control_plane/distributor/transactions_test.exs
@@ -176,7 +176,7 @@ defmodule Bedrock.ControlPlane.Distributor.TransactionsTest do
           end
         })
 
-      payload = {:set, SystemKeys.materializer_key(7), "payload"}
+      payload = {:set, SystemKeys.materializer_key(7, "wkr_a"), "payload"}
       assert :ok = Transactions.commit_checked(lock, deps, [payload])
 
       owner_key = SystemKeys.distributor_lock_owner()
@@ -196,7 +196,7 @@ defmodule Bedrock.ControlPlane.Distributor.TransactionsTest do
 
       assert {:ok, mutations} = Transaction.mutations(encoded)
       mutations = Enum.to_list(mutations)
-      assert {:set, SystemKeys.materializer_key(7), "payload"} in mutations
+      assert {:set, SystemKeys.materializer_key(7, "wkr_a"), "payload"} in mutations
       assert Enum.any?(mutations, &match?({:set, ^write_key, _fresh}, &1))
     end
 
@@ -290,7 +290,7 @@ defmodule Bedrock.ControlPlane.Distributor.TransactionsTest do
       v = Version.from_integer(77)
 
       shard_entries = [{SystemKeys.shard_key(<<0xFF, 0xFF>>), V.encode_shard_key_entry(0, <<>>)}]
-      ref_entries = [{SystemKeys.materializer_key(0), V.encode_materializer_ref("wkr", "n@h")}]
+      ref_entries = [{SystemKeys.materializer_key(0, "wkr"), V.encode_materializer_node("n@h")}]
 
       deps =
         deps(%{
@@ -307,7 +307,7 @@ defmodule Bedrock.ControlPlane.Distributor.TransactionsTest do
 
       assert {:ok, %{shard_layout: layout, materializer_refs: refs}} = Transactions.read_snapshot(deps)
       assert layout == %{<<0xFF, 0xFF>> => {0, <<>>}}
-      assert refs == %{0 => {"wkr", "n@h"}}
+      assert refs == %{0 => %{"wkr" => "n@h"}}
 
       assert_received {:range_read, _shard_start, ^v}
       assert_received {:range_read, _refs_start, ^v}

--- a/test/bedrock/data_plane/commit_proxy/fetch_routing_cadence_test.exs
+++ b/test/bedrock/data_plane/commit_proxy/fetch_routing_cadence_test.exs
@@ -29,7 +29,7 @@ defmodule Bedrock.DataPlane.CommitProxy.FetchRoutingCadenceTest do
       shard_layout: %{<<0xFF, 0xFF>> => {0, <<>>}},
       log_map: %{},
       log_services: %{},
-      materializers: %{0 => {"wkr_sys", "n1@host"}},
+      materializers: %{0 => %{"wkr_sys" => "n1@host"}},
       replication_factor: 1
     })
   end
@@ -59,33 +59,34 @@ defmodule Bedrock.DataPlane.CommitProxy.FetchRoutingCadenceTest do
              Server.handle_call({:fetch_routing, "a"}, from(), struct!(%State{mode: :locked}, []))
   end
 
-  describe "resolve_materializer" do
+  describe "materializer_members" do
     defp routing_with(materializers), do: %{RoutingData.new_empty() | materializers: materializers}
 
-    test "answers the tag's committed entry and resumes the cadence" do
-      state = running_state(batch: nil, routing_data: routing_with(%{7 => {"w7", "node@host"}}))
+    test "answers the tag's whole committed member set and resumes the cadence" do
+      members = %{"w7" => "node@host", "w7b" => "other@host"}
+      state = running_state(batch: nil, routing_data: routing_with(%{7 => members}))
 
-      assert {:noreply, _t, 1_234} = Server.handle_call({:resolve_materializer, 7}, from(), state)
-      assert_received {_ref, {:ok, {"w7", "node@host"}}}
+      assert {:noreply, _t, 1_234} = Server.handle_call({:materializer_members, 7}, from(), state)
+      assert_received {_ref, {:ok, ^members}}
     end
 
     test "an unnamed tag is authoritatively :not_found" do
       state = running_state(batch: nil, routing_data: routing_with(%{}))
 
-      assert {:noreply, _t, 1_234} = Server.handle_call({:resolve_materializer, 7}, from(), state)
+      assert {:noreply, _t, 1_234} = Server.handle_call({:materializer_members, 7}, from(), state)
       assert_received {_ref, {:error, :not_found}}
     end
 
     test "with an open batch, the zero timeout is re-armed" do
       state = running_state(batch: %Batch{}, routing_data: routing_with(%{}))
 
-      assert {:noreply, _t, 0} = Server.handle_call({:resolve_materializer, 1}, from(), state)
+      assert {:noreply, _t, 0} = Server.handle_call({:materializer_members, 1}, from(), state)
     end
 
     test "a locked proxy refuses — not a verdict" do
       state = struct!(%State{mode: :locked}, [])
 
-      assert {:reply, {:error, :locked}, _t} = Server.handle_call({:resolve_materializer, 7}, from(), state)
+      assert {:reply, {:error, :locked}, _t} = Server.handle_call({:materializer_members, 7}, from(), state)
     end
   end
 

--- a/test/bedrock/data_plane/commit_proxy/metadata_distribution_integration_test.exs
+++ b/test/bedrock/data_plane/commit_proxy/metadata_distribution_integration_test.exs
@@ -83,7 +83,7 @@ defmodule Bedrock.DataPlane.CommitProxy.MetadataDistributionIntegrationTest do
       shard_layout: %{<<0xFF, 0xFF>> => {0, <<>>}},
       log_map: %{0 => "log_1"},
       log_services: %{"log_1" => log},
-      materializers: %{0 => {"wkr_sys", "n1@host"}},
+      materializers: %{0 => %{"wkr_sys" => "n1@host"}},
       replication_factor: 1
     }
 
@@ -255,7 +255,7 @@ defmodule Bedrock.DataPlane.CommitProxy.MetadataDistributionIntegrationTest do
     test "committed shard and materializer mutations reach served covering entries", %{proxy: proxy, epoch: epoch} do
       mutations = [
         {:set, SystemKeys.shard_key("m"), Values.encode_shard_key_entry(7, "")},
-        {:set, SystemKeys.materializer_key(7), Values.encode_materializer_ref("wkr_new", "n2@host")}
+        {:set, SystemKeys.materializer_key(7, "wkr_new"), Values.encode_materializer_node("n2@host")}
       ]
 
       version = commit!(proxy, epoch, mutations, "routing_key")

--- a/test/bedrock/data_plane/commit_proxy/routing_data_test.exs
+++ b/test/bedrock/data_plane/commit_proxy/routing_data_test.exs
@@ -43,8 +43,8 @@ defmodule Bedrock.DataPlane.CommitProxy.RoutingDataTest do
 
       assert RoutingData.from_snapshot(base).materializers == %{}
 
-      with_refs = Map.put(base, :materializers, %{0 => {"wkr_sys", "n1@host"}})
-      assert RoutingData.from_snapshot(with_refs).materializers == %{0 => {"wkr_sys", "n1@host"}}
+      with_refs = Map.put(base, :materializers, %{0 => %{"wkr_sys" => "n1@host"}})
+      assert RoutingData.from_snapshot(with_refs).materializers == %{0 => %{"wkr_sys" => "n1@host"}}
     end
 
     test "is a plain immutable value: derived copies do not affect the original" do
@@ -68,7 +68,7 @@ defmodule Bedrock.DataPlane.CommitProxy.RoutingDataTest do
         shard_layout: %{"m" => {1, ""}, <<0xFF, 0xFF>> => {0, "m"}},
         log_map: %{0 => "log-a"},
         log_services: %{"log-a" => {:log_a, :node1}},
-        materializers: %{0 => {"wkr_sys", "n1@host"}, 1 => {"wkr_a", "n1@host"}},
+        materializers: %{0 => %{"wkr_sys" => "n1@host"}, 1 => %{"wkr_a" => "n1@host"}},
         replication_factor: 1
       })
     end
@@ -98,6 +98,62 @@ defmodule Bedrock.DataPlane.CommitProxy.RoutingDataTest do
         })
 
       assert RoutingData.covering_entry(routing, "apple") == {:error, :not_found}
+    end
+
+    test "a tag whose members are all gone is :not_found — an empty set is no coverage" do
+      routing =
+        RoutingData.from_snapshot(%{
+          shard_layout: %{"m" => {1, ""}},
+          log_map: %{},
+          log_services: %{},
+          materializers: %{1 => %{}},
+          replication_factor: 1
+        })
+
+      assert RoutingData.covering_entry(routing, "apple") == {:error, :not_found}
+    end
+  end
+
+  describe "a tag's members: selection and membership" do
+    defp with_members(members) do
+      RoutingData.from_snapshot(%{
+        shard_layout: %{"m" => {1, ""}},
+        log_map: %{},
+        log_services: %{},
+        materializers: %{1 => members},
+        replication_factor: 1
+      })
+    end
+
+    test "routing prefers a real worker over the placeholder — coverage beats parking" do
+      routing = with_members(%{SystemKeys.placeholder_worker_id() => "n0@host", "wkr_a" => "n1@host"})
+
+      assert RoutingData.covering_entry(routing, "apple") == {:ok, {"", "m", 1, {"wkr_a", "n1@host"}}}
+    end
+
+    test "the placeholder answers only when no real worker does" do
+      placeholder = SystemKeys.placeholder_worker_id()
+      routing = with_members(%{placeholder => "n0@host"})
+
+      assert RoutingData.covering_entry(routing, "apple") == {:ok, {"", "m", 1, {placeholder, "n0@host"}}}
+    end
+
+    test "the pick among several real workers is deterministic — every proxy answers alike" do
+      routing = with_members(%{"wkr_c" => "n3@host", "wkr_a" => "n1@host", "wkr_b" => "n2@host"})
+
+      assert {:ok, {_, _, _, picked}} = RoutingData.covering_entry(routing, "apple")
+      assert picked == {"wkr_a", "n1@host"}
+
+      # Insertion order must not change the answer.
+      reordered = with_members(%{"wkr_b" => "n2@host", "wkr_c" => "n3@host", "wkr_a" => "n1@host"})
+      assert {:ok, {_, _, _, ^picked}} = RoutingData.covering_entry(reordered, "apple")
+    end
+
+    test "materializer_members/2 answers the whole set — the worker's own question is membership" do
+      routing = with_members(%{"wkr_a" => "n1@host", "wkr_b" => "n2@host"})
+
+      assert RoutingData.materializer_members(routing, 1) == {:ok, %{"wkr_a" => "n1@host", "wkr_b" => "n2@host"}}
+      assert RoutingData.materializer_members(routing, 9) == {:error, :not_found}
     end
   end
 
@@ -232,26 +288,26 @@ defmodule Bedrock.DataPlane.CommitProxy.RoutingDataTest do
 
     test "handles materializer_key set mutation - decoded refs stay strings" do
       updates = [
-        {v(100), [{:set, SystemKeys.materializer_key(7), Values.encode_materializer_ref("wkr_a", "n1@host")}]}
+        {v(100), [{:set, SystemKeys.materializer_key(7, "wkr_a"), Values.encode_materializer_node("n1@host")}]}
       ]
 
       updated = RoutingData.apply_mutations(RoutingData.new_empty(), updates)
 
-      assert updated.materializers == %{7 => {"wkr_a", "n1@host"}}
+      assert updated.materializers == %{7 => %{"wkr_a" => "n1@host"}}
     end
 
     test "skips a materializer_key set whose value does not decode, keeping the last good entry" do
-      routing_data = %{RoutingData.new_empty() | materializers: %{7 => {"wkr_a", "n1@host"}}}
+      routing_data = %{RoutingData.new_empty() | materializers: %{7 => %{"wkr_a" => "n1@host"}}}
 
-      updates = [{v(100), [{:set, SystemKeys.materializer_key(7), <<0xEE, 0xEE>>}]}]
+      updates = [{v(100), [{:set, SystemKeys.materializer_key(7, "wkr_a"), <<0xEE, 0xEE>>}]}]
 
-      assert RoutingData.apply_mutations(routing_data, updates).materializers == %{7 => {"wkr_a", "n1@host"}}
+      assert RoutingData.apply_mutations(routing_data, updates).materializers == %{7 => %{"wkr_a" => "n1@host"}}
     end
 
     test "handles materializer_key clear mutation" do
-      routing_data = %{RoutingData.new_empty() | materializers: %{7 => {"wkr_a", "n1@host"}}}
+      routing_data = %{RoutingData.new_empty() | materializers: %{7 => %{"wkr_a" => "n1@host"}}}
 
-      updates = [{v(100), [{:clear, SystemKeys.materializer_key(7)}]}]
+      updates = [{v(100), [{:clear, SystemKeys.materializer_key(7, "wkr_a")}]}]
 
       assert RoutingData.apply_mutations(routing_data, updates).materializers == %{}
     end
@@ -259,7 +315,11 @@ defmodule Bedrock.DataPlane.CommitProxy.RoutingDataTest do
     test "clear_range over the materializers prefix drops covered entries only" do
       routing_data = %{
         RoutingData.new_empty()
-        | materializers: %{0 => {"wkr_sys", "n1@host"}, 7 => {"wkr_a", "n1@host"}, 12 => {"wkr_b", "n2@host"}}
+        | materializers: %{
+            0 => %{"wkr_sys" => "n1@host"},
+            7 => %{"wkr_a" => "n1@host", "wkr_b" => "n3@host"},
+            12 => %{"wkr_b" => "n2@host"}
+          }
       }
 
       prefix = SystemKeys.materializers_prefix()
@@ -269,12 +329,12 @@ defmodule Bedrock.DataPlane.CommitProxy.RoutingDataTest do
     end
 
     test "clear_range over an unrelated family leaves materializers untouched" do
-      routing_data = %{RoutingData.new_empty() | materializers: %{7 => {"wkr_a", "n1@host"}}}
+      routing_data = %{RoutingData.new_empty() | materializers: %{7 => %{"wkr_a" => "n1@host"}}}
 
       prefix = SystemKeys.shard_keys_prefix()
       updates = [{v(100), [{:clear_range, prefix, prefix <> <<0xFF>>}]}]
 
-      assert RoutingData.apply_mutations(routing_data, updates).materializers == %{7 => {"wkr_a", "n1@host"}}
+      assert RoutingData.apply_mutations(routing_data, updates).materializers == %{7 => %{"wkr_a" => "n1@host"}}
     end
 
     test "handles shard_key clear mutation" do

--- a/test/bedrock/data_plane/materializer/olivine/displacement_test.exs
+++ b/test/bedrock/data_plane/materializer/olivine/displacement_test.exs
@@ -24,7 +24,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.DisplacementTest do
     def init(reply), do: {:ok, reply}
 
     @impl true
-    def handle_call({:resolve_materializer, _tag}, _from, reply), do: {:reply, reply, reply}
+    def handle_call({:materializer_members, _tag}, _from, reply), do: {:reply, reply, reply}
   end
 
   defp state(overrides) do
@@ -34,7 +34,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.DisplacementTest do
   defp tsl(epoch, proxies), do: %{epoch: epoch, proxies: proxies, logs: %{}, sequencer: nil, resolvers: []}
 
   test "the keyspace naming another worker retires this one" do
-    {:ok, proxy} = StubProxy.start_link({:ok, {"someone-else", "node@host"}})
+    {:ok, proxy} = StubProxy.start_link({:ok, %{"someone-else" => "node@host"}})
 
     capture_log(fn ->
       assert {:stop, {:shutdown, :displaced}, _t} =
@@ -56,7 +56,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.DisplacementTest do
   end
 
   test "the keyspace still naming this worker keeps it" do
-    {:ok, proxy} = StubProxy.start_link({:ok, {"mat-1", "node@host"}})
+    {:ok, proxy} = StubProxy.start_link({:ok, %{"mat-1" => "node@host"}})
 
     assert {:noreply, _t} = Server.handle_info({:tsl_updated, tsl(3, [proxy])}, state([]))
     refute_received {:"$gen_cast", {:worker_retired, _}}
@@ -70,7 +70,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.DisplacementTest do
   end
 
   test "an unreachable proxy is not a verdict" do
-    {:ok, proxy} = StubProxy.start_link({:ok, {"mat-1", "node@host"}})
+    {:ok, proxy} = StubProxy.start_link({:ok, %{"mat-1" => "node@host"}})
     GenServer.stop(proxy)
 
     assert {:noreply, _t} = Server.handle_info({:tsl_updated, tsl(3, [proxy])}, state([]))
@@ -114,5 +114,16 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.DisplacementTest do
 
   test "a push with no proxies cannot validate — keep" do
     assert {:noreply, _t} = Server.handle_info({:tsl_updated, tsl(3, [])}, state([]))
+  end
+
+  test "a sibling replica's presence is not displacement — membership, not resolution" do
+    # The set names this worker AND another materializer for the same
+    # shard. Under set-valued membership (bedrock-q67.21.9) a shard may
+    # legitimately have several materializers, so the only question is
+    # whether the set still contains ME.
+    {:ok, proxy} = StubProxy.start_link({:ok, %{"mat-1" => "node@host", "sibling" => "other@host"}})
+
+    assert {:noreply, _t} =
+             Server.handle_info({:tsl_updated, %{epoch: 2, proxies: [proxy]}}, state(id: "mat-1", shard_num: 3))
   end
 end

--- a/test/bedrock/system_keys/values_test.exs
+++ b/test/bedrock/system_keys/values_test.exs
@@ -38,21 +38,21 @@ defmodule Bedrock.SystemKeys.ValuesTest do
 
   describe "materializer refs" do
     test "round-trip" do
-      assert {:ok, {"wkr_abc", "node@host"}} =
-               Values.decode_materializer_ref(Values.encode_materializer_ref("wkr_abc", "node@host"))
+      # The worker id lives in the KEY now; the value carries only what a
+      # consumer needs to build the callable ref.
+      assert {:ok, "node@host"} = Values.decode_materializer_node(Values.encode_materializer_node("node@host"))
     end
 
     test "encoder rejects non-binary input loudly - refs are encoded as strings, never atoms or pids" do
-      assert_raise FunctionClauseError, fn -> Values.encode_materializer_ref(:worker_name, "node@host") end
-      assert_raise FunctionClauseError, fn -> Values.encode_materializer_ref("wkr_abc", :node@host) end
-      assert_raise FunctionClauseError, fn -> Values.encode_materializer_ref(self(), "node@host") end
+      assert_raise FunctionClauseError, fn -> Values.encode_materializer_node(:node@host) end
+      assert_raise FunctionClauseError, fn -> Values.encode_materializer_node(self()) end
     end
 
     test "decoder never raises on garbage or wrong shapes, and never creates atoms" do
-      assert {:error, :invalid_encoding} = Values.decode_materializer_ref(<<0xEE, 0xEE>>)
-      assert {:error, :invalid_type} = Values.decode_materializer_ref(Values.encode_tag_list([1]))
-      assert {:error, :invalid_type} = Values.decode_materializer_ref(Values.encode_shard_key_entry(1, "m"))
-      assert {:error, :invalid_encoding} = Values.decode_materializer_ref(:not_binary)
+      assert {:error, :invalid_encoding} = Values.decode_materializer_node(<<0xEE, 0xEE>>)
+      assert {:error, :invalid_type} = Values.decode_materializer_node(Values.encode_tag_list([1]))
+      assert {:error, :invalid_type} = Values.decode_materializer_node(Values.encode_shard_key_entry(1, "m"))
+      assert {:error, :invalid_encoding} = Values.decode_materializer_node(:not_binary)
     end
   end
 
@@ -60,13 +60,13 @@ defmodule Bedrock.SystemKeys.ValuesTest do
     test "dispatches by parsed key family" do
       shard_value = Values.encode_shard_key_entry(3, "a")
       log_value = Values.encode_tag_list([0, 1])
-      ref_value = Values.encode_materializer_ref("wkr_abc", "node@host")
+      ref_value = Values.encode_materializer_node("node@host")
 
       assert {:ok, {3, "a"}} = Values.decode_for(SystemKeys.parse_key(SystemKeys.shard_key("m")), shard_value)
       assert {:ok, [0, 1]} = Values.decode_for(SystemKeys.parse_key(SystemKeys.layout_log("log_1")), log_value)
 
-      assert {:ok, {"wkr_abc", "node@host"}} =
-               Values.decode_for(SystemKeys.parse_key(SystemKeys.materializer_key(7)), ref_value)
+      assert {:ok, "node@host"} =
+               Values.decode_for(SystemKeys.parse_key(SystemKeys.materializer_key(7, "wkr_abc")), ref_value)
     end
 
     test "unknown families decode as errors, never raise" do

--- a/test/bedrock/system_keys_test.exs
+++ b/test/bedrock/system_keys_test.exs
@@ -13,23 +13,36 @@ defmodule Bedrock.SystemKeysTest do
       assert SystemKeys.parse_key(SystemKeys.layout_log("log_1")) == {:layout_log, "log_1"}
     end
 
-    test "materializer_key/1 round-trips through parse_key/1" do
-      assert SystemKeys.parse_key(SystemKeys.materializer_key(0)) == {:materializer_key, 0}
-      assert SystemKeys.parse_key(SystemKeys.materializer_key(42)) == {:materializer_key, 42}
+    test "materializer_key/2 round-trips through parse_key/1, carrying tag AND worker" do
+      assert SystemKeys.parse_key(SystemKeys.materializer_key(0, "wkr_sys")) == {:materializer_key, 0, "wkr_sys"}
+      assert SystemKeys.parse_key(SystemKeys.materializer_key(42, "abc12def")) == {:materializer_key, 42, "abc12def"}
     end
 
-    test "materializer keys with non-integer tags parse as :unknown" do
-      assert SystemKeys.parse_key(SystemKeys.materializers_prefix() <> "not_a_tag") == :unknown
-      assert SystemKeys.parse_key(SystemKeys.materializers_prefix() <> "12x") == :unknown
+    test "a tag's members share a prefix that excludes neighbouring tags" do
+      prefix = SystemKeys.materializer_tag_prefix(7)
+
+      assert String.starts_with?(SystemKeys.materializer_key(7, "wkr_a"), prefix)
+      assert String.starts_with?(SystemKeys.materializer_key(7, "wkr_b"), prefix)
+      refute String.starts_with?(SystemKeys.materializer_key(70, "wkr_c"), prefix)
+      refute String.starts_with?(SystemKeys.materializer_key(1, "wkr_d"), prefix)
+    end
+
+    test "malformed materializer keys parse as :unknown" do
+      assert SystemKeys.parse_key(SystemKeys.materializers_prefix() <> "not_a_tag/wkr") == :unknown
+      assert SystemKeys.parse_key(SystemKeys.materializers_prefix() <> "12x/wkr") == :unknown
       assert SystemKeys.parse_key(SystemKeys.materializers_prefix()) == :unknown
+
+      # A tag with no worker is the prefix, not an entry.
+      assert SystemKeys.parse_key(SystemKeys.materializers_prefix() <> "7") == :unknown
+      assert SystemKeys.parse_key(SystemKeys.materializers_prefix() <> "7/") == :unknown
     end
 
     test "prefixes cover exactly their families" do
       assert String.starts_with?(SystemKeys.shard_key("x"), SystemKeys.shard_keys_prefix())
       assert String.starts_with?(SystemKeys.layout_log("x"), SystemKeys.layout_logs_prefix())
-      assert String.starts_with?(SystemKeys.materializer_key(3), SystemKeys.materializers_prefix())
+      assert String.starts_with?(SystemKeys.materializer_key(3, "wkr_a"), SystemKeys.materializers_prefix())
       refute String.starts_with?(SystemKeys.layout_log("x"), SystemKeys.shard_keys_prefix())
-      refute String.starts_with?(SystemKeys.materializer_key(3), SystemKeys.shard_keys_prefix())
+      refute String.starts_with?(SystemKeys.materializer_key(3, "wkr_a"), SystemKeys.shard_keys_prefix())
     end
 
     test "unknown system keys parse as :unknown, non-system keys as :error" do


### PR DESCRIPTION
First of two PRs on the `feature/q67-materializer-set` arc branch. Closes **bedrock-q67.21.9**; unblocks **bedrock-q67.21.6** (in-band retirement) and **bedrock-q67.46** (elastic replicas). Draft for review.

## Why the old shape had to go

`materializers/<tag> = {worker_id, node}` is single-valued, so it did not merely *assume* one materializer per shard — it **enforced** it. Any retirement predicate built on it ("the entry doesn't name me") makes a second instance suicide the moment it reads the stream. That forecloses placing an extra replica near a node reading a shard hot, which is where this architecture is going.

## FDB check

FDB is on the mechanism's side. Its shard membership is already a **set** — `keyServers/<range>` decodes to a team of server UIDs and the proxy `addTags` all of them — and removal is addressed **by key**: `serverKeys/<victim>/<range>`, never inferred from a value naming someone else. (My earlier reading conflated the `serverTag` path, which is whole-server retirement.) Where Bedrock genuinely diverges is *policy*: FDB's team size is fixed by the replication factor and DD rebalances which servers hold a shard, rather than adding one for read locality.

## The shape

`materializers/<tag>/<worker_id> = node`. Tag-major, member in the key. **One family answers what FDB needs two for** — a prefix scan gives a shard's members (the `keyServers` question) and each member is individually addressable (the `serverKeys` question) — because our notices broadcast on the shard tag rather than unicasting to a per-server tag, and a worker owns exactly one shard so it needs no self-index. Membership is key *presence*; removal is a clear. The value carries only what a consumer cannot derive.

## What stayed still

The client read path is unchanged by design: `covering_entry` picks deterministically (real workers before the placeholder, then lowest worker id), so every proxy answers alike and a client's retry lands consistently. Locality- and load-aware selection is q67.46's to add in that one function.

`resolve_materializer` becomes `materializer_members`: its only production caller is a worker's rejoin validation, whose real question under a set is **membership** — a sibling replica's presence is not displacement.

## Two collapses that fell out

- **The placeholder is now an ordinary member.** Parking ADDS instead of overwriting, so it can never destroy a live twin's entry; retirement clears the departing member's own key and adds the placeholder in the *same* fenced commit when the shard would otherwise be left uncovered. The parked/degraded two-state dance collapses to commit/retry/cede — a transient failure now keeps the local view honest and retries, instead of locally hiding a corpse the keyspace still names.
- **The verification reservation disappears.** An extra materializer is legal now, so a concurrent recruit costs a redundant worker rather than a lost heal — which removes the exact interaction behind the PR #195 audit's blocking finding.

Also fixes a real gap the new clears exposed: the distributor's transaction builder handled only sets.

## Tests

TDD: key/value round-trips with the composite key, member-set decoding, deterministic pick and placeholder preference, membership-not-resolution rejoin (plus a sibling-is-not-displacement pin), retirement-retry and no-reservation pins, and recovery diffing that never removes members it did not place. Full suite 2727 green, 3-seed sweep, credo --strict, dialyzer clean.