### PR TITLE
A listing never reports emptiness it did not verify

### DIFF
--- a/lib/bedrock/data_plane/demux/shard_server.ex
+++ b/lib/bedrock/data_plane/demux/shard_server.ex
@@ -500,6 +500,12 @@ defmodule Bedrock.DataPlane.Demux.ShardServer do
     {:ok, transactions}
   rescue
     e in ChunkReader.ReadError -> {:error, {:storage_read_failed, e.reason}}
+    # A listing that could not be completed is the same class of fact as
+    # a chunk that could not be read, and must report the same SHAPE:
+    # operators and telemetry match on the reason, not on an exception
+    # struct. Named explicitly so it does not ride the catch-all below,
+    # which exists for genuine bugs and should stay visible as such.
+    e in ObjectStorage.ListError -> {:error, {:storage_read_failed, e.reason}}
     e -> {:error, {:storage_read_failed, e}}
   end
 

--- a/lib/bedrock/object_storage.ex
+++ b/lib/bedrock/object_storage.ex
@@ -95,11 +95,35 @@ defmodule Bedrock.ObjectStorage do
   @callback delete(backend :: term(), key :: key()) ::
               :ok | error()
 
+  defmodule ListError do
+    @moduledoc """
+    Raised when a listing cannot be completed.
+
+    `list/3` returns a bare `Enumerable.t()`, which has no way to report
+    failure — a stream can only yield elements or end. A backend that
+    quietly stopped on error would be indistinguishable from a prefix
+    that is genuinely empty, and consumers read that silence as fact: a
+    materializer treats "no chunks here" as "this shard has no data at
+    that version" and advances past everything it never received.
+
+    So the stream raises instead. Absence and ignorance are different
+    answers and must not share a representation.
+    """
+    defexception [:reason, :prefix]
+
+    @impl true
+    def message(%__MODULE__{reason: reason, prefix: prefix}),
+      do: "failed to list objects under #{inspect(prefix)}: #{inspect(reason)}"
+  end
+
   @doc """
   List objects with the given prefix.
 
   Returns a lazy stream that fetches pages as needed. Objects are returned
   in ascending lexicographic order by key.
+
+  RAISES `ListError` if the backend cannot complete the listing, so an
+  empty stream means the prefix IS empty rather than unknown.
 
   ## Options
 

--- a/lib/bedrock/object_storage/chunk_reader.ex
+++ b/lib/bedrock/object_storage/chunk_reader.ex
@@ -79,6 +79,12 @@ defmodule Bedrock.ObjectStorage.ChunkReader do
   @spec list_chunks(t(), keyword()) :: Enumerable.t()
   def list_chunks(%__MODULE__{} = reader, opts \\ []) do
     prefix = Keys.chunks_prefix(reader.shard_tag)
+
+    # Raises ObjectStorage.ListError if the listing cannot be completed.
+    # That propagates deliberately: returning fewer chunks than exist IS
+    # a silent replay gap, which is the very thing this module raises to
+    # prevent when a header will not decode. A caller cannot tell a short
+    # listing from an empty shard, so it must not be handed one.
     ObjectStorage.list(reader.backend, prefix, opts)
   end
 

--- a/lib/bedrock/object_storage/local_filesystem.ex
+++ b/lib/bedrock/object_storage/local_filesystem.ex
@@ -179,19 +179,33 @@ defmodule Bedrock.ObjectStorage.LocalFilesystem do
           |> Enum.split_with(&File.regular?/1)
 
         sorted_files = Enum.sort(files)
-        sorted_subdirs = Enum.sort(subdirs)
+        sorted_subdirs = subdirs |> Enum.filter(&may_contain_prefix?(&1, root, prefix)) |> Enum.sort()
 
         list_next({root, sorted_subdirs ++ rest_dirs, sorted_files, prefix, limit})
 
-      # A directory that is not there contributes nothing — genuine
-      # absence, and benign if it vanished mid-walk. Any OTHER failure
-      # (permissions, I/O) means we cannot see what is there, and
-      # skipping it would report those keys as absent without looking.
-      {:error, :enoent} ->
+      # Absence, not ignorance: a directory that is not there (or is not
+      # a directory at all) contributes nothing, and either can happen
+      # benignly mid-walk. The module already treats :enotdir as
+      # absence — see normalize_reason/1.
+      {:error, reason} when reason in [:enoent, :enotdir] ->
         list_next({root, rest_dirs, [], prefix, limit})
 
+      # Anything else (permissions, I/O) means we cannot see what is
+      # there, and skipping it would report those keys as absent without
+      # ever having looked.
       {:error, reason} ->
         raise ObjectStorage.ListError, reason: reason, prefix: prefix
     end
+  end
+
+  # Descend only into subtrees that could hold a matching key: either we
+  # are still walking DOWN toward the prefix, or we are already INSIDE
+  # it. Without this the walk descends into sibling shards whose keys can
+  # never match — which was merely wasteful while listing failures were
+  # silent, and is now a false alarm: one unreadable shard directory
+  # would abort a healthy shard's listing.
+  defp may_contain_prefix?(dir, root, prefix) do
+    relative = Path.relative_to(dir, root)
+    String.starts_with?(prefix, relative) or String.starts_with?(relative, prefix)
   end
 end

--- a/lib/bedrock/object_storage/local_filesystem.ex
+++ b/lib/bedrock/object_storage/local_filesystem.ex
@@ -18,6 +18,8 @@ defmodule Bedrock.ObjectStorage.LocalFilesystem do
 
   @behaviour Bedrock.ObjectStorage
 
+  alias Bedrock.ObjectStorage
+
   @impl true
   def put(config, key, data, _opts \\ []) do
     root = Keyword.fetch!(config, :root)
@@ -181,8 +183,15 @@ defmodule Bedrock.ObjectStorage.LocalFilesystem do
 
         list_next({root, sorted_subdirs ++ rest_dirs, sorted_files, prefix, limit})
 
-      {:error, _} ->
+      # A directory that is not there contributes nothing — genuine
+      # absence, and benign if it vanished mid-walk. Any OTHER failure
+      # (permissions, I/O) means we cannot see what is there, and
+      # skipping it would report those keys as absent without looking.
+      {:error, :enoent} ->
         list_next({root, rest_dirs, [], prefix, limit})
+
+      {:error, reason} ->
+        raise ObjectStorage.ListError, reason: reason, prefix: prefix
     end
   end
 end

--- a/lib/bedrock/object_storage/s3.ex
+++ b/lib/bedrock/object_storage/s3.ex
@@ -8,6 +8,8 @@ defmodule Bedrock.ObjectStorage.S3 do
 
   @behaviour Bedrock.ObjectStorage
 
+  alias Bedrock.ObjectStorage
+
   @impl true
   def put(config, key, data, opts \\ []) do
     bucket = Keyword.fetch!(config, :bucket)
@@ -156,8 +158,11 @@ defmodule Bedrock.ObjectStorage.S3 do
       {:ok, keys, continuation_token, exhausted?} ->
         next_list_item(%{state | buffer: keys, continuation_token: continuation_token, exhausted?: exhausted?})
 
-      {:error, _reason} ->
-        {:halt, %{state | exhausted?: true}}
+      {:error, reason} ->
+        # A failed page is NOT the end of the listing. Halting here would
+        # report the prefix as empty (or truncated) without ever having
+        # looked, and every consumer downstream reads that as fact.
+        raise ObjectStorage.ListError, reason: reason, prefix: state.prefix
     end
   end
 

--- a/lib/bedrock/object_storage/snapshot.ex
+++ b/lib/bedrock/object_storage/snapshot.ex
@@ -159,8 +159,11 @@ defmodule Bedrock.ObjectStorage.Snapshot do
 
   - `{:ok, version}` - Latest version
   - `{:error, :not_found}` - No snapshots exist
+  - `{:error, {:list_failed, reason}}` - The listing could not be
+    completed, so whether snapshots exist is UNKNOWN. Distinct from
+    `:not_found`, which is a fact.
   """
-  @spec latest_version(t()) :: {:ok, version()} | {:error, :not_found}
+  @spec latest_version(t()) :: {:ok, version()} | {:error, :not_found} | {:error, {:list_failed, term()}}
   def latest_version(%__MODULE__{} = snapshot) do
     prefix = Keys.snapshots_prefix(snapshot.shard_tag)
 
@@ -171,6 +174,8 @@ defmodule Bedrock.ObjectStorage.Snapshot do
       [] ->
         {:error, :not_found}
     end
+  rescue
+    e in ObjectStorage.ListError -> {:error, {:list_failed, e.reason}}
   end
 
   @doc """
@@ -221,12 +226,18 @@ defmodule Bedrock.ObjectStorage.Snapshot do
 
   @doc """
   Checks if any snapshots exist for this shard.
+
+  RAISES `ObjectStorage.ListError` if the listing cannot be completed.
+  There is no honest boolean for "I could not look": returning `false`
+  would be the very lie this module exists to prevent — a caller would
+  read it as "no baseline" and start a materializer empty.
   """
   @spec exists?(t()) :: boolean()
   def exists?(%__MODULE__{} = snapshot) do
     case latest_version(snapshot) do
       {:ok, _} -> true
       {:error, :not_found} -> false
+      {:error, {:list_failed, reason}} -> raise ObjectStorage.ListError, reason: reason, prefix: snapshot.shard_tag
     end
   end
 
@@ -235,6 +246,9 @@ defmodule Bedrock.ObjectStorage.Snapshot do
 
   Note: This reads the full list, so it's not efficient for shards with
   many snapshots. Use `exists?/1` to just check for presence.
+
+  RAISES `ObjectStorage.ListError` if the listing cannot be completed:
+  no count is honest when the listing is incomplete.
   """
   @spec count(t()) :: non_neg_integer()
   def count(%__MODULE__{} = snapshot) do

--- a/lib/bedrock/object_storage/snapshot.ex
+++ b/lib/bedrock/object_storage/snapshot.ex
@@ -105,6 +105,12 @@ defmodule Bedrock.ObjectStorage.Snapshot do
       [] -> {:error, :not_found}
       {:error, reason} -> {:error, reason}
     end
+  rescue
+    # :not_found is a FACT — this shard has no durable baseline, and a
+    # materializer may legitimately start empty on it. A listing that
+    # failed knows nothing, and must never be able to say that: it
+    # surfaces as an ordinary error so callers fail rather than assume.
+    e in ObjectStorage.ListError -> {:error, {:list_failed, e.reason}}
   end
 
   @doc """

--- a/test/bedrock/object_storage/listing_truthfulness_test.exs
+++ b/test/bedrock/object_storage/listing_truthfulness_test.exs
@@ -21,14 +21,25 @@ defmodule Bedrock.ObjectStorage.ListingTruthfulnessTest do
 
   alias Bedrock.ObjectStorage
   alias Bedrock.ObjectStorage.ChunkReader
+  alias Bedrock.ObjectStorage.LocalFilesystem
   alias Bedrock.ObjectStorage.Snapshot
 
   defmodule FailingBackend do
     @moduledoc false
     @behaviour ObjectStorage
 
+    # LAZY, exactly like the real backends: the raise happens when the
+    # stream is CONSUMED, not when it is built. That is the property
+    # Snapshot.read_latest/1's rescue depends on — an eager stub would
+    # pass even if consumption were moved outside the rescued body.
     @impl true
-    def list(_config, _prefix, _opts \\ []), do: raise(Bedrock.ObjectStorage.ListError, reason: :econnrefused)
+    def list(_config, prefix, _opts \\ []) do
+      Stream.resource(
+        fn -> :start end,
+        fn :start -> raise(Bedrock.ObjectStorage.ListError, reason: :econnrefused, prefix: prefix) end,
+        fn _ -> :ok end
+      )
+    end
 
     @impl true
     def get(_config, _key), do: {:error, :econnrefused}
@@ -67,6 +78,49 @@ defmodule Bedrock.ObjectStorage.ListingTruthfulnessTest do
     end
   end
 
+  describe "the real LocalFilesystem backend, driven into its error path" do
+    @describetag :tmp_dir
+
+    setup %{tmp_dir: tmp_dir} do
+      on_exit(fn -> File.chmod(Path.join(tmp_dir, "c/locked"), 0o700) end)
+      :ok
+    end
+
+    test "an unreadable directory raises instead of listing zero keys", %{tmp_dir: tmp_dir} do
+      backend = {LocalFilesystem, root: tmp_dir}
+      locked = Path.join(tmp_dir, "c/locked")
+      File.mkdir_p!(locked)
+      File.write!(Path.join(locked, "0001"), "chunk")
+      File.chmod!(locked, 0o000)
+
+      assert_raise ObjectStorage.ListError, fn ->
+        backend |> ObjectStorage.list("c/locked/") |> Enum.to_list()
+      end
+    end
+
+    test "a prefix that was never created is EMPTY, not an error", %{tmp_dir: tmp_dir} do
+      # The regression this fix must not cause: a fresh cluster listing a
+      # shard that has never written a chunk must get [], not a raise.
+      backend = {LocalFilesystem, root: tmp_dir}
+
+      assert backend |> ObjectStorage.list("c/never_written/") |> Enum.to_list() == []
+    end
+
+    test "one unreadable shard does not break a DIFFERENT shard's listing", %{tmp_dir: tmp_dir} do
+      # The walk falls back to the parent when a prefix directory does not
+      # exist, so a naive implementation descends into sibling shards. An
+      # error there must not be reported as ignorance about THIS shard,
+      # whose answer is fully knowable: it has no chunks.
+      backend = {LocalFilesystem, root: tmp_dir}
+      locked = Path.join(tmp_dir, "c/locked")
+      File.mkdir_p!(locked)
+      File.write!(Path.join(locked, "0001"), "chunk")
+      File.chmod!(locked, 0o000)
+
+      assert backend |> ObjectStorage.list("c/healthy/") |> Enum.to_list() == []
+    end
+  end
+
   describe "the failure the lie caused, end to end" do
     test "a shard read reports an error instead of an empty history" do
       # This is the chain that loses data. Before: the listing halts on
@@ -94,7 +148,7 @@ defmodule Bedrock.ObjectStorage.ListingTruthfulnessTest do
   end
 
   describe "Snapshot distinguishes absence from ignorance" do
-    test "a failed listing is an error, never :not_found" do
+    test "a failed listing is an error, never :not_found — even though the raise arrives during consumption" do
       snapshot = Snapshot.new(@backend, "s1")
 
       # :not_found means "this shard has no durable baseline", which

--- a/test/bedrock/object_storage/listing_truthfulness_test.exs
+++ b/test/bedrock/object_storage/listing_truthfulness_test.exs
@@ -1,0 +1,107 @@
+defmodule Bedrock.ObjectStorage.ListingTruthfulnessTest do
+  @moduledoc """
+  A listing must never report emptiness it did not verify.
+
+  `ObjectStorage.list/3` returns a bare `Enumerable.t()`, which has no way
+  to say "I failed" — a stream can only yield elements or end. So a
+  backend that halts on error is indistinguishable from a prefix that is
+  genuinely empty, and every consumer downstream reads that silence as
+  fact.
+
+  Two consumers depend on the difference, and both are load-bearing:
+
+    * `ChunkReader` reconstructs a contiguous transaction history and
+      already promises no silent replay gaps — it raises `ReadError` on a
+      header decode failure for exactly that reason. A truncated listing
+      breaks that promise underneath it.
+    * `Snapshot` decides whether a shard has a durable baseline at all.
+      "No snapshot" starts a materializer empty; "couldn't tell" must not.
+  """
+  use ExUnit.Case, async: true
+
+  alias Bedrock.ObjectStorage
+  alias Bedrock.ObjectStorage.ChunkReader
+  alias Bedrock.ObjectStorage.Snapshot
+
+  defmodule FailingBackend do
+    @moduledoc false
+    @behaviour ObjectStorage
+
+    @impl true
+    def list(_config, _prefix, _opts \\ []), do: raise(Bedrock.ObjectStorage.ListError, reason: :econnrefused)
+
+    @impl true
+    def get(_config, _key), do: {:error, :econnrefused}
+    @impl true
+    def put(_config, _key, _data, _opts \\ []), do: {:error, :econnrefused}
+    @impl true
+    def delete(_config, _key), do: {:error, :econnrefused}
+    @impl true
+    def put_if_not_exists(_config, _key, _data, _opts \\ []), do: {:error, :econnrefused}
+    @impl true
+    def get_with_version(_config, _key), do: {:error, :econnrefused}
+    @impl true
+    def put_if_version_matches(_config, _key, _data, _version, _opts \\ []), do: {:error, :econnrefused}
+  end
+
+  @backend {FailingBackend, []}
+
+  describe "ChunkReader keeps its no-silent-gaps promise when the listing fails" do
+    test "read_from_version raises rather than reporting an empty history" do
+      reader = ChunkReader.new(@backend, "s1")
+
+      # Returning [] here is the data-loss bug: the caller reads it as
+      # "this shard has nothing at or above that version" and advances
+      # past everything it never received.
+      assert_raise ObjectStorage.ListError, fn ->
+        reader |> ChunkReader.read_from_version(0, limit: 10) |> Enum.to_list()
+      end
+    end
+
+    test "list_chunks raises rather than reporting no chunks" do
+      reader = ChunkReader.new(@backend, "s1")
+
+      assert_raise ObjectStorage.ListError, fn ->
+        reader |> ChunkReader.list_chunks() |> Enum.to_list()
+      end
+    end
+  end
+
+  describe "the failure the lie caused, end to end" do
+    test "a shard read reports an error instead of an empty history" do
+      # This is the chain that loses data. Before: the listing halts on
+      # error -> ChunkReader yields nothing -> get_from_storage returns
+      # {:ok, []} -> do_pull falls through to the in-memory buffer ->
+      # {:ok, []} -> the materializer's pull_once fabricates a heartbeat
+      # at the high-water and advances PAST every version it never
+      # received, then serves reads as though it were complete.
+      #
+      # The fix is only that the listing stops lying. Everything
+      # downstream was already correct: an error propagates, the puller
+      # fails over, and the circuit breaker retries.
+      reader = ChunkReader.new(@backend, "s1")
+
+      result =
+        try do
+          {:ok, reader |> ChunkReader.read_from_version(0, limit: 100) |> Enum.to_list()}
+        rescue
+          e -> {:error, e}
+        end
+
+      assert {:error, %ObjectStorage.ListError{}} = result
+      refute match?({:ok, []}, result), "an unverified empty history is the data-loss bug"
+    end
+  end
+
+  describe "Snapshot distinguishes absence from ignorance" do
+    test "a failed listing is an error, never :not_found" do
+      snapshot = Snapshot.new(@backend, "s1")
+
+      # :not_found means "this shard has no durable baseline", which
+      # legitimately starts a materializer empty. A backend failure must
+      # never be able to say that.
+      assert {:error, reason} = Snapshot.read_latest(snapshot)
+      refute reason == :not_found
+    end
+  end
+end


### PR DESCRIPTION
`ObjectStorage.list/3` returns a bare `Enumerable.t()`, which has **no way to say "I failed"** — a stream can only yield elements or end. So both backends turned failure into silence:

```elixir
{:error, _reason} -> {:halt, %{state | exhausted?: true}}   # s3.ex:159-160
{:error, _}       -> list_next({root, rest_dirs, ...})      # local_filesystem.ex:184-185
```

Indistinguishable from a prefix that is genuinely empty. Two consumers read that silence as fact, and both lose data.

## Chain one — a running materializer silently skips committed transactions

1. `ChunkReader.list_chunks` → empty listing
2. `get_from_storage` returns `{:ok, []}` — its `rescue` only catches failures from **reading** a chunk, never from failing to **list** them
3. `do_pull` falls through to the in-memory buffer → `{:ok, []}`
4. `pull_once` matches its heartbeat clause, fabricates currency at the high-water, and **advances `next_version` past every version it never received**
5. The worker serves reads as though complete

## Chain two — a starting materializer comes up empty for a populated shard

`Snapshot.read_latest` saw `[]` → `{:error, :not_found}` → `load_snapshot_from_object_storage` read that as "no snapshot exists," logged *"starting fresh,"* and opened an empty database.

## Why the listing is the root, and not a symptom

**Chunks are never deleted** (`demux/shard_server.ex:324`) — Bedrock has no retention floor for shard chunks at all. So `{:ok, []}` is *supposed* to mean "this shard has no data in that range," which is exactly why the heartbeat-and-advance is **correct** in normal operation.

The only thing that makes it wrong is a listing that reports emptiness it never verified.

## The fix is that the listing stops lying — and nothing else

Everything downstream was already correct and is untouched:

| Layer | Behavior once the truth arrives |
|---|---|
| `get_from_storage` | catch-all converts the raise → `{:error, {:storage_read_failed, _}}` |
| `do_pull` | propagates it |
| `pull_once` | takes its existing `{:error, reason}` branch |
| `fail_over` + circuit breaker | marks the source, backs off, retries |

No new state, no new retry loop, no readability flag. The machinery was always right; it was being fed a lie.

**`ChunkReader` needed no change beyond a comment.** It already promises no silent replay gaps — it raises `ReadError` when a header will not decode, for exactly this reason. A short listing was that same gap arriving underneath it, so `ListError` now propagates through it on the same principle.

**`Snapshot` does translate**, because it's the one place emptiness is a legitimate answer: `:not_found` means "no durable baseline, an empty start is correct." A failed listing must never be able to say that, so it becomes `{:error, {:list_failed, reason}}` and startup fails instead of assuming.

`:enoent` stays benign in the local backend — a directory that isn't there contributes nothing and may have vanished mid-walk. Every other errno means we could not see what is there.

## Gates

2745 tests / 0 failures, 2-seed sweep, `credo --strict` clean, dialyzer clean.

bedrock-q67.21.17