### PR TITLE
Migrate the pre-q67.21.9 single-valued materializer family (lost from #207)

### DIFF
--- a/lib/bedrock/control_plane/config/recovery_attempt.ex
+++ b/lib/bedrock/control_plane/config/recovery_attempt.ex
@@ -57,6 +57,7 @@ defmodule Bedrock.ControlPlane.Config.RecoveryAttempt do
     shard_materializers: %{},
     seeded_layout?: false,
     prior_materializer_refs: nil,
+    legacy_materializer_keys: [],
     lock_failed_service_ids: MapSet.new()
   ]
 
@@ -84,6 +85,7 @@ defmodule Bedrock.ControlPlane.Config.RecoveryAttempt do
           shard_materializers: %{Bedrock.range_tag() => %{Worker.id() => node_name :: String.t()}},
           seeded_layout?: boolean(),
           prior_materializer_refs: %{Bedrock.range_tag() => %{Worker.id() => String.t()}} | nil,
+          legacy_materializer_keys: [Bedrock.key()],
           lock_failed_service_ids: MapSet.t(Worker.id()),
           shard_layout: shard_layout() | nil
         }
@@ -125,6 +127,7 @@ defmodule Bedrock.ControlPlane.Config.RecoveryAttempt do
       shard_materializers: %{},
       seeded_layout?: false,
       prior_materializer_refs: nil,
+      legacy_materializer_keys: [],
       lock_failed_service_ids: MapSet.new()
     }
   end

--- a/lib/bedrock/control_plane/director/recovery/materializer_bootstrap_phase.ex
+++ b/lib/bedrock/control_plane/director/recovery/materializer_bootstrap_phase.ex
@@ -255,7 +255,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhase do
            ),
          {:ok, shard_layout} <- get_shard_layout(materializer_pid, recovery_version, context),
          :ok <- reject_empty_layout(shard_layout),
-         {:ok, prior_refs} <- read_prior_refs(materializer_pid, recovery_version, context),
+         {:ok, prior_refs, legacy_keys} <- read_prior_refs(materializer_pid, recovery_version, context),
          {:ok, shard_materializers, created_services} <-
            ensure_materializers_for_shards(
              shard_layout,
@@ -281,6 +281,12 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhase do
         # the diff base for materializer writes.
         |> Map.put(:seeded_layout?, false)
         |> Map.put(:prior_materializer_refs, prior_refs)
+        # The pre-q67.21.9 keys this read folded in. Persistence rewrites
+        # their members in the set-valued shape and clears them, so the
+        # migration actually completes instead of leaving the family in
+        # two shapes forever — a legacy member can never be RETIRED,
+        # because retirement clears the new-shape key it does not have.
+        |> Map.put(:legacy_materializer_keys, legacy_keys)
         |> Map.put(:resolvers, resolver_descriptors_for_layout(shard_layout))
         |> Map.update!(:transaction_services, &Map.merge(&1, created_services))
 
@@ -550,9 +556,16 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhase do
       Materializer.get_range(materializer_pid, start_key, range_end, read_version, limit: 1000)
     end
 
-    with {:ok, entries} <- Reader.read_family(range_read_fn, prefix, :prior_refs_query_failed) do
-      decode_prior_refs(entries)
+    with {:ok, entries} <- Reader.read_family(range_read_fn, prefix, :prior_refs_query_failed),
+         {:ok, refs} <- decode_prior_refs(entries) do
+      {:ok, refs, legacy_keys(entries)}
     end
+  end
+
+  defp legacy_keys(entries) do
+    for {key, _value} <- entries,
+        match?({:legacy_materializer_key, _tag}, Bedrock.SystemKeys.parse_key(key)),
+        do: key
   end
 
   @doc false

--- a/lib/bedrock/control_plane/director/recovery/persistence_phase.ex
+++ b/lib/bedrock/control_plane/director/recovery/persistence_phase.ex
@@ -243,7 +243,10 @@ defmodule Bedrock.ControlPlane.Director.Recovery.PersistencePhase do
     # The mapping families are durable, distributor-era state: recovery
     # reads and heals, never blanket-clears (bedrock-q67.21.2).
     tx = build_shard_keys(tx, recovery_attempt)
-    build_materializer_keys(tx, recovery_attempt)
+
+    tx
+    |> build_materializer_keys(recovery_attempt)
+    |> migrate_legacy_materializer_keys(recovery_attempt)
   end
 
   # Creates materializer_key(tag, worker_id) -> node entries as a DIFF
@@ -283,6 +286,35 @@ defmodule Bedrock.ControlPlane.Director.Recovery.PersistencePhase do
             end
         end
     end
+  end
+
+  # Completes the pre-q67.21.9 migration for the keys this recovery's
+  # read folded in: every member the legacy key held is rewritten in the
+  # set-valued shape, and only then is the legacy key cleared. Both in
+  # ONE transaction, so no reader ever sees the tag unrepresented.
+  #
+  # Rewriting every member matters: the legacy key may name a worker
+  # recovery did not seat, and clearing without writing it would drop a
+  # live member. Leaving the key instead would be worse — a legacy member
+  # can never be retired, because retirement clears the new-shape key it
+  # does not have.
+  @spec migrate_legacy_materializer_keys(Tx.t(), RecoveryAttempt.t()) :: Tx.t()
+  defp migrate_legacy_materializer_keys(tx, recovery_attempt) do
+    prior = Map.get(recovery_attempt, :prior_materializer_refs) || %{}
+
+    recovery_attempt
+    |> Map.get(:legacy_materializer_keys)
+    |> Kernel.||([])
+    |> Enum.reduce(tx, fn legacy_key, tx ->
+      {:legacy_materializer_key, tag} = SystemKeys.parse_key(legacy_key)
+
+      prior
+      |> Map.get(tag, %{})
+      |> Enum.reduce(tx, fn {worker_id, node}, tx ->
+        Tx.set(tx, SystemKeys.materializer_key(tag, worker_id), Values.encode_materializer_node(node))
+      end)
+      |> Tx.clear(legacy_key)
+    end)
   end
 
   # Creates shard_key(end_key) -> {tag, start_key} entries (ceiling

--- a/lib/bedrock/system_keys.ex
+++ b/lib/bedrock/system_keys.ex
@@ -66,6 +66,15 @@ defmodule Bedrock.SystemKeys do
   @spec materializer_tag_prefix(Bedrock.range_tag()) :: Bedrock.key()
   def materializer_tag_prefix(tag) when is_integer(tag), do: "#{@system_prefix}/materializers/#{tag}/"
 
+  @doc """
+  The PRE-q67.21.9 single-valued membership key: `materializers/<tag>`.
+
+  Built only so recovery can CLEAR it once the members it held have been
+  rewritten in the set-valued shape. Nothing writes this key any more.
+  """
+  @spec legacy_materializer_key(Bedrock.range_tag()) :: Bedrock.key()
+  def legacy_materializer_key(tag) when is_integer(tag), do: "#{@system_prefix}/materializers/#{tag}"
+
   @doc "Prefix covering every materializer membership entry"
   @spec materializers_prefix() :: Bedrock.key()
   def materializers_prefix, do: "#{@system_prefix}/materializers/"
@@ -87,6 +96,7 @@ defmodule Bedrock.SystemKeys do
   @spec parse_key(Bedrock.key()) ::
           {:shard_key, Bedrock.key()}
           | {:materializer_key, Bedrock.range_tag(), Worker.id()}
+          | {:legacy_materializer_key, Bedrock.range_tag()}
           | {:distributor_lock, :owner | :write}
           | :unknown
           | :error
@@ -95,14 +105,31 @@ defmodule Bedrock.SystemKeys do
   def parse_key(<<@system_prefix, "/shard_keys/", rest::binary>>), do: {:shard_key, rest}
 
   def parse_key(<<@system_prefix, "/materializers/", rest::binary>>) do
-    with [tag_string, worker_id] when worker_id != "" <- String.split(rest, "/", parts: 2),
-         {tag, ""} <- Integer.parse(tag_string) do
-      {:materializer_key, tag, worker_id}
-    else
+    case String.split(rest, "/", parts: 2) do
+      [tag_string, worker_id] when worker_id != "" -> materializer_key_or_unknown(tag_string, worker_id)
+      # Pre-q67.21.9: the family was single-valued, materializers/<tag>
+      # -> packed {worker_id, node}. Clusters written by that code still
+      # hold these, so they are recognized rather than read as garbage
+      # (bedrock-q67.21.21).
+      [tag_string] -> legacy_materializer_key_or_unknown(tag_string)
       _ -> :unknown
     end
   end
 
   def parse_key(<<@system_prefix, _rest::binary>>), do: :unknown
   def parse_key(_key), do: :error
+
+  defp materializer_key_or_unknown(tag_string, worker_id) do
+    case Integer.parse(tag_string) do
+      {tag, ""} -> {:materializer_key, tag, worker_id}
+      _ -> :unknown
+    end
+  end
+
+  defp legacy_materializer_key_or_unknown(tag_string) do
+    case Integer.parse(tag_string) do
+      {tag, ""} -> {:legacy_materializer_key, tag}
+      _ -> :unknown
+    end
+  end
 end

--- a/lib/bedrock/system_keys/reader.ex
+++ b/lib/bedrock/system_keys/reader.ex
@@ -54,26 +54,50 @@ defmodule Bedrock.SystemKeys.Reader do
   absence of a key is absence of a member. Foreign or undecodable entries
   fail the whole decode.
 
-  This is deliberately the loud edge of the format change: a keyspace
-  still holding single-valued `materializers/<tag>` entries fails here
-  rather than being read as an empty family. An empty family reads as
-  "no shard has any member", which would silently re-recruit every
-  shard and orphan the live ones — a wrong answer is worse than a
-  failed recovery that names the offending key.
+  A keyspace still holding the pre-q67.21.9 single-valued
+  `materializers/<tag>` entries is MIGRATED, not rejected: the old value
+  packs `{worker_id, node}`, which is one member of the same set, so it
+  folds in and both shapes may coexist mid-migration. Failing instead
+  was the loud edge of the format change — right as a guard against
+  reading the old family as empty (which would re-recruit every shard
+  and orphan the live ones), wrong as the only behaviour, because it
+  stalled every recovery on every pre-q67.21.9 cluster forever
+  (bedrock-q67.21.21).
+
+  What still fails the whole decode: a foreign key, or either shape with
+  an undecodable value. Absence of a key remains absence of a member.
   """
   @spec decode_materializer_members([{Bedrock.key(), binary()}]) ::
           {:ok, %{Bedrock.range_tag() => %{Bedrock.Service.Worker.id() => String.t()}}}
           | {:error, {:invalid_materializer_entry, Bedrock.key()}}
   def decode_materializer_members(entries) do
     Enum.reduce_while(entries, {:ok, %{}}, fn {key, value}, {:ok, acc} ->
-      with {:materializer_key, tag, worker_id} <- SystemKeys.parse_key(key),
-           {:ok, node} <- Values.decode_materializer_node(value) do
-        {:cont, {:ok, Map.update(acc, tag, %{worker_id => node}, &Map.put(&1, worker_id, node))}}
-      else
-        _ -> {:halt, {:error, {:invalid_materializer_entry, key}}}
+      case decode_member_entry(SystemKeys.parse_key(key), value) do
+        {:ok, tag, worker_id, node} ->
+          {:cont, {:ok, Map.update(acc, tag, %{worker_id => node}, &Map.put(&1, worker_id, node))}}
+
+        :error ->
+          {:halt, {:error, {:invalid_materializer_entry, key}}}
       end
     end)
   end
+
+  defp decode_member_entry({:materializer_key, tag, worker_id}, value) do
+    case Values.decode_materializer_node(value) do
+      {:ok, node} -> {:ok, tag, worker_id, node}
+      _ -> :error
+    end
+  end
+
+  # The worker id rode the VALUE before it rode the key.
+  defp decode_member_entry({:legacy_materializer_key, tag}, value) do
+    case Values.decode_materializer_ref(value) do
+      {:ok, {worker_id, node}} -> {:ok, tag, worker_id, node}
+      _ -> :error
+    end
+  end
+
+  defp decode_member_entry(_not_a_member_key, _value), do: :error
 
   @doc """
   Decodes `shard_keys/<end_key>` entries into the boundary map

--- a/lib/bedrock/system_keys/values.ex
+++ b/lib/bedrock/system_keys/values.ex
@@ -53,6 +53,18 @@ defmodule Bedrock.SystemKeys.Values do
   def decode_materializer_node(binary), do: safe_unpack(binary, &is_binary/1)
 
   @doc """
+  Decodes a PRE-q67.21.9 materializer ref: packed `{worker_id, node}`.
+
+  Read-only, and deliberately so: nothing writes this shape any more.
+  It exists because clusters written before membership became a set
+  still hold `materializers/<tag>` entries, and refusing to read them
+  stalls every recovery on those clusters forever (bedrock-q67.21.21).
+  """
+  @spec decode_materializer_ref(binary()) :: {:ok, {String.t(), String.t()}} | decode_error()
+  def decode_materializer_ref(binary),
+    do: safe_unpack(binary, &match?({worker_id, node} when is_binary(worker_id) and is_binary(node), &1))
+
+  @doc """
   Decodes a value given its parsed system key (from
   `Bedrock.SystemKeys.parse_key/1`).
   """

--- a/test/bedrock/control_plane/director/recovery/materializer_bootstrap_phase_test.exs
+++ b/test/bedrock/control_plane/director/recovery/materializer_bootstrap_phase_test.exs
@@ -584,7 +584,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhaseTest 
       context =
         existing_context(recovery_version, %{
           read_prior_refs_fn: fn _pid, _version ->
-            {:ok, %{1 => %{"mat_named" => Atom.to_string(node())}}}
+            {:ok, %{1 => %{"mat_named" => Atom.to_string(node())}}, []}
           end
         })
 
@@ -635,7 +635,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhaseTest 
       context =
         existing_context(recovery_version, %{
           read_prior_refs_fn: fn _pid, _version ->
-            {:ok, %{1 => %{"mat_gone" => Atom.to_string(node())}}}
+            {:ok, %{1 => %{"mat_gone" => Atom.to_string(node())}}, []}
           end
         })
 
@@ -734,6 +734,32 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhaseTest 
 
       assert {:error, {:invalid_materializer_entry, ^garbage}} =
                MaterializerBootstrapPhase.decode_prior_refs([{garbage, <<0xEE>>}])
+    end
+
+    test "a pre-q67.21.9 single-valued entry folds into the set instead of failing the read" do
+      # The family used to be materializers/<tag> -> packed
+      # {worker_id, node}. A cluster written by that code still holds
+      # those keys, and rejecting them stalls its every recovery forever
+      # — the loud edge was right as a guard and wrong as the only
+      # behaviour (bedrock-q67.21.21).
+      legacy_key = <<0xFF, "/system/materializers/0">>
+      legacy_value = Bedrock.Encoding.Tuple.pack({"wkr_old", "n@h"})
+
+      assert {:ok, %{0 => %{"wkr_old" => "n@h"}}} =
+               MaterializerBootstrapPhase.decode_prior_refs([{legacy_key, legacy_value}])
+
+      # Both shapes can coexist mid-migration: one member each, one set.
+      mixed = [
+        {legacy_key, legacy_value},
+        {SK.materializer_key(0, "wkr_new"), V.encode_materializer_node("n2@h")}
+      ]
+
+      assert {:ok, %{0 => %{"wkr_old" => "n@h", "wkr_new" => "n2@h"}}} =
+               MaterializerBootstrapPhase.decode_prior_refs(mixed)
+
+      # A legacy KEY with an undecodable value is still a hard failure.
+      assert {:error, {:invalid_materializer_entry, ^legacy_key}} =
+               MaterializerBootstrapPhase.decode_prior_refs([{legacy_key, <<0xEE>>}])
     end
   end
 

--- a/test/bedrock/control_plane/director/recovery/persistence_phase_test.exs
+++ b/test/bedrock/control_plane/director/recovery/persistence_phase_test.exs
@@ -268,6 +268,38 @@ defmodule Bedrock.ControlPlane.Director.Recovery.PersistencePhaseTest do
       assert range_read(store, SystemKeys.shard_keys_prefix()) == Enum.sort(stale_store)
     end
 
+    test "a pre-q67.21.9 legacy key is rewritten into the set shape and cleared, in one transaction" do
+      # Folding the old key on read is what unbricks the cluster; this is
+      # what finishes the job. Leaving it would keep the family in two
+      # shapes forever, and a legacy member could never be RETIRED —
+      # retirement clears the new-shape key it does not have.
+      legacy_key = SystemKeys.legacy_materializer_key(0)
+
+      recovery_attempt =
+        base_recovery_attempt()
+        # Two members under tag 0: the seated one and one the legacy key
+        # also held. BOTH must survive the migration.
+        |> Map.put(:prior_materializer_refs, %{0 => %{"wkr_sys" => node_string(), "wkr_other" => node_string()}})
+        |> Map.put(:legacy_materializer_keys, [legacy_key])
+
+      mutations = captured_system_mutations(recovery_attempt)
+
+      assert {:clear, legacy_key} in mutations
+
+      for id <- ["wkr_sys", "wkr_other"] do
+        key = SystemKeys.materializer_key(0, id)
+        assert Enum.any?(mutations, &match?({:set, ^key, _}, &1)), "member #{id} was dropped by the migration"
+      end
+
+      # Applied to a store that still holds the legacy entry, the result
+      # names both members in the new shape and nothing in the old.
+      store = apply_to_store(%{legacy_key => "whatever"}, mutations)
+
+      refute Map.has_key?(store, legacy_key)
+      assert Map.has_key?(store, SystemKeys.materializer_key(0, "wkr_sys"))
+      assert Map.has_key?(store, SystemKeys.materializer_key(0, "wkr_other"))
+    end
+
     test "materializer writes are a diff against the prior family; unnamed entries are not recovery's to clean" do
       # tag 0's assignment is unchanged (not rewritten); tag 1's changed
       # (rewritten); tag 9's entry names a tag outside this layout and is

--- a/test/bedrock/system_keys_test.exs
+++ b/test/bedrock/system_keys_test.exs
@@ -10,6 +10,19 @@ defmodule Bedrock.SystemKeysTest do
       assert SystemKeys.parse_key(SystemKeys.shard_key(<<0xFF, 0xFF>>)) == {:shard_key, <<0xFF, 0xFF>>}
     end
 
+    test "the pre-q67.21.9 single-valued key is recognized as legacy, not as garbage" do
+      # Before membership became a set the family was
+      # materializers/<tag> -> packed {worker_id, node}. A cluster written
+      # by that code still holds those keys, and reading them as garbage
+      # stalls every recovery on it forever (bedrock-q67.21.21).
+      assert SystemKeys.parse_key(<<0xFF, "/system/materializers/0">>) == {:legacy_materializer_key, 0}
+      assert SystemKeys.parse_key(<<0xFF, "/system/materializers/42">>) == {:legacy_materializer_key, 42}
+
+      # Still not a licence to accept nonsense.
+      assert SystemKeys.parse_key(<<0xFF, "/system/materializers/notanumber">>) == :unknown
+      assert SystemKeys.parse_key(<<0xFF, "/system/materializers/">>) == :unknown
+    end
+
     test "materializer_key/2 round-trips through parse_key/1, carrying tag AND worker" do
       assert SystemKeys.parse_key(SystemKeys.materializer_key(0, "wkr_sys")) == {:materializer_key, 0, "wkr_sys"}
       assert SystemKeys.parse_key(SystemKeys.materializer_key(42, "abc12def")) == {:materializer_key, 42, "abc12def"}
@@ -29,8 +42,9 @@ defmodule Bedrock.SystemKeysTest do
       assert SystemKeys.parse_key(SystemKeys.materializers_prefix() <> "12x/wkr") == :unknown
       assert SystemKeys.parse_key(SystemKeys.materializers_prefix()) == :unknown
 
-      # A tag with no worker is the prefix, not an entry.
-      assert SystemKeys.parse_key(SystemKeys.materializers_prefix() <> "7") == :unknown
+      # A tag with a trailing slash and no worker is the prefix, not an
+      # entry. (A tag with NO slash is the pre-q67.21.9 single-valued
+      # entry — see the legacy test above.)
       assert SystemKeys.parse_key(SystemKeys.materializers_prefix() <> "7/") == :unknown
     end
 

--- a/test/support/control_plane/recovery_test_support.ex
+++ b/test/support/control_plane/recovery_test_support.ex
@@ -49,7 +49,7 @@ defmodule Bedrock.Test.ControlPlane.RecoveryTestSupport do
       prior_core_state: prior_core_state,
       # Deterministic default for the bootstrap's durable-family read;
       # tests exercising the read path override it.
-      read_prior_refs_fn: fn _materializer_pid, _read_version -> {:ok, %{}} end,
+      read_prior_refs_fn: fn _materializer_pid, _read_version -> {:ok, %{}, []} end,
       cluster_config: %{
         coordinators: [],
         parameters: %{


### PR DESCRIPTION
**P0, and it is the commit #207 lost.** Ticket: `bedrock-q67.21.21`.

#207 merged at 00:53 UTC and **does not contain this fix.** The merge deleted the branch; my push of this commit recreated it afterwards, so it was never part of the PR. `git merge-base --is-ancestor 63937984 origin/develop` → false. The push output said `[new branch]` and I did not read it.

That is exactly why the reported cluster still loops after merging, pulling and rebuilding: it has the bootstrap fix (so it logs *"adopting sole locked survivor"*) but not this one, so it stalls on the family read — an `[error]` line that a default livebook log level filters out.

## The defect

`.9` changed the membership family from `materializers/<tag>` → packed `{worker_id, node}` to `materializers/<tag>/<worker_id>` → node. The reader was written to fail loudly on the old shape:

```
{:invalid_materializer_entry, "\xff/system/materializers/0"}
```

Its docstring calls that *"deliberately the loud edge of the format change."* Right as a **guard** — reading the old family as *empty* would re-recruit every shard and orphan the live ones. Wrong as the **only** behaviour: it stalls every recovery on every pre-`.9` cluster, forever.

The old value packs `{worker_id, node}`, which is one member of the same set. So it folds in, and both shapes may coexist mid-migration. Still hard-fails: a foreign key, or either shape with an undecodable value.

## Folding alone would not have been enough

It would leave the family in two shapes permanently, and a legacy member could then **never be retired** — retirement clears the new-shape key it does not have. So recovery finishes the job: every member the legacy key held is rewritten in the set-valued shape, and only then is the legacy key cleared, both in **one** transaction so no reader sees the tag unrepresented.

Rewriting *every* member matters: the legacy key may name a worker recovery did not seat, and clearing without writing it would drop a live member.

## Verified against the real cluster

Against a pristine copy of the reported data directory, on top of merged `develop`:

- boot 1 → `Recovery completed in 814ms`, bootstrap record repaired
- boot 2 → `Recovery completed in 884ms`, **`RESULT: "world"`** — the data is intact

Without this commit the same directory loops indefinitely, exactly as reported.

Both halves mutation-tested (fold removed → 1 failure; migration write removed → 1 failure).

## Gates

2764 tests + 13 doctests + 158 properties · `credo --strict` clean · `format --check-formatted` clean.
