### PR TITLE
Delete the layout/logs keyspace family: a write with no reader

### DIFF
--- a/guides/quick-reads/system-keyspace.md
+++ b/guides/quick-reads/system-keyspace.md
@@ -46,14 +46,6 @@ Readers: `RoutingData` → per-key covering entries served to clients
 proxy answering for the committed state) checks whether the entry for
 its tag still names it; absence means retire.
 
-### `layout/logs/<log_id>` → tag list
-
-The epoch's log set. Log topology is epoch-constant — as in FoundationDB,
-changing it *is* a recovery — so runtime log wiring rides the recovery
-unlock seed, not mid-epoch mutations of this family. The keys are kept
-for other consumers and cluster-introspection tools: a durable, queryable
-statement of which logs the current epoch runs.
-
 ## Who writes, and the ownership handoff
 
 Recovery's **persistence phase** commits one system transaction per
@@ -62,8 +54,6 @@ epoch (`:system` mode — user commits are bounded below `\xFF`,
 FDB's `ACCESS_SYSTEM_KEYS` trust model), and follows FDB's rule that
 recovery never rewrites the mapping (bedrock-q67.21.2):
 
-- `layout/logs/` — the one epoch-scoped family: cleared and rewritten
-  each recovery (which logs THIS epoch runs).
 - `shard_keys/` — durable across epochs. Seeded only when this recovery
   invented the layout (fresh cluster, FDB's `seedShardServers`
   analogue); an existing cluster's layout is read back, and boundaries

--- a/lib/bedrock/control_plane/director/recovery/persistence_phase.ex
+++ b/lib/bedrock/control_plane/director/recovery/persistence_phase.ex
@@ -195,11 +195,17 @@ defmodule Bedrock.ControlPlane.Director.Recovery.PersistencePhase do
   # via the object-storage cluster bootstrap, which the coordinator
   # actually reads; services are rebuilt each recovery from foreman
   # discovery). Families return to the keyspace when their readers do
-  # (bedrock-q67.9, q67.25) - and only then: the log set is recorded
-  # where it is READ, in the cluster bootstrap the coordinator loads at
-  # cold start (FDB's DBCoreState) and in the epoch's broadcast wiring
-  # (FDB's logSystemConfig). A third copy here had no audience
-  # (bedrock-q67.21.10).
+  # (bedrock-q67.9, q67.25) - and only then. FDB does keep a keyspace
+  # copy of its log set (`\xff/logs`, SystemData.cpp:1171, written by the
+  # recovery transaction at ClusterRecovery.actor.cpp:1728), so the
+  # deleted layout/logs family was its analogue - but FDB's copy has
+  # three readers we have no equivalent of: recovery's stale-master
+  # fence (ClusterRecovery.actor.cpp:770-801), exclusion safety
+  # (ManagementAPI.actor.cpp:2394), and the in-progress-exclusion
+  # special-key module (SpecialKeySpace.actor.cpp:1294). Ours had none,
+  # and the tag mapping it held survives in the cluster bootstrap the
+  # coordinator actually loads. The family comes back when one of those
+  # readers does (bedrock-q67.21.10).
   @spec build_readable_keys(Tx.t(), RecoveryAttempt.t()) :: Tx.t()
   defp build_readable_keys(tx, recovery_attempt) do
     # The mapping families are durable, distributor-era state: recovery

--- a/lib/bedrock/control_plane/director/recovery/persistence_phase.ex
+++ b/lib/bedrock/control_plane/director/recovery/persistence_phase.ex
@@ -26,7 +26,6 @@ defmodule Bedrock.ControlPlane.Director.Recovery.PersistencePhase do
   alias Bedrock.DataPlane.Transaction
   alias Bedrock.Internal.Id
   alias Bedrock.Internal.TransactionBuilder.Tx
-  alias Bedrock.KeyRange
   alias Bedrock.ObjectStorage
   alias Bedrock.ObjectStorage.LocalFilesystem
   alias Bedrock.SystemKeys
@@ -189,30 +188,22 @@ defmodule Bedrock.ControlPlane.Director.Recovery.PersistencePhase do
   end
 
   # Every key written here has a named purpose: shard_keys/ feeds both
-  # RoutingData and the next recovery's materializer bootstrap,
-  # and materializers/ refs feed the client-facing routing projection
-  # (FDB's serverList analogue - runtime hints, never recovery input) and
-  # worker rejoin validation. layout/logs/ has no code reader by design:
-  # log wiring is epoch-constant and rides the unlock seed
-  # (bedrock-q67.41); the family stays durable for other consumers and
-  # cluster-introspection tools. Nothing else is written (config and
-  # policy travel via the object-storage cluster bootstrap, which the
-  # coordinator actually reads; services are rebuilt each recovery from
-  # foreman discovery). Families return to the keyspace when their
-  # readers do (bedrock-q67.9, q67.25).
+  # RoutingData and the next recovery's materializer bootstrap, and
+  # materializers/ refs feed the client-facing routing projection (FDB's
+  # serverList analogue - runtime hints, never recovery input) and worker
+  # rejoin validation. Nothing else is written (config and policy travel
+  # via the object-storage cluster bootstrap, which the coordinator
+  # actually reads; services are rebuilt each recovery from foreman
+  # discovery). Families return to the keyspace when their readers do
+  # (bedrock-q67.9, q67.25) - and only then: the log set is recorded
+  # where it is READ, in the cluster bootstrap the coordinator loads at
+  # cold start (FDB's DBCoreState) and in the epoch's broadcast wiring
+  # (FDB's logSystemConfig). A third copy here had no audience
+  # (bedrock-q67.21.10).
   @spec build_readable_keys(Tx.t(), RecoveryAttempt.t()) :: Tx.t()
   defp build_readable_keys(tx, recovery_attempt) do
-    # layout/logs is an epoch-scoped statement (which logs THIS epoch
-    # runs), so it alone is cleared and rewritten each recovery. The
-    # mapping families below are durable, distributor-era state: recovery
+    # The mapping families are durable, distributor-era state: recovery
     # reads and heals, never blanket-clears (bedrock-q67.21.2).
-    tx = clear_prefix(tx, SystemKeys.layout_logs_prefix())
-
-    tx =
-      Enum.reduce(recovery_attempt.transaction_system_layout.logs, tx, fn {log_id, log_descriptor}, tx ->
-        Tx.set(tx, SystemKeys.layout_log(log_id), Values.encode_tag_list(log_descriptor))
-      end)
-
     tx = build_shard_keys(tx, recovery_attempt)
     build_materializer_keys(tx, recovery_attempt)
   end
@@ -254,16 +245,6 @@ defmodule Bedrock.ControlPlane.Director.Recovery.PersistencePhase do
             end
         end
     end
-  end
-
-  # The epoch-scoped layout/logs family is cleared before its entries are
-  # written so a changed log set leaves no stale entries behind. The clear
-  # and the rewrite land in the same system transaction, so readers never
-  # observe a gap.
-  @spec clear_prefix(Tx.t(), Bedrock.key()) :: Tx.t()
-  defp clear_prefix(tx, prefix) do
-    {start_key, end_key} = KeyRange.from_prefix(prefix)
-    Tx.clear_range(tx, start_key, end_key)
   end
 
   # Creates shard_key(end_key) -> {tag, start_key} entries (ceiling

--- a/lib/bedrock/data_plane/commit_proxy/routing_data.ex
+++ b/lib/bedrock/data_plane/commit_proxy/routing_data.ex
@@ -212,8 +212,9 @@ defmodule Bedrock.DataPlane.CommitProxy.RoutingData do
   @doc """
   Applies metadata mutations to update routing data.
 
-  Handles shard_key and materializer_key mutations; layout_log mutations
-  are deliberately ignored (see the fold's layout_log clause).
+  Handles shard_key and materializer_key mutations. Any other system key
+  is ignored: log wiring is epoch-constant and rides the unlock seed, and
+  an unrecognized family is forward-compatibility, not an error.
 
   ## Parameters
 
@@ -241,21 +242,6 @@ defmodule Bedrock.DataPlane.CommitProxy.RoutingData do
           {:error, _} -> routing_data
         end
 
-      {:layout_log, _log_id} ->
-        # Log wiring is epoch-constant and seed-only: changing log
-        # topology IS a recovery (FDB: a new generation, a new
-        # logSystemConfig), so the only layout_log mutations that ever
-        # flow through a window are the recovery transaction's rewrite of
-        # the very set this proxy was just seeded with. Folding them was
-        # a second way of managing one table, guarding a hazard the
-        # recovery boundary precludes. The layout/logs/ FAMILY stays
-        # durable for other consumers and cluster-introspection tools —
-        # this fold just isn't a reader. Materializer refs below
-        # deliberately DO ride persisted data: they are client-facing
-        # hints, FDB serverList style, and the Distributor mutates them
-        # mid-epoch (bedrock-q67.21).
-        routing_data
-
       {:materializer_key, tag, worker_id} ->
         # Undecodable values are ignored, keeping the last good member set.
         case Values.decode_materializer_node(value) do
@@ -272,10 +258,6 @@ defmodule Bedrock.DataPlane.CommitProxy.RoutingData do
     case SystemKeys.parse_key(key) do
       {:shard_key, end_key} ->
         delete_shard(routing_data, end_key)
-
-      {:layout_log, _log_id} ->
-        # Epoch-constant; see the set clause.
-        routing_data
 
       {:materializer_key, tag, worker_id} ->
         drop_member(routing_data, tag, worker_id)

--- a/lib/bedrock/system_keys.ex
+++ b/lib/bedrock/system_keys.ex
@@ -44,14 +44,6 @@ defmodule Bedrock.SystemKeys do
   @spec shard_keys_prefix() :: Bedrock.key()
   def shard_keys_prefix, do: "#{@system_prefix}/shard_keys/"
 
-  @doc "Log layout entry: `layout/logs/<log_id>` -> tag list"
-  @spec layout_log(Bedrock.range_tag() | String.t()) :: Bedrock.key()
-  def layout_log(log_id), do: "#{@system_prefix}/layout/logs/#{log_id}"
-
-  @doc "Prefix covering every log layout entry"
-  @spec layout_logs_prefix() :: Bedrock.key()
-  def layout_logs_prefix, do: "#{@system_prefix}/layout/logs/"
-
   @doc """
   Membership entry: `materializers/<tag>/<worker_id>` -> node string.
 
@@ -97,15 +89,13 @@ defmodule Bedrock.SystemKeys do
   `:unknown` (forward compatibility); non-system keys as `:error`.
   """
   @spec parse_key(Bedrock.key()) ::
-          {:layout_log, String.t()}
-          | {:shard_key, Bedrock.key()}
+          {:shard_key, Bedrock.key()}
           | {:materializer_key, Bedrock.range_tag(), Worker.id()}
           | {:distributor_lock, :owner | :write}
           | :unknown
           | :error
   def parse_key(<<@system_prefix, "/distributor_lock/owner">>), do: {:distributor_lock, :owner}
   def parse_key(<<@system_prefix, "/distributor_lock/write">>), do: {:distributor_lock, :write}
-  def parse_key(<<@system_prefix, "/layout/logs/", rest::binary>>), do: {:layout_log, rest}
   def parse_key(<<@system_prefix, "/shard_keys/", rest::binary>>), do: {:shard_key, rest}
 
   def parse_key(<<@system_prefix, "/materializers/", rest::binary>>) do

--- a/lib/bedrock/system_keys.ex
+++ b/lib/bedrock/system_keys.ex
@@ -7,11 +7,7 @@ defmodule Bedrock.SystemKeys do
   the next recovery's materializer bootstrap; `materializers/<tag>/<worker_id>` entries
   feed the client-facing routing projection served by commit proxies
   (FDB's `serverList/` analogue - interfaces ride the keyspace) and answer
-  worker rejoin validation. `layout/logs/<log_id>` keys have no code
-  reader by design: log wiring is epoch-constant and rides the recovery
-  unlock seed (bedrock-q67.41) - the family stays durable for other
-  consumers and cluster-introspection tools, a queryable statement of
-  which logs the current epoch runs. Materializer refs are runtime hints
+  worker rejoin validation. Materializer members are runtime hints
   for clients, never recovery input: bootstrap rebuilds assignment from
   `shard_keys/` plus live foreman discovery. `distributor_lock/{owner,
   write}` is the distributor's write fence (FDB's MoveKeys lock,

--- a/lib/bedrock/system_keys/values.ex
+++ b/lib/bedrock/system_keys/values.ex
@@ -8,10 +8,9 @@ defmodule Bedrock.SystemKeys.Values do
   bytes must never create atoms.
 
   The surface is exactly the written families - `shard_keys/` entries
-  (the routing boundary map), `layout/logs/` tag lists (no code reader by
-  design: kept durable for introspection, see `Bedrock.SystemKeys`), and
-  `materializers/` refs (worker id and node as strings; consumers derive
-  the callable `{otp_name, node}` ref, so the no-atoms rule holds through
+  (the routing boundary map) and `materializers/` membership (the node as
+  a string; consumers derive the callable `{otp_name, node}` ref from it
+  and the worker id in the key, so the no-atoms rule holds through
   decode). Families return here when their readers do.
   """
 

--- a/lib/bedrock/system_keys/values.ex
+++ b/lib/bedrock/system_keys/values.ex
@@ -19,16 +19,6 @@ defmodule Bedrock.SystemKeys.Values do
 
   @type decode_error :: {:error, :invalid_encoding | :invalid_type | :unknown_family}
 
-  @doc "Encodes a list of integer range tags (log descriptor)."
-  @spec encode_tag_list([Bedrock.range_tag()]) :: binary()
-  def encode_tag_list(tags) when is_list(tags) do
-    if Enum.all?(tags, &is_integer/1) do
-      TupleEncoding.pack(tags)
-    else
-      raise ArgumentError, "tag list must contain only integers: #{inspect(tags)}"
-    end
-  end
-
   @doc """
   Encodes a shard key entry: `{tag, start_key}`.
 
@@ -54,10 +44,6 @@ defmodule Bedrock.SystemKeys.Values do
   @spec encode_materializer_node(String.t()) :: binary()
   def encode_materializer_node(node) when is_binary(node), do: TupleEncoding.pack(node)
 
-  @doc "Decodes a list of integer range tags."
-  @spec decode_tag_list(binary()) :: {:ok, [Bedrock.range_tag()]} | decode_error()
-  def decode_tag_list(binary), do: safe_unpack(binary, &(is_list(&1) and Enum.all?(&1, fn t -> is_integer(t) end)))
-
   @doc "Decodes a shard key entry to `{:ok, {tag, start_key}}`."
   @spec decode_shard_key_entry(binary()) :: {:ok, {Bedrock.range_tag(), Bedrock.key()}} | decode_error()
   def decode_shard_key_entry(binary),
@@ -74,7 +60,6 @@ defmodule Bedrock.SystemKeys.Values do
   @spec decode_for(term(), binary()) :: {:ok, term()} | decode_error()
   def decode_for({:distributor_lock, _which}, value), do: decode_lock_uid(value)
   def decode_for({:shard_key, _end_key}, value), do: decode_shard_key_entry(value)
-  def decode_for({:layout_log, _log_id}, value), do: decode_tag_list(value)
   def decode_for({:materializer_key, _tag, _worker_id}, value), do: decode_materializer_node(value)
   def decode_for(_unknown, _value), do: {:error, :unknown_family}
 

--- a/test/bedrock/control_plane/director/recovery/persistence_phase_test.exs
+++ b/test/bedrock/control_plane/director/recovery/persistence_phase_test.exs
@@ -5,7 +5,6 @@ defmodule Bedrock.ControlPlane.Director.Recovery.PersistencePhaseTest do
 
   alias Bedrock.ControlPlane.Director.Recovery.PersistencePhase
   alias Bedrock.DataPlane.Transaction
-  alias Bedrock.Key
   alias Bedrock.KeyRange
   alias Bedrock.SystemKeys
   alias Bedrock.SystemKeys.Values
@@ -107,8 +106,6 @@ defmodule Bedrock.ControlPlane.Director.Recovery.PersistencePhaseTest do
       # the shape the materializer bootstrap cross-epoch read depends on.
       assert decoded[{:shard_key, <<0xFF>>}] == {1, <<>>}
       assert decoded[{:shard_key, <<0xFF, 0xFF>>}] == {0, <<0xFF>>}
-
-      assert decoded[{:layout_log, "log_1"}] == [1, 2]
 
       # Membership: the worker id is in the KEY and the value carries the
       # node (FDB serverKeys analogue), projected from the carried
@@ -225,35 +222,17 @@ defmodule Bedrock.ControlPlane.Director.Recovery.PersistencePhaseTest do
   end
 
   describe "read-and-heal: recovery writes what it changed, never blanket-clears" do
-    test "only layout/logs is cleared and rewritten; the mapping families are never blanket-cleared" do
+    test "recovery clears nothing: every family it writes is read-and-healed" do
       mutations = captured_system_mutations(base_recovery_attempt())
 
-      {log_clear_start, log_clear_end} = KeyRange.from_prefix(SystemKeys.layout_logs_prefix())
+      # The epoch-scoped layout/logs family was the only thing recovery
+      # ever blanket-cleared, and it had no reader (bedrock-q67.21.10).
+      # What remains is durable, distributor-era state: recovery may seed
+      # or update entries, never erase a family wholesale.
+      refute Enum.any?(mutations, &match?({:clear_range, _, _}, &1)),
+             "recovery emitted a blanket clear: #{inspect(Enum.filter(mutations, &match?({:clear_range, _, _}, &1)))}"
 
-      clear_index =
-        Enum.find_index(mutations, fn
-          {:clear_range, ^log_clear_start, ^log_clear_end} -> true
-          _ -> false
-        end)
-
-      assert clear_index, "expected clear_range over layout/logs"
-
-      first_log_set =
-        Enum.find_index(mutations, fn
-          {:set, key, _} -> String.starts_with?(key, SystemKeys.layout_logs_prefix())
-          _ -> false
-        end)
-
-      assert clear_index < first_log_set
-
-      # The mapping families are durable, distributor-era state: recovery
-      # may seed or update entries, never erase the families wholesale.
-      for prefix <- [SystemKeys.shard_keys_prefix(), SystemKeys.materializers_prefix()] do
-        {clear_start, clear_end} = KeyRange.from_prefix(prefix)
-
-        refute Enum.any?(mutations, &match?({:clear_range, ^clear_start, ^clear_end}, &1)),
-               "unexpected blanket clear over #{inspect(prefix)}"
-      end
+      refute Enum.any?(mutations, &match?({:clear, _}, &1))
     end
 
     test "a fresh cluster seeds shard_keys; the seed needs no clear (the family is definitionally empty)" do
@@ -329,54 +308,6 @@ defmodule Bedrock.ControlPlane.Director.Recovery.PersistencePhaseTest do
 
       assert {:ok, _node} =
                Values.decode_materializer_node(Map.fetch!(store, SystemKeys.materializer_key(9, "wkr_stray")))
-    end
-
-    test "cleared prefix ranges do not cover any other system-key family" do
-      # The strinc bound must keep each cleared range strictly within its own
-      # family, including against future sibling families that share prefix
-      # bytes (e.g. a "shards/" neighbor of "shard_keys/": '_' (0x5F) < 's'
-      # (0x73) puts strinc("...shard_keys/") = "...shard_keys0" below it).
-      cleared_prefixes = %{
-        layout_log: SystemKeys.layout_logs_prefix()
-      }
-
-      keys_by_family = %{
-        shard_key: [SystemKeys.shard_key(<<>>), SystemKeys.shard_key(<<0xFF, 0xFF>>)],
-        shard_sibling: ["\xff/system/shards/0"],
-        layout_log: [SystemKeys.layout_log("log_1")],
-        layout_sibling: ["\xff/system/layout/id", "\xff/system/layout/services"]
-      }
-
-      # Foreignness is decided by family identity, not by whether the key
-      # happens to share the prefix's bytes — so an over-broad prefix
-      # definition (e.g. layout_logs_prefix returning "layout/") fails here
-      # instead of being filtered out of the comparison.
-      for {cleared_family, prefix} <- cleared_prefixes,
-          {family, keys} <- keys_by_family,
-          family != cleared_family,
-          key <- keys do
-        range = KeyRange.from_prefix(prefix)
-
-        refute KeyRange.contains?(range, key),
-               "clear_range over #{inspect(prefix)} would clear #{family} key #{inspect(key)}"
-      end
-    end
-
-    test "prefix range end is exact: a key at strinc(prefix) is not cleared" do
-      prefix = SystemKeys.layout_logs_prefix()
-      boundary_key = Key.strinc(prefix)
-
-      # A neighbor key exactly at the exclusive range end must survive, as must
-      # the key just below the prefix (the prefix itself minus the trailing "/").
-      below_key = binary_part(prefix, 0, byte_size(prefix) - 1)
-
-      store = %{boundary_key => "at-range-end", below_key => "below-range-start"}
-
-      mutations = captured_system_mutations(base_recovery_attempt())
-      store = apply_to_store(store, mutations)
-
-      assert store[boundary_key] == "at-range-end"
-      assert store[below_key] == "below-range-start"
     end
   end
 end

--- a/test/bedrock/data_plane/commit_proxy/metadata_distribution_integration_test.exs
+++ b/test/bedrock/data_plane/commit_proxy/metadata_distribution_integration_test.exs
@@ -277,13 +277,12 @@ defmodule Bedrock.DataPlane.CommitProxy.MetadataDistributionIntegrationTest do
     end
   end
 
-  test "routing families update the routing view; layout_log and unknown system keys are ignored",
+  test "routing families update the routing view; unknown system keys are ignored",
        %{proxy: proxy, epoch: epoch} do
     wiring_before = :sys.get_state(proxy).routing_data.log_map
 
     mutations = [
       {:set, SystemKeys.shard_key("g"), Values.encode_shard_key_entry(3, "")},
-      {:set, SystemKeys.layout_log("log-abc"), Values.encode_tag_list([0, 1])},
       {:set, <<0xFF, "/system/future/feature">>, "opaque"}
     ]
 
@@ -293,8 +292,8 @@ defmodule Bedrock.DataPlane.CommitProxy.MetadataDistributionIntegrationTest do
 
     routing_data = :sys.get_state(proxy).routing_data
     assert proxy_shard(proxy, "g") == 3
-    # Log wiring is epoch-constant and seed-only: the durable layout_log
-    # write rides the window but the routing view does not fold it.
+    # Log wiring is epoch-constant and seed-only: nothing in a window can
+    # change it.
     assert routing_data.log_map == wiring_before
     # Unknown families ride the window harmlessly (forward compatibility) -
     # the version still advances so the resolver can prune.

--- a/test/bedrock/data_plane/commit_proxy/routing_data_test.exs
+++ b/test/bedrock/data_plane/commit_proxy/routing_data_test.exs
@@ -264,21 +264,16 @@ defmodule Bedrock.DataPlane.CommitProxy.RoutingDataTest do
       assert shard_list(updated) == [{"m", {42, ""}}]
     end
 
-    test "layout_log mutations are ignored — log wiring is epoch-constant and seed-only" do
-      # The recovery transaction still writes the layout/logs/ family (it
-      # stays durable for introspection), but the fold is not a reader:
-      # the only such mutations a window can carry are the rewrite of the
-      # set this proxy was seeded with, and mid-epoch topology change is
-      # precluded (changing log topology IS a recovery).
+    test "unrecognized system families are ignored — the fold reads only what it routes on" do
+      # Log wiring is epoch-constant and rides the unlock seed, so no
+      # window can carry a log-topology change (changing log topology IS
+      # a recovery). An unknown family is forward-compatibility, not an
+      # error: it must never disturb the wiring this proxy was seeded
+      # with.
       seeded = seeded_wiring()
+      foreign = "\xff/system/some_future_family/entry"
 
-      updates = [
-        {v(100),
-         [
-           {:set, SystemKeys.layout_log("log-x"), Values.encode_tag_list([0])},
-           {:clear, SystemKeys.layout_log("log-a")}
-         ]}
-      ]
+      updates = [{v(100), [{:set, foreign, "whatever"}, {:clear, foreign}]}]
 
       updated = RoutingData.apply_mutations(seeded, updates)
 
@@ -411,10 +406,11 @@ defmodule Bedrock.DataPlane.CommitProxy.RoutingDataTest do
       assert shard_list(updated) == []
     end
 
-    test "recovery's layout_log clear_range leaves the seeded wiring untouched" do
+    test "a clear_range over an unrouted family leaves the seeded wiring untouched" do
       seeded = seeded_wiring()
+      prefix = "\xff/system/some_future_family/"
 
-      updates = [{v(100), [{:clear_range, SystemKeys.layout_log("log-a"), SystemKeys.layout_log("log-c")}]}]
+      updates = [{v(100), [{:clear_range, prefix <> "a", prefix <> "c"}]}]
 
       updated = RoutingData.apply_mutations(seeded, updates)
 
@@ -456,14 +452,16 @@ defmodule Bedrock.DataPlane.CommitProxy.RoutingDataTest do
       assert shard_list(updated) == [{"m", {10, ""}}, {<<0xFF, 0xFF>>, {11, "m"}}]
     end
 
-    test "mixed mutations: shard_key entries apply, layout_log entries do not" do
+    test "mixed mutations: shard_key entries apply, unrouted families do not" do
+      foreign = "\xff/system/some_future_family/"
+
       updates = [
         {v(100),
          [
            {:set, SystemKeys.shard_key("m"), Values.encode_shard_key_entry(1, "")},
-           {:set, SystemKeys.layout_log("log-1"), Values.encode_tag_list([0])},
+           {:set, foreign <> "log-1", "opaque"},
            {:set, SystemKeys.shard_key("z"), Values.encode_shard_key_entry(2, "m")},
-           {:set, SystemKeys.layout_log("log-2"), Values.encode_tag_list([1])}
+           {:set, foreign <> "log-2", "opaque"}
          ]}
       ]
 

--- a/test/bedrock/system_keys/values_test.exs
+++ b/test/bedrock/system_keys/values_test.exs
@@ -16,23 +16,8 @@ defmodule Bedrock.SystemKeys.ValuesTest do
 
     test "decoder never raises on garbage or wrong shapes" do
       assert {:error, :invalid_encoding} = Values.decode_shard_key_entry(<<0xEE, 0xEE>>)
-      assert {:error, :invalid_type} = Values.decode_shard_key_entry(Values.encode_tag_list([1]))
+      assert {:error, :invalid_type} = Values.decode_shard_key_entry(Values.encode_materializer_node("n"))
       assert {:error, :invalid_encoding} = Values.decode_shard_key_entry(:not_binary)
-    end
-  end
-
-  describe "tag lists" do
-    test "round-trip, including empty" do
-      assert {:ok, [1, 2, 3]} = Values.decode_tag_list(Values.encode_tag_list([1, 2, 3]))
-      assert {:ok, []} = Values.decode_tag_list(Values.encode_tag_list([]))
-    end
-
-    test "encoder rejects non-integer tags loudly" do
-      assert_raise ArgumentError, fn -> Values.encode_tag_list([1, "two"]) end
-    end
-
-    test "decoder never raises on garbage" do
-      assert {:error, :invalid_encoding} = Values.decode_tag_list(<<0xEE>>)
     end
   end
 
@@ -50,7 +35,6 @@ defmodule Bedrock.SystemKeys.ValuesTest do
 
     test "decoder never raises on garbage or wrong shapes, and never creates atoms" do
       assert {:error, :invalid_encoding} = Values.decode_materializer_node(<<0xEE, 0xEE>>)
-      assert {:error, :invalid_type} = Values.decode_materializer_node(Values.encode_tag_list([1]))
       assert {:error, :invalid_type} = Values.decode_materializer_node(Values.encode_shard_key_entry(1, "m"))
       assert {:error, :invalid_encoding} = Values.decode_materializer_node(:not_binary)
     end
@@ -59,11 +43,9 @@ defmodule Bedrock.SystemKeys.ValuesTest do
   describe "decode_for/2 - the writer/reader contract" do
     test "dispatches by parsed key family" do
       shard_value = Values.encode_shard_key_entry(3, "a")
-      log_value = Values.encode_tag_list([0, 1])
       ref_value = Values.encode_materializer_node("node@host")
 
       assert {:ok, {3, "a"}} = Values.decode_for(SystemKeys.parse_key(SystemKeys.shard_key("m")), shard_value)
-      assert {:ok, [0, 1]} = Values.decode_for(SystemKeys.parse_key(SystemKeys.layout_log("log_1")), log_value)
 
       assert {:ok, "node@host"} =
                Values.decode_for(SystemKeys.parse_key(SystemKeys.materializer_key(7, "wkr_abc")), ref_value)

--- a/test/bedrock/system_keys_test.exs
+++ b/test/bedrock/system_keys_test.exs
@@ -9,10 +9,6 @@ defmodule Bedrock.SystemKeysTest do
       assert SystemKeys.parse_key(SystemKeys.shard_key(<<0xFF, 0xFF>>)) == {:shard_key, <<0xFF, 0xFF>>}
     end
 
-    test "layout_log/1 round-trips through parse_key/1" do
-      assert SystemKeys.parse_key(SystemKeys.layout_log("log_1")) == {:layout_log, "log_1"}
-    end
-
     test "materializer_key/2 round-trips through parse_key/1, carrying tag AND worker" do
       assert SystemKeys.parse_key(SystemKeys.materializer_key(0, "wkr_sys")) == {:materializer_key, 0, "wkr_sys"}
       assert SystemKeys.parse_key(SystemKeys.materializer_key(42, "abc12def")) == {:materializer_key, 42, "abc12def"}
@@ -39,9 +35,7 @@ defmodule Bedrock.SystemKeysTest do
 
     test "prefixes cover exactly their families" do
       assert String.starts_with?(SystemKeys.shard_key("x"), SystemKeys.shard_keys_prefix())
-      assert String.starts_with?(SystemKeys.layout_log("x"), SystemKeys.layout_logs_prefix())
       assert String.starts_with?(SystemKeys.materializer_key(3, "wkr_a"), SystemKeys.materializers_prefix())
-      refute String.starts_with?(SystemKeys.layout_log("x"), SystemKeys.shard_keys_prefix())
       refute String.starts_with?(SystemKeys.materializer_key(3, "wkr_a"), SystemKeys.shard_keys_prefix())
     end
 

--- a/test/bedrock/system_keys_test.exs
+++ b/test/bedrock/system_keys_test.exs
@@ -1,6 +1,7 @@
 defmodule Bedrock.SystemKeysTest do
   use ExUnit.Case, async: true
 
+  alias Bedrock.KeyRange
   alias Bedrock.SystemKeys
 
   describe "key construction and parsing round-trip" do
@@ -37,6 +38,44 @@ defmodule Bedrock.SystemKeysTest do
       assert String.starts_with?(SystemKeys.shard_key("x"), SystemKeys.shard_keys_prefix())
       assert String.starts_with?(SystemKeys.materializer_key(3, "wkr_a"), SystemKeys.materializers_prefix())
       refute String.starts_with?(SystemKeys.materializer_key(3, "wkr_a"), SystemKeys.shard_keys_prefix())
+    end
+
+    test "each family's prefix RANGE holds its own keys and no other family's" do
+      # A prefix is only safe to scan or clear if [prefix, strinc(prefix))
+      # is strictly its own family. An over-broad definition (a
+      # materializers_prefix of "materializers" without the slash, say)
+      # would swallow a sibling family that shares prefix bytes. Pinned
+      # on the RANGE, not on starts_with?, because the range is what
+      # readers and any future clear actually use.
+      families = %{
+        shard_key: {SystemKeys.shard_keys_prefix(), [SystemKeys.shard_key(<<>>), SystemKeys.shard_key(<<0xFF, 0xFF>>)]},
+        materializer_key:
+          {SystemKeys.materializers_prefix(),
+           [SystemKeys.materializer_key(0, "wkr_a"), SystemKeys.materializer_key(4200, "wkr_b")]}
+      }
+
+      # Plausible future siblings that share leading bytes with a family.
+      siblings = ["\xff/system/shards/0", "\xff/system/materializer_policy/0", "\xff/system/layout/id"]
+
+      for {family, {prefix, keys}} <- families do
+        range = KeyRange.from_prefix(prefix)
+
+        for key <- keys do
+          assert KeyRange.contains?(range, key), "#{family} range must hold its own key #{inspect(key)}"
+        end
+
+        for {other_family, {_p, other_keys}} <- families,
+            other_family != family,
+            other_key <- other_keys do
+          refute KeyRange.contains?(range, other_key),
+                 "#{family} range must not cover #{other_family} key #{inspect(other_key)}"
+        end
+
+        for sibling <- siblings do
+          refute KeyRange.contains?(range, sibling),
+                 "#{family} range must not cover sibling #{inspect(sibling)}"
+        end
+      end
     end
 
     test "unknown system keys parse as :unknown, non-system keys as :error" do


### PR DESCRIPTION
Recovery cleared and rewrote `\xFF/system/layout/logs/<log_id> = [tag]` on every recovery. Nothing read it — the code said so outright:

> `layout/logs/` has no code reader by design: log wiring is epoch-constant and rides the unlock seed (bedrock-q67.41); the family stays durable for other consumers and cluster-introspection tools.

Those consumers never arrived.

## Why it goes — the honest version

An earlier draft of this PR argued that FDB records its log set twice and that our keyspace copy had "no analogue." **That was wrong**, and the cold audit caught it. FDB keeps a keyspace copy too: `\xff/logs` (`SystemData.cpp:1171`), written by the recovery transaction itself (`ClusterRecovery.actor.cpp:1728`). The deleted family was its analogue.

What actually separates them is **readers**. FDB's `\xff/logs` has three, and we have no equivalent of any:

| FDB reader | What it does | Bedrock equivalent |
|---|---|---|
| `ClusterRecovery.actor.cpp:770-801` | stale-master fence — rejects a superseded master's write (`"old master attempted to change logsKey"`) | none; we fence via epochs + the distributor lock |
| `ManagementAPI.actor.cpp:2394` | exclusion safety | no exclusion machinery |
| `SpecialKeySpace.actor.cpp:1294` | in-progress-exclusion special-key module | no special-key space |

Ours had zero readers, and the tag mapping it carried survives in the `ClusterBootstrap` record the coordinator actually loads at cold start. So this is the project's existing convention rather than an exception to it: **the family returns when one of those readers does.**

## What collapsed with it

The writer was the smaller half:

- **SystemKeys** loses `layout_log/1`, `layout_logs_prefix/0`, and a `parse_key` clause — one fewer family in the parse surface.
- **Values** loses `encode_tag_list/1` and `decode_tag_list/1`, which existed *only* for this family, plus a `decode_for/2` clause.
- **RoutingData** loses two `apply_mutation` clauses whose entire body was a comment explaining why they did nothing.
- **PersistencePhase** loses `clear_prefix/2` along with its last caller — and with it **recovery's only blanket clear**. Recovery now writes nothing it doesn't read back, pinned directly by the rewritten test.

## Safety for existing clusters (audited, with executed evidence)

Legacy `layout/logs` keys are provably inert. Every family scan is bounded by `KeyRange.from_prefix/1` = `[prefix, strinc(prefix))`, and the family sorts strictly below both scanned families (`'l'(0x6C) < 'm'(0x6D) < 's'(0x73)`), so no scan can reach them — including the decoders that `:halt` on an unparseable entry. `Reader.page_entries` only ever resumes forward. An upgrading cluster cannot fail recovery on these keys.

## Tests

Two pins went vacuous with the clear — both were parameterized over the cleared prefixes, so they iterated nothing once no clear was emitted. Removed rather than propped up.

But one of them was designed to catch an over-broad prefix *definition*, and nothing else asserted that. **Restored as a direct property** on each family's prefix RANGE (what readers actually use), independent of clearing — and verified falsifiable: a prefix of `"materializer"` instead of `"materializers/"` swallows a sibling family and the test catches it.

The routing tests kept their real property — irrelevant metadata mutations must not disturb the seeded wiring — but now exercise it through a genuinely unknown family. The audit confirmed this isn't vacuous: `Transaction.metadata_mutation?/1` admits any leading-`0xFF` key, so the synthetic key reaches the identical fallthrough a legacy key now takes.

## Docs

Three documents still described the family as live, including the moduledoc of a file this branch edits: `SystemKeys`, `SystemKeys.Values`, and `guides/quick-reads/system-keyspace.md`.

## Migration

None. Stale keys are inert; recovery simply stops rewriting them.

## Gates

2729 tests / 0 failures, `credo --strict` clean, dialyzer clean, CI green on all 4 matrix jobs. Cold audit: **PASS**.

bedrock-q67.21.10