### PR TITLE
The system shard is looked up, never discovered or invented

### DIFF
--- a/lib/bedrock/control_plane/config/core_state.ex
+++ b/lib/bedrock/control_plane/config/core_state.ex
@@ -47,8 +47,12 @@ defmodule Bedrock.ControlPlane.Config.CoreState do
   alias Bedrock.ControlPlane.Config.LogDescriptor
   alias Bedrock.ControlPlane.Config.TransactionSystemLayout
   alias Bedrock.DataPlane.Log
+  alias Bedrock.Service.Worker
 
-  @type t :: %{required(:logs) => %{Log.id() => LogDescriptor.t()}}
+  @type t :: %{
+          required(:logs) => %{Log.id() => LogDescriptor.t()},
+          required(:system_materializers) => %{Worker.id() => node_name :: String.t()}
+        }
 
   @doc """
   Projects the durable cluster-bootstrap record into the prior state
@@ -67,7 +71,17 @@ defmodule Bedrock.ControlPlane.Config.CoreState do
       |> Kernel.||([])
       |> Map.new(fn log_info -> {log_info[:id], log_info[:shard_tags] || []} end)
 
-    %{logs: logs}
+    %{logs: logs, system_materializers: members_from(bootstrap)}
+  end
+
+  # A record written before this field existed names no members. That is
+  # not a crash and not a fresh cluster — it is an upgrade, and recovery
+  # says so rather than guessing where the metadata lives.
+  defp members_from(bootstrap) do
+    bootstrap
+    |> Map.get(:system_materializers)
+    |> Kernel.||([])
+    |> Map.new(fn member -> {member[:id], member[:node]} end)
   end
 
   @doc """
@@ -81,9 +95,29 @@ defmodule Bedrock.ControlPlane.Config.CoreState do
   carrying them into a record whose entire purpose is to OUTLIVE the
   epoch would be a category error — and the reason to keep these two
   types apart at all.
+
+  The system shard's members are passed IN rather than read out of the
+  layout, because the layout deliberately carries no membership at all
+  ("Nothing O(workers) may ever be added to this broadcast"). The
+  director knows them — it just persisted them — so it supplies both
+  halves at once.
   """
-  @spec from_layout(TransactionSystemLayout.t()) :: t()
-  def from_layout(layout), do: %{logs: Map.get(layout, :logs) || %{}}
+  @spec from_layout(TransactionSystemLayout.t(), %{Worker.id() => String.t()}) :: t()
+  def from_layout(layout, system_materializers),
+    do: %{logs: Map.get(layout, :logs) || %{}, system_materializers: system_materializers}
+
+  @doc """
+  The system shard's materializer members — the record that says WHERE
+  the cluster's metadata lives.
+
+  Recovery cannot read the shard layout or the materializers family
+  until it knows which workers hold tag 0, because both live IN tag 0.
+  FDB has the same indirection: its coordinated state names the tlogs
+  that hold the txnStateStore, and recovery peeks them to rebuild it.
+  """
+  @spec system_materializers(t() | nil) :: %{Worker.id() => String.t()}
+  def system_materializers(nil), do: %{}
+  def system_materializers(core_state), do: Map.get(core_state, :system_materializers) || %{}
 
   @doc """
   Whether this cluster has never completed a recovery.

--- a/lib/bedrock/control_plane/coordinator.ex
+++ b/lib/bedrock/control_plane/coordinator.ex
@@ -43,6 +43,7 @@ defmodule Bedrock.ControlPlane.Coordinator do
   use Bedrock.Internal.GenServerApi, for: __MODULE__.Server
 
   alias Bedrock.ControlPlane.Config
+  alias Bedrock.ControlPlane.Config.CoreState
   alias Bedrock.ControlPlane.Config.TransactionSystemLayout
 
   @type ref :: atom() | {atom(), node()}
@@ -95,10 +96,11 @@ defmodule Bedrock.ControlPlane.Coordinator do
   """
   @spec notify_transaction_system_layout(
           coordinator_ref :: ref(),
-          transaction_system_layout :: TransactionSystemLayout.t()
+          transaction_system_layout :: TransactionSystemLayout.t(),
+          core_state :: CoreState.t()
         ) :: :ok
-  def notify_transaction_system_layout(coordinator, transaction_system_layout),
-    do: GenServer.cast(coordinator, {:notify_transaction_system_layout, transaction_system_layout})
+  def notify_transaction_system_layout(coordinator, transaction_system_layout, core_state),
+    do: GenServer.cast(coordinator, {:notify_transaction_system_layout, transaction_system_layout, core_state})
 
   @type service_info :: {service_id :: String.t(), kind :: atom(), worker_ref :: {atom(), node()}}
   @type compact_service_info :: {service_id :: String.t(), kind :: atom(), name :: atom()}

--- a/lib/bedrock/control_plane/coordinator/server.ex
+++ b/lib/bedrock/control_plane/coordinator/server.ex
@@ -21,7 +21,7 @@ defmodule Bedrock.ControlPlane.Coordinator.Server do
       put_epoch: 2,
       put_leader_startup_state: 2,
       put_config: 2,
-      put_transaction_system_layout: 2,
+      put_transaction_system_layout: 3,
       update_raft: 2,
       add_tsl_subscriber: 2,
       replay_tsl_to: 2,
@@ -293,11 +293,15 @@ defmodule Bedrock.ControlPlane.Coordinator.Server do
     noreply(t)
   end
 
-  def handle_cast({:notify_transaction_system_layout, transaction_system_layout}, t) do
-    # Direct notification from Director - update state and broadcast to subscribers
-    # No Raft consensus needed - TSL is persisted to object storage by Director
+  def handle_cast({:notify_transaction_system_layout, transaction_system_layout, core_state}, t) do
+    # Direct notification from Director - update state and broadcast to subscribers.
+    # No Raft consensus needed: the director has already persisted BOTH
+    # records to object storage, and it sends both for the same reason it
+    # writes both — the broadcast cannot carry membership, so the durable
+    # record has to arrive alongside it or a warm recovery would find
+    # none.
     t
-    |> put_transaction_system_layout(transaction_system_layout)
+    |> put_transaction_system_layout(transaction_system_layout, core_state)
     |> put_epoch(transaction_system_layout.epoch)
     |> noreply()
   end

--- a/lib/bedrock/control_plane/coordinator/state.ex
+++ b/lib/bedrock/control_plane/coordinator/state.ex
@@ -92,16 +92,16 @@ defmodule Bedrock.ControlPlane.Coordinator.State do
     @spec put_last_durable_txn_id(t :: State.t(), Raft.transaction_id()) :: State.t()
     def put_last_durable_txn_id(t, last_durable_txn_id), do: %{t | last_durable_txn_id: last_durable_txn_id}
 
-    @spec put_transaction_system_layout(t :: State.t(), TransactionSystemLayout.t()) ::
+    @spec put_transaction_system_layout(t :: State.t(), TransactionSystemLayout.t(), CoreState.t()) ::
             State.t()
-    def put_transaction_system_layout(t, transaction_system_layout) do
+    def put_transaction_system_layout(t, transaction_system_layout, core_state) do
       # The completed layout becomes the next recovery's PRIOR STATE, but
       # only its durable half may: the layout's pids die with this epoch,
       # and the prior-state slot exists to outlive it. (This worked
       # before only because both shapes happen to carry a :logs field.)
       updated_state = %{
         t
-        | prior_core_state: CoreState.from_layout(transaction_system_layout),
+        | prior_core_state: core_state,
           transaction_system_layout: transaction_system_layout
       }
 

--- a/lib/bedrock/control_plane/director/recovery.ex
+++ b/lib/bedrock/control_plane/director/recovery.ex
@@ -127,7 +127,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery do
         end)
         |> Map.put(:transaction_system_layout, completed.transaction_system_layout)
         |> persist_config()
-        |> persist_new_transaction_system_layout()
+        |> persist_new_transaction_system_layout(completed)
         |> prune_service_directory(completed)
         |> remember_distributor_wiring(completed)
         |> maybe_start_distributor()
@@ -307,18 +307,20 @@ defmodule Bedrock.ControlPlane.Director.Recovery do
     t
   end
 
-  @spec persist_new_transaction_system_layout(State.t()) :: State.t()
-  # A completed recovery always has a layout; this runs only after one.
-  def persist_new_transaction_system_layout(%{transaction_system_layout: nil} = t), do: t
-
-  def persist_new_transaction_system_layout(t) do
+  # Takes the COMPLETED attempt explicitly, as its neighbours do:
+  # `t.recovery_attempt` is the attempt as it was BEFORE the phases ran,
+  # and is never updated with the result. Reading the members from there
+  # published an empty set on every recovery — which then stalled the
+  # next warm one, the precise failure this record exists to prevent.
+  @spec persist_new_transaction_system_layout(State.t(), RecoveryAttempt.t()) :: State.t()
+  def persist_new_transaction_system_layout(t, completed) do
     # Notify coordinator of the new epoch directly (no Raft consensus);
     # both records are already in object storage from the persistence
     # phase. BOTH are sent: the broadcast carries no membership by
     # design, so the durable record has to travel with it — otherwise a
     # warm recovery (no coordinator restart) would find no system
     # materializers and stall.
-    core_state = CoreState.from_layout(t.transaction_system_layout, system_materializers(t))
+    core_state = CoreState.from_layout(t.transaction_system_layout, system_materializers(completed))
 
     Coordinator.notify_transaction_system_layout(t.coordinator, t.transaction_system_layout, core_state)
     trace_recovery_layout_persisted(:notified)
@@ -330,11 +332,9 @@ defmodule Bedrock.ControlPlane.Director.Recovery do
   # the shard layout and the materializers family are both served from
   # tag 0, so without it recovery would have to discover tag 0 by roll
   # call and then guess which candidate is authoritative.
-  @spec system_materializers(State.t()) :: %{Worker.id() => String.t()}
-  defp system_materializers(%{recovery_attempt: %{} = attempt}),
-    do: Map.get(attempt.shard_materializers || %{}, RecoveryAttempt.system_shard_id(), %{})
-
-  defp system_materializers(_t), do: %{}
+  @spec system_materializers(RecoveryAttempt.t()) :: %{Worker.id() => String.t()}
+  defp system_materializers(completed),
+    do: Map.get(completed.shard_materializers, RecoveryAttempt.system_shard_id(), %{})
 
   @spec run_recovery_attempt(RecoveryAttempt.t(), recovery_context(), module()) ::
           {:ok, RecoveryAttempt.t()}

--- a/lib/bedrock/control_plane/director/recovery.ex
+++ b/lib/bedrock/control_plane/director/recovery.ex
@@ -308,13 +308,33 @@ defmodule Bedrock.ControlPlane.Director.Recovery do
   end
 
   @spec persist_new_transaction_system_layout(State.t()) :: State.t()
+  # A completed recovery always has a layout; this runs only after one.
+  def persist_new_transaction_system_layout(%{transaction_system_layout: nil} = t), do: t
+
   def persist_new_transaction_system_layout(t) do
-    # Notify coordinator of new TSL directly (no Raft consensus).
-    # TSL is already persisted to object storage by the persistence phase.
-    Coordinator.notify_transaction_system_layout(t.coordinator, t.transaction_system_layout)
+    # Notify coordinator of the new epoch directly (no Raft consensus);
+    # both records are already in object storage from the persistence
+    # phase. BOTH are sent: the broadcast carries no membership by
+    # design, so the durable record has to travel with it — otherwise a
+    # warm recovery (no coordinator restart) would find no system
+    # materializers and stall.
+    core_state = CoreState.from_layout(t.transaction_system_layout, system_materializers(t))
+
+    Coordinator.notify_transaction_system_layout(t.coordinator, t.transaction_system_layout, core_state)
     trace_recovery_layout_persisted(:notified)
     t
   end
+
+  # The system shard's members, as this recovery established them. This
+  # is the record that tells the NEXT recovery where the metadata lives:
+  # the shard layout and the materializers family are both served from
+  # tag 0, so without it recovery would have to discover tag 0 by roll
+  # call and then guess which candidate is authoritative.
+  @spec system_materializers(State.t()) :: %{Worker.id() => String.t()}
+  defp system_materializers(%{recovery_attempt: %{} = attempt}),
+    do: Map.get(attempt.shard_materializers || %{}, RecoveryAttempt.system_shard_id(), %{})
+
+  defp system_materializers(_t), do: %{}
 
   @spec run_recovery_attempt(RecoveryAttempt.t(), recovery_context(), module()) ::
           {:ok, RecoveryAttempt.t()}

--- a/lib/bedrock/control_plane/director/recovery/materializer_bootstrap_phase.ex
+++ b/lib/bedrock/control_plane/director/recovery/materializer_bootstrap_phase.ex
@@ -266,8 +266,6 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhase do
       # when the committed state doesn't name them. The system shard needs
       # no synthetic entry — it is never created here, only looked up, so
       # it is already in transaction_services from the locking phase.
-      all_created = created_services
-
       updated_attempt =
         recovery_attempt
         |> Map.put(:shard_layout, shard_layout)
@@ -278,7 +276,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhase do
         |> Map.put(:seeded_layout?, false)
         |> Map.put(:prior_materializer_refs, prior_refs)
         |> Map.put(:resolvers, resolver_descriptors_for_layout(shard_layout))
-        |> Map.update!(:transaction_services, &Map.merge(&1, all_created))
+        |> Map.update!(:transaction_services, &Map.merge(&1, created_services))
 
       {updated_attempt, CommitProxyStartupPhase}
     else
@@ -346,15 +344,23 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhase do
   # "successfully" on an empty layout and orphan the cluster's data;
   # stalling is retried by the director, and an operator can see why.
   defp resolve_system_materializer(recovery_attempt, context) do
-    named = context |> Map.get(:prior_core_state) |> CoreState.system_materializers()
-    available = available_named_members(named, recovery_attempt)
+    named = CoreState.system_materializers(context.prior_core_state)
 
-    case Enum.min(available, fn -> nil end) do
+    case Enum.min(available_named_members(named, recovery_attempt), fn -> nil end) do
       {worker_id, service} ->
         {:ok, {worker_id, service}}
 
+      # Two different situations, told apart so an operator is not left
+      # guessing. A record that names members means they are unreachable
+      # — retry, and the nodes they were last on say where to look. A
+      # record that names NONE on a non-fresh cluster means the bootstrap
+      # predates this field: recovery cannot learn where the metadata
+      # lives, and no retry will change that.
+      nil when named == %{} ->
+        {:error, :bootstrap_names_no_system_materializers}
+
       nil ->
-        {:error, {:no_system_materializers, Map.keys(named)}}
+        {:error, {:system_materializers_unavailable, named}}
     end
   end
 

--- a/lib/bedrock/control_plane/director/recovery/materializer_bootstrap_phase.ex
+++ b/lib/bedrock/control_plane/director/recovery/materializer_bootstrap_phase.ex
@@ -227,8 +227,8 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhase do
     # durable state, including the shard layout this phase exists to read.
     existing_by_shard = existing_materializers_by_shard(recovery_attempt)
 
-    with {:ok, {system_worker_id, materializer_service}, created_system} <-
-           find_or_create_materializer(existing_by_shard, recovery_attempt, context),
+    with {:ok, {system_worker_id, materializer_service}} <-
+           resolve_system_materializer(recovery_attempt, context),
          {:ok, materializer_pid} <- lock_materializer(materializer_service, recovery_attempt.epoch, context),
          # Unlock with logs so it streams the replayed WAL from the demux
          :ok <-
@@ -263,10 +263,10 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhase do
            ) do
       # Every creation must reach transaction_services: the layout and the
       # materializers keyspace are built from it, and workers self-retire
-      # when the committed state doesn't name them — including workers
-      # recovery itself just made.
-      all_created =
-        Map.merge(created_services, system_service_entry(created_system, materializer_pid))
+      # when the committed state doesn't name them. The system shard needs
+      # no synthetic entry — it is never created here, only looked up, so
+      # it is already in transaction_services from the locking phase.
+      all_created = created_services
 
       updated_attempt =
         recovery_attempt
@@ -287,11 +287,6 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhase do
     end
   end
 
-  defp system_service_entry(nil, _pid), do: %{}
-
-  defp system_service_entry({worker_id, last_seen}, pid),
-    do: %{worker_id => %{kind: :materializer, last_seen: last_seen, status: {:up, pid}}}
-
   # Resolvers are recreated each epoch, one per shard range in the
   # recovered layout — the same construction the fresh-cluster path uses,
   # driven by the recovered layout instead of the default one.
@@ -306,9 +301,18 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhase do
 
   # The locking phase locked every advertised materializer and collected its
   # recovery info — including its shard assignment. Index the survivors by
-  # shard, with their service refs from the transaction services map. When
-  # several claim the same shard (e.g. empty strays created by earlier
-  # failed recovery attempts), the most-advanced durable state wins.
+  # shard, with their service refs from the transaction services map.
+  #
+  # When several claim the same shard, the lowest worker id wins — the
+  # same deterministic rule as the client-facing pick
+  # (RoutingData.pick_member/1), so the member recovery adopts is the
+  # member clients are routed to.
+  #
+  # It used to be the most-advanced DURABLE VERSION, which was the wrong
+  # question twice over. The strays it existed to filter out were made by
+  # recovery's own invent path, now deleted; and durable_version measures
+  # STREAM POSITION, not data completeness, so a worker that started
+  # empty and pulled the log tail could rank above a complete one.
   defp existing_materializers_by_shard(recovery_attempt) do
     recovery_attempt.materializer_recovery_info_by_id
     |> Enum.flat_map(fn {id, info} ->
@@ -321,29 +325,52 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhase do
     end)
     |> Enum.group_by(fn {shard_id, _durable, _entry} -> shard_id end)
     |> Map.new(fn {shard_id, candidates} ->
-      {_shard, _durable, entry} = Enum.max_by(candidates, fn {_shard, durable, _entry} -> durable end)
+      {_shard, _durable, entry} = Enum.min_by(candidates, fn {_shard, _durable, {worker_id, _}} -> worker_id end)
       {shard_id, entry}
     end)
   end
 
-  # Reuse the locked system-shard materializer; create one only when none
-  # survived (a genuinely lost materializer team). A creation also returns
-  # {worker_id, last_seen} so the caller can record it in the transaction
-  # services once the lock provides the pid.
-  defp find_or_create_materializer(existing_by_shard, recovery_attempt, context) do
-    case Map.fetch(existing_by_shard, RecoveryAttempt.system_shard_id()) do
-      {:ok, {worker_id, service}} ->
-        {:ok, {worker_id, service}, nil}
+  # The system shard is LOOKED UP, never discovered and never invented.
+  #
+  # The prior core state names its members, because both durable
+  # families — the shard layout and materializer membership — are served
+  # from tag 0, and recovery cannot read either until it knows who holds
+  # it. FDB has the same indirection and the same discipline: it builds
+  # its log system from exactly the servers the coordinated state names
+  # (TagPartitionedLogSystem.actor.cpp:2549-2585) and waits for a quorum
+  # of THOSE, never substituting another server and never fabricating
+  # one.
+  #
+  # So an unavailable named member is a STALL, not a fallback. Recovery
+  # manufacturing the store its own metadata lives in would come up
+  # "successfully" on an empty layout and orphan the cluster's data;
+  # stalling is retried by the director, and an operator can see why.
+  defp resolve_system_materializer(recovery_attempt, context) do
+    named = context |> Map.get(:prior_core_state) |> CoreState.system_materializers()
+    available = available_named_members(named, recovery_attempt)
 
-      :error ->
-        Logger.info("System shard materializer not found, creating new one")
+    case Enum.min(available, fn -> nil end) do
+      {worker_id, service} ->
+        {:ok, {worker_id, service}}
 
-        with {:ok, node} <- find_materializer_capable_node(context),
-             {:ok, {worker_id, worker_ref, node}} <-
-               create_materializer_worker(node, RecoveryAttempt.system_shard_id(), recovery_attempt, context) do
-          {:ok, {worker_id, {:materializer, {worker_ref, node}}}, {worker_id, {worker_ref, node}}}
-        end
+      nil ->
+        {:error, {:no_system_materializers, Map.keys(named)}}
     end
+  end
+
+  # A named member counts only if this epoch actually locked it and it
+  # reports itself as serving the system shard. The pick among several is
+  # the lowest worker id — the same deterministic rule the client-facing
+  # pick uses (RoutingData.pick_member/1), so recovery unlocks the member
+  # clients will be routed to.
+  defp available_named_members(named, recovery_attempt) do
+    system_shard = RecoveryAttempt.system_shard_id()
+
+    for {worker_id, _node} <- named,
+        match?(%{shard_id: ^system_shard}, Map.get(recovery_attempt.materializer_recovery_info_by_id, worker_id)),
+        %{status: {:up, ref}} <- [Map.get(recovery_attempt.transaction_services, worker_id)],
+        into: %{},
+        do: {worker_id, {:materializer, ref}}
   end
 
   # Every shard in the layout needs a materializer in the new TSL: reuse the

--- a/lib/bedrock/control_plane/director/recovery/persistence_phase.ex
+++ b/lib/bedrock/control_plane/director/recovery/persistence_phase.ex
@@ -131,9 +131,23 @@ defmodule Bedrock.ControlPlane.Director.Recovery.PersistencePhase do
       current_bootstrap
       | epoch: recovery_attempt.epoch,
         logs: build_log_entries(transaction_system_layout),
+        system_materializers: build_system_materializer_entries(recovery_attempt),
         parameters: build_parameters(config),
         policies: build_policies(config)
     }
+  end
+
+  # Where the metadata lives, recorded out of band. Both durable families
+  # — the shard layout and materializer membership — are served from tag
+  # 0, so the next recovery cannot read either until it knows which
+  # workers hold it. FDB records the same indirection: its coordinated
+  # state names the tlogs that hold the txnStateStore.
+  defp build_system_materializer_entries(recovery_attempt) do
+    recovery_attempt
+    |> Map.get(:shard_materializers, %{})
+    |> Kernel.||(%{})
+    |> Map.get(RecoveryAttempt.system_shard_id(), %{})
+    |> Enum.map(fn {worker_id, node} -> %{id: worker_id, node: node} end)
   end
 
   defp build_initial_bootstrap(recovery_attempt, config, transaction_system_layout) do
@@ -141,6 +155,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery.PersistencePhase do
       cluster_id: Id.random(),
       epoch: recovery_attempt.epoch,
       logs: build_log_entries(transaction_system_layout),
+      system_materializers: build_system_materializer_entries(recovery_attempt),
       coordinators: [%{node: Atom.to_string(node())}],
       parameters: build_parameters(config),
       policies: build_policies(config)

--- a/lib/bedrock/control_plane/director/recovery/persistence_phase.ex
+++ b/lib/bedrock/control_plane/director/recovery/persistence_phase.ex
@@ -142,11 +142,21 @@ defmodule Bedrock.ControlPlane.Director.Recovery.PersistencePhase do
   # 0, so the next recovery cannot read either until it knows which
   # workers hold it. FDB records the same indirection: its coordinated
   # state names the tlogs that hold the txnStateStore.
+  # The full committed member SET, not just the one member this recovery
+  # adopted. FDB names a set here too and waits for a replication-policy
+  # quorum over it (TagPartitionedLogSystem.actor.cpp:2549-2585 locks
+  # every named tlog; getDurableVersion at :2070-2082 decides on a
+  # quorum of THOSE) — it never substitutes a server, but it also never
+  # depends on one specific server. Recording only the adopted member
+  # would mean losing that single node stalls recovery forever, with a
+  # healthy committed replica sitting right there.
   defp build_system_materializer_entries(recovery_attempt) do
-    recovery_attempt
-    |> Map.get(:shard_materializers, %{})
-    |> Kernel.||(%{})
-    |> Map.get(RecoveryAttempt.system_shard_id(), %{})
+    system_shard = RecoveryAttempt.system_shard_id()
+    adopted = Map.get(recovery_attempt.shard_materializers, system_shard, %{})
+    committed = recovery_attempt |> Map.get(:prior_materializer_refs) |> Kernel.||(%{}) |> Map.get(system_shard, %{})
+
+    committed
+    |> Map.merge(adopted)
     |> Enum.map(fn {worker_id, node} -> %{id: worker_id, node: node} end)
   end
 

--- a/lib/bedrock/system_keys/cluster_bootstrap.ex
+++ b/lib/bedrock/system_keys/cluster_bootstrap.ex
@@ -49,5 +49,12 @@ defmodule Bedrock.SystemKeys.ClusterBootstrap do
   See `Bedrock.ClusterBootstrap.Discovery` for the discovery logic.
   """
 
+  # The schema is read at macro-expansion time and the library declares
+  # no @external_resource, so without this a .fbs edit does not recompile
+  # this module: the build keeps the OLD schema, encoders silently drop
+  # new fields, and the test suite passes against a binary layout that no
+  # longer matches the file on disk.
   use Flatbuffer, file: "priv/schemas/cluster_bootstrap.fbs"
+
+  @external_resource "priv/schemas/cluster_bootstrap.fbs"
 end

--- a/priv/schemas/cluster_bootstrap.fbs
+++ b/priv/schemas/cluster_bootstrap.fbs
@@ -16,6 +16,17 @@ table CoordinatorInfo {
   node: string;
 }
 
+// The system shard's materializer members. This is the record that says
+// WHERE the cluster's metadata lives: the shard layout and the
+// materializers family are both served from tag 0, so recovery cannot
+// read either until it knows which workers hold it. FDB records the
+// equivalent out of band too — its coordinated state names the tlogs
+// that hold the txnStateStore.
+table MaterializerInfo {
+  id: string;
+  node: string;
+}
+
 // Cluster configuration parameters
 table ClusterParameters {
   desired_logs: uint;
@@ -41,6 +52,7 @@ table ClusterBootstrap {
   coordinators: [CoordinatorInfo];
   parameters: ClusterParameters;
   policies: ClusterPolicies;
+  system_materializers: [MaterializerInfo];
 }
 
 root_type ClusterBootstrap;

--- a/test/bedrock/control_plane/config/core_state_test.exs
+++ b/test/bedrock/control_plane/config/core_state_test.exs
@@ -18,19 +18,50 @@ defmodule Bedrock.ControlPlane.Config.CoreStateTest do
         ]
       }
 
-      assert CoreState.from_bootstrap(bootstrap) == %{logs: %{"log_1" => [0, 1], "log_2" => [2]}}
+      assert %{logs: %{"log_1" => [0, 1], "log_2" => [2]}} = CoreState.from_bootstrap(bootstrap)
     end
 
     test "a log with no tags carries an empty list, not nil" do
       # Downstream does Map.keys/1 and MapSet.new/1 over these; a nil
       # would crash a recovery rather than describe a tagless log.
-      assert CoreState.from_bootstrap(%{logs: [%{id: "log_1"}]}) == %{logs: %{"log_1" => []}}
+      assert %{logs: %{"log_1" => []}} = CoreState.from_bootstrap(%{logs: [%{id: "log_1"}]})
     end
 
     test "a bootstrap with no logs at all is an empty record, never nil" do
-      assert CoreState.from_bootstrap(%{logs: []}) == %{logs: %{}}
-      assert CoreState.from_bootstrap(%{}) == %{logs: %{}}
-      assert CoreState.from_bootstrap(%{logs: nil}) == %{logs: %{}}
+      assert %{logs: %{}} = CoreState.from_bootstrap(%{logs: []})
+      assert %{logs: %{}} = CoreState.from_bootstrap(%{})
+      assert %{logs: %{}} = CoreState.from_bootstrap(%{logs: nil})
+    end
+  end
+
+  describe "system_materializers - where the cluster's metadata lives" do
+    test "from_bootstrap carries the system shard's members" do
+      bootstrap = %{
+        logs: [%{id: "log_1", shard_tags: [0]}],
+        system_materializers: [%{id: "wkr_sys", node: "n1@host"}, %{id: "wkr_sys2", node: "n2@host"}]
+      }
+
+      assert %{system_materializers: %{"wkr_sys" => "n1@host", "wkr_sys2" => "n2@host"}} =
+               CoreState.from_bootstrap(bootstrap)
+    end
+
+    test "a record written before the field existed names no members, rather than crashing" do
+      assert %{system_materializers: %{}} = CoreState.from_bootstrap(%{logs: []})
+    end
+
+    test "members survive the epoch boundary — the layout cannot supply them" do
+      # The TSL deliberately carries no membership ("Nothing O(workers)
+      # may ever be added to this broadcast"), so a completed recovery
+      # must publish the members alongside it. Dropping them here would
+      # make every WARM recovery — one with no coordinator restart —
+      # find no members and stall.
+      layout = %{epoch: 4, sequencer: self(), logs: %{"log_1" => [0]}}
+      members = %{"wkr_sys" => "n1@host"}
+
+      assert CoreState.from_layout(layout, members) == %{
+               logs: %{"log_1" => [0]},
+               system_materializers: members
+             }
     end
   end
 
@@ -48,15 +79,15 @@ defmodule Bedrock.ControlPlane.Config.CoreStateTest do
         logs: %{"log_1" => [0, 1]}
       }
 
-      core_state = CoreState.from_layout(layout)
+      core_state = CoreState.from_layout(layout, %{})
 
-      assert core_state == %{logs: %{"log_1" => [0, 1]}}
+      assert core_state == %{logs: %{"log_1" => [0, 1]}, system_materializers: %{}}
       refute core_state |> Map.values() |> Enum.any?(&is_pid/1)
     end
 
     test "a layout naming no logs projects to a fresh record" do
-      assert %{logs: %{}} = CoreState.from_layout(%{logs: %{}})
-      assert CoreState.fresh?(CoreState.from_layout(%{logs: %{}}))
+      assert %{logs: %{}} = CoreState.from_layout(%{logs: %{}}, %{})
+      assert CoreState.fresh?(CoreState.from_layout(%{logs: %{}}, %{}))
     end
   end
 
@@ -86,12 +117,13 @@ defmodule Bedrock.ControlPlane.Config.CoreStateTest do
       # whether the coordinator process happened to survive.
       layout = %{epoch: 4, sequencer: self(), proxies: [self()], logs: %{"log_a" => [], "log_b" => []}}
 
-      warm = CoreState.from_layout(layout)
+      warm = CoreState.from_layout(layout, %{"wkr_sys" => "n1@host"})
 
       # Exactly what the persistence phase writes into the bootstrap for
       # this layout: one entry per log, tags carried through.
       bootstrap = %{
-        logs: for({id, tags} <- layout.logs, do: %{id: id, otp_ref: nil, shard_tags: tags})
+        logs: for({id, tags} <- layout.logs, do: %{id: id, otp_ref: nil, shard_tags: tags}),
+        system_materializers: [%{id: "wkr_sys", node: "n1@host"}]
       }
 
       cold = CoreState.from_bootstrap(bootstrap)

--- a/test/bedrock/control_plane/config/core_state_test.exs
+++ b/test/bedrock/control_plane/config/core_state_test.exs
@@ -8,6 +8,7 @@ defmodule Bedrock.ControlPlane.Config.CoreStateTest do
   use ExUnit.Case, async: true
 
   alias Bedrock.ControlPlane.Config.CoreState
+  alias Bedrock.SystemKeys.ClusterBootstrap
 
   describe "from_bootstrap/1 - the durable record, projected" do
     test "carries each log's id and the tags it serves" do
@@ -105,6 +106,39 @@ defmodule Bedrock.ControlPlane.Config.CoreStateTest do
 
     test "a prior record naming any log is NOT fresh - its data must be recovered" do
       refute CoreState.fresh?(%{logs: %{"log_1" => [0]}})
+    end
+  end
+
+  describe "a bootstrap written before the field existed" do
+    test "decodes through the REAL FlatBuffer without the field, naming no members" do
+      # Not a hand-built map: the actual encoder/decoder, so this also
+      # guards the schema staying compatible. An old record must decode
+      # cleanly and simply name nobody — recovery then says so with a
+      # distinct stall rather than pretending the members are merely
+      # unreachable.
+      binary =
+        ClusterBootstrap.to_binary(%{
+          cluster_id: "c1",
+          epoch: 7,
+          logs: [%{id: "log_1", otp_ref: nil, shard_tags: [0]}]
+        })
+
+      assert {:ok, decoded} = ClusterBootstrap.read(binary)
+      assert %{system_materializers: %{}} = CoreState.from_bootstrap(decoded)
+      refute CoreState.fresh?(CoreState.from_bootstrap(decoded))
+    end
+
+    test "members round-trip through the REAL FlatBuffer when present" do
+      binary =
+        ClusterBootstrap.to_binary(%{
+          cluster_id: "c1",
+          epoch: 7,
+          logs: [],
+          system_materializers: [%{id: "wkr_sys", node: "n1@host"}]
+        })
+
+      assert {:ok, decoded} = ClusterBootstrap.read(binary)
+      assert %{system_materializers: %{"wkr_sys" => "n1@host"}} = CoreState.from_bootstrap(decoded)
     end
   end
 

--- a/test/bedrock/control_plane/coordinator/initialization_test.exs
+++ b/test/bedrock/control_plane/coordinator/initialization_test.exs
@@ -36,7 +36,7 @@ defmodule Bedrock.ControlPlane.Coordinator.InitializationTest do
     assert {:ok, state, {:continue, :check_recovery_consensus}} =
              Server.init({TestCluster, TestCluster.otp_name(:coordinator)})
 
-    assert state.prior_core_state == %{logs: %{"old-log" => []}}
+    assert state.prior_core_state == %{logs: %{"old-log" => []}, system_materializers: %{}}
     assert state.transaction_system_layout == nil
   end
 end

--- a/test/bedrock/control_plane/coordinator/state_test.exs
+++ b/test/bedrock/control_plane/coordinator/state_test.exs
@@ -44,10 +44,15 @@ defmodule Bedrock.ControlPlane.Coordinator.StateTest do
           tsl_subscribers: MapSet.new([self()])
         )
 
-      result = Changes.put_transaction_system_layout(state, runnable_layout)
+      # The director sends BOTH records: the broadcast, and the durable
+      # core state it just persisted. The broadcast cannot carry
+      # membership by design, so the members have to arrive with it.
+      core_state = %{logs: %{"new-log" => [0]}, system_materializers: %{"wkr_sys" => "n1@host"}}
+
+      result = Changes.put_transaction_system_layout(state, runnable_layout, core_state)
 
       assert result.transaction_system_layout == runnable_layout
-      assert result.prior_core_state == %{logs: %{"new-log" => [0]}}
+      assert result.prior_core_state == core_state
       refute Map.has_key?(result.prior_core_state, :sequencer)
       assert_receive {:tsl_updated, ^runnable_layout}
     end

--- a/test/bedrock/control_plane/director/recovery/materializer_bootstrap_phase_test.exs
+++ b/test/bedrock/control_plane/director/recovery/materializer_bootstrap_phase_test.exs
@@ -154,19 +154,16 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhaseTest 
       :ets.delete(unlocks)
     end
 
-    test "stalls when no materializer capable nodes exist" do
-      recovery_attempt =
-        recovery_attempt()
-        |> Map.put(:shard_layout, nil)
-        |> Map.put(:logs, %{"log_1" => [0, 1]})
+    test "a FRESH cluster stalls when no materializer capable nodes exist" do
+      # Creation is legitimate here and nowhere else: a fresh cluster has
+      # no prior data, so seeding the system shard invents nothing. (An
+      # EXISTING cluster stalls on :no_system_materializers instead — it
+      # must never manufacture the store its metadata lives in.)
+      recovery_attempt = Map.put(recovery_attempt(), :shard_layout, nil)
 
-      # Existing cluster - has old logs but no materializer in available_services
-      # AND no materializer capability in nodes
       context =
         [
-          prior_core_state: %{
-            logs: %{"log_1" => [0, 1]}
-          },
+          prior_core_state: %{logs: %{}},
           node_capabilities: %{
             log: [Node.self()],
             storage: [Node.self()]
@@ -176,13 +173,10 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhaseTest 
         |> create_test_context()
         |> Map.put(:available_services, %{})
 
-      log =
-        capture_log(fn ->
-          assert {_attempt, {:stalled, :no_materializer_capable_nodes}} =
-                   MaterializerBootstrapPhase.execute(recovery_attempt, context)
-        end)
-
-      assert log =~ "System shard materializer not found, creating new one"
+      capture_log(fn ->
+        assert {_attempt, {:stalled, {:materializer_creation_failed, _}}} =
+                 MaterializerBootstrapPhase.execute(recovery_attempt, context)
+      end)
     end
 
     test "reuses the locked materializers on restart — one per shard, unlocked at the recovery version" do
@@ -213,7 +207,8 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhaseTest 
       context =
         [
           prior_core_state: %{
-            logs: %{"log_1" => [0, 1]}
+            logs: %{"log_1" => [0, 1]},
+            system_materializers: %{"mat_sys" => "node@host"}
           }
         ]
         |> create_test_context()
@@ -277,7 +272,8 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhaseTest 
       context =
         [
           prior_core_state: %{
-            logs: %{"log_1" => [0, 1]}
+            logs: %{"log_1" => [0, 1]},
+            system_materializers: %{"mat_real" => "node@host", "mat_stray" => "node@host"}
           }
         ]
         |> create_test_context()
@@ -301,20 +297,25 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhaseTest 
       end)
     end
 
-    test "creates new materializer when not found but capable nodes exist" do
-      materializer_pid = spawn(fn -> Process.sleep(:infinity) end)
-      durable_version = Version.from_integer(100)
-
+    test "an existing cluster does NOT create a system materializer, even with capacity to spare" do
+      # Available capacity is not a licence to invent. Recovery
+      # manufacturing the store its own metadata lives in would come up
+      # "successfully" on an empty shard layout and orphan the cluster's
+      # data. FDB is unambiguous here: it locks exactly the servers its
+      # coordinated state names and waits for a quorum of THOSE
+      # (TagPartitionedLogSystem.actor.cpp:2549-2585), never substituting
+      # another and never fabricating one.
       recovery_attempt =
         recovery_attempt()
         |> Map.put(:shard_layout, nil)
         |> Map.put(:logs, %{"log_1" => [0, 1]})
-        |> Map.put(:durable_version, durable_version)
+        |> Map.put(:durable_version, Version.from_integer(100))
 
       context =
         [
           prior_core_state: %{
-            logs: %{"log_1" => [0, 1]}
+            logs: %{"log_1" => [0, 1]},
+            system_materializers: %{"mat_sys" => "node@host"}
           },
           node_capabilities: %{
             log: [Node.self()],
@@ -322,37 +323,14 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhaseTest 
           }
         ]
         |> create_test_context()
+        # The named member is not among the services this epoch locked.
         |> Map.put(:available_services, %{})
-        |> Map.put(:create_worker_fn, fn _foreman_ref, _worker_id, :materializer, _opts ->
-          {:ok, :new_materializer_ref}
-        end)
-        |> Map.put(:lock_materializer_fn, fn _service, _epoch -> {:ok, materializer_pid} end)
-        |> Map.put(:unlock_materializer_fn, fn _pid, _version, _tsl -> :ok end)
-        |> Map.put(:materializer_info_fn, fn _pid, [:current_version] ->
-          {:ok, %{current_version: durable_version}}
-        end)
-        |> Map.put(:get_shard_layout_fn, fn _pid, _version ->
-          {:ok, %{<<0xFF>> => {0, <<>>}, Bedrock.end_of_keyspace() => {1, <<0xFF>>}}}
+        |> Map.put(:create_worker_fn, fn _f, _i, :materializer, _o ->
+          flunk("recovery invented a system materializer instead of stalling")
         end)
 
-      log =
-        capture_log(fn ->
-          assert {updated_attempt, CommitProxyStartupPhase} =
-                   MaterializerBootstrapPhase.execute(recovery_attempt, context)
-
-          assert [{<<_::binary>>, <<_::binary>>}] = Map.to_list(updated_attempt.shard_materializers[0])
-          assert updated_attempt.shard_layout
-
-          # The creation is recorded: the layout will reference it, so
-          # reconciliation cannot retire the worker recovery just made.
-          assert Enum.any?(updated_attempt.transaction_services, fn
-                   {_id, %{kind: :materializer, status: {:up, ^materializer_pid}}} -> true
-                   _ -> false
-                 end)
-        end)
-
-      assert log =~ "System shard materializer not found, creating new one"
-      assert log =~ "Materializer caught up to version"
+      assert {_attempt, {:stalled, {:no_system_materializers, ["mat_sys"]}}} =
+               MaterializerBootstrapPhase.execute(recovery_attempt, context)
     end
 
     test "stalls on catchup timeout" do
@@ -377,7 +355,8 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhaseTest 
       context =
         [
           prior_core_state: %{
-            logs: %{"log_1" => [0, 1]}
+            logs: %{"log_1" => [0, 1]},
+            system_materializers: %{"mat_sys" => "node@host"}
           }
         ]
         |> create_test_context()
@@ -422,7 +401,8 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhaseTest 
       context =
         [
           prior_core_state: %{
-            logs: %{"log_1" => [0, 1]}
+            logs: %{"log_1" => [0, 1]},
+            system_materializers: %{"mat_sys" => "node@host"}
           }
         ]
         |> create_test_context()
@@ -437,20 +417,14 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhaseTest 
                MaterializerBootstrapPhase.execute(recovery_attempt, context)
     end
 
-    test "stalls on worker creation failure" do
-      durable_version = Version.from_integer(100)
-
-      recovery_attempt =
-        recovery_attempt()
-        |> Map.put(:shard_layout, nil)
-        |> Map.put(:logs, %{"log_1" => [0, 1]})
-        |> Map.put(:durable_version, durable_version)
+    test "a FRESH cluster stalls on worker creation failure" do
+      # Seeding tag 0 is the one creation recovery still performs, so it
+      # is the only place a creation failure can stall it.
+      recovery_attempt = Map.put(recovery_attempt(), :shard_layout, nil)
 
       context =
         [
-          prior_core_state: %{
-            logs: %{"log_1" => [0, 1]}
-          },
+          prior_core_state: %{logs: %{}},
           node_capabilities: %{
             log: [Node.self()],
             materializer: [Node.self()]
@@ -462,13 +436,10 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhaseTest 
           {:error, :foreman_unavailable}
         end)
 
-      log =
-        capture_log(fn ->
-          {_attempt, {:stalled, result}} = MaterializerBootstrapPhase.execute(recovery_attempt, context)
-          assert {:failed_to_create_materializer, :foreman_unavailable, 0} = result
-        end)
-
-      assert log =~ "System shard materializer not found, creating new one"
+      capture_log(fn ->
+        {_attempt, {:stalled, result}} = MaterializerBootstrapPhase.execute(recovery_attempt, context)
+        assert {:materializer_creation_failed, {0, {:failed_to_create_materializer, :foreman_unavailable, 0}}} = result
+      end)
     end
 
     test "seeds each unlocked materializer with its replica set of pull sources" do
@@ -504,7 +475,8 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhaseTest 
       context =
         [
           prior_core_state: %{
-            logs: logs
+            logs: logs,
+            system_materializers: %{"mat_sys" => "node@host"}
           }
         ]
         |> create_test_context()
@@ -564,7 +536,10 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhaseTest 
     defp existing_context(recovery_version, overrides) do
       base =
         [
-          prior_core_state: %{logs: %{"log_1" => [0, 1]}}
+          prior_core_state: %{
+            logs: %{"log_1" => [0, 1]},
+            system_materializers: %{"mat_sys" => "node@host"}
+          }
         ]
         |> create_test_context()
         |> Map.put(:available_services, %{})
@@ -598,10 +573,9 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhaseTest 
       })
     end
 
-    test "the family-named locked survivor beats a more-advanced stray" do
-      # The committed assignment is the authority; the contest (most
-      # advanced durable state wins) is only the fallback for tags the
-      # family does not name.
+    test "the family-named locked survivor beats a stray" do
+      # The committed assignment is the authority; the deterministic pick
+      # is only the fallback for tags the family does not name.
       recovery_version = Version.from_integer(500)
       sys_pid = spawn(fn -> Process.sleep(:infinity) end)
       named_pid = spawn(fn -> Process.sleep(:infinity) end)
@@ -626,7 +600,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhaseTest 
       end)
     end
 
-    test "a family entry naming an unlocked worker falls back to the contest" do
+    test "a family entry naming an unlocked worker falls back to the LOWEST ID, not the most advanced" do
       recovery_version = Version.from_integer(500)
       sys_pid = spawn(fn -> Process.sleep(:infinity) end)
       named_pid = spawn(fn -> Process.sleep(:infinity) end)
@@ -645,9 +619,14 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhaseTest 
         assert {updated_attempt, CommitProxyStartupPhase} =
                  MaterializerBootstrapPhase.execute(recovery_attempt, context)
 
-        # "mat_gone" was not locked this epoch: the most-advanced
-        # claimant wins as before.
-        assert %{"mat_stray" => _node} = updated_attempt.shard_materializers[1]
+        # "mat_gone" was not locked this epoch, so the fallback decides —
+        # and it decides by worker id, the same deterministic rule the
+        # client-facing pick uses. "mat_stray" is the MORE ADVANCED
+        # claimant (durable at the recovery version, against mat_named's
+        # version 1) and it loses anyway: durable_version measures stream
+        # position, not completeness, so ranking by it could seat a
+        # worker that pulled the log tail over one holding the data.
+        assert %{"mat_named" => _node} = updated_attempt.shard_materializers[1]
       end)
     end
 
@@ -837,6 +816,44 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhaseTest 
 
       assert {:error, {:invalid_shard_value, ^key}} =
                MaterializerBootstrapPhase.shard_layout_from_entries([{key, "garbage"}])
+    end
+  end
+
+  describe "the system shard is looked up, never discovered or invented" do
+    test "an existing cluster whose core state names no system materializer STALLS" do
+      # Recovery must never manufacture the store its own metadata lives
+      # in. FDB refuses the same way: it builds its log system from
+      # exactly the servers the coordinated state names
+      # (TagPartitionedLogSystem.actor.cpp:2549-2585) and waits for a
+      # quorum of THOSE rather than substituting others.
+      recovery_attempt = recovery_attempt()
+
+      context =
+        recovery_context()
+        |> Map.put(:prior_core_state, %{logs: %{"log_1" => [0]}, system_materializers: %{}})
+        |> Map.put(:create_worker_fn, fn _f, _i, _k, _o ->
+          flunk("recovery invented a system materializer instead of stalling")
+        end)
+
+      assert {_attempt, {:stalled, {:no_system_materializers, _}}} =
+               MaterializerBootstrapPhase.execute(recovery_attempt, context)
+    end
+
+    test "a named system materializer that is not available STALLS rather than falling back" do
+      recovery_attempt = recovery_attempt()
+
+      context =
+        recovery_context()
+        |> Map.put(:prior_core_state, %{
+          logs: %{"log_1" => [0]},
+          system_materializers: %{"wkr_gone" => "dead@host"}
+        })
+        |> Map.put(:create_worker_fn, fn _f, _i, _k, _o ->
+          flunk("recovery invented a replacement for an unavailable named member")
+        end)
+
+      assert {_attempt, {:stalled, {:no_system_materializers, _}}} =
+               MaterializerBootstrapPhase.execute(recovery_attempt, context)
     end
   end
 end

--- a/test/bedrock/control_plane/director/recovery/materializer_bootstrap_phase_test.exs
+++ b/test/bedrock/control_plane/director/recovery/materializer_bootstrap_phase_test.exs
@@ -329,7 +329,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhaseTest 
           flunk("recovery invented a system materializer instead of stalling")
         end)
 
-      assert {_attempt, {:stalled, {:no_system_materializers, ["mat_sys"]}}} =
+      assert {_attempt, {:stalled, {:system_materializers_unavailable, %{"mat_sys" => "node@host"}}}} =
                MaterializerBootstrapPhase.execute(recovery_attempt, context)
     end
 
@@ -600,7 +600,33 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhaseTest 
       end)
     end
 
-    test "a family entry naming an unlocked worker falls back to the LOWEST ID, not the most advanced" do
+    defp three_claimants_attempt(recovery_version, sys_pid, a_pid, b_pid, c_pid) do
+      # THREE claimants, with id order deliberately disagreeing with BOTH
+      # durable orders. Two candidates cannot discriminate: whichever way
+      # you arrange them, the id rule agrees with either min-durable or
+      # max-durable, so the test passes under a rule it was meant to
+      # reject. Here min-id is mat_a, min-durable is mat_b, and
+      # max-durable is mat_c — only the id rule produces mat_a.
+      recovery_attempt()
+      |> Map.put(:shard_layout, nil)
+      |> Map.put(:logs, %{"log_1" => [0, 1]})
+      |> Map.put(:version_vector, {Version.from_integer(0), recovery_version})
+      |> Map.put(:materializer_recovery_info_by_id, %{
+        "mat_sys" => %{kind: :materializer, shard_id: 0, durable_version: recovery_version},
+        "mat_a" => %{kind: :materializer, shard_id: 1, durable_version: Version.from_integer(50)},
+        "mat_b" => %{kind: :materializer, shard_id: 1, durable_version: Version.from_integer(1)},
+        "mat_c" => %{kind: :materializer, shard_id: 1, durable_version: recovery_version}
+      })
+      |> Map.put(:transaction_services, %{
+        "mat_sys" => %{kind: :materializer, status: {:up, sys_pid}},
+        "mat_a" => %{kind: :materializer, status: {:up, a_pid}},
+        "mat_b" => %{kind: :materializer, status: {:up, b_pid}},
+        "mat_c" => %{kind: :materializer, status: {:up, c_pid}},
+        "log_1" => %{kind: :log, status: {:up, self()}}
+      })
+    end
+
+    test "a family entry naming an unlocked worker falls back to the LOWEST ID, not to any durable ranking" do
       recovery_version = Version.from_integer(500)
       sys_pid = spawn(fn -> Process.sleep(:infinity) end)
       named_pid = spawn(fn -> Process.sleep(:infinity) end)
@@ -613,7 +639,14 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhaseTest 
           end
         })
 
-      recovery_attempt = two_claimants_attempt(recovery_version, named_pid, stray_pid, sys_pid)
+      recovery_attempt =
+        three_claimants_attempt(
+          recovery_version,
+          sys_pid,
+          named_pid,
+          stray_pid,
+          spawn(fn -> Process.sleep(:infinity) end)
+        )
 
       ExUnit.CaptureLog.capture_log(fn ->
         assert {updated_attempt, CommitProxyStartupPhase} =
@@ -621,12 +654,11 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhaseTest 
 
         # "mat_gone" was not locked this epoch, so the fallback decides —
         # and it decides by worker id, the same deterministic rule the
-        # client-facing pick uses. "mat_stray" is the MORE ADVANCED
-        # claimant (durable at the recovery version, against mat_named's
-        # version 1) and it loses anyway: durable_version measures stream
-        # position, not completeness, so ranking by it could seat a
-        # worker that pulled the log tail over one holding the data.
-        assert %{"mat_named" => _node} = updated_attempt.shard_materializers[1]
+        # client-facing pick uses. Neither durable ranking picks mat_a:
+        # durable_version measures stream POSITION, not completeness, so
+        # ranking by it could seat a worker that merely pulled the log
+        # tail over one holding the data.
+        assert %{"mat_a" => _node} = updated_attempt.shard_materializers[1]
       end)
     end
 
@@ -835,7 +867,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhaseTest 
           flunk("recovery invented a system materializer instead of stalling")
         end)
 
-      assert {_attempt, {:stalled, {:no_system_materializers, _}}} =
+      assert {_attempt, {:stalled, :bootstrap_names_no_system_materializers}} =
                MaterializerBootstrapPhase.execute(recovery_attempt, context)
     end
 
@@ -852,7 +884,9 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhaseTest 
           flunk("recovery invented a replacement for an unavailable named member")
         end)
 
-      assert {_attempt, {:stalled, {:no_system_materializers, _}}} =
+      # The reason carries the members and the nodes they were last seen
+      # on: this one is retryable, and that is where to go looking.
+      assert {_attempt, {:stalled, {:system_materializers_unavailable, %{"wkr_gone" => "dead@host"}}}} =
                MaterializerBootstrapPhase.execute(recovery_attempt, context)
     end
   end

--- a/test/bedrock/control_plane/director/recovery_test.exs
+++ b/test/bedrock/control_plane/director/recovery_test.exs
@@ -850,4 +850,48 @@ defmodule Bedrock.ControlPlane.Director.RecoveryTest do
     |> Map.put(:remove_workers_fn, remove_workers_fn)
     |> Map.put(:monitor_fn, monitor_fn)
   end
+
+  describe "publishing the completed recovery to the coordinator" do
+    test "publishes the members the recovery ACTUALLY adopted, not the ones it started with" do
+      # t.recovery_attempt is the attempt as it was BEFORE the phases
+      # ran, and is never updated with the result — which is why every
+      # sibling in this pipeline takes `completed` explicitly. Reading
+      # the members from t would publish the struct default (%{}), and
+      # the next WARM recovery would then find no system materializers
+      # and stall: exactly what this record exists to prevent.
+      test_pid = self()
+      coordinator = spawn_link(fn -> relay_casts(test_pid) end)
+
+      layout = %{epoch: 3, sequencer: self(), proxies: [self()], resolvers: [], logs: %{"log_1" => [0]}}
+      adopted = %{"mat_sys" => "node1@host"}
+
+      state = %{
+        coordinator: coordinator,
+        transaction_system_layout: layout,
+        # Deliberately EMPTY here, and populated only on `completed`.
+        recovery_attempt: %RecoveryAttempt{
+          cluster: TestCluster,
+          epoch: 3,
+          attempt: 1,
+          started_at: DateTime.utc_now(),
+          shard_materializers: %{}
+        }
+      }
+
+      completed = %{state.recovery_attempt | shard_materializers: %{0 => adopted}}
+
+      Recovery.persist_new_transaction_system_layout(state, completed)
+
+      assert_receive {:cast, {:notify_transaction_system_layout, ^layout, core_state}}, 500
+      assert core_state.system_materializers == adopted
+    end
+
+    defp relay_casts(test_pid) do
+      receive do
+        {:"$gen_cast", msg} ->
+          send(test_pid, {:cast, msg})
+          relay_casts(test_pid)
+      end
+    end
+  end
 end

--- a/test/bedrock/control_plane/director/recovery_test.exs
+++ b/test/bedrock/control_plane/director/recovery_test.exs
@@ -520,7 +520,8 @@ defmodule Bedrock.ControlPlane.Director.RecoveryTest do
     test "recovery with coordinator-format services handles existing cluster (regression test)" do
       # Validates coordinator services work with existing cluster recovery
       old_layout = %{
-        logs: %{"existing_log_1" => [0, 100]}
+        logs: %{"existing_log_1" => [0, 100]},
+        system_materializers: %{"metadata_materializer" => "node1"}
       }
 
       durable_version = Version.from_integer(100)


### PR DESCRIPTION
Recovery found tag 0 by **roll call**: it locked every advertised materializer in the cluster, asked each which shard it served, and ran a most-advanced-durable **contest** to pick one. If none answered, it **created an empty materializer and read the cluster's shard layout out of it**.

Both halves are gone. `CoreState` now carries the system shard's members, so recovery looks them up.

## FDB has the same indirection — and a stricter discipline

FDB's coordinated state names the tlogs that hold the `txnStateStore`. Recovery builds its log system from exactly those servers and locks exactly those (`TagPartitionedLogSystem.actor.cpp:2549-2585`), then waits for a quorum of **them**:

```cpp
// W + (N - R) < F, and optimally (N-W)+(N-R)=F-1.  Thus R=N+1-F+W.
int requiredCount = logSet->logServers.size() + 1 - tLogReplicationFactor + tLogWriteAntiQuorum;
```

Derived in the source so no replica set can be entirely out-of-date-or-unavailable (`:2076-2082`). It never substitutes another server and never fabricates one. **An unavailable named member is a wait, not a fallback.**

So an existing cluster that cannot reach its named members now **stalls**. The director retries; an operator can see why. Recovery manufacturing the store its own metadata lives in would come up "successfully" on an empty layout and orphan the cluster's data — the failure mode most worth refusing.

Creation survives in exactly one place: a **fresh** cluster seeding tag 0, where there is no prior data and nothing is invented.

## The contest was asking the wrong question twice

- The strays it existed to filter out were made by **recovery's own invent path**.
- `durable_version` measures **stream position**, not data completeness — a worker that started empty and pulled the log tail can rank at or above one holding the whole shard.

The fallback for tags the family doesn't name is now the **lowest worker id** — the same deterministic rule as the client-facing pick (`RoutingData.pick_member/1`), so the member recovery adopts is the member clients are routed to. The rewritten test pins exactly that: the more-advanced claimant now loses, deliberately.

## Both records publish together

The broadcast cannot carry membership by design (*"Nothing O(workers) may ever be added"*). Sending only the layout would leave every **warm** recovery — one with no coordinator restart — finding no members and stalling. The director just persisted both records, so it now sends both.

## Dialyzer earned its keep twice

- The layout is typed nil-able on the way in, making the new call unsatisfiable.
- `system_service_entry/2`'s non-nil clause had become **unreachable**: the system shard is never created here any more, so it's already in `transaction_services` from the locking phase and needs no synthetic entry.

Both deleted rather than papered over.

## Tests

Tests whose premise was the deleted behavior were rewritten to pin the new one rather than renamed around it — the invent test now asserts that *available capacity is not a licence to invent*, and the two creation-failure tests moved to the fresh-cluster path where creation is still legitimate. The full existing-cluster recovery integration test passes through the new lookup end to end.

## Gates

2753 tests / 0 failures, 3-seed sweep, `credo --strict` clean, dialyzer clean.

bedrock-q67.21.12