### PR TITLE
Carry bootstrap records that predate system_materializers

### DIFF
--- a/lib/bedrock/control_plane/director/recovery/materializer_bootstrap_phase.ex
+++ b/lib/bedrock/control_plane/director/recovery/materializer_bootstrap_phase.ex
@@ -350,17 +350,41 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhase do
       {worker_id, service} ->
         {:ok, {worker_id, service}}
 
-      # Two different situations, told apart so an operator is not left
-      # guessing. A record that names members means they are unreachable
-      # — retry, and the nodes they were last on say where to look. A
-      # record that names NONE on a non-fresh cluster means the bootstrap
-      # predates this field: recovery cannot learn where the metadata
-      # lives, and no retry will change that.
+      # A record that names NONE predates this field. That is not a lost
+      # cause: the locking phase has already locked every advertised
+      # materializer, and each one reports its own shard_id, so tag 0 can
+      # be READ from evidence rather than invented. Recovery adopts it,
+      # the persistence phase records it, and the next recovery resolves
+      # by name — the migration is one-time and self-healing.
       nil when named == %{} ->
-        {:error, :bootstrap_names_no_system_materializers}
+        discover_system_materializer(recovery_attempt)
 
+      # A record that DOES name members is authoritative, and substituting
+      # a different worker is the fabrication FDB refuses: it locks
+      # exactly the servers its coordinated state names
+      # (TagPartitionedLogSystem.actor.cpp:2549-2585) and waits for a
+      # quorum of THOSE. So this stalls even with a healthy stranger
+      # available, and the reason carries the nodes to go looking on.
       nil ->
         {:error, {:system_materializers_unavailable, named}}
+    end
+  end
+
+  # The legacy path only. Recovery reads which locked worker claims the
+  # system shard; it never creates one, so a cluster with nothing to
+  # adopt still stalls rather than coming up on an empty layout and
+  # orphaning its data.
+  defp discover_system_materializer(recovery_attempt) do
+    case recovery_attempt
+         |> existing_materializers_by_shard()
+         |> Map.fetch(RecoveryAttempt.system_shard_id()) do
+      {:ok, {worker_id, service}} ->
+        Logger.info("Bootstrap record names no system materializers; adopting locked survivor #{worker_id}")
+
+        {:ok, {worker_id, service}}
+
+      :error ->
+        {:error, :no_system_materializer_found}
     end
   end
 

--- a/lib/bedrock/control_plane/director/recovery/materializer_bootstrap_phase.ex
+++ b/lib/bedrock/control_plane/director/recovery/materializer_bootstrap_phase.ex
@@ -15,15 +15,20 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhase do
   ## Existing Cluster
 
   For an existing cluster:
-  1. Find materializer with shard_id = 0 (system shard) in available_services
-  2. If not found, create a new materializer on a capable node
-  3. Lock materializer for recovery
-  4. Unlock it with its replica set of pull sources to start pulling
-  5. Wait for materializer to catch up (60s timeout)
-  6. Query shard layout from `\\xff/system/shard_keys/*`
+  1. Resolve the system materializer BY NAME from the prior core state —
+     it is looked up, never invented (bedrock-q67.21.12)
+  2. Lock it for recovery
+  3. Unlock it with its replica set of pull sources to start pulling
+  4. Wait for it to catch up (60s timeout)
+  5. Query the shard layout from `\\xff/system/shard_keys/*`
 
-  Stalls if the materializer is unavailable and cannot be created, or if catchup
-  times out. Transitions to CommitProxyStartupPhase with the materializer pid and
+  Stalls if the named members are unavailable, if catchup times out, or if
+  the recovered layout reads empty. Records written before the core state
+  carried system materializers take a one-time migration: recovery adopts
+  the sole locked worker claiming tag 0, and refuses to choose when
+  several do (bedrock-q67.21.21).
+
+  Transitions to CommitProxyStartupPhase with the materializer pid and
   shard layout.
   """
 
@@ -249,6 +254,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhase do
              context
            ),
          {:ok, shard_layout} <- get_shard_layout(materializer_pid, recovery_version, context),
+         :ok <- reject_empty_layout(shard_layout),
          {:ok, prior_refs} <- read_prior_refs(materializer_pid, recovery_version, context),
          {:ok, shard_materializers, created_services} <-
            ensure_materializers_for_shards(
@@ -284,6 +290,24 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhase do
         {recovery_attempt, {:stalled, reason}}
     end
   end
+
+  # An empty shard_keys family decodes as a SUCCESSFUL read of no shards
+  # (Reader.shard_layout_from_entries([]) returns {:ok, %{}}), and nothing
+  # downstream objects — resolvers for zero ranges is {:ok, []} too. So
+  # recovery would complete on a cluster with no keyspace map at all,
+  # silently, and the next recovery would inherit it.
+  #
+  # A cluster with committed logs has a committed layout: the same
+  # recovery writes both, and boundaries never change without splits. An
+  # empty read is therefore never an empty cluster — it is a materializer
+  # that cannot answer for the system shard, and adopting its silence
+  # would orphan every shard the cluster owns. Stalling is retryable; the
+  # materializer may simply still be catching up.
+  @spec reject_empty_layout(RecoveryAttempt.shard_layout()) :: :ok | {:error, :recovered_shard_layout_is_empty}
+  defp reject_empty_layout(shard_layout) when map_size(shard_layout) == 0,
+    do: {:error, :recovered_shard_layout_is_empty}
+
+  defp reject_empty_layout(_shard_layout), do: :ok
 
   # Resolvers are recreated each epoch, one per shard range in the
   # recovered layout — the same construction the fresh-cluster path uses,
@@ -328,7 +352,9 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhase do
     end)
   end
 
-  # The system shard is LOOKED UP, never discovered and never invented.
+  # The system shard is LOOKED UP by name. Discovery exists only as
+  # the one-time migration for records that predate the field, and it
+  # refuses to choose when the answer is ambiguous.
   #
   # The prior core state names its members, because both durable
   # families — the shard layout and materializer membership — are served
@@ -370,22 +396,44 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhase do
     end
   end
 
-  # The legacy path only. Recovery reads which locked worker claims the
-  # system shard; it never creates one, so a cluster with nothing to
-  # adopt still stalls rather than coming up on an empty layout and
-  # orphaning its data.
+  # The legacy path only, and it adopts exactly one UNAMBIGUOUS survivor.
+  #
+  # Recovery reads which locked worker claims the system shard; it never
+  # creates one. But it also refuses to CHOOSE. This path runs only on
+  # records written before the field existed — precisely the clusters
+  # whose recovery could invent a replacement when a tag-0 node missed
+  # the 2s roll call, so empty strays claiming shard 0 are the expected
+  # population here, not an exotic case. Picking among them by lowest
+  # RANDOM worker id would be a coin toss, and the winner is then written
+  # to the durable record and resolved by name forever: one wrong flip is
+  # permanent.
+  #
+  # So ambiguity stalls, naming the candidates. An operator can see the
+  # choice and make it; recovery cannot make it silently.
   defp discover_system_materializer(recovery_attempt) do
-    case recovery_attempt
-         |> existing_materializers_by_shard()
-         |> Map.fetch(RecoveryAttempt.system_shard_id()) do
-      {:ok, {worker_id, service}} ->
-        Logger.info("Bootstrap record names no system materializers; adopting locked survivor #{worker_id}")
+    case tag_zero_claimants(recovery_attempt) do
+      [{worker_id, service}] ->
+        Logger.info("Bootstrap record names no system materializers; adopting sole locked survivor #{worker_id}")
 
         {:ok, {worker_id, service}}
 
-      :error ->
+      [] ->
         {:error, :no_system_materializer_found}
+
+      several ->
+        {:error, {:ambiguous_system_materializer, Enum.map(several, fn {worker_id, _} -> worker_id end)}}
     end
+  end
+
+  # Every locked worker that reports itself serving the system shard,
+  # ordered so the stall reason is stable across attempts.
+  defp tag_zero_claimants(recovery_attempt) do
+    system_shard = RecoveryAttempt.system_shard_id()
+
+    for {worker_id, info} <- Enum.sort(recovery_attempt.materializer_recovery_info_by_id),
+        Map.get(info, :shard_id) == system_shard,
+        %{status: {:up, ref}} <- [Map.get(recovery_attempt.transaction_services, worker_id)],
+        do: {worker_id, {:materializer, ref}}
   end
 
   # A named member counts only if this epoch actually locked it and it

--- a/lib/bedrock/control_plane/director/recovery/persistence_phase.ex
+++ b/lib/bedrock/control_plane/director/recovery/persistence_phase.ex
@@ -126,15 +126,22 @@ defmodule Bedrock.ControlPlane.Director.Recovery.PersistencePhase do
     end
   end
 
-  defp build_updated_bootstrap(current_bootstrap, recovery_attempt, config, transaction_system_layout) do
-    %{
-      current_bootstrap
-      | epoch: recovery_attempt.epoch,
-        logs: build_log_entries(transaction_system_layout),
-        system_materializers: build_system_materializer_entries(recovery_attempt),
-        parameters: build_parameters(config),
-        policies: build_policies(config)
-    }
+  # MERGE, not %{record | ...}. The update operator raises badkey for a
+  # key the map does not already have, and a record written before a
+  # field existed decodes without it — so updating in place crashes the
+  # director on exactly the clusters that most need to be upgraded. Merge
+  # adds what is missing and overwrites what is not, which is what
+  # "rewrite these fields" actually means.
+  @doc false
+  @spec build_updated_bootstrap(map(), RecoveryAttempt.t(), map(), map()) :: map()
+  def build_updated_bootstrap(current_bootstrap, recovery_attempt, config, transaction_system_layout) do
+    Map.merge(current_bootstrap, %{
+      epoch: recovery_attempt.epoch,
+      logs: build_log_entries(transaction_system_layout),
+      system_materializers: build_system_materializer_entries(recovery_attempt),
+      parameters: build_parameters(config),
+      policies: build_policies(config)
+    })
   end
 
   # Where the metadata lives, recorded out of band. Both durable families

--- a/test/bedrock/control_plane/director/recovery/materializer_bootstrap_phase_test.exs
+++ b/test/bedrock/control_plane/director/recovery/materializer_bootstrap_phase_test.exs
@@ -851,7 +851,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhaseTest 
     end
   end
 
-  describe "the system shard is looked up, never discovered or invented" do
+  describe "the system shard is looked up; discovery is the legacy migration only" do
     test "an existing cluster whose core state names no system materializer, and has none to adopt, STALLS" do
       # Recovery must never manufacture the store its own metadata lives
       # in. FDB refuses the same way: it builds its log system from
@@ -940,6 +940,78 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhaseTest 
       # on: this one is retryable, and that is where to go looking.
       assert {_attempt, {:stalled, {:system_materializers_unavailable, %{"wkr_gone" => "dead@host"}}}} =
                MaterializerBootstrapPhase.execute(recovery_attempt, context)
+    end
+
+    test "legacy discovery STALLS when more than one worker claims tag 0" do
+      # The migration runs only on pre-q67.21.12 records — precisely the
+      # clusters whose recovery could invent a replacement when a tag-0
+      # node missed the 2s roll call. So empty strays claiming shard 0
+      # are exactly the population here, and picking by lowest RANDOM
+      # worker id would be a coin toss whose result is then written to
+      # the durable record and resolved by name forever.
+      #
+      # Ambiguity is not a decision recovery gets to make silently.
+      a = spawn(fn -> Process.sleep(:infinity) end)
+      b = spawn(fn -> Process.sleep(:infinity) end)
+
+      recovery_attempt =
+        recovery_attempt()
+        |> Map.put(:materializer_recovery_info_by_id, %{
+          "mat_a" => %{kind: :materializer, shard_id: 0, durable_version: Version.from_integer(500)},
+          "mat_b" => %{kind: :materializer, shard_id: 0, durable_version: Version.from_integer(500)}
+        })
+        |> Map.put(:transaction_services, %{
+          "mat_a" => %{kind: :materializer, status: {:up, a}},
+          "mat_b" => %{kind: :materializer, status: {:up, b}}
+        })
+
+      context = Map.put(recovery_context(), :prior_core_state, %{logs: %{"log_1" => [0]}})
+
+      assert {_attempt, {:stalled, {:ambiguous_system_materializer, ["mat_a", "mat_b"]}}} =
+               MaterializerBootstrapPhase.execute(recovery_attempt, context)
+    end
+
+    test "a recovered shard layout that reads EMPTY stalls instead of completing" do
+      # An empty shard_keys family decodes as a successful read of no
+      # shards (Reader.shard_layout_from_entries([]) -> {:ok, %{}}), and
+      # nothing downstream objects: resolvers for zero ranges is also
+      # {:ok, []}. So recovery would COMPLETE on a cluster with no
+      # keyspace map at all.
+      #
+      # A cluster with committed logs has a committed layout — the same
+      # recovery writes both. So an empty read is never an empty cluster;
+      # it is a materializer that cannot answer for the system shard, and
+      # adopting its silence would orphan every shard the cluster owns.
+      system_pid = spawn(fn -> Process.sleep(:infinity) end)
+      recovery_version = Version.from_integer(500)
+
+      recovery_attempt =
+        recovery_attempt()
+        |> Map.put(:shard_layout, nil)
+        |> Map.put(:logs, %{"log_1" => [0]})
+        |> Map.put(:version_vector, {Version.from_integer(0), recovery_version})
+        |> Map.put(:materializer_recovery_info_by_id, %{
+          "mat_empty" => %{kind: :materializer, shard_id: 0, durable_version: recovery_version}
+        })
+        |> Map.put(:transaction_services, %{"mat_empty" => %{kind: :materializer, status: {:up, system_pid}}})
+
+      context =
+        recovery_context()
+        |> Map.put(:prior_core_state, %{
+          logs: %{"log_1" => [0]},
+          system_materializers: %{"mat_empty" => "n@host"}
+        })
+        |> Map.put(:lock_materializer_fn, fn {:materializer, ref}, _epoch -> {:ok, ref} end)
+        |> Map.put(:unlock_materializer_fn, fn _pid, _v, _s -> :ok end)
+        |> Map.put(:materializer_info_fn, fn _pid, [:current_version] ->
+          {:ok, %{current_version: recovery_version}}
+        end)
+        |> Map.put(:get_shard_layout_fn, fn _pid, _v -> {:ok, %{}} end)
+
+      capture_log(fn ->
+        assert {_attempt, {:stalled, :recovered_shard_layout_is_empty}} =
+                 MaterializerBootstrapPhase.execute(recovery_attempt, context)
+      end)
     end
 
     test "a NAMED-but-unavailable record never falls back to a healthy stranger" do

--- a/test/bedrock/control_plane/director/recovery/materializer_bootstrap_phase_test.exs
+++ b/test/bedrock/control_plane/director/recovery/materializer_bootstrap_phase_test.exs
@@ -852,7 +852,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhaseTest 
   end
 
   describe "the system shard is looked up, never discovered or invented" do
-    test "an existing cluster whose core state names no system materializer STALLS" do
+    test "an existing cluster whose core state names no system materializer, and has none to adopt, STALLS" do
       # Recovery must never manufacture the store its own metadata lives
       # in. FDB refuses the same way: it builds its log system from
       # exactly the servers the coordinated state names
@@ -867,8 +867,60 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhaseTest 
           flunk("recovery invented a system materializer instead of stalling")
         end)
 
-      assert {_attempt, {:stalled, :bootstrap_names_no_system_materializers}} =
+      assert {_attempt, {:stalled, :no_system_materializer_found}} =
                MaterializerBootstrapPhase.execute(recovery_attempt, context)
+    end
+
+    test "a legacy record naming NO members adopts a locked tag-0 survivor instead of stalling forever" do
+      # The upgrade path. A bootstrap written before system_materializers
+      # existed names nobody, and treating that as unrecoverable bricks
+      # every cluster created before the field: recovery stalls, the
+      # director retries the stall, and every client read hangs.
+      #
+      # The information is not actually lost. The locking phase has
+      # already locked every advertised materializer and each reports its
+      # own shard_id, so tag 0 can be READ from evidence rather than
+      # invented. Recovery then records what it adopted, and the next
+      # recovery takes the named path — a one-time, self-healing
+      # migration.
+      system_pid = spawn(fn -> Process.sleep(:infinity) end)
+      recovery_version = Version.from_integer(500)
+
+      recovery_attempt =
+        recovery_attempt()
+        |> Map.put(:shard_layout, nil)
+        |> Map.put(:logs, %{"log_1" => [0]})
+        |> Map.put(:version_vector, {Version.from_integer(0), recovery_version})
+        |> Map.put(:materializer_recovery_info_by_id, %{
+          "mat_legacy" => %{kind: :materializer, shard_id: 0, durable_version: recovery_version}
+        })
+        |> Map.put(:transaction_services, %{"mat_legacy" => %{kind: :materializer, status: {:up, system_pid}}})
+
+      context =
+        recovery_context()
+        # The legacy shape: the field is simply absent from the record.
+        |> Map.put(:prior_core_state, %{logs: %{"log_1" => [0]}})
+        |> Map.put(:lock_materializer_fn, fn {:materializer, ref}, _epoch -> {:ok, ref} end)
+        |> Map.put(:unlock_materializer_fn, fn _pid, _v, _s -> :ok end)
+        |> Map.put(:materializer_info_fn, fn _pid, [:current_version] ->
+          {:ok, %{current_version: recovery_version}}
+        end)
+        |> Map.put(:get_shard_layout_fn, fn _pid, _v ->
+          {:ok, %{Bedrock.end_of_keyspace() => {0, <<0xFF>>}}}
+        end)
+        |> Map.put(:create_worker_fn, fn _f, _i, _k, _o ->
+          flunk("the migration invented a materializer instead of adopting the survivor")
+        end)
+
+      capture_log(fn ->
+        assert {updated_attempt, CommitProxyStartupPhase} =
+                 MaterializerBootstrapPhase.execute(recovery_attempt, context)
+
+        # Recorded, so the persistence phase writes the field and the NEXT
+        # recovery resolves by name. That is what makes it one-time.
+        assert %{"mat_legacy" => _node} =
+                 updated_attempt.shard_materializers[RecoveryAttempt.system_shard_id()]
+      end)
     end
 
     test "a named system materializer that is not available STALLS rather than falling back" do
@@ -886,6 +938,32 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhaseTest 
 
       # The reason carries the members and the nodes they were last seen
       # on: this one is retryable, and that is where to go looking.
+      assert {_attempt, {:stalled, {:system_materializers_unavailable, %{"wkr_gone" => "dead@host"}}}} =
+               MaterializerBootstrapPhase.execute(recovery_attempt, context)
+    end
+
+    test "a NAMED-but-unavailable record never falls back to a healthy stranger" do
+      # The invariant the legacy migration must not weaken. Discovery is
+      # for a record that names NOBODY; a record that names someone is
+      # authoritative, and substituting a different worker is exactly the
+      # fabrication FDB refuses. Here a perfectly healthy tag-0
+      # materializer is locked and available — and recovery must still
+      # stall, because the record does not name it.
+      stranger_pid = spawn(fn -> Process.sleep(:infinity) end)
+
+      recovery_attempt =
+        recovery_attempt()
+        |> Map.put(:materializer_recovery_info_by_id, %{
+          "mat_stranger" => %{kind: :materializer, shard_id: 0, durable_version: Version.from_integer(500)}
+        })
+        |> Map.put(:transaction_services, %{"mat_stranger" => %{kind: :materializer, status: {:up, stranger_pid}}})
+
+      context =
+        Map.put(recovery_context(), :prior_core_state, %{
+          logs: %{"log_1" => [0]},
+          system_materializers: %{"wkr_gone" => "dead@host"}
+        })
+
       assert {_attempt, {:stalled, {:system_materializers_unavailable, %{"wkr_gone" => "dead@host"}}}} =
                MaterializerBootstrapPhase.execute(recovery_attempt, context)
     end

--- a/test/bedrock/control_plane/director/recovery/persistence_phase_test.exs
+++ b/test/bedrock/control_plane/director/recovery/persistence_phase_test.exs
@@ -310,4 +310,61 @@ defmodule Bedrock.ControlPlane.Director.Recovery.PersistencePhaseTest do
                Values.decode_materializer_node(Map.fetch!(store, SystemKeys.materializer_key(9, "wkr_stray")))
     end
   end
+
+  describe "rewriting a bootstrap record that predates a field" do
+    alias Bedrock.ControlPlane.Config.RecoveryAttempt
+    alias Bedrock.SystemKeys.ClusterBootstrap
+
+    test "a legacy record without system_materializers is rewritten, not crashed on" do
+      # The real decoded shape, not a hand-built map: a record written
+      # before the field existed comes back WITHOUT the key, and
+      # %{record | key: ...} raises badkey for a key the map lacks. That
+      # crashed the director in a tight retry loop on every cluster
+      # created before bedrock-q67.21.12 — the ones an upgrade must
+      # carry, not brick.
+      legacy =
+        %{
+          cluster_id: "abc",
+          epoch: 3,
+          logs: [%{id: "log_1", otp_ref: nil, shard_tags: []}],
+          coordinators: [%{node: "a@host"}],
+          parameters: %{
+            desired_logs: 1,
+            desired_replication_factor: 1,
+            desired_commit_proxies: 1,
+            desired_coordinators: 1,
+            desired_read_version_proxies: 1,
+            ping_rate_in_hz: 10,
+            retransmission_rate_in_hz: 20,
+            transaction_window_in_ms: 5000,
+            empty_transaction_timeout_ms: 1000
+          },
+          policies: %{allow_volunteer_nodes_to_join: true}
+        }
+        |> ClusterBootstrap.to_binary()
+        |> ClusterBootstrap.read()
+        |> then(fn {:ok, decoded} -> decoded end)
+
+      refute Map.has_key?(legacy, :system_materializers)
+
+      attempt =
+        %RecoveryAttempt{cluster: nil, epoch: 4, attempt: 1}
+        |> Map.put(:shard_materializers, %{0 => %{"mat_sys" => "a@host"}})
+        |> Map.put(:prior_materializer_refs, %{})
+
+      config = %{
+        parameters: legacy.parameters,
+        policies: legacy.policies
+      }
+
+      updated =
+        PersistencePhase.build_updated_bootstrap(legacy, attempt, config, %{logs: %{"log_1" => []}})
+
+      assert updated.epoch == 4
+      assert updated.system_materializers == [%{id: "mat_sys", node: "a@host"}]
+      # Untouched fields survive the merge.
+      assert updated.cluster_id == "abc"
+      assert updated.coordinators == [%{node: "a@host"}]
+    end
+  end
 end


### PR DESCRIPTION
**P0 against `develop`.** Ticket: `bedrock-q67.21.21`. Regression from `bedrock-q67.21.12` (#203, merged today).

Every cluster created before #203 is bricked by upgrading: recovery never completes, and every client read hangs.

## Reproduced, variable isolated

| Bootstrap record | Result |
|---|---|
| Fresh cluster on `develop` | `RESULT: nil` — works |
| **Same cluster, same data, `system_materializers` stripped** | `:bootstrap_names_no_system_materializers`, retried forever |

A user's real broken cluster decodes to exactly that: `system_materializers: %{}`, `fresh?: false`, epoch 3, one log. Its record was last written at 13:33 while the worker dirs were touched at 19:25 — recovery ran and never completed.

## Two defects, one assumption

Both from assuming a newly added field is always present.

**1. `resolve_system_materializer` treated "the record names nobody" as unrecoverable.** The ticket said so outright — *"recovery cannot learn where the metadata lives, and no retry will change that."* That is wrong. The locking phase has already locked every advertised materializer and each reports its own `shard_id`, so tag 0 can be **read from evidence**. Reading evidence is not inventing a metadata store — inventing is what `.12` actually forbids, and this does not do it.

**2. `build_updated_bootstrap` used `%{record | field: ...}`**, which raises `badkey` for a key the map does not already have. A record decoded from a FlatBuffer written before the field simply has no such key, so the director crashed in a tight retry loop — on exactly the clusters an upgrade must carry. `Map.merge` adds what is missing and overwrites what is not, which is what "rewrite these fields" means.

## What does not change

A record that **does** name members, none of them available, still stalls — **even with a healthy stranger locked and ready.** Substituting a different worker is the fabrication FDB refuses (`TagPartitionedLogSystem.actor.cpp:2549-2585`: it locks exactly the servers its coordinated state names and waits for a quorum of *those*). That case now has its own test, which passed before this change and must keep passing.

The legacy branch is distinguishable only because `.12` had already split the two errors apart.

## Verified end to end, not just in tests

- the stripped-record cluster **recovers on first boot**
- the bootstrap record is **repaired** — `[%{id: "ihclawa7", node: "spike@127.0.0.1"}]`
- a **second boot takes the named path** with no discovery: one-time, self-healing
- the real broken record's bytes rewrite and round-trip cleanly, `cluster_id` preserved

## Tests

Both fixes mutation-tested **independently** — restoring by re-editing, not `git checkout`, because sequential checkout restores silently invalidate each other (that mistake produced a false mutation-test claim on #206).

- legacy discovery removed → 2 failures
- `Map.merge` reverted to the update operator → 1 failure (`badkey`)

New tests: a legacy record adopts a locked tag-0 survivor; a legacy record with nothing to adopt still stalls (`:no_system_materializer_found`); a named-but-unavailable record never falls back to a healthy stranger; a real decoded legacy record is rewritten rather than crashed on.

## Gates

2759 tests + 13 doctests + 158 properties across seeds 3 / 999 / 42424 · `credo --strict` clean · dialyzer 0 errors · formatted.
