### PR TITLE
Split CoreState from TransactionSystemLayout: make the durable/broadcast divide honest

### DIFF
--- a/lib/bedrock/control_plane/config/core_state.ex
+++ b/lib/bedrock/control_plane/config/core_state.ex
@@ -33,10 +33,11 @@ defmodule Bedrock.ControlPlane.Config.CoreState do
   consumed as recovery's prior state — so projecting them here would
   add fields with no reader.
 
-  Log LOCATIONS are likewise absent: the bootstrap stores an `otp_ref`
-  per log, but recovery discovers live services through foreman
-  registration rather than trusting a durable address. The record says
-  WHICH logs, never where they were last seen.
+  Log LOCATIONS are likewise absent: the bootstrap schema HAS an
+  `otp_ref` per log, but the writer always sets it to nil
+  (`persistence_phase.ex`), because recovery discovers live services
+  through foreman registration rather than trusting a durable address.
+  The record says WHICH logs, never where they were last seen.
 
   Materializer membership joins this record in bedrock-q67.21.12, for
   the one shard recovery cannot do without: the system shard, whose
@@ -44,6 +45,7 @@ defmodule Bedrock.ControlPlane.Config.CoreState do
   """
 
   alias Bedrock.ControlPlane.Config.LogDescriptor
+  alias Bedrock.ControlPlane.Config.TransactionSystemLayout
   alias Bedrock.DataPlane.Log
 
   @type t :: %{required(:logs) => %{Log.id() => LogDescriptor.t()}}
@@ -80,13 +82,18 @@ defmodule Bedrock.ControlPlane.Config.CoreState do
   epoch would be a category error — and the reason to keep these two
   types apart at all.
   """
-  @spec from_layout(map()) :: t()
+  @spec from_layout(TransactionSystemLayout.t()) :: t()
   def from_layout(layout), do: %{logs: Map.get(layout, :logs) || %{}}
 
   @doc """
-  Whether this cluster has never completed a recovery — FDB's
-  `neverCreated`, set when `!cstate.prevDBState.tLogs.size()`
-  (`ClusterRecovery.actor.cpp:981`).
+  Whether this cluster has never completed a recovery.
+
+  FDB makes the same call on the same evidence, in
+  `TagPartitionedLogSystem::recoverAndEndEpoch`
+  (`TagPartitionedLogSystem.actor.cpp:2416`): `if (!prevState.tLogs.size())
+  { // This is a brand new database` — the branch that MANUFACTURES a
+  log system rather than recovering one, keyed on the prior core state
+  naming no logs.
 
   A missing record and a record naming no logs mean the same thing:
   there is no prior epoch's data to recover, so recovery seeds rather
@@ -102,7 +109,12 @@ defmodule Bedrock.ControlPlane.Config.CoreState do
   The log ids the prior epoch ran — the services recovery must lock and
   copy from. A fresh cluster names none.
   """
-  @spec log_ids(t() | nil) :: MapSet.t(Log.id())
+  @spec log_ids(t() | nil | map()) :: MapSet.t(Log.id())
   def log_ids(nil), do: MapSet.new()
   def log_ids(%{logs: logs}), do: logs |> Map.keys() |> MapSet.new()
+  # A record without the key names no logs, exactly as every open-coded
+  # predecessor of this function assumed. Kept symmetric with fresh?/1:
+  # a strict clause here would let fresh?(%{}) route an empty record to
+  # the existing-cluster path and then crash the director on it.
+  def log_ids(_no_logs_key), do: MapSet.new()
 end

--- a/lib/bedrock/control_plane/config/core_state.ex
+++ b/lib/bedrock/control_plane/config/core_state.ex
@@ -1,0 +1,108 @@
+defmodule Bedrock.ControlPlane.Config.CoreState do
+  @moduledoc """
+  The durable record a recovery recovers FROM — FDB's `DBCoreState`,
+  held during recovery as `cstate.prevDBState`.
+
+  This is the other half of a divide FDB keeps in two structures and
+  Bedrock, until now, kept in one type:
+
+    * `CoreState` — DURABLE. Persisted (for us, in the object-storage
+      cluster bootstrap the coordinator loads at cold start), it names
+      what the next recovery must find in order to recover at all.
+      FDB's `DBCoreState` (`DBCoreState.h:132`): the tLog sets, old
+      generations, `recoveryCount`.
+    * `TransactionSystemLayout` — TRANSIENT. Rebuilt every recovery and
+      broadcast so workers can reach each other; it carries pids, which
+      are meaningless the moment the epoch ends. FDB's `ServerDBInfo`,
+      whose own comment reads: "This structure contains transient
+      information which is broadcast to all workers for a database,
+      permitting them to communicate with each other."
+
+  The rule the split makes structural: what must SURVIVE goes here;
+  what must be REACHED goes in the layout. That is why the layout may
+  never carry anything `O(workers)` (see its moduledoc) while this
+  record may — a thing you must recover is worth persisting, a thing
+  you must merely contact is not worth broadcasting.
+
+  ## Why only `logs`
+
+  Recovery consumes exactly one fact from its prior state: which logs
+  the last epoch ran, so it can lock them and copy from them. The
+  durable bootstrap record also carries the epoch, the cluster id and
+  the coordinator set — all read by the coordinator directly, none
+  consumed as recovery's prior state — so projecting them here would
+  add fields with no reader.
+
+  Log LOCATIONS are likewise absent: the bootstrap stores an `otp_ref`
+  per log, but recovery discovers live services through foreman
+  registration rather than trusting a durable address. The record says
+  WHICH logs, never where they were last seen.
+
+  Materializer membership joins this record in bedrock-q67.21.12, for
+  the one shard recovery cannot do without: the system shard, whose
+  keyspace holds the metadata every later phase reads.
+  """
+
+  alias Bedrock.ControlPlane.Config.LogDescriptor
+  alias Bedrock.DataPlane.Log
+
+  @type t :: %{required(:logs) => %{Log.id() => LogDescriptor.t()}}
+
+  @doc """
+  Projects the durable cluster-bootstrap record into the prior state
+  recovery consumes.
+
+  A log with no recorded tags is carried as `[]` rather than `nil`:
+  downstream takes `Map.keys/1` and `MapSet.new/1` over these, so a nil
+  would crash a recovery instead of describing a log that serves no
+  shard.
+  """
+  @spec from_bootstrap(map()) :: t()
+  def from_bootstrap(bootstrap) do
+    logs =
+      bootstrap
+      |> Map.get(:logs)
+      |> Kernel.||([])
+      |> Map.new(fn log_info -> {log_info[:id], log_info[:shard_tags] || []} end)
+
+    %{logs: logs}
+  end
+
+  @doc """
+  Projects a completed recovery's layout into the record the NEXT
+  recovery reads as its prior state — FDB's `logSystem->toCoreState`,
+  which likewise distills a live log system down to what the coordinated
+  state must hold.
+
+  Only the durable half crosses the epoch boundary. The layout's pids
+  (sequencer, proxies, resolvers) die with the epoch that made them, so
+  carrying them into a record whose entire purpose is to OUTLIVE the
+  epoch would be a category error — and the reason to keep these two
+  types apart at all.
+  """
+  @spec from_layout(map()) :: t()
+  def from_layout(layout), do: %{logs: Map.get(layout, :logs) || %{}}
+
+  @doc """
+  Whether this cluster has never completed a recovery — FDB's
+  `neverCreated`, set when `!cstate.prevDBState.tLogs.size()`
+  (`ClusterRecovery.actor.cpp:981`).
+
+  A missing record and a record naming no logs mean the same thing:
+  there is no prior epoch's data to recover, so recovery seeds rather
+  than reads. Absence of the record is not an error — it is the first
+  boot.
+  """
+  @spec fresh?(t() | nil) :: boolean()
+  def fresh?(nil), do: true
+  def fresh?(%{logs: logs}) when map_size(logs) == 0, do: true
+  def fresh?(_core_state), do: false
+
+  @doc """
+  The log ids the prior epoch ran — the services recovery must lock and
+  copy from. A fresh cluster names none.
+  """
+  @spec log_ids(t() | nil) :: MapSet.t(Log.id())
+  def log_ids(nil), do: MapSet.new()
+  def log_ids(%{logs: logs}), do: logs |> Map.keys() |> MapSet.new()
+end

--- a/lib/bedrock/control_plane/coordinator/director_management.ex
+++ b/lib/bedrock/control_plane/coordinator/director_management.ex
@@ -30,7 +30,7 @@ defmodule Bedrock.ControlPlane.Coordinator.DirectorManagement do
   def try_to_start_director(t) when t.leader_node == t.my_node and t.director == :unavailable do
     t = maybe_put_default_config(t)
 
-    trace_director_launch(t.epoch, t.old_transaction_system_layout)
+    trace_director_launch(t.epoch, t.prior_core_state)
 
     case start_director_with_monitoring(t) do
       {:ok, new_director} ->
@@ -64,7 +64,7 @@ defmodule Bedrock.ControlPlane.Coordinator.DirectorManagement do
             [
               cluster: t.cluster,
               config: t.config,
-              old_transaction_system_layout: t.old_transaction_system_layout,
+              prior_core_state: t.prior_core_state,
               epoch: t.epoch,
               coordinator: self(),
               services: t.service_directory,

--- a/lib/bedrock/control_plane/coordinator/server.ex
+++ b/lib/bedrock/control_plane/coordinator/server.ex
@@ -43,6 +43,7 @@ defmodule Bedrock.ControlPlane.Coordinator.Server do
 
   import Bedrock.Internal.GenServer.Replies
 
+  alias Bedrock.ControlPlane.Config.CoreState
   alias Bedrock.ControlPlane.Coordinator.Commands
   alias Bedrock.ControlPlane.Coordinator.DiskRaftLog
   alias Bedrock.ControlPlane.Coordinator.RaftAdapter
@@ -89,8 +90,9 @@ defmodule Bedrock.ControlPlane.Coordinator.Server do
     with {:ok, coordinator_nodes} <- cluster.fetch_coordinator_nodes(),
          true <- my_node in coordinator_nodes || {:error, :not_a_coordinator},
          {:ok, raft_log} <- init_raft_log(cluster) do
-      # Load config and old TSL from object storage (source of truth)
-      {loaded_epoch, loaded_config, loaded_tsl} = load_state_from_object_storage(cluster)
+      # Load config and the prior core state from object storage (the
+      # durable record; FDB reads its cstate at the same point)
+      {loaded_epoch, loaded_config, loaded_core_state} = load_state_from_object_storage(cluster)
 
       {:ok,
        %State{
@@ -100,7 +102,7 @@ defmodule Bedrock.ControlPlane.Coordinator.Server do
          supervisor_otp_name: cluster.otp_name(:sup),
          epoch: loaded_epoch,
          config: loaded_config,
-         old_transaction_system_layout: loaded_tsl,
+         prior_core_state: loaded_core_state,
          transaction_system_layout: nil,
          raft:
            Raft.new(
@@ -455,10 +457,10 @@ defmodule Bedrock.ControlPlane.Coordinator.Server do
          {:ok, bootstrap} <- parse_bootstrap_data(data, cluster) do
       epoch = bootstrap.epoch
       config = build_config_from_bootstrap(bootstrap, cluster)
-      old_tsl = build_old_tsl_from_bootstrap(bootstrap)
+      core_state = CoreState.from_bootstrap(bootstrap)
 
       Logger.info("Bedrock [#{cluster}]: Loaded cluster bootstrap from object storage (epoch: #{epoch})")
-      {epoch, config, old_tsl}
+      {epoch, config, core_state}
     else
       {:error, :no_object_storage} -> {nil, nil, nil}
       {:error, :not_found} -> {nil, nil, nil}
@@ -538,18 +540,6 @@ defmodule Bedrock.ControlPlane.Coordinator.Server do
 
   defp build_policies(nil), do: %{allow_volunteer_nodes_to_join: true}
   defp build_policies(p), do: %{allow_volunteer_nodes_to_join: p[:allow_volunteer_nodes_to_join] || false}
-
-  # Build old_transaction_system_layout from ClusterBootstrap logs
-  # Recovery only uses the logs field to determine which logs to copy from
-  defp build_old_tsl_from_bootstrap(bootstrap) do
-    logs =
-      Map.new(bootstrap[:logs] || [], fn log_info ->
-        # LogDescriptor is just [range_tag] - a list of shard tags
-        {log_info[:id], log_info[:shard_tags] || []}
-      end)
-
-    %{logs: logs}
-  end
 
   @spec get_object_storage_backend(module()) :: {:ok, ObjectStorage.backend()} | {:error, :no_object_storage}
   defp get_object_storage_backend(cluster) do

--- a/lib/bedrock/control_plane/coordinator/state.ex
+++ b/lib/bedrock/control_plane/coordinator/state.ex
@@ -5,6 +5,7 @@ defmodule Bedrock.ControlPlane.Coordinator.State do
 
   alias Bedrock.Cluster
   alias Bedrock.ControlPlane.Config
+  alias Bedrock.ControlPlane.Config.CoreState
   alias Bedrock.ControlPlane.Config.TransactionSystemLayout
   alias Bedrock.ControlPlane.Coordinator.RecoveryCapabilityTracker
   alias Bedrock.ControlPlane.Director
@@ -23,8 +24,7 @@ defmodule Bedrock.ControlPlane.Coordinator.State do
           supervisor_otp_name: atom(),
           last_durable_txn_id: Raft.transaction_id(),
           config: Config.t() | nil,
-          old_transaction_system_layout:
-            TransactionSystemLayout.t() | %{required(:logs) => TransactionSystemLayout.log_map()} | nil,
+          prior_core_state: CoreState.t() | nil,
           transaction_system_layout: TransactionSystemLayout.t() | nil,
           waiting_list: %{Raft.transaction_id() => pid()},
           service_directory: %{String.t() => {atom(), {atom(), node()}}},
@@ -43,7 +43,7 @@ defmodule Bedrock.ControlPlane.Coordinator.State do
             supervisor_otp_name: nil,
             last_durable_txn_id: nil,
             config: nil,
-            old_transaction_system_layout: nil,
+            prior_core_state: nil,
             transaction_system_layout: nil,
             waiting_list: %{},
             service_directory: %{},
@@ -95,9 +95,13 @@ defmodule Bedrock.ControlPlane.Coordinator.State do
     @spec put_transaction_system_layout(t :: State.t(), TransactionSystemLayout.t()) ::
             State.t()
     def put_transaction_system_layout(t, transaction_system_layout) do
+      # The completed layout becomes the next recovery's PRIOR STATE, but
+      # only its durable half may: the layout's pids die with this epoch,
+      # and the prior-state slot exists to outlive it. (This worked
+      # before only because both shapes happen to carry a :logs field.)
       updated_state = %{
         t
-        | old_transaction_system_layout: transaction_system_layout,
+        | prior_core_state: CoreState.from_layout(transaction_system_layout),
           transaction_system_layout: transaction_system_layout
       }
 

--- a/lib/bedrock/control_plane/coordinator/telemetry.ex
+++ b/lib/bedrock/control_plane/coordinator/telemetry.ex
@@ -1,6 +1,6 @@
 defmodule Bedrock.ControlPlane.Coordinator.Telemetry do
   @moduledoc false
-  alias Bedrock.ControlPlane.Config.TransactionSystemLayout
+  alias Bedrock.ControlPlane.Config.CoreState
   alias Bedrock.Telemetry
 
   @spec trace_started(cluster :: module(), otp_name :: atom()) :: :ok
@@ -27,15 +27,15 @@ defmodule Bedrock.ControlPlane.Coordinator.Telemetry do
 
   @spec trace_director_launch(
           epoch :: non_neg_integer(),
-          old_transaction_system_layout :: TransactionSystemLayout.t() | nil
+          prior_core_state :: CoreState.t() | nil
         ) :: :ok
-  def trace_director_launch(epoch, old_transaction_system_layout) do
+  def trace_director_launch(epoch, prior_core_state) do
     config_summary =
-      if old_transaction_system_layout do
+      if prior_core_state do
         %{
-          epoch: old_transaction_system_layout[:epoch],
+          epoch: prior_core_state[:epoch],
           has_transaction_system_layout: true,
-          logs_count: map_size(old_transaction_system_layout[:logs] || %{})
+          logs_count: map_size(prior_core_state[:logs] || %{})
         }
       end
 

--- a/lib/bedrock/control_plane/coordinator/telemetry.ex
+++ b/lib/bedrock/control_plane/coordinator/telemetry.ex
@@ -30,13 +30,13 @@ defmodule Bedrock.ControlPlane.Coordinator.Telemetry do
           prior_core_state :: CoreState.t() | nil
         ) :: :ok
   def trace_director_launch(epoch, prior_core_state) do
+    # The prior core state names logs and nothing else — no epoch, no
+    # layout. The epoch below is this launch's, which is the one an
+    # operator wants anyway; reading a nonexistent :epoch off the record
+    # printed an empty string.
     config_summary =
       if prior_core_state do
-        %{
-          epoch: prior_core_state[:epoch],
-          has_transaction_system_layout: true,
-          logs_count: map_size(prior_core_state[:logs] || %{})
-        }
+        %{prior_logs_count: map_size(prior_core_state[:logs] || %{})}
       end
 
     Telemetry.execute([:bedrock, :control_plane, :coordinator, :director_launch], %{}, %{

--- a/lib/bedrock/control_plane/coordinator/tracing.ex
+++ b/lib/bedrock/control_plane/coordinator/tracing.ex
@@ -54,10 +54,10 @@ defmodule Bedrock.ControlPlane.Coordinator.Tracing do
   def trace(:director_changed, _, %{director: director}), do: info("Director changed to #{inspect(director)}")
 
   def trace(:director_launch, _, %{epoch: epoch, config_summary: nil}),
-    do: info("Starting director for epoch #{epoch} with NO CONFIG")
+    do: info("Starting director for epoch #{epoch} with NO PRIOR STATE (fresh cluster)")
 
   def trace(:director_launch, _, %{epoch: epoch, config_summary: summary}),
-    do: info("Starting director for epoch #{epoch} with config (epoch: #{summary.epoch}, logs: #{summary.logs_count})")
+    do: info("Starting director for epoch #{epoch} (prior state names #{summary.prior_logs_count} logs)")
 
   def trace(:director_shutdown, _, %{director: director, reason: reason}),
     do: info("Shutting down director #{inspect(director)} (reason: #{reason})")

--- a/lib/bedrock/control_plane/director/recovery.ex
+++ b/lib/bedrock/control_plane/director/recovery.ex
@@ -29,8 +29,8 @@ defmodule Bedrock.ControlPlane.Director.Recovery do
   import Bedrock.Internal.Time, only: [now: 0]
 
   alias Bedrock.ControlPlane.Config
+  alias Bedrock.ControlPlane.Config.CoreState
   alias Bedrock.ControlPlane.Config.RecoveryAttempt
-  alias Bedrock.ControlPlane.Config.TransactionSystemLayout
   alias Bedrock.ControlPlane.Coordinator
   alias Bedrock.ControlPlane.Director.State
   alias Bedrock.ControlPlane.Distributor
@@ -41,7 +41,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery do
 
   @type recovery_context :: %{
           cluster_config: Config.t(),
-          old_transaction_system_layout: TransactionSystemLayout.t(),
+          prior_core_state: CoreState.t() | nil,
           node_capabilities: %{Bedrock.Cluster.capability() => [node()]},
           lock_token: binary(),
           available_services: %{Worker.id() => {atom(), {atom(), node()}}},
@@ -107,7 +107,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery do
 
     context = %{
       cluster_config: t.config,
-      old_transaction_system_layout: t.old_transaction_system_layout,
+      prior_core_state: t.prior_core_state,
       node_capabilities: t.node_capabilities,
       lock_token: t.lock_token,
       available_services: t.services,

--- a/lib/bedrock/control_plane/director/recovery/locking_phase.ex
+++ b/lib/bedrock/control_plane/director/recovery/locking_phase.ex
@@ -20,6 +20,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery.LockingPhase do
 
   use Bedrock.ControlPlane.Director.Recovery.RecoveryPhase
 
+  alias Bedrock.ControlPlane.Config.CoreState
   alias Bedrock.DataPlane.Log
   alias Bedrock.DataPlane.Materializer
   alias Bedrock.Service.Worker
@@ -28,7 +29,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery.LockingPhase do
   def execute(recovery_attempt, context) do
     old_system_services =
       extract_old_system_services(
-        context.old_transaction_system_layout,
+        context.prior_core_state,
         context.available_services
       )
 
@@ -150,12 +151,8 @@ defmodule Bedrock.ControlPlane.Director.Recovery.LockingPhase do
   # state — including the shard layout the bootstrap phase reads — and
   # locking them both fences old epochs and collects their recovery info
   # (durable version, shard assignment) for reuse.
-  defp extract_old_system_services(old_layout, available_services) do
-    old_log_ids =
-      old_layout
-      |> Map.get(:logs, %{})
-      |> Map.keys()
-      |> MapSet.new()
+  defp extract_old_system_services(prior_core_state, available_services) do
+    old_log_ids = CoreState.log_ids(prior_core_state)
 
     available_services
     |> Enum.filter(fn

--- a/lib/bedrock/control_plane/director/recovery/log_recovery_planning_phase.ex
+++ b/lib/bedrock/control_plane/director/recovery/log_recovery_planning_phase.ex
@@ -28,12 +28,13 @@ defmodule Bedrock.ControlPlane.Director.Recovery.LogRecoveryPlanningPhase do
 
   import Bedrock.ControlPlane.Director.Recovery.Telemetry
 
+  alias Bedrock.ControlPlane.Config.CoreState
   alias Bedrock.DataPlane.Log
   alias Bedrock.DataPlane.Version
 
   @impl true
   def execute(%RecoveryAttempt{} = recovery_attempt, context) do
-    old_log_ids = Map.keys(context.old_transaction_system_layout[:logs] || %{})
+    old_log_ids = context.prior_core_state |> CoreState.log_ids() |> MapSet.to_list()
     log_recovery_info = recovery_attempt.log_recovery_info_by_id
     locked_count = map_size(log_recovery_info)
     total_count = length(old_log_ids)

--- a/lib/bedrock/control_plane/director/recovery/log_recruitment_phase.ex
+++ b/lib/bedrock/control_plane/director/recovery/log_recruitment_phase.ex
@@ -26,6 +26,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery.LogRecruitmentPhase do
 
   import Bedrock.ControlPlane.Director.Recovery.Telemetry
 
+  alias Bedrock.ControlPlane.Config.CoreState
   alias Bedrock.DataPlane.Log
   alias Bedrock.Service.Foreman
   alias Bedrock.Service.Worker
@@ -109,10 +110,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery.LogRecruitmentPhase do
     end
   end
 
-  defp get_old_system_log_ids(%{old_transaction_system_layout: %{logs: old_logs}}),
-    do: old_logs |> Map.keys() |> MapSet.new()
-
-  defp get_old_system_log_ids(_), do: MapSet.new()
+  defp get_old_system_log_ids(context), do: context |> Map.get(:prior_core_state) |> CoreState.log_ids()
 
   defp get_available_log_ids(%{available_services: available_services}) do
     available_services

--- a/lib/bedrock/control_plane/director/recovery/log_recruitment_phase.ex
+++ b/lib/bedrock/control_plane/director/recovery/log_recruitment_phase.ex
@@ -110,7 +110,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery.LogRecruitmentPhase do
     end
   end
 
-  defp get_old_system_log_ids(context), do: context |> Map.get(:prior_core_state) |> CoreState.log_ids()
+  defp get_old_system_log_ids(context), do: CoreState.log_ids(context.prior_core_state)
 
   defp get_available_log_ids(%{available_services: available_services}) do
     available_services

--- a/lib/bedrock/control_plane/director/recovery/materializer_bootstrap_phase.ex
+++ b/lib/bedrock/control_plane/director/recovery/materializer_bootstrap_phase.ex
@@ -76,9 +76,12 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhase do
 
   # Private implementation
 
-  # FDB's neverCreated: a prior record naming no logs means there is no
-  # prior epoch's data to recover, so recovery seeds instead of reading.
-  defp fresh_cluster?(context), do: context |> Map.get(:prior_core_state) |> CoreState.fresh?()
+  # A prior record naming no logs means there is no prior epoch's data to
+  # recover, so recovery seeds instead of reading. Read the key
+  # STRICTLY: the context type declares it required, and the two answers
+  # here are "invent a default layout" and "read the committed one" — a
+  # missing key must raise, not silently pick the destructive one.
+  defp fresh_cluster?(context), do: CoreState.fresh?(context.prior_core_state)
 
   defp handle_fresh_cluster(recovery_attempt, context) do
     Logger.debug("Fresh cluster detected, using default shard layout")

--- a/lib/bedrock/control_plane/director/recovery/materializer_bootstrap_phase.ex
+++ b/lib/bedrock/control_plane/director/recovery/materializer_bootstrap_phase.ex
@@ -32,6 +32,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhase do
   import Bedrock, only: [end_of_keyspace: 0]
   import Bedrock.ControlPlane.Config.ResolverDescriptor, only: [resolver_descriptor: 2]
 
+  alias Bedrock.ControlPlane.Config.CoreState
   alias Bedrock.ControlPlane.Director.Recovery.CommitProxyStartupPhase
   alias Bedrock.DataPlane.Materializer
   alias Bedrock.DataPlane.ShardRouter
@@ -75,9 +76,9 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhase do
 
   # Private implementation
 
-  defp fresh_cluster?(%{old_transaction_system_layout: nil}), do: true
-  defp fresh_cluster?(%{old_transaction_system_layout: %{logs: logs}}) when map_size(logs) == 0, do: true
-  defp fresh_cluster?(_context), do: false
+  # FDB's neverCreated: a prior record naming no logs means there is no
+  # prior epoch's data to recover, so recovery seeds instead of reading.
+  defp fresh_cluster?(context), do: context |> Map.get(:prior_core_state) |> CoreState.fresh?()
 
   defp handle_fresh_cluster(recovery_attempt, context) do
     Logger.debug("Fresh cluster detected, using default shard layout")

--- a/lib/bedrock/control_plane/director/recovery/recovery_phase.ex
+++ b/lib/bedrock/control_plane/director/recovery/recovery_phase.ex
@@ -11,7 +11,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery.RecoveryPhase do
 
   @type context :: %{
           cluster_config: Config.t(),
-          old_transaction_system_layout: Config.TransactionSystemLayout.t(),
+          prior_core_state: Config.CoreState.t() | nil,
           node_capabilities: %{Bedrock.Cluster.capability() => [node()]},
           lock_token: binary(),
           available_services: %{String.t() => {atom(), {atom(), node()}}},

--- a/lib/bedrock/control_plane/director/recovery/tsl_validation_phase.ex
+++ b/lib/bedrock/control_plane/director/recovery/tsl_validation_phase.ex
@@ -3,17 +3,22 @@ defmodule Bedrock.ControlPlane.Director.Recovery.TSLValidationPhase do
   Early recovery phase that type-checks the PRIOR CORE STATE before any
   later phase trusts it.
 
-  The record is durable: it was written by a previous epoch, possibly a
-  previous version of this software, and read back off object storage.
-  Everything after this point locks and copies from the logs it names,
-  so a type mismatch here (integer ranges arriving as Version.t()
-  binaries, say) surfaces later as an MVCC lookup failure far from its
-  cause. Validating at the boundary makes the durable record the thing
-  that fails, with diagnostics naming it.
+  On a cold boot the record is genuinely durable — written by a previous
+  epoch, possibly by a previous version of this software, and read back
+  off object storage. (On a warm relaunch it is projected in memory from
+  this coordinator's own last layout and never round-trips storage, so
+  the check is cheap there and meaningful here.) Everything after this
+  point locks and copies from the logs it names, so a type mismatch
+  (integer tag ranges arriving as Version.t() binaries, say) would
+  otherwise surface as an MVCC lookup failure far from its cause.
+  Validating at the boundary makes the durable record the thing that
+  fails, with diagnostics naming it.
 
-  It validates the `logs` field: each entry's tag ranges must be
-  integers, not binaries. That is the whole prior record today
-  (`Bedrock.ControlPlane.Config.CoreState`), so it is the whole check.
+  What it checks is the `logs` field: each entry's tag ranges must be
+  integers, not binaries. The validator also has a `resolvers` check,
+  which is vacuous against this record — the prior core state carries no
+  resolvers, and the previous epoch's resolver pids would be worthless
+  if it did.
 
   ## Error Handling
 

--- a/lib/bedrock/control_plane/director/recovery/tsl_validation_phase.ex
+++ b/lib/bedrock/control_plane/director/recovery/tsl_validation_phase.ex
@@ -1,15 +1,19 @@
 defmodule Bedrock.ControlPlane.Director.Recovery.TSLValidationPhase do
   @moduledoc """
-  Early recovery phase that validates TSL type safety to prevent data corruption.
+  Early recovery phase that type-checks the PRIOR CORE STATE before any
+  later phase trusts it.
 
-  This phase runs defensively on recovered TSL data, checking for type mismatches
-  like integer-to-binary version conversion errors that can cause MVCC lookup failures.
-  It specifically validates:
+  The record is durable: it was written by a previous epoch, possibly a
+  previous version of this software, and read back off object storage.
+  Everything after this point locks and copies from the logs it names,
+  so a type mismatch here (integer ranges arriving as Version.t()
+  binaries, say) surfaces later as an MVCC lookup failure far from its
+  cause. Validating at the boundary makes the durable record the thing
+  that fails, with diagnostics naming it.
 
-  - `logs` field has integer ranges (not Version.t() binaries)
-  - `version_vector` field contains Version.t() binaries (not integers)
-  - `durable_version` field contains Version.t() binary (not integer)
-  - `resolvers` structure is valid
+  It validates the `logs` field: each entry's tag ranges must be
+  integers, not binaries. That is the whole prior record today
+  (`Bedrock.ControlPlane.Config.CoreState`), so it is the whole check.
 
   ## Error Handling
 
@@ -33,7 +37,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery.TSLValidationPhase do
   alias Bedrock.ControlPlane.Config.TSLTypeValidator
 
   @doc """
-  Validates TSL type safety using defensive validation.
+  Validates the prior core state's type safety.
 
   Returns `{:stalled, {:corrupted_tsl, validation_error}}` on validation failure
   to halt recovery and provide clear diagnostics. Logs detailed error information
@@ -43,14 +47,14 @@ defmodule Bedrock.ControlPlane.Director.Recovery.TSLValidationPhase do
   recovery attempt (this is a pure validation phase).
   """
   @impl true
-  def execute(%RecoveryAttempt{} = recovery_attempt, %{old_transaction_system_layout: %{} = tsl_to_validate}) do
-    case TSLTypeValidator.validate_type_safety(tsl_to_validate) do
+  def execute(%RecoveryAttempt{} = recovery_attempt, %{prior_core_state: %{} = core_state}) do
+    case TSLTypeValidator.validate_type_safety(core_state) do
       :ok ->
         trace_recovery_tsl_validation_success()
         {recovery_attempt, Bedrock.ControlPlane.Director.Recovery.LockingPhase}
 
       {:error, validation_error} ->
-        trace_recovery_tsl_validation_failed(tsl_to_validate, validation_error)
+        trace_recovery_tsl_validation_failed(core_state, validation_error)
         {recovery_attempt, {:stalled, {:corrupted_tsl, validation_error}}}
     end
   end

--- a/lib/bedrock/control_plane/director/server.ex
+++ b/lib/bedrock/control_plane/director/server.ex
@@ -21,7 +21,7 @@ defmodule Bedrock.ControlPlane.Director.Server do
   import Bedrock.Internal.GenServer.Replies
 
   alias Bedrock.ControlPlane.Config
-  alias Bedrock.ControlPlane.Config.TransactionSystemLayout
+  alias Bedrock.ControlPlane.Config.CoreState
   alias Bedrock.ControlPlane.Coordinator
   alias Bedrock.ControlPlane.Director.Recovery
   alias Bedrock.ControlPlane.Director.State
@@ -33,7 +33,7 @@ defmodule Bedrock.ControlPlane.Director.Server do
           opts :: [
             cluster: module(),
             config: Config.t(),
-            old_transaction_system_layout: TransactionSystemLayout.t() | nil,
+            prior_core_state: CoreState.t() | nil,
             epoch: Bedrock.epoch(),
             coordinator: Coordinator.ref(),
             services: %{String.t() => {atom(), {atom(), node()}}} | nil,
@@ -47,7 +47,7 @@ defmodule Bedrock.ControlPlane.Director.Server do
     coordinator = opts[:coordinator] || raise "Missing :coordinator param"
     services = opts[:services] || %{}
     node_capabilities = opts[:node_capabilities] || %{}
-    old_transaction_system_layout = opts[:old_transaction_system_layout] || nil
+    prior_core_state = opts[:prior_core_state] || nil
 
     %{
       id: __MODULE__,
@@ -55,19 +55,19 @@ defmodule Bedrock.ControlPlane.Director.Server do
         {GenServer, :start_link,
          [
            __MODULE__,
-           {cluster, config, old_transaction_system_layout, epoch, coordinator, services, node_capabilities}
+           {cluster, config, prior_core_state, epoch, coordinator, services, node_capabilities}
          ]},
       restart: :temporary
     }
   end
 
   @impl true
-  def init({cluster, config, old_transaction_system_layout, epoch, coordinator, services, node_capabilities}) do
+  def init({cluster, config, prior_core_state, epoch, coordinator, services, node_capabilities}) do
     state = %State{
       epoch: epoch,
       cluster: cluster,
       config: config,
-      old_transaction_system_layout: old_transaction_system_layout,
+      prior_core_state: prior_core_state,
       coordinator: coordinator,
       node_capabilities: node_capabilities,
       lock_token: :crypto.strong_rand_bytes(32),

--- a/lib/bedrock/control_plane/director/state.ex
+++ b/lib/bedrock/control_plane/director/state.ex
@@ -5,6 +5,7 @@ defmodule Bedrock.ControlPlane.Director.State do
 
   alias Bedrock.Cluster
   alias Bedrock.ControlPlane.Config
+  alias Bedrock.ControlPlane.Config.CoreState
   alias Bedrock.ControlPlane.Config.TransactionSystemLayout
   alias Bedrock.Service.Worker
 
@@ -22,7 +23,7 @@ defmodule Bedrock.ControlPlane.Director.State do
           cluster: module(),
           config: Config.t() | nil,
           transaction_system_layout: TransactionSystemLayout.t() | nil,
-          old_transaction_system_layout: TransactionSystemLayout.t() | nil,
+          prior_core_state: CoreState.t() | nil,
           coordinator: pid(),
           node_capabilities: %{Cluster.capability() => [node()]},
           timers: timer_registry() | nil,
@@ -40,7 +41,7 @@ defmodule Bedrock.ControlPlane.Director.State do
             cluster: nil,
             config: nil,
             transaction_system_layout: nil,
-            old_transaction_system_layout: nil,
+            prior_core_state: nil,
             coordinator: nil,
             node_capabilities: %{},
             timers: nil,

--- a/test/bedrock/control_plane/config/core_state_test.exs
+++ b/test/bedrock/control_plane/config/core_state_test.exs
@@ -1,0 +1,89 @@
+defmodule Bedrock.ControlPlane.Config.CoreStateTest do
+  @moduledoc """
+  The durable record recovery recovers FROM — FDB's `DBCoreState`, held
+  at recovery as `cstate.prevDBState`. Distinct from the
+  `TransactionSystemLayout` broadcast (FDB's `ServerDBInfo`), which is
+  transient wiring rebuilt every epoch and never persisted.
+  """
+  use ExUnit.Case, async: true
+
+  alias Bedrock.ControlPlane.Config.CoreState
+
+  describe "from_bootstrap/1 - the durable record, projected" do
+    test "carries each log's id and the tags it serves" do
+      bootstrap = %{
+        logs: [
+          %{id: "log_1", shard_tags: [0, 1], otp_ref: %{otp_name: "log_1_name", node: "n1@host"}},
+          %{id: "log_2", shard_tags: [2]}
+        ]
+      }
+
+      assert CoreState.from_bootstrap(bootstrap) == %{logs: %{"log_1" => [0, 1], "log_2" => [2]}}
+    end
+
+    test "a log with no tags carries an empty list, not nil" do
+      # Downstream does Map.keys/1 and MapSet.new/1 over these; a nil
+      # would crash a recovery rather than describe a tagless log.
+      assert CoreState.from_bootstrap(%{logs: [%{id: "log_1"}]}) == %{logs: %{"log_1" => []}}
+    end
+
+    test "a bootstrap with no logs at all is an empty record, never nil" do
+      assert CoreState.from_bootstrap(%{logs: []}) == %{logs: %{}}
+      assert CoreState.from_bootstrap(%{}) == %{logs: %{}}
+      assert CoreState.from_bootstrap(%{logs: nil}) == %{logs: %{}}
+    end
+  end
+
+  describe "from_layout/1 - what survives the epoch that just ended" do
+    test "keeps the log set and drops everything transient" do
+      # A completed recovery's layout becomes the NEXT recovery's prior
+      # state. Only the durable half may cross that boundary: pids die
+      # with the epoch, so carrying them into a record whose whole job
+      # is to outlive the epoch is a category error.
+      layout = %{
+        epoch: 7,
+        sequencer: self(),
+        proxies: [self()],
+        resolvers: [%{start_key: "", resolver: self()}],
+        logs: %{"log_1" => [0, 1]}
+      }
+
+      core_state = CoreState.from_layout(layout)
+
+      assert core_state == %{logs: %{"log_1" => [0, 1]}}
+      refute core_state |> Map.values() |> Enum.any?(&is_pid/1)
+    end
+
+    test "a layout naming no logs projects to a fresh record" do
+      assert %{logs: %{}} = CoreState.from_layout(%{logs: %{}})
+      assert CoreState.fresh?(CoreState.from_layout(%{logs: %{}}))
+    end
+  end
+
+  describe "fresh?/1 - FDB's neverCreated" do
+    test "no prior record at all is a fresh cluster" do
+      assert CoreState.fresh?(nil)
+    end
+
+    test "a prior record naming no logs is a fresh cluster" do
+      # FDB: `!self->cstate.prevDBState.tLogs.size()` sets neverCreated
+      # (ClusterRecovery.actor.cpp:981). A cluster that has never
+      # committed a recovery has a record, but it names nothing.
+      assert CoreState.fresh?(%{logs: %{}})
+    end
+
+    test "a prior record naming any log is NOT fresh - its data must be recovered" do
+      refute CoreState.fresh?(%{logs: %{"log_1" => [0]}})
+    end
+  end
+
+  describe "log_ids/1 - the services recovery must lock" do
+    test "names exactly the logs the prior epoch ran" do
+      assert CoreState.log_ids(%{logs: %{"log_1" => [0], "log_2" => [1]}}) == MapSet.new(["log_1", "log_2"])
+    end
+
+    test "an absent record names nothing - a fresh cluster locks no prior logs" do
+      assert CoreState.log_ids(nil) == MapSet.new()
+    end
+  end
+end

--- a/test/bedrock/control_plane/config/core_state_test.exs
+++ b/test/bedrock/control_plane/config/core_state_test.exs
@@ -77,6 +77,40 @@ defmodule Bedrock.ControlPlane.Config.CoreStateTest do
     end
   end
 
+  describe "the cold and warm paths must agree" do
+    test "a layout projected directly and the same layout round-tripped through the durable record produce the SAME prior state" do
+      # The invariant the whole split rests on. A coordinator that never
+      # restarts projects the layout in memory (from_layout); one that
+      # cold-boots reads the bootstrap it wrote (from_bootstrap). If
+      # these disagree, a recovery behaves differently depending only on
+      # whether the coordinator process happened to survive.
+      layout = %{epoch: 4, sequencer: self(), proxies: [self()], logs: %{"log_a" => [], "log_b" => []}}
+
+      warm = CoreState.from_layout(layout)
+
+      # Exactly what the persistence phase writes into the bootstrap for
+      # this layout: one entry per log, tags carried through.
+      bootstrap = %{
+        logs: for({id, tags} <- layout.logs, do: %{id: id, otp_ref: nil, shard_tags: tags})
+      }
+
+      cold = CoreState.from_bootstrap(bootstrap)
+
+      assert warm == cold
+    end
+  end
+
+  describe "a record missing its :logs key names nothing" do
+    test "log_ids/1 and fresh?/1 agree, so an empty record cannot crash a recovery" do
+      # These two must stay symmetric: if fresh?/1 tolerates a map with
+      # no :logs (answering 'not fresh') while log_ids/1 raises on it,
+      # that record routes to the existing-cluster path and then crashes
+      # the director on the very next call.
+      assert CoreState.log_ids(%{}) == MapSet.new()
+      refute CoreState.fresh?(%{})
+    end
+  end
+
   describe "log_ids/1 - the services recovery must lock" do
     test "names exactly the logs the prior epoch ran" do
       assert CoreState.log_ids(%{logs: %{"log_1" => [0], "log_2" => [1]}}) == MapSet.new(["log_1", "log_2"])

--- a/test/bedrock/control_plane/coordinator/initialization_test.exs
+++ b/test/bedrock/control_plane/coordinator/initialization_test.exs
@@ -36,7 +36,7 @@ defmodule Bedrock.ControlPlane.Coordinator.InitializationTest do
     assert {:ok, state, {:continue, :check_recovery_consensus}} =
              Server.init({TestCluster, TestCluster.otp_name(:coordinator)})
 
-    assert state.old_transaction_system_layout == %{logs: %{"old-log" => []}}
+    assert state.prior_core_state == %{logs: %{"old-log" => []}}
     assert state.transaction_system_layout == nil
   end
 end

--- a/test/bedrock/control_plane/coordinator/integration_test.exs
+++ b/test/bedrock/control_plane/coordinator/integration_test.exs
@@ -69,7 +69,7 @@ defmodule Bedrock.ControlPlane.Coordinator.IntegrationTest do
       expected_args = [
         cluster: TestCluster,
         config: %{},
-        old_transaction_system_layout: %{},
+        prior_core_state: %{},
         epoch: 1,
         coordinator: self(),
         services: services

--- a/test/bedrock/control_plane/coordinator/state_test.exs
+++ b/test/bedrock/control_plane/coordinator/state_test.exs
@@ -11,7 +11,7 @@ defmodule Bedrock.ControlPlane.Coordinator.StateTest do
 
       state =
         struct!(State,
-          old_transaction_system_layout: recovery_source,
+          prior_core_state: recovery_source,
           transaction_system_layout: runnable_layout,
           tsl_subscribers: MapSet.new([self()])
         )
@@ -19,16 +19,27 @@ defmodule Bedrock.ControlPlane.Coordinator.StateTest do
       result = Changes.clear_transaction_system_layout(state)
 
       assert result.transaction_system_layout == nil
-      assert result.old_transaction_system_layout == recovery_source
+      assert result.prior_core_state == recovery_source
       assert_receive {:tsl_updated, nil}
     end
 
-    test "publishing a runnable layout also refreshes the recovery source" do
-      runnable_layout = %{id: "layout-2", epoch: 8, logs: %{}, services: %{}}
+    test "publishing a runnable layout refreshes the recovery source with its DURABLE half only" do
+      # The broadcast goes out whole - subscribers need the pids. What is
+      # kept as the next recovery's prior state is the core state
+      # projected from it: the epoch's pids die with the epoch, and this
+      # slot exists to outlive it.
+      runnable_layout = %{
+        id: "layout-2",
+        epoch: 8,
+        sequencer: self(),
+        proxies: [self()],
+        logs: %{"new-log" => [0]},
+        services: %{}
+      }
 
       state =
         struct!(State,
-          old_transaction_system_layout: %{logs: %{"old-log" => []}},
+          prior_core_state: %{logs: %{"old-log" => []}},
           transaction_system_layout: nil,
           tsl_subscribers: MapSet.new([self()])
         )
@@ -36,7 +47,8 @@ defmodule Bedrock.ControlPlane.Coordinator.StateTest do
       result = Changes.put_transaction_system_layout(state, runnable_layout)
 
       assert result.transaction_system_layout == runnable_layout
-      assert result.old_transaction_system_layout == runnable_layout
+      assert result.prior_core_state == %{logs: %{"new-log" => [0]}}
+      refute Map.has_key?(result.prior_core_state, :sequencer)
       assert_receive {:tsl_updated, ^runnable_layout}
     end
   end

--- a/test/bedrock/control_plane/coordinator/tsl_replay_test.exs
+++ b/test/bedrock/control_plane/coordinator/tsl_replay_test.exs
@@ -58,7 +58,7 @@ defmodule Bedrock.ControlPlane.Coordinator.TslReplayTest do
   test "a recovery-only layout is not replayed as runnable" do
     state =
       follower_state(%{
-        old_transaction_system_layout: %{logs: %{"old-log" => []}},
+        prior_core_state: %{logs: %{"old-log" => []}},
         transaction_system_layout: nil
       })
 
@@ -70,7 +70,7 @@ defmodule Bedrock.ControlPlane.Coordinator.TslReplayTest do
   test "fetch returns unavailable when no runnable layout exists" do
     state =
       follower_state(%{
-        old_transaction_system_layout: %{logs: %{"old-log" => []}},
+        prior_core_state: %{logs: %{"old-log" => []}},
         transaction_system_layout: nil
       })
 

--- a/test/bedrock/control_plane/director/recovery/log_recovery_planning_phase_test.exs
+++ b/test/bedrock/control_plane/director/recovery/log_recovery_planning_phase_test.exs
@@ -13,7 +13,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery.LogRecoveryPlanningPhaseTest do
       with_log_recovery_info(recovery_attempt(), log_recovery_info),
       %{
         node_tracking: nil,
-        old_transaction_system_layout: %{logs: old_logs},
+        prior_core_state: %{logs: old_logs},
         cluster_config: %{
           parameters: %{desired_logs: desired_logs},
           transaction_system_layout: %{logs: old_logs}

--- a/test/bedrock/control_plane/director/recovery/log_recruitment_phase_test.exs
+++ b/test/bedrock/control_plane/director/recovery/log_recruitment_phase_test.exs
@@ -17,7 +17,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery.LogRecruitmentPhaseTest do
   # Helper to create basic test context with common configuration
   defp create_recovery_context(old_logs, available_services \\ %{}, opts \\ []) do
     [
-      old_transaction_system_layout: %{
+      prior_core_state: %{
         logs: old_logs
       }
     ]

--- a/test/bedrock/control_plane/director/recovery/materializer_bootstrap_phase_test.exs
+++ b/test/bedrock/control_plane/director/recovery/materializer_bootstrap_phase_test.exs
@@ -25,7 +25,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhaseTest 
       # Fresh cluster context - no old logs, but with materializer capability
       context =
         [
-          old_transaction_system_layout: %{logs: %{}},
+          prior_core_state: %{logs: %{}},
           node_capabilities: %{
             log: [Node.self()],
             materializer: [Node.self()]
@@ -111,7 +111,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhaseTest 
 
       context =
         [
-          old_transaction_system_layout: %{logs: %{}},
+          prior_core_state: %{logs: %{}},
           node_capabilities: %{
             log: [Node.self()],
             materializer: [Node.self()]
@@ -164,7 +164,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhaseTest 
       # AND no materializer capability in nodes
       context =
         [
-          old_transaction_system_layout: %{
+          prior_core_state: %{
             logs: %{"log_1" => [0, 1]}
           },
           node_capabilities: %{
@@ -212,7 +212,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhaseTest 
 
       context =
         [
-          old_transaction_system_layout: %{
+          prior_core_state: %{
             logs: %{"log_1" => [0, 1]}
           }
         ]
@@ -276,7 +276,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhaseTest 
 
       context =
         [
-          old_transaction_system_layout: %{
+          prior_core_state: %{
             logs: %{"log_1" => [0, 1]}
           }
         ]
@@ -313,7 +313,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhaseTest 
 
       context =
         [
-          old_transaction_system_layout: %{
+          prior_core_state: %{
             logs: %{"log_1" => [0, 1]}
           },
           node_capabilities: %{
@@ -376,7 +376,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhaseTest 
 
       context =
         [
-          old_transaction_system_layout: %{
+          prior_core_state: %{
             logs: %{"log_1" => [0, 1]}
           }
         ]
@@ -421,7 +421,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhaseTest 
 
       context =
         [
-          old_transaction_system_layout: %{
+          prior_core_state: %{
             logs: %{"log_1" => [0, 1]}
           }
         ]
@@ -448,7 +448,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhaseTest 
 
       context =
         [
-          old_transaction_system_layout: %{
+          prior_core_state: %{
             logs: %{"log_1" => [0, 1]}
           },
           node_capabilities: %{
@@ -503,7 +503,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhaseTest 
 
       context =
         [
-          old_transaction_system_layout: %{
+          prior_core_state: %{
             logs: logs
           }
         ]
@@ -564,7 +564,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhaseTest 
     defp existing_context(recovery_version, overrides) do
       base =
         [
-          old_transaction_system_layout: %{logs: %{"log_1" => [0, 1]}}
+          prior_core_state: %{logs: %{"log_1" => [0, 1]}}
         ]
         |> create_test_context()
         |> Map.put(:available_services, %{})
@@ -676,7 +676,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhaseTest 
 
       context =
         [
-          old_transaction_system_layout: %{logs: %{}},
+          prior_core_state: %{logs: %{}},
           node_capabilities: %{log: [Node.self()], materializer: [Node.self()]}
         ]
         |> create_test_context()

--- a/test/bedrock/control_plane/director/recovery/tsl_validation_phase_test.exs
+++ b/test/bedrock/control_plane/director/recovery/tsl_validation_phase_test.exs
@@ -15,7 +15,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery.TSLValidationPhaseTest do
         resolvers: []
       }
 
-      context = %{old_transaction_system_layout: valid_tsl}
+      context = %{prior_core_state: valid_tsl}
 
       {result_attempt, next_phase} = TSLValidationPhase.execute(recovery_attempt, context)
 
@@ -35,7 +35,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery.TSLValidationPhaseTest do
         resolvers: []
       }
 
-      context = %{old_transaction_system_layout: invalid_tsl}
+      context = %{prior_core_state: invalid_tsl}
 
       {result_attempt, next_phase} = TSLValidationPhase.execute(recovery_attempt, context)
 
@@ -43,10 +43,10 @@ defmodule Bedrock.ControlPlane.Director.Recovery.TSLValidationPhaseTest do
       assert {:stalled, {:corrupted_tsl, _validation_error}} = next_phase
     end
 
-    test "transitions to InitializationPhase when context has no old_transaction_system_layout" do
+    test "transitions to InitializationPhase when context has no prior_core_state" do
       recovery_attempt = %RecoveryAttempt{}
 
-      # Context without old_transaction_system_layout
+      # Context without prior_core_state
       context = %{}
 
       {result_attempt, next_phase} = TSLValidationPhase.execute(recovery_attempt, context)
@@ -55,11 +55,11 @@ defmodule Bedrock.ControlPlane.Director.Recovery.TSLValidationPhaseTest do
       assert next_phase == InitializationPhase
     end
 
-    test "transitions to InitializationPhase when old_transaction_system_layout is nil" do
+    test "transitions to InitializationPhase when prior_core_state is nil" do
       recovery_attempt = %RecoveryAttempt{}
 
-      # Context with nil old_transaction_system_layout
-      context = %{old_transaction_system_layout: nil}
+      # Context with nil prior_core_state
+      context = %{prior_core_state: nil}
 
       {result_attempt, next_phase} = TSLValidationPhase.execute(recovery_attempt, context)
 

--- a/test/bedrock/control_plane/director/recovery_test.exs
+++ b/test/bedrock/control_plane/director/recovery_test.exs
@@ -21,7 +21,7 @@ defmodule Bedrock.ControlPlane.Director.RecoveryTest do
       cluster: __MODULE__.TestCluster,
       epoch: 1,
       node_capabilities: node_capabilities,
-      old_transaction_system_layout: %{
+      prior_core_state: %{
         logs: %{}
       },
       config: %{
@@ -422,7 +422,7 @@ defmodule Bedrock.ControlPlane.Director.RecoveryTest do
 
       context =
         create_test_context(
-          old_transaction_system_layout: %{
+          prior_core_state: %{
             logs: %{"existing_log_1" => [0, 100]}
           }
         )
@@ -547,7 +547,7 @@ defmodule Bedrock.ControlPlane.Director.RecoveryTest do
 
       context =
         coordinator_services
-        |> create_coordinator_format_context(old_transaction_system_layout: old_layout)
+        |> create_coordinator_format_context(prior_core_state: old_layout)
         |> Map.update!(
           :available_services,
           &Map.put(&1, "metadata_materializer", {:materializer, {:materializer, :node1}})
@@ -585,7 +585,7 @@ defmodule Bedrock.ControlPlane.Director.RecoveryTest do
       # Mock lock_service_fn to return newer_epoch_exists
       context =
         [
-          old_transaction_system_layout: %{
+          prior_core_state: %{
             logs: %{"existing_log_1" => [0, 100]}
           }
         ]
@@ -680,7 +680,7 @@ defmodule Bedrock.ControlPlane.Director.RecoveryTest do
       |> with_complete_mocking()
 
     # Apply any additional overrides that weren't handled by create_test_context
-    additional_overrides = Keyword.delete(overrides, :old_transaction_system_layout)
+    additional_overrides = Keyword.delete(overrides, :prior_core_state)
 
     Enum.reduce(additional_overrides, base_context, fn {key, value}, ctx ->
       Map.put(ctx, key, value)

--- a/test/bedrock/control_plane/director/service_integration_test.exs
+++ b/test/bedrock/control_plane/director/service_integration_test.exs
@@ -10,7 +10,7 @@ defmodule Bedrock.ControlPlane.Director.ServiceIntegrationTest do
     [
       cluster: TestCluster,
       config: Config.new([:node1, :node2]),
-      old_transaction_system_layout: %{},
+      prior_core_state: %{},
       epoch: 1,
       coordinator: self()
     ]

--- a/test/bedrock/control_plane/director/service_locking_integration_test.exs
+++ b/test/bedrock/control_plane/director/service_locking_integration_test.exs
@@ -31,11 +31,11 @@ defmodule Bedrock.ControlPlane.Director.Recovery.LockingPhaseTest do
       }
 
       # Empty old layout (first-time initialization)
-      old_transaction_system_layout = %{
+      prior_core_state = %{
         logs: %{}
       }
 
-      context = create_full_mocked_context(available_services, old_transaction_system_layout)
+      context = create_full_mocked_context(available_services, prior_core_state)
 
       # Execute TSL validation phase first (this comes before LockingPhase now)
       # Should proceed to LockingPhase since TSL validation passed
@@ -68,13 +68,13 @@ defmodule Bedrock.ControlPlane.Director.Recovery.LockingPhaseTest do
       }
 
       # Old layout from epoch 1 (only bwecaxvz and gb6cddk5 were used)
-      old_transaction_system_layout = %{
+      prior_core_state = %{
         logs: %{"bwecaxvz" => [0, 5]}
       }
 
       context =
         available_services
-        |> create_basic_context(old_transaction_system_layout)
+        |> create_basic_context(prior_core_state)
         |> with_mocked_service_locking()
 
       # Execute TSL validation phase first (this comes before LockingPhase now)
@@ -108,11 +108,11 @@ defmodule Bedrock.ControlPlane.Director.Recovery.LockingPhaseTest do
       }
 
       # Set up old system layout so bwecaxvz is excluded from recruitment
-      old_transaction_system_layout = %{
+      prior_core_state = %{
         logs: %{"bwecaxvz" => [0, 1]}
       }
 
-      context = create_tracking_context(available_services, old_transaction_system_layout)
+      context = create_tracking_context(available_services, prior_core_state)
 
       # Execute log recruitment phase
       # Should have recruited kilvu2af and proceed to LogReplayPhase
@@ -146,11 +146,11 @@ defmodule Bedrock.ControlPlane.Director.Recovery.LockingPhaseTest do
         "kilvu2af" => {:log, {:log_2, :node2}}
       }
 
-      old_transaction_system_layout = %{
+      prior_core_state = %{
         logs: %{"bwecaxvz" => [0, 1]}
       }
 
-      context = create_tracking_context(available_services, old_transaction_system_layout)
+      context = create_tracking_context(available_services, prior_core_state)
 
       # 1. Test selective locking phase - should lock only old system log services
       assert {lock_result, _next_phase} = LockingPhase.execute(recovery_attempt, context)
@@ -324,7 +324,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery.LockingPhaseTest do
   defp create_basic_context(available_services, old_layout) do
     create_test_context()
     |> Map.put(:available_services, available_services)
-    |> Map.put(:old_transaction_system_layout, old_layout)
+    |> Map.put(:prior_core_state, old_layout)
     |> with_multiple_nodes()
   end
 

--- a/test/support/control_plane/recovery_test_support.ex
+++ b/test/support/control_plane/recovery_test_support.ex
@@ -272,27 +272,6 @@ defmodule Bedrock.Test.ControlPlane.RecoveryTestSupport do
   end
 
   @doc """
-  Sets old transaction system layout.
-  """
-  def with_old_layout(context, opts) do
-    layout = %{
-      logs:
-        case Keyword.get(opts, :logs) do
-          nil ->
-            %{}
-
-          count when is_integer(count) ->
-            for i <- 1..count, into: %{}, do: {{:log, i}, ["tag_#{i}"]}
-
-          logs when is_map(logs) ->
-            logs
-        end
-    }
-
-    Map.put(context, :prior_core_state, layout)
-  end
-
-  @doc """
   Sets available services of a specific type.
   """
   def with_available_services(context, service_type, spec) do

--- a/test/support/control_plane/recovery_test_support.ex
+++ b/test/support/control_plane/recovery_test_support.ex
@@ -41,12 +41,12 @@ defmodule Bedrock.Test.ControlPlane.RecoveryTestSupport do
         resolution: [Node.self()]
       })
 
-    old_transaction_system_layout =
-      Keyword.get(opts, :old_transaction_system_layout, %{logs: %{}})
+    prior_core_state =
+      Keyword.get(opts, :prior_core_state, %{logs: %{}})
 
     %{
       node_capabilities: node_capabilities,
-      old_transaction_system_layout: old_transaction_system_layout,
+      prior_core_state: prior_core_state,
       # Deterministic default for the bootstrap's durable-family read;
       # tests exercising the read path override it.
       read_prior_refs_fn: fn _materializer_pid, _read_version -> {:ok, %{}} end,
@@ -289,7 +289,7 @@ defmodule Bedrock.Test.ControlPlane.RecoveryTestSupport do
         end
     }
 
-    Map.put(context, :old_transaction_system_layout, layout)
+    Map.put(context, :prior_core_state, layout)
   end
 
   @doc """


### PR DESCRIPTION
`TransactionSystemLayout` was doing two jobs that FDB keeps in separate structures — and the seam was already a **lie in the type system**.

The coordinator built `%{logs: logs}` — one field — and handed it to recovery typed as `TransactionSystemLayout.t()`, which declares `epoch`, `sequencer`, `proxies`, `resolvers` and `logs` all as `required(...)`. Its own comment admitted it:

> `# Recovery only uses the logs field to determine which logs to copy from`

And the consumers were defensive because they knew: `Map.get(old_layout, :logs, %{})` in the locking phase, `context.prior_core_state[:logs] || %{}` in log-recovery planning, and a fresh-cluster check that matched `%{logs: logs}` because that was the only field really present.

## FDB's divide — which we already had in storage, just not in types

| | FDB | Bedrock |
|---|---|---|
| **Durable** — what the next recovery must find | `DBCoreState` (`DBCoreState.h:132`), held as `cstate.prevDBState` | `ClusterBootstrap` in object storage (no pids) → **now `CoreState`** |
| **Transient** — how this epoch's workers reach each other | `ServerDBInfo` (`ServerDBInfo.actor.h:41`) | `TransactionSystemLayout` (pids) |

`ServerDBInfo`'s own comment states the rule: *"This structure contains transient information which is broadcast to all workers for a database, permitting them to communicate with each other."*

The naming and the predicate are FDB's, not invented:
- `prevDBState` → `prior_core_state`
- `fresh?/1` is FDB's `neverCreated`, which it sets on exactly `!self->cstate.prevDBState.tLogs.size()` (`ClusterRecovery.actor.cpp:981`) — the same "prior record names no logs" test our `fresh_cluster?/1` already performed.

## The split found a real defect on its first day

`put_transaction_system_layout/2` assigned the **whole TSL into the prior-state slot** — storing this epoch's pids as the *next* recovery's durable input. Dialyzer flagged it the moment `prior_core_state` got an honest type.

It worked only because both shapes happen to carry a `:logs` field of the same shape: accidental compatibility, precisely the kind the split exists to eliminate. It now stores `CoreState.from_layout/1`, mirroring FDB's `logSystem->toCoreState` (`ClusterRecovery.actor.cpp:466`), which likewise distills a live log system into what the coordinated state may hold.

**The split also showed its own work:** three modules turned out to alias `TransactionSystemLayout` *only* to type the prior state. Their aliases are now unused and removed — they never touched the broadcast at all.

## Consumers stopped reaching into the map

`CoreState.log_ids/1` and `fresh?/1` replace four separate open-coded expressions (`[:logs] || %{}`, `Map.get(:logs, %{})`, `map_size(logs) == 0`, `Map.keys |> MapSet.new`).

## Deliberately NOT in scope: names

`TSLValidationPhase` now validates a `CoreState`, and the `:corrupted_tsl` stall reason still says TSL. Both are **bedrock-q67.21.14**'s, which renames once purposes have settled rather than twice.

Its moduledoc *is* corrected here, because it was false independent of naming: it claimed to validate `version_vector` and `durable_version`, and the code has never checked either — `validate_type_safety/1` calls exactly `validate_logs` and `validate_resolvers`.

## Gates

2739 tests / 0 failures, 2-seed sweep, `credo --strict` clean, dialyzer clean (was 1 error before the `from_layout` fix).

bedrock-q67.21.11