### PR TITLE
Recovery stops at tag 0: the distributor owns data-tag materializers

### DIFF
--- a/lib/bedrock/control_plane/director/recovery.ex
+++ b/lib/bedrock/control_plane/director/recovery.ex
@@ -177,21 +177,35 @@ defmodule Bedrock.ControlPlane.Director.Recovery do
     |> Enum.reject(&MapSet.member?(referenced, &1))
   end
 
-  # The completed layout's statement of what exists: the new-generation
-  # logs and the active shard materializers — computed from the attempt
-  # (the TSL carries no membership map). Ghost pruning treats anything
-  # the completed recovery does not reference as a candidate ghost.
+  # What this epoch knows to exist: the new-generation logs, every
+  # materializer that ANSWERED the epoch's lock, and the tag-0
+  # materializer recovery seated (on a fresh cluster it was created here
+  # and never locked, so it is in neither of the others).
+  #
+  # Answering the lock is the load-bearing term. Recovery adopts only tag
+  # 0 (bedrock-q67.21.13), so "recovery did not seat it" now describes
+  # every data-tag materializer in a healthy cluster — reading that as
+  # death would deregister the whole data plane on every recovery. It was
+  # already wrong for the replicas of a tag recovery did not pick.
+  #
+  # A ghost is a registration nothing answered for: a worker on a node
+  # that no longer exists under that name, which cannot deregister
+  # itself. The locking phase records only the workers that replied, so
+  # its key set is exactly that distinction, already computed. Read it
+  # strictly — a missing key must raise, not silently deregister the
+  # cluster.
   @spec layout_reference_ids(RecoveryAttempt.t()) :: MapSet.t(Worker.id())
   defp layout_reference_ids(completed_attempt) do
     log_ids = completed_attempt.logs |> Map.keys() |> MapSet.new()
+    answered_ids = completed_attempt.materializer_recovery_info_by_id |> Map.keys() |> MapSet.new()
 
-    materializer_ids =
+    seated_ids =
       for {_tag, members} <- completed_attempt.shard_materializers,
           {worker_id, _node} <- members,
           into: MapSet.new(),
           do: worker_id
 
-    MapSet.union(log_ids, materializer_ids)
+    log_ids |> MapSet.union(answered_ids) |> MapSet.union(seated_ids)
   end
 
   # The runtime wiring recruitment needs — the epoch's log refs and node

--- a/lib/bedrock/control_plane/director/recovery/materializer_bootstrap_phase.ex
+++ b/lib/bedrock/control_plane/director/recovery/materializer_bootstrap_phase.ex
@@ -1,30 +1,46 @@
 defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhase do
   @moduledoc """
-  Bootstraps the metadata shard materializer for recovery.
+  Brings up the system shard, and stops there.
 
-  The metadata materializer holds the authoritative shard layout - the mapping from
-  key ranges to shard tags. This phase ensures the materializer is available and
-  queries it for the current shard layout.
+  Tag 0 holds the cluster's metadata — the shard layout and materializer
+  membership — so recovery cannot read either until a tag-0 materializer
+  is serving. That is this phase's entire job.
 
-  ## Fresh Cluster
+  ## Existing cluster
 
-  For a fresh cluster (no old logs), creates a default shard layout with two shards:
-  - System shard (tag 0): Keys from 0xFF to end-of-keyspace (system metadata)
-  - User shard (tag 1): Keys from empty string to 0xFF (user data)
+  1. Look up the system materializer named by the prior core state. It is
+     LOOKED UP, never discovered and never invented: an unavailable named
+     member stalls (bedrock-q67.21.12).
+  2. Lock it into this epoch, unlock it with its replica set of pull
+     sources, and wait for it to reach the recovery version.
+  3. Read the shard layout from `\\xff/system/shard_keys/*` and the
+     committed tag-0 members from `\\xff/system/materializers/0/*`.
 
-  ## Existing Cluster
+  ## Fresh cluster
 
-  For an existing cluster:
-  1. Find materializer with shard_id = 0 (system shard) in available_services
-  2. If not found, create a new materializer on a capable node
-  3. Lock materializer for recovery
-  4. Unlock it with its replica set of pull sources to start pulling
-  5. Wait for materializer to catch up (60s timeout)
-  6. Query shard layout from `\\xff/system/shard_keys/*`
+  No prior epoch's data exists, so recovery seeds: the default two-shard
+  layout (tag 0 for system keys, tag 1 for user keys) and one created
+  materializer for tag 0.
 
-  Stalls if the materializer is unavailable and cannot be created, or if catchup
-  times out. Transitions to CommitProxyStartupPhase with the materializer pid and
-  shard layout.
+  ## What it deliberately does not do
+
+  The layout names data tags, and the locking phase locked their
+  materializers into this epoch — but recovery does not seat, unlock, or
+  record any of them. That belongs to the distributor, whose startup
+  sweep verifies every committed member is in service, adopts the ones
+  that are not, heals what it cannot adopt, and covers gaps with the
+  placeholder, after every recovery regardless (bedrock-q67.21.13).
+
+  This is FDB's division. Its recovery touches storage servers through a
+  single key — `\\xff/lastEpochEnd`
+  (`ClusterRecovery.actor.cpp:1692-1698`) — and storage learns the epoch
+  in-band from the mutation stream; `RecoveryState::STORAGE_RECOVERED`
+  (`:519-520`) is a status label recovery fires when the old tlog
+  generations drop away. Recovery observes storage. It does not drive it.
+
+  Stalls if the named system materializer is unavailable, if catchup
+  times out, or if either family read fails. Transitions to
+  `CommitProxyStartupPhase`.
   """
 
   use Bedrock.ControlPlane.Director.Recovery.RecoveryPhase
@@ -88,76 +104,37 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhase do
 
     shard_layout = default_shard_layout()
 
-    # Only the system shard is recovery's to create (stall-only-for-tag-0
-    # completed, bedrock-q67.21.4): data-tag gaps are left ABSENT — the
-    # distributor's sweep covers them with the placeholder and demand
-    # recruits real workers. Recovery no longer manufactures data-plane
-    # coverage it does not itself need.
-    case create_materializers_for_shards([RecoveryAttempt.system_shard_id()], recovery_attempt, context) do
-      {:ok, shard_materializers, created_services} ->
+    # The system shard is the only one recovery creates. The layout it
+    # just invented names a data tag too, but that gap is the
+    # distributor's to cover — its sweep places the placeholder over it
+    # and demand recruits a real worker. Recovery does not manufacture
+    # data-plane coverage it has no use for.
+    case create_and_start_materializer(RecoveryAttempt.system_shard_id(), recovery_attempt, context) do
+      {:ok, {worker_id, node, _pid}, {worker_id, descriptor}} ->
         updated_attempt =
           recovery_attempt
           |> Map.put(:shard_layout, shard_layout)
-          |> Map.put(:shard_materializers, to_materializer_refs(shard_materializers))
+          |> Map.put(
+            :shard_materializers,
+            %{RecoveryAttempt.system_shard_id() => %{worker_id => Atom.to_string(node)}}
+          )
           # Provenance for the persistence phase: this recovery INVENTED
           # the layout (fresh cluster), so it seeds the durable families;
           # the empty prior means every assignment writes.
           |> Map.put(:seeded_layout?, true)
           |> Map.put(:prior_materializer_refs, %{})
-          |> Map.update!(:transaction_services, &Map.merge(&1, created_services))
+          # The creation must reach transaction_services: the layout and
+          # the materializers keyspace are built from it, and a worker the
+          # committed state does not name retires itself.
+          |> Map.update!(:transaction_services, &Map.put(&1, worker_id, descriptor))
 
         {updated_attempt, CommitProxyStartupPhase}
 
       {:error, reason} ->
-        Logger.warning("Failed to create materializers for fresh cluster: #{inspect(reason)}")
-        {recovery_attempt, {:stalled, {:materializer_creation_failed, reason}}}
+        Logger.warning("Failed to create the system materializer for a fresh cluster: #{inspect(reason)}")
+
+        {recovery_attempt, {:stalled, {:materializer_creation_failed, {RecoveryAttempt.system_shard_id(), reason}}}}
     end
-  end
-
-  # The one projection, at the one boundary it belongs: the phase
-  # orchestrates with live pids (lock, unlock, catchup), but the attempt
-  # carries the refs exactly as every reader consumes them — the
-  # family's MEMBER shape, %{worker_id => node}, all strings. The
-  # persistence writer and the routing-snapshot seed embed this map
-  # verbatim, so the seed and the keyspace are the same map read twice;
-  # ghost pruning takes its worker ids from it directly. Recovery adopts
-  # exactly one member per tag (see prefer_family_named/3), so the map
-  # it builds is a singleton per tag — but it is member-SHAPED, because
-  # the family is a set and every reader treats it as one. A pid is phase-local
-  # orchestration state, not a fact any reader needs — a future consumer
-  # that wants one should ask where it lives (the directory, or the
-  # worker), not have it carried speculatively.
-  @spec to_materializer_refs(%{Bedrock.range_tag() => {Worker.id(), node(), pid()}}) ::
-          %{Bedrock.range_tag() => %{Worker.id() => String.t()}}
-  defp to_materializer_refs(shard_materializers) do
-    Map.new(shard_materializers, fn {tag, {worker_id, node, _pid}} ->
-      {tag, %{worker_id => Atom.to_string(node)}}
-    end)
-  end
-
-  # Extract unique shard tags from shard_layout
-  defp extract_shard_tags(shard_layout) do
-    shard_layout
-    |> Map.values()
-    |> Enum.map(fn {tag, _start_key} -> tag end)
-    |> Enum.uniq()
-  end
-
-  # Create materializers for multiple shards, collecting both the pid map
-  # and the service records of what was created — a created worker that
-  # never reaches transaction_services never reaches the layout or the
-  # materializers keyspace, and rejoin validation would retire the
-  # workers recovery just made.
-  defp create_materializers_for_shards(shard_tags, recovery_attempt, context) do
-    Enum.reduce_while(shard_tags, {:ok, %{}, %{}}, fn shard_tag, {:ok, by_shard, services} ->
-      case create_and_start_materializer(shard_tag, recovery_attempt, context) do
-        {:ok, {_worker_id, _node, _pid} = assignment, {worker_id, descriptor}} ->
-          {:cont, {:ok, Map.put(by_shard, shard_tag, assignment), Map.put(services, worker_id, descriptor)}}
-
-        {:error, reason} ->
-          {:halt, {:error, {shard_tag, reason}}}
-      end
-    end)
   end
 
   # Create a materializer for a specific shard and start it pulling.
@@ -222,11 +199,6 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhase do
     # would discard real state.)
     {_available_after, recovery_version} = recovery_attempt.version_vector
 
-    # Materializers were locked during the locking phase; their recovery
-    # info carries their shard assignments. Reuse them — they hold the
-    # durable state, including the shard layout this phase exists to read.
-    existing_by_shard = existing_materializers_by_shard(recovery_attempt)
-
     with {:ok, {system_worker_id, materializer_service}} <-
            resolve_system_materializer(recovery_attempt, context),
          {:ok, materializer_pid} <- lock_materializer(materializer_service, recovery_attempt.epoch, context),
@@ -249,34 +221,28 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhase do
              context
            ),
          {:ok, shard_layout} <- get_shard_layout(materializer_pid, recovery_version, context),
-         {:ok, prior_refs} <- read_prior_refs(materializer_pid, recovery_version, context),
-         {:ok, shard_materializers, created_services} <-
-           ensure_materializers_for_shards(
-             shard_layout,
-             prefer_family_named(existing_by_shard, prior_refs, recovery_attempt),
-             %{
-               RecoveryAttempt.system_shard_id() => {system_worker_id, node(materializer_pid), materializer_pid}
-             },
-             recovery_version,
-             recovery_attempt,
-             context
-           ) do
-      # Every creation must reach transaction_services: the layout and the
-      # materializers keyspace are built from it, and workers self-retire
-      # when the committed state doesn't name them. The system shard needs
-      # no synthetic entry — it is never created here, only looked up, so
-      # it is already in transaction_services from the locking phase.
+         {:ok, prior_refs} <- read_prior_refs(materializer_pid, recovery_version, context) do
+      # Recovery stops here. The layout names data tags, and the locking
+      # phase locked their materializers into this epoch, but seating them
+      # is the distributor's job — its startup sweep verifies every
+      # committed member is in service, adopts the ones that are not,
+      # heals what it cannot adopt, and covers gaps with the placeholder,
+      # after every recovery regardless. The system shard needs no
+      # synthetic services entry: it is looked up, never created, so it is
+      # already there from the locking phase.
       updated_attempt =
         recovery_attempt
         |> Map.put(:shard_layout, shard_layout)
-        |> Map.put(:shard_materializers, to_materializer_refs(shard_materializers))
+        |> Map.put(
+          :shard_materializers,
+          %{RecoveryAttempt.system_shard_id() => %{system_worker_id => Atom.to_string(node(materializer_pid))}}
+        )
         # Provenance for the persistence phase: the layout was READ from
-        # the durable family (nothing to rewrite), and the prior refs are
-        # the diff base for materializer writes.
+        # the durable family (nothing to rewrite), and the prior members
+        # are the diff base for the tag-0 write.
         |> Map.put(:seeded_layout?, false)
         |> Map.put(:prior_materializer_refs, prior_refs)
         |> Map.put(:resolvers, resolver_descriptors_for_layout(shard_layout))
-        |> Map.update!(:transaction_services, &Map.merge(&1, created_services))
 
       {updated_attempt, CommitProxyStartupPhase}
     else
@@ -295,37 +261,6 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhase do
     |> Enum.sort()
     |> Enum.with_index(1)
     |> Enum.map(fn {start_key, index} -> resolver_descriptor(start_key, {:vacancy, index}) end)
-  end
-
-  # The locking phase locked every advertised materializer and collected its
-  # recovery info — including its shard assignment. Index the survivors by
-  # shard, with their service refs from the transaction services map.
-  #
-  # When several claim the same shard, the lowest worker id wins — the
-  # same deterministic rule as the client-facing pick
-  # (RoutingData.pick_member/1), so the member recovery adopts is the
-  # member clients are routed to.
-  #
-  # It used to be the most-advanced DURABLE VERSION, which was the wrong
-  # question twice over. The strays it existed to filter out were made by
-  # recovery's own invent path, now deleted; and durable_version measures
-  # STREAM POSITION, not data completeness, so a worker that started
-  # empty and pulled the log tail could rank above a complete one.
-  defp existing_materializers_by_shard(recovery_attempt) do
-    recovery_attempt.materializer_recovery_info_by_id
-    |> Enum.flat_map(fn {id, info} ->
-      with shard_id when is_integer(shard_id) <- Map.get(info, :shard_id),
-           %{status: {:up, ref}} <- Map.get(recovery_attempt.transaction_services, id) do
-        [{shard_id, Map.get(info, :durable_version), {id, {:materializer, ref}}}]
-      else
-        _ -> []
-      end
-    end)
-    |> Enum.group_by(fn {shard_id, _durable, _entry} -> shard_id end)
-    |> Map.new(fn {shard_id, candidates} ->
-      {_shard, _durable, entry} = Enum.min_by(candidates, fn {_shard, _durable, {worker_id, _}} -> worker_id end)
-      {shard_id, entry}
-    end)
   end
 
   # The system shard is LOOKED UP, never discovered and never invented.
@@ -379,99 +314,23 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhase do
         do: {worker_id, {:materializer, ref}}
   end
 
-  # Every shard in the layout needs a materializer in the new TSL: reuse the
-  # survivors (unlocking each so it streams), create only the missing.
-  defp ensure_materializers_for_shards(
-         shard_layout,
-         existing_by_shard,
-         already_started,
-         recovery_version,
-         recovery_attempt,
-         context
-       ) do
-    shard_layout
-    |> extract_shard_tags()
-    |> Enum.reduce_while({:ok, already_started, %{}}, fn shard_tag, {:ok, acc, services} ->
-      case Map.fetch(acc, shard_tag) do
-        {:ok, _assignment} ->
-          {:cont, {:ok, acc, services}}
-
-        :error ->
-          shard_tag
-          |> start_materializer_for_shard(existing_by_shard, recovery_version, recovery_attempt, context)
-          |> case do
-            {:ok, :absent, _created} ->
-              {:cont, {:ok, acc, services}}
-
-            {:ok, assignment, created} ->
-              {:cont, {:ok, Map.put(acc, shard_tag, assignment), Map.merge(services, created)}}
-
-            {:error, reason} ->
-              {:halt, {:error, {shard_tag, reason}}}
-          end
-      end
-    end)
-  end
-
-  defp start_materializer_for_shard(shard_tag, existing_by_shard, recovery_version, recovery_attempt, context) do
-    case Map.fetch(existing_by_shard, shard_tag) do
-      {:ok, {worker_id, service}} ->
-        with {:ok, pid} <- lock_materializer(service, recovery_attempt.epoch, context),
-             :ok <- unlock_and_start_pulling(pid, shard_tag, recovery_version, recovery_attempt, context) do
-          {:ok, {worker_id, node(pid), pid}, %{}}
-        end
-
-      :error ->
-        # No survivor: the gap is the distributor's to heal, not
-        # recovery's to fill (stall-only-for-tag-0 completed,
-        # bedrock-q67.21.4). The slot stays ABSENT; the sweep covers it
-        # with the placeholder and demand recruits a real worker. The
-        # shard's durable history is safe regardless — chunks are
-        # shard-keyed, epoch-spanning, and never deleted.
-        Logger.info("Materializer for shard #{shard_tag} not found; leaving for the distributor to heal")
-        {:ok, :absent, %{}}
-    end
-  end
-
-  # The committed materializers/ family is the re-adoption authority: a
-  # family-named worker that this epoch's locking phase actually locked
-  # (and whose own shard assignment agrees) is preferred over the
-  # most-advanced-durable contest, which remains the fallback for tags
-  # the family does not name — and for tag 0, whose selection happens
-  # before the family can be read (the family lives IN the system shard).
-  # Recovery adopts exactly ONE member per tag. The family may name
-  # several (the distributor can place replicas), but recovery's job is
-  # to get each shard served, not to re-establish every replica; the
-  # members it does not adopt keep their committed keys and the
-  # distributor's sweep verifies and adopts them into this epoch. The
-  # pick is the LOWEST worker id — the same deterministic rule
-  # RoutingData.pick_member/1 uses, so the member recovery unlocks is
-  # the member clients are routed to, with no window where the pick
-  # names a materializer still locked at the prior epoch.
-  defp prefer_family_named(existing_by_shard, prior_refs, recovery_attempt) do
-    named =
-      for {tag, members} <- prior_refs,
-          {worker_id, _node} <- Enum.sort(members),
-          match?(%{shard_id: ^tag}, Map.get(recovery_attempt.materializer_recovery_info_by_id, worker_id)),
-          %{status: {:up, ref}} <- [Map.get(recovery_attempt.transaction_services, worker_id)],
-          reduce: %{} do
-        acc -> Map.put_new(acc, tag, {worker_id, {:materializer, ref}})
-      end
-
-    Map.merge(existing_by_shard, named)
-  end
-
-  # Read the durable materializers/ family at the recovery version: the
-  # re-adoption input and the persistence phase's diff base. Read from
+  # The committed tag-0 members at the recovery version: the diff base
+  # for the keyspace write and the set recorded in the durable pointer
+  # (the cluster bootstrap), so losing the one member this recovery
+  # adopted does not leave the next one with nowhere to look. Read from
   # the same materializer, at the same version, as the shard layout — a
   # torn view is impossible (the families rewrite transactionally).
+  #
+  # Scoped to tag 0. Data-tag membership belongs to the distributor and
+  # is not recovery's input; reading the whole family would drag it back
+  # in as a standing invitation to start consuming it again.
   defp read_prior_refs(materializer_pid, read_version, context) do
     read_fn = Map.get(context, :read_prior_refs_fn, &default_read_prior_refs/2)
     read_fn.(materializer_pid, read_version)
   end
 
   defp default_read_prior_refs(materializer_pid, read_version) do
-    prefix = Bedrock.SystemKeys.materializers_prefix()
+    prefix = Bedrock.SystemKeys.materializer_tag_prefix(RecoveryAttempt.system_shard_id())
     {_range_start, range_end} = Bedrock.KeyRange.from_prefix(prefix)
 
     range_read_fn = fn start_key ->

--- a/lib/bedrock/control_plane/director/recovery/persistence_phase.ex
+++ b/lib/bedrock/control_plane/director/recovery/persistence_phase.ex
@@ -240,16 +240,24 @@ defmodule Bedrock.ControlPlane.Director.Recovery.PersistencePhase do
   end
 
   # Creates materializer_key(tag, worker_id) -> node entries as a DIFF
-  # against the prior family (read by bootstrap): only assignments this
-  # recovery changed are written; unchanged entries are left in place,
-  # and entries for tags outside this layout are not recovery's to clean
-  # — read-and-heal means stale reconciliation belongs to the
-  # distributor (bedrock-q67.21.4). A nil prior means the family was not
-  # read (fresh cluster, legacy path): every assignment writes, the safe
-  # direction. The attempt carries refs in the family's member shape, so
-  # keyspace and routing-snapshot seed remain one map read twice. Gated
-  # on the same INPUT as before: shard_materializers absent/empty means
-  # shard management is not active.
+  # against the prior members (read by bootstrap): only what this
+  # recovery changed is written; unchanged entries are left in place, and
+  # entries recovery never touched are not its to clean — read-and-heal
+  # means stale reconciliation belongs to the distributor
+  # (bedrock-q67.21.4).
+  #
+  # In practice this now writes tag 0 and nothing else, because that is
+  # all recovery seats (bedrock-q67.21.13); the loop stays general
+  # because the family is one family and this is a diff, not a
+  # tag-specific rule. Tag 0 must be written: on a fresh cluster nobody
+  # else knows the materializer recovery just created, and the
+  # distributor's own sweep reads the families through a client
+  # transaction that has to route to tag 0 to see anything at all.
+  #
+  # A nil prior means the family was not read (fresh cluster): every
+  # assignment writes, the safe direction. The attempt carries members in
+  # the family's own shape, so keyspace and routing-snapshot seed remain
+  # one map read twice.
   @spec build_materializer_keys(Tx.t(), RecoveryAttempt.t()) :: Tx.t()
   defp build_materializer_keys(tx, recovery_attempt) do
     case Map.get(recovery_attempt, :shard_materializers) do

--- a/lib/bedrock/control_plane/distributor/server.ex
+++ b/lib/bedrock/control_plane/distributor/server.ex
@@ -732,9 +732,19 @@ defmodule Bedrock.ControlPlane.Distributor.Server do
       spawn_monitor(fn ->
         verdict =
           try do
-            case info_fn.({name, node_atom}, [:epoch], timeout_in_ms: @verification_timeout_ms) do
-              {:ok, %{epoch: ^epoch}} -> :current
-              {:ok, %{epoch: _stale_or_nil}} -> Recruitment.adopt(tag, worker_id, node_atom, ctx)
+            case info_fn.({name, node_atom}, [:epoch, :mode], timeout_in_ms: @verification_timeout_ms) do
+              # In the epoch AND serving it. Both halves are load-bearing:
+              # recovery locks every advertised materializer into its
+              # epoch and unlocks only tag 0's, so a data-tag materializer
+              # is normally in the current epoch and NOT pulling. Reads
+              # carry no mode guard, so left alone it would go on
+              # answering at a frozen version for the whole epoch —
+              # silent staleness rather than a stall. Anything that is
+              # not demonstrably running is adopted; adoption of a
+              # healthy worker costs a lock/unlock round trip and it
+              # resumes from its own durable version.
+              {:ok, %{epoch: ^epoch, mode: :running}} -> :current
+              {:ok, %{epoch: _epoch, mode: _not_running}} -> Recruitment.adopt(tag, worker_id, node_atom, ctx)
               {:error, reason} -> {:error, reason}
             end
           catch

--- a/lib/bedrock/data_plane/materializer/olivine/logic.ex
+++ b/lib/bedrock/data_plane/materializer/olivine/logic.ex
@@ -260,6 +260,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Logic do
       path
       key_ranges
       kind
+      mode
       n_keys
       otp_name
       shard_id
@@ -280,6 +281,12 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Logic do
   # worker that is IN the epoch from one the epoch never embraced — a
   # node that missed recovery's roll call and rejoined later.
   defp gather_info(:epoch, t), do: t.epoch
+  # Whether the worker is SERVING that epoch. Locking fences :ingest and
+  # :apply_transactions; only an unlock lifts it, and reads are never
+  # fenced at all — so a locked worker keeps answering, frozen at the
+  # version it last applied. The epoch alone cannot tell those apart, and
+  # the worker is the only process that knows.
+  defp gather_info(:mode, t), do: t.mode
   defp gather_info(:id, t), do: t.id
   defp gather_info(:key_ranges, t), do: IndexManager.info(t.index_manager, :key_ranges)
   defp gather_info(:kind, _t), do: :materializer

--- a/test/bedrock/control_plane/director/recovery/materializer_bootstrap_phase_test.exs
+++ b/test/bedrock/control_plane/director/recovery/materializer_bootstrap_phase_test.exs
@@ -9,6 +9,22 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhaseTest 
   alias Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhase
   alias Bedrock.DataPlane.Version
 
+  defmodule RangeRecorder do
+    @moduledoc false
+    # Answers get_range like a materializer would, forwarding the bounds
+    # it was asked for so a test can assert on them.
+    use GenServer
+
+    @impl true
+    def init(reporter), do: {:ok, reporter}
+
+    @impl true
+    def handle_call({:get_range, start_key, end_key, _version, _opts}, _from, reporter) do
+      send(reporter, {:range_read, start_key, end_key})
+      {:reply, {:ok, {[], false}}, reporter}
+    end
+  end
+
   describe "execute/2" do
     test "for fresh cluster, creates default shard layout and materializers" do
       system_materializer_pid = spawn(fn -> Process.sleep(:infinity) end)
@@ -179,7 +195,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhaseTest 
       end)
     end
 
-    test "reuses the locked materializers on restart — one per shard, unlocked at the recovery version" do
+    test "reuses the locked system materializer on restart, unlocked at the recovery version" do
       system_pid = spawn(fn -> Process.sleep(:infinity) end)
       user_pid = spawn(fn -> Process.sleep(:infinity) end)
       recovery_version = Version.from_integer(24_000_000)
@@ -230,26 +246,23 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhaseTest 
           assert {updated_attempt, CommitProxyStartupPhase} =
                    MaterializerBootstrapPhase.execute(recovery_attempt, context)
 
-          # The system-shard survivor answers the layout query...
-          assert %{"mat_sys" => _node} = updated_attempt.shard_materializers[RecoveryAttempt.system_shard_id()]
+          # The system-shard survivor answers the layout query, and is the
+          # only materializer recovery seats — tag 1's survivor is left
+          # for the distributor to verify and adopt.
+          assert %{0 => %{"mat_sys" => _}} = updated_attempt.shard_materializers
+          assert map_size(updated_attempt.shard_materializers) == 1
           assert updated_attempt.shard_layout
-
-          # ...and every shard in the layout gets its surviving
-          # materializer — nothing newly created, nothing orphaned.
-          assert %{0 => %{"mat_sys" => _}, 1 => %{"mat_user" => _}} = updated_attempt.shard_materializers
-
-          assert map_size(updated_attempt.shard_materializers) == 2
         end)
 
-      # Both were unlocked at the recovery version (vector last), never at
-      # the regressed durable floor.
+      # Unlocked at the recovery version (vector last), never at the
+      # regressed durable floor.
       assert_receive {:unlocked, ^system_pid, ^recovery_version}
-      assert_receive {:unlocked, ^user_pid, ^recovery_version}
+      refute_receive {:unlocked, ^user_pid, _}
 
       assert log =~ "Materializer caught up to version"
     end
 
-    test "when several materializers claim a shard, the most-advanced durable state wins" do
+    test "when several materializers claim the system shard, the lowest worker id wins" do
       real_pid = spawn(fn -> Process.sleep(:infinity) end)
       stray_pid = spawn(fn -> Process.sleep(:infinity) end)
       recovery_version = Version.from_integer(24_000_000)
@@ -532,6 +545,95 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhaseTest 
     end
   end
 
+  describe "recovery stops at tag 0" do
+    # FDB's recovery does essentially nothing to storage servers: the
+    # entire interaction is one key (\xff/lastEpochEnd,
+    # ClusterRecovery.actor.cpp:1692-1698), and storage learns the epoch
+    # IN-BAND from the mutation stream. Recovery OBSERVES storage —
+    # RecoveryState::STORAGE_RECOVERED (:519-520) is a status label fired
+    # when the old tlog generations drop away — it never drives it.
+    #
+    # Ours drove it: it re-locked and unlocked a materializer for every
+    # data tag. Nothing in the transaction system needed that (the
+    # recovery version comes from tlogs alone), and the distributor's
+    # startup sweep does it properly — verify, adopt, heal, recruit —
+    # after every recovery regardless.
+
+    test "an existing cluster's shard_materializers names ONLY tag 0, however many data-tag survivors are locked" do
+      recovery_version = Version.from_integer(500)
+      sys_pid = spawn(fn -> Process.sleep(:infinity) end)
+      a_pid = spawn(fn -> Process.sleep(:infinity) end)
+      b_pid = spawn(fn -> Process.sleep(:infinity) end)
+      test_pid = self()
+
+      context =
+        existing_context(recovery_version, %{
+          read_prior_refs_fn: fn _pid, _version -> {:ok, %{0 => %{"mat_sys" => Atom.to_string(node())}}} end,
+          unlock_materializer_fn: fn pid, version, _sources ->
+            send(test_pid, {:unlocked, pid, version})
+            :ok
+          end
+        })
+
+      recovery_attempt = two_claimants_attempt(recovery_version, a_pid, b_pid, sys_pid)
+
+      capture_log(fn ->
+        assert {updated_attempt, CommitProxyStartupPhase} =
+                 MaterializerBootstrapPhase.execute(recovery_attempt, context)
+
+        # The layout has tag 1 in it, and both tag-1 claimants are locked,
+        # healthy, and available. Recovery still leaves them alone.
+        assert updated_attempt.shard_layout[<<0xFF>>] == {1, <<>>}
+        assert %{0 => %{"mat_sys" => _}} = updated_attempt.shard_materializers
+        assert map_size(updated_attempt.shard_materializers) == 1
+      end)
+
+      assert_receive {:unlocked, ^sys_pid, ^recovery_version}
+      refute_receive {:unlocked, ^a_pid, _}
+      refute_receive {:unlocked, ^b_pid, _}
+    end
+
+    test "the committed-member read is scoped to tag 0 — data-tag membership is never recovery's input" do
+      recovery_version = Version.from_integer(500)
+      # A real materializer stub, so this drives the DEFAULT read path
+      # rather than a stubbed-out one: the range bounds under test are the
+      # ones production computes.
+      {:ok, sys_pid} = GenServer.start_link(RangeRecorder, self())
+
+      # The shared support context stubs the family read; drop the stub so
+      # the production bounds are the ones under test.
+      context = recovery_version |> existing_context(%{}) |> Map.delete(:read_prior_refs_fn)
+
+      recovery_attempt =
+        two_claimants_attempt(
+          recovery_version,
+          spawn(fn -> Process.sleep(:infinity) end),
+          spawn(fn -> Process.sleep(:infinity) end),
+          sys_pid
+        )
+
+      capture_log(fn ->
+        assert {_updated_attempt, CommitProxyStartupPhase} =
+                 MaterializerBootstrapPhase.execute(recovery_attempt, context)
+      end)
+
+      # Reading the whole materializers/ family would sweep in every data
+      # tag's members — bytes recovery has no use for, and a standing
+      # invitation to start consuming them again.
+      {tag_zero_start, tag_zero_end} =
+        RecoveryAttempt.system_shard_id()
+        |> Bedrock.SystemKeys.materializer_tag_prefix()
+        |> Bedrock.KeyRange.from_prefix()
+
+      assert_receive {:range_read, ^tag_zero_start, ^tag_zero_end}
+
+      {family_start, _family_end} =
+        Bedrock.KeyRange.from_prefix(Bedrock.SystemKeys.materializers_prefix())
+
+      refute_receive {:range_read, ^family_start, _}
+    end
+  end
+
   describe "prior materializer family as re-adoption input" do
     defp existing_context(recovery_version, overrides) do
       base =
@@ -571,95 +673,6 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhaseTest 
         "mat_stray" => %{kind: :materializer, status: {:up, stray_pid}},
         "log_1" => %{kind: :log, status: {:up, self()}}
       })
-    end
-
-    test "the family-named locked survivor beats a stray" do
-      # The committed assignment is the authority; the deterministic pick
-      # is only the fallback for tags the family does not name.
-      recovery_version = Version.from_integer(500)
-      sys_pid = spawn(fn -> Process.sleep(:infinity) end)
-      named_pid = spawn(fn -> Process.sleep(:infinity) end)
-      stray_pid = spawn(fn -> Process.sleep(:infinity) end)
-
-      context =
-        existing_context(recovery_version, %{
-          read_prior_refs_fn: fn _pid, _version ->
-            {:ok, %{1 => %{"mat_named" => Atom.to_string(node())}}}
-          end
-        })
-
-      recovery_attempt = two_claimants_attempt(recovery_version, named_pid, stray_pid, sys_pid)
-
-      ExUnit.CaptureLog.capture_log(fn ->
-        assert {updated_attempt, CommitProxyStartupPhase} =
-                 MaterializerBootstrapPhase.execute(recovery_attempt, context)
-
-        assert %{"mat_named" => _node} = updated_attempt.shard_materializers[1]
-        assert updated_attempt.prior_materializer_refs == %{1 => %{"mat_named" => Atom.to_string(node())}}
-        refute updated_attempt.seeded_layout?
-      end)
-    end
-
-    defp three_claimants_attempt(recovery_version, sys_pid, a_pid, b_pid, c_pid) do
-      # THREE claimants, with id order deliberately disagreeing with BOTH
-      # durable orders. Two candidates cannot discriminate: whichever way
-      # you arrange them, the id rule agrees with either min-durable or
-      # max-durable, so the test passes under a rule it was meant to
-      # reject. Here min-id is mat_a, min-durable is mat_b, and
-      # max-durable is mat_c — only the id rule produces mat_a.
-      recovery_attempt()
-      |> Map.put(:shard_layout, nil)
-      |> Map.put(:logs, %{"log_1" => [0, 1]})
-      |> Map.put(:version_vector, {Version.from_integer(0), recovery_version})
-      |> Map.put(:materializer_recovery_info_by_id, %{
-        "mat_sys" => %{kind: :materializer, shard_id: 0, durable_version: recovery_version},
-        "mat_a" => %{kind: :materializer, shard_id: 1, durable_version: Version.from_integer(50)},
-        "mat_b" => %{kind: :materializer, shard_id: 1, durable_version: Version.from_integer(1)},
-        "mat_c" => %{kind: :materializer, shard_id: 1, durable_version: recovery_version}
-      })
-      |> Map.put(:transaction_services, %{
-        "mat_sys" => %{kind: :materializer, status: {:up, sys_pid}},
-        "mat_a" => %{kind: :materializer, status: {:up, a_pid}},
-        "mat_b" => %{kind: :materializer, status: {:up, b_pid}},
-        "mat_c" => %{kind: :materializer, status: {:up, c_pid}},
-        "log_1" => %{kind: :log, status: {:up, self()}}
-      })
-    end
-
-    test "a family entry naming an unlocked worker falls back to the LOWEST ID, not to any durable ranking" do
-      recovery_version = Version.from_integer(500)
-      sys_pid = spawn(fn -> Process.sleep(:infinity) end)
-      named_pid = spawn(fn -> Process.sleep(:infinity) end)
-      stray_pid = spawn(fn -> Process.sleep(:infinity) end)
-
-      context =
-        existing_context(recovery_version, %{
-          read_prior_refs_fn: fn _pid, _version ->
-            {:ok, %{1 => %{"mat_gone" => Atom.to_string(node())}}}
-          end
-        })
-
-      recovery_attempt =
-        three_claimants_attempt(
-          recovery_version,
-          sys_pid,
-          named_pid,
-          stray_pid,
-          spawn(fn -> Process.sleep(:infinity) end)
-        )
-
-      ExUnit.CaptureLog.capture_log(fn ->
-        assert {updated_attempt, CommitProxyStartupPhase} =
-                 MaterializerBootstrapPhase.execute(recovery_attempt, context)
-
-        # "mat_gone" was not locked this epoch, so the fallback decides —
-        # and it decides by worker id, the same deterministic rule the
-        # client-facing pick uses. Neither durable ranking picks mat_a:
-        # durable_version measures stream POSITION, not completeness, so
-        # ranking by it could seat a worker that merely pulled the log
-        # tail over one holding the data.
-        assert %{"mat_a" => _node} = updated_attempt.shard_materializers[1]
-      end)
     end
 
     test "a failed family read stalls the attempt — never a silently unnamed layout" do

--- a/test/bedrock/control_plane/director/recovery_test.exs
+++ b/test/bedrock/control_plane/director/recovery_test.exs
@@ -170,8 +170,6 @@ defmodule Bedrock.ControlPlane.Director.RecoveryTest do
 
   describe "ghost_directory_ids/2" do
     test "selects exactly the directory entries the completed recovery does not reference" do
-      live_mat_pid = spawn(fn -> Process.sleep(:infinity) end)
-
       services = %{
         "live_log" => {:log, {:a, :node1}},
         "live_mat" => {:materializer, {:b, :node1}},
@@ -181,10 +179,7 @@ defmodule Bedrock.ControlPlane.Director.RecoveryTest do
       completed = %{
         logs: %{"live_log" => []},
         shard_materializers: %{0 => %{"live_mat" => Atom.to_string(node())}},
-        transaction_services: %{
-          "live_log" => %{kind: :log, status: {:up, self()}},
-          "live_mat" => %{kind: :materializer, status: {:up, live_mat_pid}}
-        }
+        materializer_recovery_info_by_id: %{"live_mat" => %{kind: :materializer, shard_id: 0}}
       }
 
       assert Recovery.ghost_directory_ids(services, completed) == ["ghost"]
@@ -200,10 +195,7 @@ defmodule Bedrock.ControlPlane.Director.RecoveryTest do
       completed = %{
         logs: %{"old_log" => [], "brand_new_log" => []},
         shard_materializers: %{},
-        transaction_services: %{
-          "old_log" => %{kind: :log, status: {:up, self()}},
-          "brand_new_log" => %{kind: :log, status: {:up, self()}}
-        }
+        materializer_recovery_info_by_id: %{}
       }
 
       assert Recovery.ghost_directory_ids(services, completed) == []
@@ -218,31 +210,52 @@ defmodule Bedrock.ControlPlane.Director.RecoveryTest do
       completed = %{
         logs: %{},
         shard_materializers: %{0 => %{"assigned_mat" => Atom.to_string(node())}},
-        transaction_services: %{}
+        materializer_recovery_info_by_id: %{}
       }
 
       assert Recovery.ghost_directory_ids(services, completed) == []
     end
 
-    test "a locked-but-inactive materializer is not referenced — it is a ghost candidate" do
-      active_pid = spawn(fn -> Process.sleep(:infinity) end)
-      inactive_pid = spawn(fn -> Process.sleep(:infinity) end)
-
+    test "a materializer that answered this epoch's lock is referenced, even though recovery never adopts it" do
+      # A ghost is a registration nothing answered for — a worker on a node
+      # that no longer exists under that name, which cannot deregister
+      # itself. Answering the lock is proof of the opposite, and the
+      # locking phase already computed exactly that set.
+      #
+      # Recovery adopts only tag 0 now, so "not adopted" describes EVERY
+      # data-tag materializer in a healthy cluster. Reading absence from
+      # shard_materializers as death would deregister the entire data
+      # plane on every recovery.
       services = %{
-        "active_mat" => {:materializer, {:a, :node1}},
-        "inactive_mat" => {:materializer, {:b, :node1}}
+        "sys_mat" => {:materializer, {:a, :node1}},
+        "data_mat" => {:materializer, {:b, :node1}}
       }
 
       completed = %{
         logs: %{},
-        shard_materializers: %{0 => %{"active_mat" => Atom.to_string(node())}},
-        transaction_services: %{
-          "active_mat" => %{kind: :materializer, status: {:up, active_pid}},
-          "inactive_mat" => %{kind: :materializer, status: {:up, inactive_pid}}
+        shard_materializers: %{0 => %{"sys_mat" => Atom.to_string(node())}},
+        materializer_recovery_info_by_id: %{
+          "sys_mat" => %{kind: :materializer, shard_id: 0},
+          "data_mat" => %{kind: :materializer, shard_id: 1}
         }
       }
 
-      assert Recovery.ghost_directory_ids(services, completed) == ["inactive_mat"]
+      assert Recovery.ghost_directory_ids(services, completed) == []
+    end
+
+    test "a materializer that did NOT answer the lock is a ghost candidate" do
+      services = %{
+        "sys_mat" => {:materializer, {:a, :node1}},
+        "silent_mat" => {:materializer, {:b, :dead@nowhere}}
+      }
+
+      completed = %{
+        logs: %{},
+        shard_materializers: %{0 => %{"sys_mat" => Atom.to_string(node())}},
+        materializer_recovery_info_by_id: %{"sys_mat" => %{kind: :materializer, shard_id: 0}}
+      }
+
+      assert Recovery.ghost_directory_ids(services, completed) == ["silent_mat"]
     end
   end
 

--- a/test/bedrock/control_plane/distributor/server_test.exs
+++ b/test/bedrock/control_plane/distributor/server_test.exs
@@ -277,7 +277,7 @@ defmodule Bedrock.ControlPlane.Distributor.ServerTest do
             node_capabilities: %{materializer: [node()]},
             logs: %{"log_1" => []},
             log_refs: %{"log_1" => :ref},
-            info_fn: fn _worker, [:epoch], _opts -> {:ok, %{epoch: 3}} end,
+            info_fn: fn _worker, [:epoch, :mode], _opts -> {:ok, %{epoch: 3, mode: :running}} end,
             create_worker_fn: fn _f, _i, _k, _o -> {:error, :scripted} end
           }
         )
@@ -303,7 +303,10 @@ defmodule Bedrock.ControlPlane.Distributor.ServerTest do
         {SystemKeys.materializer_key(1, "wkr_a"), Values.encode_materializer_node(Atom.to_string(node()))}
       ]
 
-      t = verified_sweep_state(refs_entries, test_pid, fn _worker, [:epoch], _opts -> {:ok, %{epoch: 3}} end)
+      t =
+        verified_sweep_state(refs_entries, test_pid, fn _worker, [:epoch, :mode], _opts ->
+          {:ok, %{epoch: 3, mode: :running}}
+        end)
 
       assert {:noreply, t2} = Server.handle_continue(:startup_sweep, t)
 
@@ -326,6 +329,54 @@ defmodule Bedrock.ControlPlane.Distributor.ServerTest do
       refute_received {:committed, _}
     end
 
+    test "a member IN this epoch but still LOCKED is adopted — being in the epoch is not being in service" do
+      # Recovery locks every advertised materializer into its epoch and
+      # now unlocks only tag 0's. So the data-tag materializers the sweep
+      # meets are in the CURRENT epoch and not pulling: locking fences
+      # :ingest and :apply_transactions, and nothing else will lift it.
+      #
+      # Asking only "which epoch are you in?" answers a question that
+      # stopped being the right one. Left as :current, the worker stays
+      # locked for the whole epoch — still answering reads, since reads
+      # carry no mode guard, at a version frozen where the last epoch
+      # left it. Silent staleness, not a stall.
+      test_pid = self()
+      node_string = Atom.to_string(node())
+
+      refs_entries = [
+        {SystemKeys.materializer_key(0, "wkr_sys"), Values.encode_materializer_node(node_string)},
+        {SystemKeys.materializer_key(1, "wkr_idle"), Values.encode_materializer_node(node_string)}
+      ]
+
+      adopted = spawn(fn -> Process.sleep(:infinity) end)
+
+      info_fn = fn {name, _node}, facts, _opts ->
+        if name == otp_name_for_worker("wkr_idle"),
+          do: {:ok, %{epoch: 3, mode: :locked}},
+          else: {:ok, Map.new(facts, &{&1, if(&1 == :epoch, do: 3, else: :running)})}
+      end
+
+      t = verified_sweep_state(refs_entries, test_pid, info_fn)
+
+      ctx =
+        Map.merge(t.recruitment_ctx, %{
+          lock_materializer_fn: fn _worker, _epoch -> {:ok, adopted, %{durable_version: Version.from_integer(9)}} end,
+          unlock_materializer_fn: fn _pid, version, _sources ->
+            send(test_pid, {:adopt_unlocked, version})
+            :ok
+          end
+        })
+
+      assert {:noreply, _t2} = Server.handle_continue(:startup_sweep, %{t | recruitment_ctx: ctx})
+
+      assert_receive {:assignment_verified, 1, "wkr_idle", {:adopted, ^adopted, _node, "wkr_idle"}}
+      assert_receive {:adopt_unlocked, version}
+      assert version == Version.from_integer(9)
+
+      # Tag 0 is running, and recovery already unlocked it: no adoption.
+      assert_receive {:assignment_verified, 0, "wkr_sys", :current}
+    end
+
     test "a stale-epoch assignment is adopted: locked, unlocked at its own version, re-asserted under the fence" do
       test_pid = self()
       {lock, _} = Lock.take(nil, nil)
@@ -340,8 +391,10 @@ defmodule Bedrock.ControlPlane.Distributor.ServerTest do
       adopted = spawn(fn -> Process.sleep(:infinity) end)
 
       info_fn = fn
-        {name, _node}, [:epoch], _opts ->
-          if name == otp_name_for_worker("wkr_stale"), do: {:ok, %{epoch: 2}}, else: {:ok, %{epoch: 3}}
+        {name, _node}, [:epoch, :mode], _opts ->
+          if name == otp_name_for_worker("wkr_stale"),
+            do: {:ok, %{epoch: 2, mode: :running}},
+            else: {:ok, %{epoch: 3, mode: :running}}
       end
 
       t = verified_sweep_state(refs_entries, test_pid, info_fn)
@@ -397,8 +450,10 @@ defmodule Bedrock.ControlPlane.Distributor.ServerTest do
       # A stale answer whose adoption then definitively fails: wedged
       # mid-adopt, alive — heal, never remove.
       info_fn = fn
-        {name, _node}, [:epoch], _opts ->
-          if name == otp_name_for_worker("wkr_wedged"), do: {:ok, %{epoch: 2}}, else: {:ok, %{epoch: 3}}
+        {name, _node}, [:epoch, :mode], _opts ->
+          if name == otp_name_for_worker("wkr_wedged"),
+            do: {:ok, %{epoch: 2, mode: :running}},
+            else: {:ok, %{epoch: 3, mode: :running}}
       end
 
       t = verified_sweep_state(refs_entries, test_pid, info_fn)
@@ -441,7 +496,11 @@ defmodule Bedrock.ControlPlane.Distributor.ServerTest do
       node_string = Atom.to_string(node())
 
       refs_entries = [{SystemKeys.materializer_key(0, "wkr_far"), Values.encode_materializer_node(node_string)}]
-      t = verified_sweep_state(refs_entries, test_pid, fn _w, [:epoch], _o -> {:ok, %{epoch: 3}} end)
+
+      t =
+        verified_sweep_state(refs_entries, test_pid, fn _w, [:epoch, :mode], _o ->
+          {:ok, %{epoch: 3, mode: :running}}
+        end)
 
       t = %{
         t
@@ -481,7 +540,11 @@ defmodule Bedrock.ControlPlane.Distributor.ServerTest do
       adopted = spawn(fn -> Process.sleep(:infinity) end)
 
       refs_entries = [{SystemKeys.materializer_key(0, "wkr_adopt"), Values.encode_materializer_node(node_string)}]
-      t = verified_sweep_state(refs_entries, test_pid, fn _w, [:epoch], _o -> {:ok, %{epoch: 3}} end)
+
+      t =
+        verified_sweep_state(refs_entries, test_pid, fn _w, [:epoch, :mode], _o ->
+          {:ok, %{epoch: 3, mode: :running}}
+        end)
 
       ctx =
         Map.put(t.recruitment_ctx, :remove_worker_fn, fn _f, _i, _o ->
@@ -518,7 +581,11 @@ defmodule Bedrock.ControlPlane.Distributor.ServerTest do
       adopted = spawn(fn -> Process.sleep(:infinity) end)
 
       refs_entries = [{SystemKeys.materializer_key(0, "wkr_adopt"), Values.encode_materializer_node(node_string)}]
-      t = verified_sweep_state(refs_entries, test_pid, fn _w, [:epoch], _o -> {:ok, %{epoch: 3}} end)
+
+      t =
+        verified_sweep_state(refs_entries, test_pid, fn _w, [:epoch, :mode], _o ->
+          {:ok, %{epoch: 3, mode: :running}}
+        end)
 
       ctx =
         Map.put(t.recruitment_ctx, :remove_worker_fn, fn _f, _i, _o ->
@@ -554,9 +621,9 @@ defmodule Bedrock.ControlPlane.Distributor.ServerTest do
       refs_entries = [{SystemKeys.materializer_key(0, "wkr_back"), Values.encode_materializer_node(node_string)}]
 
       t =
-        verified_sweep_state(refs_entries, test_pid, fn _w, [:epoch], _o ->
+        verified_sweep_state(refs_entries, test_pid, fn _w, [:epoch, :mode], _o ->
           send(test_pid, :probed)
-          {:ok, %{epoch: 3}}
+          {:ok, %{epoch: 3, mode: :running}}
         end)
 
       t = %{
@@ -586,7 +653,11 @@ defmodule Bedrock.ControlPlane.Distributor.ServerTest do
         {SystemKeys.materializer_key(1, "wkr_gone"), Values.encode_materializer_node(node_string)}
       ]
 
-      t = verified_sweep_state(refs_entries, test_pid, fn _w, [:epoch], _o -> {:ok, %{epoch: 3}} end)
+      t =
+        verified_sweep_state(refs_entries, test_pid, fn _w, [:epoch, :mode], _o ->
+          {:ok, %{epoch: 3, mode: :running}}
+        end)
+
       assert {:noreply, t2} = Server.handle_continue(:startup_sweep, t)
 
       # Death healing re-owned tag 1 meanwhile: the ref now names the
@@ -1437,7 +1508,7 @@ defmodule Bedrock.ControlPlane.Distributor.ServerTest do
           snapshot: %{shard_layout: %{}, materializer_refs: %{7 => %{"wkr_alive" => Atom.to_string(node())}}}
         )
 
-      ctx = Map.put(t.recruitment_ctx, :info_fn, fn _w, [:epoch], _o -> {:ok, %{epoch: 3}} end)
+      ctx = Map.put(t.recruitment_ctx, :info_fn, fn _w, [:epoch, :mode], _o -> {:ok, %{epoch: 3, mode: :running}} end)
       t = %{t | recruitment_ctx: ctx, unreachable_counts: %{{7, "wkr_alive"} => 2}}
 
       assert {:noreply, t2} = Server.handle_info({:reverify_assignment, 7, "wkr_alive"}, t)

--- a/test/bedrock/data_plane/materializer/olivine/logic_test.exs
+++ b/test/bedrock/data_plane/materializer/olivine/logic_test.exs
@@ -532,4 +532,25 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.LogicTest do
       Logic.shutdown(locked)
     end
   end
+
+  describe "the :mode info fact" do
+    test "a locked worker reports :locked; unlocking reports :running", %{test_dir: test_dir} do
+      # The epoch says which generation embraced this worker. It does not
+      # say whether the worker is SERVING that generation — locking fences
+      # ingest and transaction application, and only an unlock lifts it.
+      # The distributor's assignment verification needs the second
+      # question, so the worker answers it: it is the only process that
+      # knows.
+      {:ok, state} = Logic.startup(:mode_fact_test, self(), "mode_wkr", test_dir)
+
+      {:ok, locked} = Logic.lock_for_recovery(state, self(), 7)
+      assert {:ok, %{mode: :locked}} = Logic.info(locked, [:mode])
+      assert :mode in elem(Logic.info(locked, [:supported_info]), 1).supported_info
+
+      {:ok, running} = Logic.unlock_after_recovery(locked, Version.zero(), [])
+      assert {:ok, %{epoch: 7, mode: :running}} = Logic.info(running, [:epoch, :mode])
+
+      Logic.shutdown(running)
+    end
+  end
 end


### PR DESCRIPTION
Stacked on #203 (`feature/q67.21.12-system-materializers`). Ticket: `bedrock-q67.21.13`.

## FDB sanity check

FDB's recovery does essentially nothing to storage servers. Re-verified against the tree at `afeef452b`:

| Claim | Citation |
|---|---|
| The entire interaction is **one key** — `\xff/lastEpochEnd`; storage learns the epoch in-band from the mutation stream | `ClusterRecovery.actor.cpp:1692-1698` |
| `RecoveryState::STORAGE_RECOVERED` is a **status label**, fired when `!newState.oldTLogData.size()` — recovery *observes* storage | `ClusterRecovery.actor.cpp:519-520` |
| Recovery never reads *from* storage: it rebuilds `txnStateStore` by peeking the old log system | `ClusterRecovery.actor.cpp:1111` |
| `keyServersPrefix` / `serverKeysPrefix` are metadata mutations, so routing lives in that log-replayed store | `ApplyMetadataMutation.h:120-121` |

The recovery version comes from tlogs alone, and we already match that (`log_recovery_planning_phase`'s `calculate_durable_version`). **No materializer gates it**, so none of the deleted work was load-bearing for transaction-system correctness.

Ours, by contrast, re-locked and unlocked a materializer for *every* data tag, picked one member per tag, seeded routing with it, and diffed the result into the persistence commit.

## What this does

Recovery brings up tag 0 and stops.

**Deleted** from `materializer_bootstrap_phase.ex`: `prefer_family_named/3` — and with it the PR #198 audit's finding #8 seam, where recovery's pick and the client-facing pick agreed only by construction; the seam is gone rather than patched — plus `existing_materializers_by_shard/1`, `ensure_materializers_for_shards/6`, `start_materializer_for_shard/5`, `extract_shard_tags/1`, `to_materializer_refs/1`, and `create_materializers_for_shards/3`.

**Narrowed**: the committed-member read is scoped to `materializers/0/`. Recovery reads exactly what it uses.

**Kept against the plan**: `persistence_phase`'s `build_materializer_keys`. The ticket said delete it and make the distributor the family's sole writer. That is chicken-and-egg for tag 0 in both directions — on a fresh cluster nobody else knows about the materializer recovery just created, and the distributor's own sweep reads the families through a client transaction that must route to tag 0 to see anything at all. Recovery writes tag 0; the distributor writes everything else.

## Two defects this exposed

Both fixed here, because without them the change is a silent data bug rather than a refactor.

**Ghost pruning would have deregistered the data plane.** `layout_reference_ids/1` built its reference set from `shard_materializers`, so *"recovery did not seat it"* meant *"ghost"* — and ghosts get deregistered from the coordinator directory. With recovery seating only tag 0, that is every data-tag materializer in a healthy cluster. It was **already wrong** for the non-adopted replicas of a tag. The reference set now unions in `materializer_recovery_info_by_id` — the workers that *answered* this epoch's lock, which is exactly the distinction the doc always claimed (*"a ghost is a registration nothing answered for"*).

**The distributor's verification asked the wrong question.** It asked `info_fn` for `[:epoch]` and verdicted `:current` on a match. Recovery locks every advertised materializer into its epoch and now unlocks only tag 0's — so a data-tag materializer is in the **current** epoch and **not pulling**. Verdicted `:current`, it stays locked for the whole epoch. Locking fences `:ingest` (`olivine/server.ex:140`) and `:apply_transactions` (`:350`) but **not reads** (`{:get, ...}` at `:82` and `{:get_range, ...}` at `:109` carry no mode guard), so it goes on answering at a frozen version. Silent staleness — strictly worse than a stall.

A new `:mode` info fact answers what the epoch cannot; verification asks `[:epoch, :mode]` and verdicts `:current` only on epoch match **and** `mode: :running`. Anything not demonstrably running is adopted — that costs a healthy worker one lock/unlock, and it resumes from its own durable version. This bug also existed before this change, for the replicas recovery did not pick.

## Why it is safe

`Recruitment.adopt/4` is recruitment minus creation: locks at the epoch, unlocks at the durable version the worker itself reports, never removes the worker on failure. That is exactly what recovery's data-tag path did. The distributor's startup sweep (`server.ex:118`) runs after every recovery regardless.

Routing is not a problem: `RoutingData` is seeded from the topology snapshot and then updated **in-band** from committed `materializer_key` mutations (`routing_data.ex` `apply_mutations/2`), so the distributor's publishes reach the proxies without a broadcast.

**Honest cost**: between recovery completing and the sweep adopting, data materializers are not pulling, so reads needing versions past their durable point wait and time out into a client retry. That window already existed for every replica recovery did not adopt; this generalizes it and forces a real answer instead of relying on the pick agreeing.

## Tests

TDD — each was red against the old code for the stated reason:

- `shard_materializers` names **only** tag 0, however many data-tag survivors are locked *(was `%{0 => ..., 1 => ...}`)*
- the committed-member read is scoped to tag 0 — driven against a **stub materializer through the default read path**, so the bounds under test are the ones production computes *(was the whole-family prefix)*
- a materializer that answered the lock is **not** a ghost; one that stayed silent is
- a member in this epoch but still `:locked` is **adopted**, not `:current`
- the `:mode` fact: `:locked` after lock, `:running` after unlock

## Still open

Tag 0 has **two** membership owners: the distributor treats it like any other tag and may retire a member the durable pointer still names, stalling the next recovery with a healthy replica sitting right there. Present today, not introduced here — carved out to `bedrock-q67.21.20` with four candidate resolutions and FDB's answer (the servers holding recovery-bootstrap metadata change membership only during recovery, and FDB's `txnStateStore` lives on the tlogs, structurally outside DD's reach).

## Gates

2759 tests + 13 doctests + 158 properties across seeds 11 / 4242 / 90210 · `credo --strict` clean · dialyzer 0 errors · formatted.
