### PR TITLE
In-band retirement: the victim learns from its own stream

### DIFF
--- a/lib/bedrock/control_plane/distributor/recruitment.ex
+++ b/lib/bedrock/control_plane/distributor/recruitment.ex
@@ -78,8 +78,10 @@ defmodule Bedrock.ControlPlane.Distributor.Recruitment do
   Unlike a failed recruitment, a failed adoption never removes the
   worker: it pre-exists this attempt and holds real state — enforced
   structurally by there being no removal call on this path. The caller
-  heals the tag instead (placeholder + fresh recruit); the unadopted
-  worker later observes the new entry and retires itself in-band.
+  heals the tag instead, and healing CLEARS this worker's own key — a
+  clear the proxy privatizes onto the shard's stream, so the worker
+  retires in-band, at the version its assignment ends
+  (bedrock-q67.21.6).
   """
   @spec adopt(Bedrock.range_tag(), Worker.id(), node(), context()) ::
           {:ok, pid(), node(), Worker.id()} | {:error, term()}

--- a/lib/bedrock/control_plane/distributor/server.ex
+++ b/lib/bedrock/control_plane/distributor/server.ex
@@ -183,7 +183,8 @@ defmodule Bedrock.ControlPlane.Distributor.Server do
   # Verification verdicts serialize back through the server. A verdict
   # for a worker the committed set no longer contains is DROPPED: some
   # other mechanism (death healing, idle retirement, a newer owner)
-  # already removed it, and a late-adopted stray retires itself in-band.
+  # already removed it, and a late-adopted stray retires itself in-band
+  # when its own key is cleared.
   # Nothing is reserved while a probe is in flight — with set-valued
   # membership an extra materializer is legal, so the only cost of a
   # concurrent recruit is a redundant worker, never a lost heal.
@@ -699,7 +700,8 @@ defmodule Bedrock.ControlPlane.Distributor.Server do
   # epoch, unlocked at its own durable version, its entry re-asserted
   # under the fence. Anything else (wedged, dead, unreachable beyond the
   # monitor's damping) is healed; the worker itself is never removed —
-  # it retires in-band when it observes the replacing entry. One shot,
+  # it retires in-band when its OWN key is cleared — membership is a set,
+  # so another member appearing is not displacement. One shot,
   # at the sweep. Nothing is reserved while a probe runs: membership is
   # a set, so a concurrent recruit costs a redundant worker, never a
   # lost heal.

--- a/lib/bedrock/data_plane/commit_proxy/finalization.ex
+++ b/lib/bedrock/data_plane/commit_proxy/finalization.ex
@@ -35,6 +35,7 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization do
   alias Bedrock.DataPlane.ShardRouter
   alias Bedrock.DataPlane.Transaction
   alias Bedrock.Internal.Time
+  alias Bedrock.SystemKeys
 
   @type metadata_mutations :: [Bedrock.Internal.TransactionBuilder.Tx.mutation()]
 
@@ -853,9 +854,47 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization do
           add_tagged_mutation_to_logs({split_mutation, tag}, acc, log_map, m)
         end)
 
+      # Then any privatized copy, addressed by an EXPLICIT tag rather than
+      # a boundary walk — split_mutation_by_shards/2 would find no shard
+      # for a key past every boundary and fail the whole batch.
+      updated_acc =
+        Enum.reduce(privatized_mutations(mutation), updated_acc, fn tagged, acc ->
+          add_tagged_mutation_to_logs(tagged, acc, log_map, m)
+        end)
+
       {:cont, {:ok, updated_acc}}
     end
   end
+
+  @doc """
+  The privatized copies a committed mutation must also put on the stream.
+
+  A membership CLEAR retires the worker it names, and the worker must
+  learn it IN-BAND — from the stream it already follows — rather than
+  waiting for the next recovery push. So the proxy emits a second copy of
+  the mutation, prefixed past `end_of_keyspace/0` and addressed to the
+  shard tag the key itself carries.
+
+  The prefix does two jobs, both FDB's (`ApplyMetadataMutation.cpp:291-317`
+  privatizes `serverKeys` with `withPrefix(systemKeys.begin)` and
+  `toCommit->addTag(tag)`): it moves the key outside every shard's range
+  so no materializer can ever store it, and it makes the notice
+  unforgeable, because commit ingress rejects that range in BOTH modes —
+  only this function, running after validation, can produce one.
+
+  Only removals travel. A worker gaining membership learns it from the
+  distributor that recruited it, so a privatized SET would be a mutation
+  with no reader.
+  """
+  @spec privatized_mutations(term()) :: [{term(), non_neg_integer()}]
+  def privatized_mutations({:clear, key}) do
+    case SystemKeys.parse_key(key) do
+      {:materializer_key, tag, _worker_id} -> [{{:clear, Bedrock.end_of_keyspace() <> key}, tag}]
+      _not_a_membership_key -> []
+    end
+  end
+
+  def privatized_mutations(_mutation), do: []
 
   # Add a tagged mutation to the appropriate logs
   @spec add_tagged_mutation_to_logs(

--- a/lib/bedrock/data_plane/materializer/olivine/index_update.ex
+++ b/lib/bedrock/data_plane/materializer/olivine/index_update.ex
@@ -122,6 +122,16 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.IndexUpdate do
   end
 
   @spec apply_mutation(Tx.mutation(), Bedrock.version(), t()) :: t()
+  # A key at or past the index's own upper bound is not index data: only
+  # the commit proxy can synthesize one, and it does so precisely to
+  # address a worker rather than a shard (see
+  # Finalization.privatized_mutations/1). Written verbatim it would become
+  # a durable out-of-bounds key that survives compaction and snapshot
+  # upload, and would corrupt the n_keys/size_in_bytes facts that gate
+  # idle spin-down.
+  defp apply_mutation({_op, key}, _target_version, index_update) when key >= @max_key, do: index_update
+  defp apply_mutation({_op, key, _value}, _target_version, index_update) when key >= @max_key, do: index_update
+
   defp apply_mutation({:set, key, value}, target_version, index_update) do
     insertion_page = Tree.page_for_key(index_update.index.tree, key)
     {:ok, locator, database} = Database.store_value(index_update.database, key, target_version, value)

--- a/lib/bedrock/data_plane/materializer/olivine/logic.ex
+++ b/lib/bedrock/data_plane/materializer/olivine/logic.ex
@@ -14,6 +14,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Logic do
   alias Bedrock.DataPlane.Materializer.Olivine.Streaming
   alias Bedrock.DataPlane.Materializer.Olivine.Telemetry, as: OlivineTelemetry
   alias Bedrock.DataPlane.Materializer.Telemetry
+  alias Bedrock.DataPlane.Transaction
   alias Bedrock.DataPlane.Version
   alias Bedrock.ObjectStorage.Config, as: ObjectStorageConfig
   alias Bedrock.ObjectStorage.Keys
@@ -126,6 +127,40 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Logic do
 
   @spec ensure_directory_exists(Path.t()) :: :ok | {:error, File.posix()}
   defp ensure_directory_exists(path), do: File.mkdir_p(path)
+
+  @doc """
+  This worker's retirement notice key, or nil if it has no assignment.
+
+  The worker id is IN the key, so the question a private mutation poses
+  is FDB's own — `startsWith(data->sk)`, "is this about me?"
+  (`storageserver.actor.cpp:11523`) — not "does this value name someone
+  else". Set-valued membership is what collapses it: a sibling joining or
+  leaving is not this worker's business.
+  """
+  @spec retirement_notice_key(State.t()) :: Bedrock.key() | nil
+  def retirement_notice_key(%State{id: id, shard_num: shard_num}) when is_binary(id) and is_integer(shard_num),
+    do: Bedrock.end_of_keyspace() <> Bedrock.SystemKeys.materializer_key(shard_num, id)
+
+  def retirement_notice_key(_unassigned), do: nil
+
+  @doc """
+  Whether a batch carries this worker's retirement notice.
+
+  Asked at the single point where stream data becomes durable state, so
+  the worker retires at exactly the version its assignment ends — the
+  notice rides the same commit that removed the membership entry.
+  """
+  @spec retirement_notice?([Transaction.encoded()], Bedrock.key() | nil) :: boolean()
+  def retirement_notice?(_batch, nil), do: false
+
+  def retirement_notice?(batch, notice_key) do
+    Enum.any?(batch, fn transaction ->
+      case Transaction.mutations(transaction) do
+        {:ok, mutations} -> Enum.any?(mutations, &match?({:clear, ^notice_key}, &1))
+        _no_mutations -> false
+      end
+    end)
+  end
 
   @spec shutdown(State.t()) :: :ok
   def shutdown(%State{} = t) do

--- a/lib/bedrock/data_plane/materializer/olivine/server.ex
+++ b/lib/bedrock/data_plane/materializer/olivine/server.ex
@@ -247,12 +247,28 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Server do
 
       {batch, _batch_last_version, updated_intake_queue} ->
         updated_state = maybe_release_ingest(%{t | intake_queue: updated_intake_queue})
-        # Process small batch for responsiveness
-        {:ok, state_with_txns, version} = Logic.apply_transactions(updated_state, batch)
-        final_state = notify_waiting_fetches(state_with_txns, version)
 
-        # Check for more transactions to process
-        noreply(final_state, continue: :maybe_process_transactions)
+        # Retirement arrives in-band, on the stream this worker already
+        # follows, at the version its assignment ends — no recovery push,
+        # no proxy round trip. Asked here because this is the single point
+        # where stream data becomes durable state, and the answer is to
+        # stop rather than apply. No epoch gate: a private mutation is
+        # from the current epoch by construction, since the proxy that
+        # synthesized it is the current epoch's.
+        if Logic.retirement_notice?(batch, Logic.retirement_notice_key(updated_state)) do
+          require Logger
+
+          Logger.info("Bedrock materializer #{t.id}: membership cleared for shard #{t.shard_num}; retiring")
+          Foreman.worker_retired(t.foreman, t.id)
+          {:stop, {:shutdown, :displaced}, updated_state}
+        else
+          # Process small batch for responsiveness
+          {:ok, state_with_txns, version} = Logic.apply_transactions(updated_state, batch)
+          final_state = notify_waiting_fetches(state_with_txns, version)
+
+          # Check for more transactions to process
+          noreply(final_state, continue: :maybe_process_transactions)
+        end
     end
   end
 

--- a/test/bedrock/data_plane/commit_proxy/finalization/ingress_rejection_test.exs
+++ b/test/bedrock/data_plane/commit_proxy/finalization/ingress_rejection_test.exs
@@ -139,6 +139,26 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization.IngressRejectionTest do
     assert_receive {:user_tx, {:error, {:key_out_of_range, ^system_key}}}
   end
 
+  test "a privatized key is unforgeable — even a system commit cannot write one" do
+    # What makes an in-band retirement notice trustworthy: the notice is
+    # built by prefixing end_of_keyspace, and ingress rejects every key at
+    # or past that sentinel in BOTH modes. Only the proxy, synthesizing
+    # after validation, can put one on the stream — FDB's reason for
+    # moving privatized keys outside allKeys.
+    private = Bedrock.end_of_keyspace() <> Bedrock.SystemKeys.materializer_key(7, "wkr_victim")
+
+    batch =
+      batch_of([
+        {reply_to_self(:system_tx), encode([{:clear, private}], "s"), :system},
+        {reply_to_self(:user_tx), encode([{:clear, private}], "u"), :user}
+      ])
+
+    assert {:ok, 2, 0} = finalize(batch)
+
+    assert_receive {:system_tx, {:error, {:key_out_of_range, ^private}}}
+    assert_receive {:user_tx, {:error, {:key_out_of_range, ^private}}}
+  end
+
   test "a corrupt mutation payload fails closed without failing the batch" do
     corrupt = corrupt_mutation_payload(encode([{:set, "k", "v"}], "k"))
 

--- a/test/bedrock/data_plane/commit_proxy/finalization/private_mutation_test.exs
+++ b/test/bedrock/data_plane/commit_proxy/finalization/private_mutation_test.exs
@@ -1,0 +1,122 @@
+defmodule Bedrock.DataPlane.CommitProxy.FinalizationPrivateMutationTest do
+  @moduledoc """
+  Retirement travels in-band, on the stream the victim already follows.
+
+  FDB's proxy privatizes a `serverKeys` mutation by prefixing it with
+  `systemKeys.begin` — moving the key outside `allKeys` so no shard can
+  store it — addresses it to the affected server's tag, and writes it
+  into the SAME commit's mutation stream
+  (`ApplyMetadataMutation.cpp:291-317`). The storage server recognizes
+  the prefix and diverts it to `applyPrivateData` before any normal
+  application (`storageserver.actor.cpp:11444-11450`), and asks FDB's
+  own "is this about me?" question — `startsWith(data->sk)` (`:11523`).
+
+  Ours is the same shape, with the collapse that set-valued membership
+  bought: the worker id is IN the key, so the victim is NAMED rather
+  than inferred from a value naming someone else.
+  """
+  use ExUnit.Case, async: true
+
+  alias Bedrock.DataPlane.CommitProxy.Batch
+  alias Bedrock.DataPlane.CommitProxy.Finalization
+  alias Bedrock.DataPlane.CommitProxy.ResolverLayout
+  alias Bedrock.DataPlane.Transaction
+  alias Bedrock.DataPlane.Version
+  alias Bedrock.SystemKeys
+  alias Bedrock.SystemKeys.Values
+  alias Bedrock.Test.DataPlane.FinalizationTestSupport, as: Support
+
+  describe "privatized_mutations/1" do
+    test "a membership CLEAR is addressed to the shard the key names" do
+      key = SystemKeys.materializer_key(7, "wkr_victim")
+
+      assert [{{:clear, private}, 7}] = Finalization.privatized_mutations({:clear, key})
+
+      # Prefixed past end_of_keyspace, exactly as FDB moves the key
+      # outside allKeys: no shard can store it, and the routing tag is
+      # explicit rather than derived from a boundary walk that would
+      # raise for a key past every shard.
+      assert private == Bedrock.end_of_keyspace() <> key
+    end
+
+    test "a membership SET produces nothing — only removal retires" do
+      # Gaining a member is not news the victim needs, and adoption is
+      # already director-driven. Emitting it would be a mutation with no
+      # reader (guard-only-real-hazards).
+      key = SystemKeys.materializer_key(7, "wkr_new")
+
+      assert Finalization.privatized_mutations({:set, key, Values.encode_materializer_node("node@host")}) == []
+    end
+
+    test "ordinary mutations produce nothing" do
+      assert Finalization.privatized_mutations({:clear, "user_key"}) == []
+      assert Finalization.privatized_mutations({:clear, SystemKeys.shard_key("m")}) == []
+      assert Finalization.privatized_mutations({:set, "user_key", "v"}) == []
+      assert Finalization.privatized_mutations({:clear_range, "a", "z"}) == []
+      assert Finalization.privatized_mutations({:atomic, :add, "k", <<1>>}) == []
+    end
+  end
+
+  describe "the notice reaches the log stream" do
+    test "a committed membership clear pushes BOTH the mutation and its privatized copy, tagged from the key" do
+      # The layout here is one shard, tag 0, covering everything — so the
+      # ordinary mutation routes to tag 0 by boundary walk. The notice is
+      # addressed to tag 5, which appears in no boundary at all: proof the
+      # tag came from the KEY rather than from a shard lookup, and proof
+      # that a key past every boundary does not fail the batch.
+      key = SystemKeys.materializer_key(5, "wkr_victim")
+      test_pid = self()
+
+      layout = %{logs: %{"log_1" => [0]}, services: %{"log_1" => %{kind: :log, status: {:up, self()}}}}
+      routing_data = Support.build_routing_data(layout)
+
+      batch = %Batch{
+        started_at: 0,
+        finalized_at: 0,
+        last_commit_version: Version.from_integer(99),
+        commit_version: Version.from_integer(100),
+        n_transactions: 1,
+        buffer: [
+          {0, fn _result -> :ok end,
+           Transaction.encode(%{
+             mutations: [{:clear, key}],
+             read_conflicts: nil,
+             write_conflicts: [{key, key <> <<0>>}]
+           }), :system}
+        ]
+      }
+
+      assert {:ok, 0, 1} =
+               Finalization.finalize_batch(batch,
+                 epoch: 1,
+                 sequencer: :test_sequencer,
+                 resolver_layout: %ResolverLayout.Single{resolver_ref: :test_resolver},
+                 metadata_apply_fn: Support.metadata_apply_fn(routing_data),
+                 resolver_fn: fn _r, _e, last, commit, _txns, _md, _o ->
+                   {:ok, [], Support.tiling_window(last, commit)}
+                 end,
+                 batch_log_push_fn: fn _last, by_log, _commit, _opts ->
+                   send(test_pid, {:pushed, by_log})
+                   :ok
+                 end,
+                 sequencer_notify_fn: fn _s, _e, _c, _o -> :ok end
+               )
+
+      assert_receive {:pushed, by_log}
+      pushed = Map.fetch!(by_log, "log_1")
+      private = Bedrock.end_of_keyspace() <> key
+
+      assert {:ok, mutations} = Transaction.mutations(pushed)
+      mutations = Enum.to_list(mutations)
+
+      assert {:clear, key} in mutations
+      assert {:clear, private} in mutations
+
+      # The SHARD_INDEX is what the demux slices on, so the tag must be
+      # recorded there — tag 5 for the notice, alongside tag 0 for the
+      # ordinary mutation the boundary walk placed.
+      tags = pushed |> Transaction.shard_index!() |> Enum.map(&elem(&1, 0)) |> Enum.sort()
+      assert tags == [0, 5]
+    end
+  end
+end

--- a/test/bedrock/data_plane/materializer/olivine/displacement_test.exs
+++ b/test/bedrock/data_plane/materializer/olivine/displacement_test.exs
@@ -1,18 +1,30 @@
 defmodule Bedrock.DataPlane.Materializer.Olivine.DisplacementTest do
   @moduledoc """
-  A materializer decides its own retirement by rejoin validation (FDB's
-  storage-server rejoin against a commit proxy's txnStateStore): on each
-  relayed layout push from a progressed epoch, it asks a commit proxy
-  whether the committed `materializers/<tag>` entry still names it.
-  Absence or another worker's id is an authoritative verdict; errors are
-  not — the next push revalidates.
+  A materializer decides its own retirement — no component decides
+  another process's — by two routes, both FDB's.
+
+  IN-BAND, the mid-epoch route: the commit proxy privatizes a membership
+  CLEAR onto the shard's own stream, and the worker retires when it sees
+  its own key cleared, at exactly the version its assignment ends. This
+  is FDB's `applyPrivateData` path, and it is the route that covers
+  healing and adoption (bedrock-q67.21.6).
+
+  REJOIN VALIDATION, at the recovery boundary: on a relayed layout push
+  from a progressed epoch, it asks a commit proxy whether the committed
+  entry still names it. Absence or another worker's id is an
+  authoritative verdict; errors are not — the next push revalidates.
   """
   use ExUnit.Case, async: true
 
   import ExUnit.CaptureLog
 
+  alias Bedrock.DataPlane.Materializer.Olivine.IntakeQueue
+  alias Bedrock.DataPlane.Materializer.Olivine.Logic
   alias Bedrock.DataPlane.Materializer.Olivine.Server
   alias Bedrock.DataPlane.Materializer.Olivine.State
+  alias Bedrock.DataPlane.Transaction
+  alias Bedrock.DataPlane.Version
+  alias Bedrock.SystemKeys
 
   defmodule StubProxy do
     @moduledoc false
@@ -30,6 +42,16 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.DisplacementTest do
   defp state(overrides) do
     struct!(%State{id: "mat-1", shard_num: 3, epoch: 2, foreman: self()}, overrides)
   end
+
+  defp txn(mutations) do
+    encoded = Transaction.encode(%{mutations: mutations, read_conflicts: {nil, []}, write_conflicts: []})
+    {:ok, with_version} = Transaction.add_commit_version(encoded, Version.from_integer(10))
+    with_version
+  end
+
+  defp queued(mutations), do: state(intake_queue: IntakeQueue.add_transactions(IntakeQueue.new(), [txn(mutations)]))
+
+  defp private(key), do: Bedrock.end_of_keyspace() <> key
 
   defp tsl(epoch, proxies), do: %{epoch: epoch, proxies: proxies, logs: %{}, sequencer: nil, resolvers: []}
 
@@ -125,5 +147,46 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.DisplacementTest do
 
     assert {:noreply, _t} =
              Server.handle_info({:tsl_updated, %{epoch: 2, proxies: [proxy]}}, state(id: "mat-1", shard_num: 3))
+  end
+
+  describe "in-band retirement (bedrock-q67.21.6)" do
+    test "a privatized CLEAR of my own key retires me, from my own stream" do
+      # The notice rides the same commit that removed the membership
+      # entry, on the stream this worker already follows — so it retires
+      # at exactly the version its assignment ends, with no recovery
+      # push and no proxy round trip.
+      t = queued([{:clear, private(SystemKeys.materializer_key(3, "mat-1"))}])
+
+      capture_log(fn ->
+        assert {:stop, {:shutdown, :displaced}, _t} = Server.handle_continue(:process_transactions, t)
+        assert_received {:"$gen_cast", {:worker_retired, "mat-1"}}
+      end)
+    end
+
+    test "the notice names me: another worker's clear, or my id on another shard, is not my business" do
+      # Membership is a set: a sibling leaving says nothing about me. The
+      # worker id is IN the key, so this is FDB's own question — "is this
+      # about me?" — not "does this value name someone else".
+      mine = Logic.retirement_notice_key(state([]))
+
+      refute Logic.retirement_notice?([txn([{:clear, private(SystemKeys.materializer_key(3, "someone-else"))}])], mine)
+      refute Logic.retirement_notice?([txn([{:clear, private(SystemKeys.materializer_key(9, "mat-1"))}])], mine)
+      assert Logic.retirement_notice?([txn([{:clear, mine}])], mine)
+    end
+
+    test "the unprivatized membership key is NOT a notice" do
+      # Only the proxy-synthesized copy retires anyone. The ordinary
+      # committed key is shard data for tag 0 and must never be read as a
+      # verdict — otherwise every materializer watching the system shard
+      # would retire on someone else's removal.
+      mine = Logic.retirement_notice_key(state([]))
+
+      refute Logic.retirement_notice?([txn([{:clear, SystemKeys.materializer_key(3, "mat-1")}])], mine)
+    end
+
+    test "a worker with no shard assignment has no notice key" do
+      assert Logic.retirement_notice_key(state(shard_num: nil)) == nil
+      refute Logic.retirement_notice?([txn([{:clear, private("anything")}])], nil)
+    end
   end
 end


### PR DESCRIPTION
Ticket: `bedrock-q67.21.6` — the **last open child** of `bedrock-q67.21`. Based directly on `develop`.

## Why

Healing and adoption introduce mid-epoch membership changes, so a materializer whose assignment is withdrawn must learn *now*. Until this, the only trigger was `{:tsl_updated, ...}` — broadcast solely on recovery completion. Retirement latency was unbounded, and three live comments already promised in-band behaviour that did not exist.

## Mechanism: FDB's privatization

Re-verified against the tree at `afeef452b`:

| Claim | Citation |
|---|---|
| Proxy privatizes with `withPrefix(systemKeys.begin)`, then `toCommit->addTag(tag)` and `writeMutation(privatized)` | `ApplyMetadataMutation.cpp:291-317` |
| Storage diverts on the prefix to `applyPrivateData`, before any normal application | `storageserver.actor.cpp:11444-11450` |
| The predicate is "is this about me?" — `startsWith(data->sk)` | `storageserver.actor.cpp:11523` |

*(The ticket cited `11571-11601` for the recognizer; that range is the rollback branch **inside** `applyPrivateData`. Claims were right, line numbers weren't — corrected here and in the ticket.)*

**Producer.** The commit proxy emits a second copy of a committed membership `CLEAR`, prefixed past `end_of_keyspace/0` and addressed to the shard tag **the key itself carries** — an explicit tag, not a boundary walk, since `split_mutation_by_shards/2` finds no shard for a key past every boundary and would fail the batch.

The prefix does two jobs. It moves the key outside every shard's range so no materializer can store it, and it makes the notice **unforgeable**: ingress already rejects that range in *both* modes, so only the proxy, synthesizing after validation, can produce one.

**Consumer.** The victim recognizes it at the single point where stream data becomes durable state, and stops rather than applies. The predicate is FDB's own, collapsed by the set-valued family that just landed: the worker id is **in the key**, so the victim is *named* rather than inferred from a value naming someone else. A sibling joining or leaving is not this worker's business. No epoch gate — a private mutation is from the current epoch by construction, since the proxy that made it is.

**Only removals travel.** A worker gaining membership learns it from the distributor that recruited it, so a privatized `SET` would be a mutation with no reader.

## The producer is real

Checked before building, not after: `retire_member/3` (`distributor/server.ex:619`) clears `materializer_key(tag, worker_id)` in a fenced commit, and `heal_member/3` routes through it. This is not a mechanism waiting for a caller.

## Also here

`IndexUpdate` now ignores keys at or past its own upper bound. Written verbatim a privatized key would become a durable out-of-bounds key that survives compaction and snapshot upload, and would corrupt the `n_keys`/`size_in_bytes` facts gating idle spin-down.

Three comments that described the old single-valued logic ("retires when it observes the replacing entry") now describe what the code does: a worker retires when its **own** key is cleared.

Rejoin validation stays as the recovery-boundary route; both are documented together in the test moduledoc.

## Tests

Each mutation-tested — I reverted each of the three production changes and confirmed the relevant tests fail:

- `privatized_mutations/1`: a `CLEAR` is addressed to the shard the key names; a `SET` produces nothing; ordinary mutations produce nothing
- **wiring** — a committed membership clear pushes *both* the mutation and its privatized copy to the log, with `SHARD_INDEX` tags `[0, 5]`: the ordinary mutation placed by boundary walk at tag 0, the notice at tag 5, **a tag in no boundary at all**. Proof the tag comes from the key, and that a key past every boundary doesn't fail the batch.
- unforgeability driven through real ingress: both a system and a user commit of a privatized key are rejected `{:key_out_of_range, _}`
- the victim retires from its own stream; another worker's clear, or this id on another shard, is not a notice; the *unprivatized* key is not a notice; an unassigned worker has no notice key

## Gates

2765 tests + 13 doctests + 158 properties across seeds 7 / 1234 / 55555 · `credo --strict` clean · dialyzer 0 errors · formatted.
