### PR TITLE
A materializer refuses reads for data it cannot account for

### DIFF
--- a/lib/bedrock/data_plane/materializer/olivine/logic.ex
+++ b/lib/bedrock/data_plane/materializer/olivine/logic.ex
@@ -232,8 +232,9 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Logic do
     # over synchronously; the server withholds the reply for backpressure.
     server = self()
     ingest_fn = fn transactions, kcv -> GenServer.call(server, {:ingest, transactions, kcv}, :infinity) end
+    on_hole_fn = fn floor -> send(server, {:shard_hole, floor}) end
 
-    puller = Streaming.start_pulling(shard_num, start_after, sources, ingest_fn)
+    puller = Streaming.start_pulling(shard_num, start_after, sources, ingest_fn, on_hole_fn)
     put_puller(t, puller)
   end
 

--- a/lib/bedrock/data_plane/materializer/olivine/server.ex
+++ b/lib/bedrock/data_plane/materializer/olivine/server.ex
@@ -79,6 +79,21 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Server do
 
   @impl true
 
+  # A worker that cannot account for its shard's full history refuses,
+  # rather than answering from an incomplete database. Absence and
+  # ignorance are different facts and must never share a reply: {:ok,
+  # nil} here would report "no such key" for keys that exist below a
+  # retention floor this worker cannot reach. :unavailable is retryable
+  # AND routing-invalidating for clients (Internal.Repo), so the caller
+  # re-asks a proxy and may land on a member of the set that CAN answer —
+  # FDB's wrong_shard_server, whose whole purpose is to send the client
+  # somewhere else.
+  def handle_call({:get, _key, _version, _opts}, _from, %State{unreadable_below: floor} = t) when floor != nil,
+    do: reply(t, {:error, :unavailable})
+
+  def handle_call({:get_range, _s, _e, _version, _opts}, _from, %State{unreadable_below: floor} = t) when floor != nil,
+    do: reply(t, {:error, :unavailable})
+
   def handle_call({:get, key, version, opts}, from, %State{} = t) do
     t = touch_read_activity(t)
 
@@ -322,6 +337,26 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Server do
   # placeholder in WITHOUT eager re-recruitment: demand revives the
   # shard on the next read.
   @impl true
+  # The puller found a hole: the cluster's retention floor is above where
+  # our data ends, so the span between exists nowhere we can reach. This
+  # is not transient and not a fault of any one log — every replica
+  # answers identically — so it is recorded once and the worker stops
+  # answering reads. It stays unreadable for its lifetime: Bedrock has no
+  # equivalent of FDB's fetchKeys, so nothing here can close the gap.
+  # Making it VISIBLE is the point; a worker serving an incomplete shard
+  # silently is the failure this prevents.
+  def handle_info({:shard_hole, _floor}, %State{unreadable_below: existing} = t) when existing != nil, do: noreply(t)
+
+  def handle_info({:shard_hole, floor}, %State{} = t) do
+    Logger.error(
+      "Bedrock materializer #{t.id} (shard #{inspect(t.shard_id)}): log retention floor #{inspect(floor)} is above " <>
+        "this worker's data; it cannot serve this shard and will refuse reads"
+    )
+
+    OlivineTelemetry.trace_shard_unreadable(t.id, t.shard_id, floor)
+    noreply(%{t | unreadable_below: floor})
+  end
+
   def handle_info(:idle_check, %State{idle_timeout: :infinity} = t), do: noreply(t)
 
   # A locked worker is mid-recovery: the director is counting on it, and

--- a/lib/bedrock/data_plane/materializer/olivine/state.ex
+++ b/lib/bedrock/data_plane/materializer/olivine/state.ex
@@ -34,7 +34,8 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.State do
           idle_timeout: pos_integer() | :infinity,
           last_read_at: integer() | nil,
           known_committed_version: Bedrock.version() | nil,
-          pending_ingest: GenServer.from() | nil
+          pending_ingest: GenServer.from() | nil,
+          unreadable_below: Bedrock.version() | nil
         }
   defstruct otp_name: nil,
             path: nil,
@@ -58,7 +59,13 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.State do
             idle_timeout: :infinity,
             last_read_at: nil,
             known_committed_version: nil,
-            pending_ingest: nil
+            pending_ingest: nil,
+            # The cluster's retention floor, recorded ONLY when the log has
+            # told us it sits above where our data ends. Non-nil means this
+            # worker cannot account for its shard's full history and must
+            # refuse reads rather than answer from an incomplete database
+            # (FDB: a shard that has not finished fetching is not readable).
+            unreadable_below: nil
 
   @spec update_mode(t(), :locked | :running) :: t()
   def update_mode(t, mode), do: %{t | mode: mode}

--- a/lib/bedrock/data_plane/materializer/olivine/streaming.ex
+++ b/lib/bedrock/data_plane/materializer/olivine/streaming.ex
@@ -43,6 +43,13 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Streaming do
 
   @type source :: {Log.id(), Log.ref()}
 
+  @typedoc """
+  Reports that this materializer cannot account for its shard's full
+  history: the cluster's retention floor sits above where our data ends,
+  so everything between is unreachable from here. Called with the floor.
+  """
+  @type on_hole_fn :: (Bedrock.version() -> any())
+
   @type puller_state :: %{
           shard_num: non_neg_integer(),
           next_version: Bedrock.version(),
@@ -50,16 +57,18 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Streaming do
           failed_logs: %{Log.id() => integer()},
           shard_server: pid() | nil,
           current_log_id: Log.id() | nil,
-          ingest_fn: ingest_fn()
+          ingest_fn: ingest_fn(),
+          on_hole_fn: on_hole_fn()
         }
 
   @spec start_pulling(
           shard_num :: non_neg_integer(),
           start_after :: Bedrock.version(),
           sources :: [source()],
-          ingest_fn()
+          ingest_fn(),
+          on_hole_fn()
         ) :: Task.t()
-  def start_pulling(shard_num, start_after, sources, ingest_fn) do
+  def start_pulling(shard_num, start_after, sources, ingest_fn, on_hole_fn) do
     state = %{
       shard_num: shard_num,
       next_version: Version.increment(start_after),
@@ -67,7 +76,8 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Streaming do
       failed_logs: %{},
       shard_server: nil,
       current_log_id: nil,
-      ingest_fn: ingest_fn
+      ingest_fn: ingest_fn,
+      on_hole_fn: on_hole_fn
     }
 
     Task.async(fn -> stream_loop(state) end)
@@ -127,6 +137,19 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Streaming do
 
       {:error, :timeout} ->
         # A quiet long-poll window: same server, ask again.
+        state
+
+      {:error, {:version_too_old, floor}} ->
+        # NOT this log's fault, and not transient: our position is below
+        # the cluster's retention floor, so the data between what we hold
+        # and that floor exists nowhere we can reach. Every replica
+        # answers identically — failing over rotates through all of them,
+        # trips the breaker, and loops forever while reads keep being
+        # served from an incomplete database. Report it and let the worker
+        # refuse reads instead (FDB: a shard that has not finished
+        # fetching is not readable).
+        trace_log_pull_failed(state.next_version, {:version_too_old, floor})
+        state.on_hole_fn.(floor)
         state
 
       {:error, reason} ->

--- a/lib/bedrock/data_plane/materializer/olivine/telemetry.ex
+++ b/lib/bedrock/data_plane/materializer/olivine/telemetry.ex
@@ -4,6 +4,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Telemetry do
   """
 
   alias Bedrock.DataPlane.Materializer.Telemetry
+  alias Bedrock.Service.Worker
 
   @spec trace_read_operation_complete(term(), term(), keyword()) :: :ok
   def trace_read_operation_complete(operation, key, opts) do
@@ -75,6 +76,21 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Telemetry do
     }
 
     Telemetry.emit_materializer_operation(:compaction_started, measurements, metadata)
+  end
+
+  @doc """
+  This worker cannot account for its shard's full history: the log's
+  retention floor sits above where its data ends. It will refuse reads
+  from here on, so this is the event that explains a shard going
+  unavailable rather than silently wrong.
+  """
+  @spec trace_shard_unreadable(Worker.id(), String.t() | nil, Bedrock.version()) :: :ok
+  def trace_shard_unreadable(worker_id, shard_id, floor) do
+    Telemetry.emit_materializer_operation(
+      :shard_unreadable,
+      %{},
+      %{worker_id: worker_id, shard_id: shard_id, retention_floor: floor}
+    )
   end
 
   @spec trace_compaction_complete(Bedrock.version(), keyword()) :: :ok

--- a/test/bedrock/data_plane/materializer/olivine/readability_test.exs
+++ b/test/bedrock/data_plane/materializer/olivine/readability_test.exs
@@ -1,0 +1,71 @@
+defmodule Bedrock.DataPlane.Materializer.Olivine.ReadabilityTest do
+  @moduledoc """
+  A materializer answers questions it has the answers to, and refuses the
+  ones it doesn't — FoundationDB's storage-server contract.
+
+  FDB tracks per-shard state (`storageserver.actor.cpp:470`) and gates
+  reads on it: `isReadable()` is `readWrite != nullptr` (`:558`), and a
+  shard still fetching gets `wrong_shard_server` at the request boundary
+  (`:2994`). It never ranks itself against peers and never guesses; it
+  knows locally whether it can serve, and says so.
+
+  Our evidence for "I cannot serve this" is the log's own answer:
+  `{:error, {:version_too_old, floor}}` means the cluster's retention
+  floor sits above where this worker's data ends, so the span between is
+  unreachable from here. Anything it returned for those keys would be
+  absence-shaped and wrong.
+  """
+  use ExUnit.Case, async: false
+
+  alias Bedrock.DataPlane.Materializer.Olivine
+  alias Bedrock.DataPlane.Version
+
+  @moduletag :tmp_dir
+
+  defp start_worker(tmp_dir) do
+    worker_id = "readable_wkr_#{System.unique_integer([:positive])}"
+    otp_name = :"olivine_readable_#{System.unique_integer([:positive])}"
+
+    child_spec =
+      Olivine.child_spec(otp_name: otp_name, foreman: self(), id: worker_id, path: tmp_dir, params: %{})
+
+    {GenServer, :start_link, args} = child_spec.start
+    {:ok, pid} = apply(GenServer, :start, args)
+
+    receive do
+      {:"$gen_cast", {:worker_health, ^worker_id, {:ok, ^pid}}} -> :ok
+    after
+      5_000 -> flunk("no health report")
+    end
+
+    :sys.replace_state(pid, &%{&1 | mode: :running})
+    pid
+  end
+
+  describe "a worker that cannot account for its shard's history refuses reads" do
+    test "a get is refused with :unavailable, never answered as an absent key", %{tmp_dir: tmp_dir} do
+      pid = start_worker(tmp_dir)
+      v = Version.from_integer(0)
+
+      # Before the hole is known the worker ANSWERS: it believes it holds
+      # the shard, so it reports the key as absent.
+      assert {:error, :not_found} = GenServer.call(pid, {:get, "k", v, [timeout: 100]}, 500)
+
+      send(pid, {:shard_hole, Version.from_integer(9000)})
+
+      # After it, the SAME read must not answer. An absence reply here
+      # would be a wrong answer dressed as a right one: the key may well
+      # exist below the retention floor this worker cannot reach.
+      assert {:error, :unavailable} = GenServer.call(pid, {:get, "k", v, [timeout: 100]}, 500)
+    end
+
+    test "a get_range is refused too — the same data is missing either way", %{tmp_dir: tmp_dir} do
+      pid = start_worker(tmp_dir)
+      v = Version.from_integer(0)
+
+      send(pid, {:shard_hole, Version.from_integer(9000)})
+
+      assert {:error, :unavailable} = GenServer.call(pid, {:get_range, "a", "z", v, [timeout: 100]}, 500)
+    end
+  end
+end

--- a/test/bedrock/data_plane/materializer/olivine/streaming_test.exs
+++ b/test/bedrock/data_plane/materializer/olivine/streaming_test.exs
@@ -67,8 +67,35 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.StreamingTest do
         failed_logs: %{},
         shard_server: shard_server,
         current_log_id: "log-a",
-        ingest_fn: ingest_fn
+        ingest_fn: ingest_fn,
+        on_hole_fn: fn _floor -> :ok end
       }
+    end
+
+    test "version_too_old is a HOLE in our own data, not a fault of the log we asked" do
+      # Every log will answer the same way: the position is below the
+      # retention floor, which is a statement about THIS materializer, not
+      # about that replica. Failing over rotates through every log,
+      # marks them all bad, and loops forever — while reads keep being
+      # served from a database that is missing everything below the floor.
+      floor = Version.from_integer(9000)
+      test_pid = self()
+
+      {:ok, stub} = StubShardServer.start_link([{:reply, {:error, {:version_too_old, floor}}}], self())
+
+      state =
+        stub
+        |> state_with(fn _t, _kcv -> :ok end)
+        |> Map.put(:on_hole_fn, fn reported_floor -> send(test_pid, {:hole, reported_floor}) end)
+
+      new_state = Streaming.pull_once(state)
+
+      # Reported once, with the floor, so the worker can refuse reads.
+      assert_receive {:hole, ^floor}
+
+      # NOT treated as a per-log failure: the log we asked is fine.
+      assert new_state.failed_logs == %{}
+      assert new_state.current_log_id == "log-a"
     end
 
     test "ingests pulled slices and advances past the last version" do
@@ -210,7 +237,8 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.StreamingTest do
           1,
           Version.from_integer(99),
           [{"log-a", log}],
-          ingest_fn
+          ingest_fn,
+          fn _floor -> :ok end
         )
 
       # on_exit runs outside the task's owner, so stop the raw pid directly


### PR DESCRIPTION
A materializer answered **every** read, whether or not it held the shard's data. Absence and ignorance shared one reply: a key that exists below a retention floor the worker cannot reach came back indistinguishable from a key that was never written.

## The evidence was already arriving — and being thrown away

The log answers `{:error, {:version_too_old, floor}}` when a puller's position is below the retention floor (`shale/pulling.ex:23,40`). That's a statement about **this worker's data**, not about that replica.

`pull_once/1` treated it as a generic pull failure and failed over:

```elixir
{:error, reason} ->
  trace_log_pull_failed(state.next_version, reason)
  fail_over(state)
```

So the worker rotated through every log, got the identical answer from each (it's not a per-log condition), marked them all bad, tripped the circuit breaker, slept, reset, and looped. **Forever.** While serving reads from an incomplete database.

That path is now the readability signal.

## FDB's contract

A storage server tracks per-shard state locally (`storageserver.actor.cpp:470` — `notAssigned` / `adding` / `moveInShard` / `readWrite`) and gates reads on it:

```cpp
bool isReadable() const { return readWrite != nullptr; }     // :558
if (!data->isReadable(req.range))                            // :2994
    req.reply.sendError(wrong_shard_server());
```

A shard still fetching is **not readable**. The server never ranks itself against peers and never guesses — it knows locally whether it can serve, and says so.

## Why `:unavailable` and not a version error

Both are retryable, but only the routing-invalidating set makes a client drop its cached location and re-ask a proxy (`Internal.Repo`) — which is the point: another member of the shard's set may be able to answer.

A version error would retry **the same worker forever**, because a version miss means "come back later," not "ask someone else." Repo's own comment says it: *"Version window misses are not routing's fault."*

| Condition | Reply | Client |
|---|---|---|
| Holds the shard, not yet at that version | version error | retry, keep routing |
| Does **not** hold the shard's data | `:unavailable` | retry **and** re-fetch routing |
| Key genuinely absent | absence | done |

The third row must never absorb the second.

## What this does NOT do

**It does not close the hole.** Bedrock has no equivalent of FDB's `fetchKeys`, so an unreadable worker stays unreadable for its lifetime.

This trades a silent wrong answer for a visible unavailability. That's the right trade and not a free one: with one real member per shard — the common case today — a client that re-asks gets the same worker and is refused again. Availability improves as the set model fills in and the pick learns to prefer readable members; that is deliberately not smuggled in here.

## Relationship to q67.21.17

It **contains** the S3-list bug (a backend error silently becoming an empty listing, so a materializer starts empty for a populated shard). Such a worker is now refused by the log and marks itself unreadable rather than serving an empty shard. Containment, not a fix — that bug still causes needless full replays and spurious unreadable shards, and is filed separately.

## Gates

2744 tests / 0 failures, 2-seed sweep, `credo --strict` clean, dialyzer clean.

bedrock-q67.21.16