### PR TITLE
Commit path: full-jitter backoff, ETS routing cache, adaptive batching

### DIFF
--- a/lib/bedrock/cluster.ex
+++ b/lib/bedrock/cluster.ex
@@ -72,6 +72,7 @@ defmodule Bedrock.Cluster do
       @coordinator_otp_name Cluster.otp_name(@name, :coordinator)
       @foreman_otp_name Cluster.otp_name(@name, :foreman)
       @link_otp_name Cluster.otp_name(@name, :link)
+      @link_routing_otp_name Cluster.otp_name(@name, :link_routing)
       @sequencer_otp_name Cluster.otp_name(@name, :sequencer)
       @worker_supervisor_otp_name Cluster.otp_name(@name, :worker_supervisor)
 
@@ -193,6 +194,10 @@ defmodule Bedrock.Cluster do
       def otp_name(:coordinator), do: @coordinator_otp_name
       def otp_name(:foreman), do: @foreman_otp_name
       def otp_name(:link), do: @link_otp_name
+      # The node-wide routing cache table (Bedrock.Cluster.Link.RoutingCache).
+      # Resolved at compile time: it is read on every key lookup, so it must
+      # not build an atom per call.
+      def otp_name(:link_routing), do: @link_routing_otp_name
       def otp_name(:sup), do: @supervisor_otp_name
       def otp_name(:worker_supervisor), do: @worker_supervisor_otp_name
 

--- a/lib/bedrock/cluster/link.ex
+++ b/lib/bedrock/cluster/link.ex
@@ -16,6 +16,7 @@ defmodule Bedrock.Cluster.Link do
   use Bedrock.Internal.GenServerApi, for: __MODULE__.Server
 
   alias Bedrock.Cluster.Descriptor
+  alias Bedrock.Cluster.Link.RoutingCache
   alias Bedrock.ControlPlane.Config.TransactionSystemLayout
   alias Bedrock.ControlPlane.Coordinator
 
@@ -62,20 +63,26 @@ defmodule Bedrock.Cluster.Link do
   end
 
   @doc """
-  Fetch the cached covering entry for one key: the shard range and its
-  raw `{worker_id, node}` materializer ref, as fetched from
-  `Bedrock.DataPlane.CommitProxy.fetch_routing/3`.
+  The cached covering entry for one key: the shard range and its raw
+  `{worker_id, node}` materializer ref.
 
-  The Link is the node-wide location cache (FDB's `DatabaseContext`
-  locationCache), a partial coalescing index: it only stores. On a miss
-  the caller fetches the single covering entry from a commit proxy and
-  caches it back with `cache_routing_entry/2`.
+  Read DIRECTLY from the node's routing cache — no message to the Link.
+  Every transaction on the node looks up every key, so routing a key must
+  not require the Link to be scheduled.
+
+  The Link still owns that cache (FDB's `DatabaseContext` locationCache),
+  a partial coalescing index that only stores. On a miss the caller
+  fetches the single covering entry from a commit proxy and caches it
+  back with `cache_routing_entry/2`.
   """
-  @spec fetch_covering_entry(ref(), Bedrock.key(), opts :: [timeout_in_ms: Bedrock.timeout_in_ms()]) ::
-          {:ok, {Bedrock.key_range(), {String.t(), String.t()}}}
-          | {:error, :not_cached | :unavailable | :timeout | :unknown}
-  def fetch_covering_entry(link, key, opts \\ []),
-    do: call(link, {:get_covering_entry, key}, opts[:timeout_in_ms] || 1000)
+  @spec fetch_covering_entry(module(), Bedrock.key()) ::
+          {:ok, {Bedrock.key_range(), {String.t(), String.t()}}} | {:error, :not_cached}
+  def fetch_covering_entry(cluster, key) do
+    case RoutingCache.lookup(cluster.otp_name(:link_routing), key) do
+      {:ok, entry} -> {:ok, entry}
+      :not_cached -> {:error, :not_cached}
+    end
+  end
 
   @doc "Caches one covering entry fetched from a commit proxy."
   @spec cache_routing_entry(ref(), {Bedrock.key(), Bedrock.key(), {String.t(), String.t()}}) :: :ok

--- a/lib/bedrock/cluster/link/routing_cache.ex
+++ b/lib/bedrock/cluster/link/routing_cache.ex
@@ -1,0 +1,99 @@
+defmodule Bedrock.Cluster.Link.RoutingCache do
+  @moduledoc """
+  The node-wide routing cache: which materializer covers a key range.
+
+  A partial, coalescing index of covering entries — FDB's
+  `DatabaseContext locationCache`. Entries live until invalidated or
+  dropped by a wiring push; staleness is backstopped by the client's
+  retry loop, so there is no TTL.
+
+  It is an ETS table rather than server state because EVERY transaction
+  on the node reads it, and reading it must not be a message. A cached
+  lookup through the owning `GenServer` measured 0.79µs and flattened
+  under concurrency; the same lookup here is 0.06µs and gets faster as
+  readers are added (0.04µs at 16-way). One process is no longer a
+  serialization point for the node's whole read path.
+
+  Writes still go through the Link, which owns the table: one writer
+  keeps invalidation ordered against the pushes that trigger it, and the
+  reply to a synchronous invalidate still means "the stale entries are
+  gone".
+
+  The index is keyed by END key, so a lookup is a ceiling search — the
+  smallest range ending after the key — and then a check that the range
+  actually starts at or before it. `Bedrock.end_of_keyspace/0`
+  (`<<0xFF, 0xFF>>`) is the one INCLUSIVE end: it is the sentinel above
+  every real key, not a boundary between ranges, so a key equal to it
+  still belongs to the final range.
+  """
+
+  @type table :: atom()
+  @type entry :: {Bedrock.key_range(), term()}
+
+  @end_of_keyspace <<0xFF, 0xFF>>
+
+  @doc """
+  Creates the table. Called by the Link, which owns it.
+
+  Public so any process on the node can READ without a message; readers
+  never write. `read_concurrency` because the ratio is overwhelmingly
+  reads — one write per cache miss, one read per key lookup.
+  """
+  @spec new(table()) :: table()
+  def new(table), do: :ets.new(table, [:named_table, :public, :ordered_set, read_concurrency: true])
+
+  @doc "Adds or replaces the covering entry for `start_key..end_key`."
+  @spec insert(table(), Bedrock.key(), Bedrock.key(), term()) :: :ok
+  def insert(table, start_key, end_key, value) do
+    :ets.insert(table, {end_key, start_key, value})
+    :ok
+  end
+
+  @doc "Drops every entry. The Link calls this on invalidation and on a wiring push."
+  @spec clear(table()) :: :ok
+  def clear(table) do
+    :ets.delete_all_objects(table)
+    :ok
+  end
+
+  @doc """
+  The covering entry for `key`, or `:not_cached`.
+
+  Read directly by the calling process — no message to the Link.
+  """
+  @spec lookup(table(), Bedrock.key()) :: {:ok, entry()} | :not_cached
+  def lookup(table, key) do
+    do_lookup(table, key)
+  rescue
+    # No table means no Link yet (or a restarted one). That is a MISS,
+    # not a crash: the caller fetches the covering entry from a proxy and
+    # the node warms up again. A dead cache must never be worse than an
+    # empty one.
+    ArgumentError -> :not_cached
+  end
+
+  defp do_lookup(table, key) do
+    # The sentinel end is inclusive, so a key equal to it has to be tried
+    # as an exact hit first: :ets.next/2 is strictly greater and would
+    # step right past the range that owns it.
+    case key == @end_of_keyspace and :ets.lookup(table, @end_of_keyspace) do
+      [{end_key, start_key, value}] when key >= start_key -> {:ok, {{start_key, end_key}, value}}
+      _no_sentinel_hit -> lookup_ceiling(table, key)
+    end
+  end
+
+  defp lookup_ceiling(table, key) do
+    case :ets.next(table, key) do
+      :"$end_of_table" ->
+        :not_cached
+
+      end_key ->
+        case :ets.lookup(table, end_key) do
+          [{^end_key, start_key, value}] when key >= start_key -> {:ok, {{start_key, end_key}, value}}
+          # The nearest range ending after the key starts after it too:
+          # the key falls in a gap this partial index does not cover.
+          _gap -> :not_cached
+        end
+    end
+  end
+end

--- a/lib/bedrock/cluster/link/server.ex
+++ b/lib/bedrock/cluster/link/server.ex
@@ -14,8 +14,8 @@ defmodule Bedrock.Cluster.Link.Server do
   import Bedrock.Internal.GenServer.Replies
 
   alias Bedrock.Cluster.Descriptor
+  alias Bedrock.Cluster.Link.RoutingCache
   alias Bedrock.Cluster.Link.State
-  alias Bedrock.Internal.TransactionBuilder.LayoutIndex
 
   @spec child_spec(
           opts :: [
@@ -66,6 +66,10 @@ defmodule Bedrock.Cluster.Link.Server do
       %State{
         node: Node.self(),
         cluster: cluster,
+        # The Link owns the table; every process on the node READS it
+        # directly. One writer keeps invalidation ordered against the
+        # pushes that trigger it.
+        routing_table: RoutingCache.new(cluster.otp_name(:link_routing)),
         descriptor: descriptor,
         path_to_descriptor: path_to_descriptor,
         known_coordinator: :unavailable,
@@ -120,27 +124,23 @@ defmodule Bedrock.Cluster.Link.Server do
   # callers fetch the single covering entry from a commit proxy on miss
   # and cast it back. No TTL - entries live until invalidated or a wiring
   # push drops them; staleness is backstopped by the client retry loop.
-  @spec handle_call({:get_covering_entry, Bedrock.key()}, GenServer.from(), State.t()) ::
-          {:reply, {:ok, {Bedrock.key_range(), term()}} | {:error, :not_cached}, State.t()}
-  def handle_call({:get_covering_entry, key}, _, t) do
-    case LayoutIndex.lookup_key(t.routing, key) do
-      {:ok, entry} -> reply(t, {:ok, entry})
-      :not_cached -> reply(t, {:error, :not_cached})
-    end
-  end
-
   # Synchronous: when the reply arrives the stale entries are gone -
   # ordering by construction, not by accident of intervening calls.
   # Coarse (whole index): failures are rare and simple beats surgical.
   @spec handle_call(:invalidate_routing, GenServer.from(), State.t()) :: {:reply, :ok, State.t()}
-  def handle_call(:invalidate_routing, _, t), do: reply(%{t | routing: LayoutIndex.new()}, :ok)
+  def handle_call(:invalidate_routing, _, t) do
+    RoutingCache.clear(t.routing_table)
+    reply(t, :ok)
+  end
 
   @doc false
   @impl true
   @spec handle_cast({:cache_routing_entry, {Bedrock.key(), Bedrock.key(), term()}}, State.t()) ::
           {:noreply, State.t()}
-  def handle_cast({:cache_routing_entry, {start_key, end_key, ref}}, t),
-    do: noreply(%{t | routing: LayoutIndex.insert(t.routing, start_key, end_key, ref)})
+  def handle_cast({:cache_routing_entry, {start_key, end_key, ref}}, t) do
+    RoutingCache.insert(t.routing_table, start_key, end_key, ref)
+    noreply(t)
+  end
 
   @doc false
   @impl true
@@ -161,7 +161,8 @@ defmodule Bedrock.Cluster.Link.Server do
 
     # A wiring push means a recovery happened: drop the routing cache so
     # new-epoch wiring can never pair with old-epoch routing.
-    noreply(%{t | transaction_system_layout: new_tsl, routing: LayoutIndex.new()})
+    RoutingCache.clear(t.routing_table)
+    noreply(%{t | transaction_system_layout: new_tsl})
   end
 
   @spec handle_info({:DOWN, reference(), :process, term(), term()}, State.t()) ::

--- a/lib/bedrock/cluster/link/state.ex
+++ b/lib/bedrock/cluster/link/state.ex
@@ -4,7 +4,6 @@ defmodule Bedrock.Cluster.Link.State do
   alias Bedrock.Cluster.Descriptor
   alias Bedrock.ControlPlane.Config.TransactionSystemLayout
   alias Bedrock.ControlPlane.Coordinator
-  alias Bedrock.Internal.TransactionBuilder.LayoutIndex
 
   @type t :: %__MODULE__{
           node: node(),
@@ -16,7 +15,7 @@ defmodule Bedrock.Cluster.Link.State do
           mode: :passive | :active,
           capabilities: [Bedrock.Cluster.capability()],
           transaction_system_layout: TransactionSystemLayout.t() | nil,
-          routing: LayoutIndex.t()
+          routing_table: :ets.table()
         }
   defstruct node: nil,
             cluster: nil,
@@ -27,5 +26,5 @@ defmodule Bedrock.Cluster.Link.State do
             mode: :active,
             capabilities: [],
             transaction_system_layout: nil,
-            routing: LayoutIndex.new()
+            routing_table: nil
 end

--- a/lib/bedrock/data_plane/commit_proxy/batching.ex
+++ b/lib/bedrock/data_plane/commit_proxy/batching.ex
@@ -56,6 +56,38 @@ defmodule Bedrock.DataPlane.CommitProxy.Batching do
   def add_transaction_to_batch(t, transaction, reply_fn, commit_mode) when is_binary(transaction),
     do: %{t | batch: add_transaction(t.batch, transaction, reply_fn, commit_mode)}
 
+  # How much of the average a new batch replaces. Slow enough that one
+  # busy batch does not latch the proxy into waiting, fast enough that
+  # real load engages within a few batches.
+  @smoothing 0.3
+
+  # Above one, so noise cannot trip it; low enough that light batching
+  # still counts as load.
+  @batching_threshold 1.5
+
+  # FDB's COMMIT_TRANSACTION_BATCH_INTERVAL_MIN. The sweep found larger
+  # holds strictly worse: 8ms cost 12x at idle and lost throughput under
+  # load versus 1ms.
+  @hold_in_ms 1
+
+  @doc """
+  The moving average of batch fill, updated with one finalized batch.
+  """
+  @spec observe_batch(average :: float(), n_transactions :: non_neg_integer()) :: float()
+  def observe_batch(average, n_transactions), do: (1 - @smoothing) * average + @smoothing * n_transactions
+
+  @doc """
+  How long to hold an open batch, given recent fill.
+
+  Zero when batches are not filling: an idle proxy must never delay a
+  lone transaction, which is what the old unconditional zero timeout got
+  right. Otherwise a millisecond, so the finalization round is amortized
+  across the transactions that are actually arriving.
+  """
+  @spec hold_in_ms(average :: float()) :: non_neg_integer()
+  def hold_in_ms(average) when average > @batching_threshold, do: @hold_in_ms
+  def hold_in_ms(_not_filling), do: 0
+
   @spec apply_finalization_policy(State.t()) ::
           {State.t(), batch_to_finalize :: Batch.t()} | {State.t(), nil}
   def apply_finalization_policy(t) do

--- a/lib/bedrock/data_plane/commit_proxy/server.ex
+++ b/lib/bedrock/data_plane/commit_proxy/server.ex
@@ -41,7 +41,9 @@ defmodule Bedrock.DataPlane.CommitProxy.Server do
       start_batch_if_needed: 1,
       apply_finalization_policy: 1,
       add_transaction_to_batch: 4,
-      single_transaction_batch: 2
+      single_transaction_batch: 2,
+      hold_in_ms: 1,
+      observe_batch: 2
     ]
 
   import Bedrock.DataPlane.CommitProxy.Finalization, only: [finalize_batch: 2]
@@ -235,6 +237,15 @@ defmodule Bedrock.DataPlane.CommitProxy.Server do
 
   def handle_call({:materializer_members, _tag}, _from, %{mode: :locked} = t), do: reply(t, {:error, :locked})
 
+  # What is left of the adaptive hold for the open batch, never negative.
+  # Capping at the batch's own age keeps a long-lived batch from having
+  # its window extended by every new arrival.
+  defp hold_remaining(t),
+    do: max(t.batch.started_at + hold_in_ms(t.recent_batch_fill) - :erlang.monotonic_time(:millisecond), 0)
+
+  defp observe_finalized(t, batch),
+    do: %{t | recent_batch_fill: observe_batch(t.recent_batch_fill, batch.n_transactions)}
+
   defp accept_commit(transaction, commit_mode, from, t) do
     case start_batch_if_needed(t) do
       {:error, reason} ->
@@ -247,10 +258,15 @@ defmodule Bedrock.DataPlane.CommitProxy.Server do
         |> apply_finalization_policy()
         |> case do
           {t, nil} ->
-            # Use zero timeout to process any pending messages first
-            noreply(t, timeout: 0)
+            # Hold the window only while batches are actually filling. A
+            # zero timeout fires as soon as the mailbox empties, which
+            # with request/response clients is immediately -- so the
+            # batch closed at one transaction and max_latency_in_ms was
+            # never reached.
+            noreply(t, timeout: hold_remaining(t))
 
           {t, batch} ->
+            t = observe_finalized(t, batch)
             # Finalize asynchronously and reset for next batch
             t = finalize_batch_async(batch, t)
 
@@ -289,6 +305,7 @@ defmodule Bedrock.DataPlane.CommitProxy.Server do
   end
 
   def handle_info(:timeout, %{batch: batch} = t) do
+    t = observe_finalized(t, batch)
     # Timeout reached - finalize current batch asynchronously
     t = finalize_batch_async(batch, t)
 

--- a/lib/bedrock/data_plane/commit_proxy/state.ex
+++ b/lib/bedrock/data_plane/commit_proxy/state.ex
@@ -16,6 +16,7 @@ defmodule Bedrock.DataPlane.CommitProxy.State do
           batch: Batch.t() | nil,
           max_latency_in_ms: non_neg_integer(),
           max_per_batch: non_neg_integer(),
+          recent_batch_fill: float(),
           empty_transaction_timeout_ms: non_neg_integer(),
           mode: mode(),
           lock_token: binary(),
@@ -33,6 +34,9 @@ defmodule Bedrock.DataPlane.CommitProxy.State do
             batch: nil,
             max_latency_in_ms: nil,
             max_per_batch: nil,
+            # Moving average of how full recent batches were; decides
+            # whether holding an open batch would collect anything.
+            recent_batch_fill: 1.0,
             empty_transaction_timeout_ms: nil,
             mode: :locked,
             lock_token: nil,

--- a/lib/bedrock/internal/repo.ex
+++ b/lib/bedrock/internal/repo.ex
@@ -324,10 +324,12 @@ defmodule Bedrock.Internal.Repo do
 
   defp routing_fn_for_transaction(cluster, nil, link) do
     fn key ->
-      case Link.fetch_covering_entry(link, key) do
+      # A direct ETS read, so the only outcomes are hit and miss. There is
+      # no unavailable/timeout arm any more: the cache is not a process to
+      # be asked, and a table that does not exist reads as a miss.
+      case Link.fetch_covering_entry(cluster, key) do
         {:ok, {{start_key, end_key}, raw_ref}} -> {:ok, {start_key, end_key, [callable_ref(cluster, raw_ref)]}}
         {:error, :not_cached} -> fetch_and_cache_entry(cluster, link, key)
-        {:error, reason} -> {:error, reason}
       end
     end
   end

--- a/lib/bedrock/internal/repo.ex
+++ b/lib/bedrock/internal/repo.ex
@@ -9,6 +9,7 @@ defmodule Bedrock.Internal.Repo do
   alias Bedrock.KeySelector
 
   @default_timeout_in_ms 5_000
+  @max_retry_delay_in_ms 1_000
 
   # Read failures that never resolve without new information, only with a
   # retry: version window misses resolve with a fresh read version, and the
@@ -406,10 +407,33 @@ defmodule Bedrock.Internal.Repo do
       reraise exception, __STACKTRACE__
   end
 
+  @doc """
+  The delay before retry number `retry_count`, in milliseconds.
+
+  FULL JITTER: a uniform draw from the whole interval below a ceiling
+  that doubles, capped. The ceiling schedule is unchanged — what changed
+  is that the delay is drawn from ALL of it rather than from a 3ms band
+  at the top.
+
+  That distinction is the whole point. Transactions contending on one key
+  fail at nearly the same instant; if they then compute nearly the same
+  delay they wake together and collide again, and the round trip repeats
+  at twice the delay. Spreading them across the interval means some
+  contender arrives while the key is uncontended instead of every
+  contender re-colliding. Identical 100-way workloads varied 278ms to
+  2059ms on the old schedule.
+
+  This is FDB's client backoff (`NativeAPI.actor.cpp:4436`:
+  `returnedBackoff *= deterministicRandom()->random01()`, with the
+  ceiling grown at :4446 by `BACKOFF_GROWTH_RATE`). Never zero, so a
+  retry can never become a spin.
+  """
+  @spec retry_delay_in_ms(non_neg_integer()) :: pos_integer()
+  def retry_delay_in_ms(retry_count) when is_integer(retry_count) and retry_count >= 0,
+    do: :rand.uniform(min(1 <<< retry_count, @max_retry_delay_in_ms))
+
   defp wait_before_retry(repo, retry_count, last_reason) do
-    base_delay = 1 <<< retry_count
-    jitter = :rand.uniform(3)
-    wait_time_in_ms = min(base_delay + jitter, 1000)
+    wait_time_in_ms = retry_delay_in_ms(retry_count)
     remaining = TransactionContext.remaining_timeout!(repo, last_reason)
 
     Process.sleep(min_timeout(wait_time_in_ms, remaining))

--- a/test/bedrock/cluster/link/routing_cache_test.exs
+++ b/test/bedrock/cluster/link/routing_cache_test.exs
@@ -1,76 +1,137 @@
 defmodule Bedrock.Cluster.Link.RoutingCacheTest do
+  @moduledoc """
+  The node-wide routing cache, readable WITHOUT a message.
+
+  It was a `LayoutIndex` held in the Link's state, so every cached lookup
+  cost a `GenServer.call` into one process — 0.79µs at rest, and a
+  serialization point that every transaction on the node funnels through.
+  An ETS read of the same entry is 0.06µs, and gets FASTER under
+  concurrency (0.04µs at 16-way) where the call flattens.
+
+  This is FDB's shape: `DatabaseContext locationCache` is a plain
+  in-memory structure the calling context reads directly, not a server it
+  asks.
+
+  Semantics must not drift from `LayoutIndex`, so the tests below check
+  the two against each other rather than restating the rules — including
+  the one that is easy to lose: an end key of `<<0xFF, 0xFF>>` is
+  INCLUSIVE, because it is the end-of-keyspace sentinel rather than a
+  real boundary.
+  """
   use ExUnit.Case, async: true
 
-  alias Bedrock.Cluster.Link.Server
-  alias Bedrock.Cluster.Link.State
+  alias Bedrock.Cluster.Link.RoutingCache
+  alias Bedrock.Internal.TransactionBuilder.LayoutIndex
 
-  defmodule TestCluster do
-    @moduledoc false
-    def otp_name(component) when is_atom(component), do: :"routing_cache_test_#{component}"
+  setup do
+    table = :"routing_cache_test_#{:erlang.unique_integer([:positive])}"
+    RoutingCache.new(table)
+    on_exit(fn -> :ets.info(table) != :undefined && :ets.delete(table) end)
+    {:ok, table: table}
   end
 
-  @entry {<<>>, <<0xFF, 0xFF>>, {"wkr_sys", "n1@host"}}
-
-  defp state(overrides \\ []) do
-    struct!(%State{node: node(), cluster: TestCluster, capabilities: []}, overrides)
+  # The same ranges loaded into both structures.
+  defp load(table, ranges) do
+    Enum.reduce(ranges, LayoutIndex.new(), fn {s, e, ref}, index ->
+      RoutingCache.insert(table, s, e, ref)
+      LayoutIndex.insert(index, s, e, ref)
+    end)
   end
 
-  defp cache(state, entry), do: elem(Server.handle_cast({:cache_routing_entry, entry}, state), 1)
+  defp agree?(table, index, key) do
+    RoutingCache.lookup(table, key) == LayoutIndex.lookup_key(index, key)
+  end
 
-  describe "routing cache" do
-    test "empty cache misses" do
-      assert {:reply, {:error, :not_cached}, _} =
-               Server.handle_call({:get_covering_entry, "a"}, self_from(), state())
+  describe "agreement with LayoutIndex" do
+    test "adjacent ranges, keys inside, on the boundaries, and outside", %{table: table} do
+      ranges = [{"a", "d", :r1}, {"d", "m", :r2}, {"m", "z", :r3}]
+      index = load(table, ranges)
+
+      for key <- ~w[a b c d e l m n y z A "" zz] do
+        assert agree?(table, index, key), "disagreed on #{inspect(key)}"
+      end
     end
 
-    test "a cached covering entry answers keys in its range, and only those" do
-      cached = cache(state(), {"m", "z", {"wkr_a", "n1@host"}})
+    test "the end-of-keyspace sentinel is INCLUSIVE, in both", %{table: table} do
+      # <<0xFF,0xFF>> is the sentinel, not a boundary: a key equal to it
+      # still lands in the final range. Losing this makes system-keyspace
+      # reads uncacheable.
+      ranges = [{<<0xFF>>, <<0xFF, 0xFF>>, :system}]
+      index = load(table, ranges)
 
-      assert {:reply, {:ok, {{"m", "z"}, {"wkr_a", "n1@host"}}}, _} =
-               Server.handle_call({:get_covering_entry, "pear"}, self_from(), cached)
-
-      # Keys outside the fetched range are honest misses — the cache is
-      # partial by design, never a whole-map projection.
-      assert {:reply, {:error, :not_cached}, _} =
-               Server.handle_call({:get_covering_entry, "apple"}, self_from(), cached)
-
-      assert {:reply, {:error, :not_cached}, _} =
-               Server.handle_call({:get_covering_entry, "z"}, self_from(), cached)
+      assert {:ok, {{_, _}, :system}} = RoutingCache.lookup(table, <<0xFF, 0xFF>>)
+      assert agree?(table, index, <<0xFF, 0xFF>>)
+      assert agree?(table, index, <<0xFF, 0x00>>)
+      assert agree?(table, index, <<0xFE>>)
     end
 
-    test "entries coalesce: each fetched shard adds coverage" do
-      cached =
-        state()
-        |> cache({"m", "z", {"wkr_a", "n1@host"}})
-        |> cache({<<>>, "m", {"wkr_b", "n2@host"}})
+    test "a gap between ranges is a miss in both", %{table: table} do
+      ranges = [{"a", "d", :r1}, {"m", "z", :r3}]
+      index = load(table, ranges)
 
-      assert {:reply, {:ok, {{<<>>, "m"}, {"wkr_b", "n2@host"}}}, _} =
-               Server.handle_call({:get_covering_entry, "apple"}, self_from(), cached)
-
-      assert {:reply, {:ok, {{"m", "z"}, {"wkr_a", "n1@host"}}}, _} =
-               Server.handle_call({:get_covering_entry, "pear"}, self_from(), cached)
+      for key <- ~w[d e f l] do
+        assert RoutingCache.lookup(table, key) == :not_cached
+        assert agree?(table, index, key)
+      end
     end
 
-    test "invalidate_routing empties the whole cache synchronously — coarse by design" do
-      cached = cache(state(), @entry)
-      assert {:reply, :ok, invalidated} = Server.handle_call(:invalidate_routing, self_from(), cached)
-
-      assert {:reply, {:error, :not_cached}, _} =
-               Server.handle_call({:get_covering_entry, "a"}, self_from(), invalidated)
+    test "an empty cache misses everything", %{table: table} do
+      index = LayoutIndex.new()
+      for key <- ~w[a m z], do: assert(agree?(table, index, key))
     end
 
-    test "a wiring push drops the cached routing - new-epoch wiring must never pair with old-epoch routing" do
-      cached = cache(state(), @entry)
+    test "re-inserting the same range replaces its ref, in both", %{table: table} do
+      index = load(table, [{"a", "z", :old}])
+      index = load(table, [{"a", "z", :new}])
 
-      new_tsl = %{epoch: 2, sequencer: self(), proxies: [self()]}
-      assert {:noreply, updated} = Server.handle_info({:tsl_updated, new_tsl}, cached)
+      assert {:ok, {_, :new}} = RoutingCache.lookup(table, "m")
+      assert agree?(table, index, "m")
+    end
 
-      assert updated.transaction_system_layout == new_tsl
+    test "randomized ranges and probes agree", %{table: table} do
+      # Differential fuzzing: the two must be indistinguishable.
+      ranges =
+        for i <- 0..19 do
+          s = <<i>>
+          {s, <<i + 1>>, {:shard, i}}
+        end
 
-      assert {:reply, {:error, :not_cached}, _} =
-               Server.handle_call({:get_covering_entry, "a"}, self_from(), updated)
+      index = load(table, Enum.shuffle(ranges))
+
+      for _ <- 1..500 do
+        key = <<:rand.uniform(24) - 1>>
+        assert agree?(table, index, key), "disagreed on #{inspect(key)}"
+      end
     end
   end
 
-  defp self_from, do: {self(), make_ref()}
+  describe "clear/1" do
+    test "drops every entry", %{table: table} do
+      load(table, [{"a", "z", :r1}])
+      assert {:ok, _} = RoutingCache.lookup(table, "m")
+
+      RoutingCache.clear(table)
+      assert RoutingCache.lookup(table, "m") == :not_cached
+    end
+  end
+
+  describe "readable without a message" do
+    test "a lookup from another process needs no call into the owner", %{table: table} do
+      # The whole point: the reader is not the owner and does not message it.
+      load(table, [{"a", "z", :r1}])
+
+      task = Task.async(fn -> RoutingCache.lookup(table, "m") end)
+      assert {:ok, {_, :r1}} = Task.await(task)
+    end
+  end
+
+  describe "a missing table" do
+    test "is a MISS, not a crash" do
+      # If the Link has not started (or restarted), the table is gone. A
+      # dead cache must be no worse than an empty one: the caller falls
+      # back to asking a proxy and the node warms up again.
+      assert RoutingCache.lookup(:no_such_routing_table, "k") == :not_cached
+      assert RoutingCache.lookup(:no_such_routing_table, <<0xFF, 0xFF>>) == :not_cached
+    end
+  end
 end

--- a/test/bedrock/data_plane/commit_proxy/adaptive_batching_test.exs
+++ b/test/bedrock/data_plane/commit_proxy/adaptive_batching_test.exs
@@ -1,0 +1,101 @@
+defmodule Bedrock.DataPlane.CommitProxy.AdaptiveBatchingTest do
+  @moduledoc """
+  A batch should wait only when waiting would collect something.
+
+  The proxy closed its batch on a zero timeout, which fires as soon as the
+  mailbox is empty. With request/response clients the mailbox is almost
+  always empty, so the window closed on the first transaction and
+  `max_latency_in_ms` was never reached: measured batch sizes were 1.0 at
+  one-way concurrency and still only 1.41 at 128-way. Every transaction
+  paid a full finalization round (~3.8ms of resolver plus log push).
+
+  Holding the window fixes throughput and hurts idle latency. Measured,
+  uncontended writes to distinct keys:
+
+      policy        conc=1     conc=32     conc=128    p50 @128
+      close now     1768/s      6749/s      7586/s     15-17ms
+      hold 1ms       490/s     15598/s     24137/s      5-6ms
+      adaptive      1952/s     17044/s     25962/s      4-6ms
+
+  So the wait is decided by whether recent batches actually FILLED. An
+  idle proxy sees batches of one, keeps its average low, and waits zero —
+  a lone transaction is never delayed. Under load the average climbs
+  within a few batches and the proxy starts amortizing.
+
+  FDB adapts the same knob from the other side: its interval tracks a
+  fraction of observed latency, smoothed, clamped to
+  `[COMMIT_TRANSACTION_BATCH_INTERVAL_MIN, ..._MAX]` = `[1ms, 20ms]`
+  (`CommitProxyServer.actor.cpp:2843-2849`, knobs at
+  `ServerKnobs.cpp:701-704`). Its floor is 1ms, so an idle FDB commit
+  always pays it; ours can reach zero because version advancement is
+  already guaranteed separately by the empty-transaction timeout.
+  """
+  use ExUnit.Case, async: true
+
+  alias Bedrock.DataPlane.CommitProxy.Batching
+
+  describe "observe_batch/2" do
+    test "a run of single-transaction batches keeps the average at one" do
+      average = Enum.reduce(1..20, 1.0, fn _, avg -> Batching.observe_batch(avg, 1) end)
+      assert_in_delta average, 1.0, 0.001
+    end
+
+    test "a run of full batches raises the average" do
+      average = Enum.reduce(1..20, 1.0, fn _, avg -> Batching.observe_batch(avg, 10) end)
+      assert average > 9.0
+    end
+
+    test "it is a moving average, so a single busy batch does not latch it high" do
+      # One full batch among singles must not commit the proxy to waiting
+      # forever; the average has to decay back.
+      busy = Batching.observe_batch(1.0, 10)
+      assert busy > 1.5
+
+      decayed = Enum.reduce(1..20, busy, fn _, avg -> Batching.observe_batch(avg, 1) end)
+      assert_in_delta decayed, 1.0, 0.01
+    end
+  end
+
+  describe "hold_in_ms/1" do
+    test "an idle proxy waits ZERO — a lone transaction is never delayed" do
+      # The property the old zero-timeout got right, and which any
+      # batching policy must keep: nothing to batch with, so no wait.
+      assert Batching.hold_in_ms(1.0) == 0
+    end
+
+    test "a filling proxy waits, so the finalization round is amortized" do
+      assert Batching.hold_in_ms(8.0) > 0
+    end
+
+    test "the wait is small — 1ms, FDB's floor, not a latency budget" do
+      # The sweep showed larger holds are strictly worse: 8ms cost 12x at
+      # idle and LOST throughput at 128-way versus 1ms.
+      assert Batching.hold_in_ms(100.0) == 1
+    end
+
+    test "the switch sits above one, so noise in the average cannot trip it" do
+      assert Batching.hold_in_ms(1.4) == 0
+      assert Batching.hold_in_ms(1.6) == 1
+    end
+  end
+
+  describe "the two composed: a proxy learns and unlearns" do
+    test "idle proxy stays at zero wait through a long quiet run" do
+      average = Enum.reduce(1..50, 1.0, fn _, avg -> Batching.observe_batch(avg, 1) end)
+      assert Batching.hold_in_ms(average) == 0
+    end
+
+    test "a proxy under load starts waiting within a few batches" do
+      average = Enum.reduce(1..3, 1.0, fn _, avg -> Batching.observe_batch(avg, 10) end)
+      assert Batching.hold_in_ms(average) == 1
+    end
+
+    test "and stops waiting again once the load goes away" do
+      loaded = Enum.reduce(1..10, 1.0, fn _, avg -> Batching.observe_batch(avg, 10) end)
+      assert Batching.hold_in_ms(loaded) == 1
+
+      quiet = Enum.reduce(1..10, loaded, fn _, avg -> Batching.observe_batch(avg, 1) end)
+      assert Batching.hold_in_ms(quiet) == 0
+    end
+  end
+end

--- a/test/bedrock/internal/repo_retry_backoff_test.exs
+++ b/test/bedrock/internal/repo_retry_backoff_test.exs
@@ -1,0 +1,81 @@
+defmodule Bedrock.Internal.RepoRetryBackoffTest do
+  @moduledoc """
+  Retry backoff must DECORRELATE contenders, not just space them out.
+
+  The schedule was `(1 <<< retry_count) + rand(3)`: a ceiling that
+  doubles, and jitter of one to three milliseconds. With N transactions
+  contending on one key they all fail at nearly the same instant, all
+  compute nearly the same delay, and all wake together — so they collide
+  again, and the round trip repeats at twice the delay. The work is
+  trivial; the wall clock is set by whichever contender happens to climb
+  furthest up the ladder. Identical 100-way workloads measured 278ms,
+  540ms, 1052ms and 2059ms on the same build.
+
+  FDB's client answers this with FULL JITTER: the delay is a uniform draw
+  from the whole interval below the ceiling, and only the CEILING grows
+  (`NativeAPI.actor.cpp:4436`, `returnedBackoff *= random01()`, then
+  `backoff = min(backoff * BACKOFF_GROWTH_RATE, maxBackoff)` at :4446;
+  knobs at `ClientKnobs.cpp:67-69` — 10ms initial, 1s max, growth 2.0).
+
+  Spreading contenders across `[1, ceiling]` means they no longer wake in
+  lockstep, so each round some contender finds the key uncontended
+  instead of every contender re-colliding.
+  """
+  use ExUnit.Case, async: true
+
+  import Bitwise
+
+  alias Bedrock.Internal.Repo
+
+  describe "retry_delay_in_ms/1" do
+    test "the ceiling doubles, exactly as before" do
+      # The growth schedule is not what was wrong, so it does not change:
+      # 1, 2, 4, ... FDB grows its ceiling the same way.
+      for n <- 0..9 do
+        assert Enum.max(for(_ <- 1..200, do: Repo.retry_delay_in_ms(n))) <= 1 <<< n
+      end
+    end
+
+    test "the ceiling is capped, so a long retry chain cannot sleep unboundedly" do
+      for n <- 10..40 do
+        assert Repo.retry_delay_in_ms(n) <= 1000
+      end
+    end
+
+    test "every delay is at least 1ms, so a retry never becomes a spin" do
+      for n <- 0..12, _ <- 1..50 do
+        assert Repo.retry_delay_in_ms(n) >= 1
+      end
+    end
+
+    test "delays SPREAD across the interval rather than clustering at the ceiling" do
+      # The property that actually fixes the pileup. Under the old
+      # schedule every contender at the same retry count drew from a
+      # 3ms-wide band at the top of the interval; here they are spread
+      # across the whole thing, so they stop waking together.
+      samples = for _ <- 1..2000, do: Repo.retry_delay_in_ms(9)
+      ceiling = 1 <<< 9
+
+      assert Enum.min(samples) < div(ceiling, 4),
+             "no contender drew from the bottom quarter — delays are still clustered high"
+
+      assert Enum.max(samples) > div(3 * ceiling, 4),
+             "no contender drew from the top quarter — the ceiling is not being used"
+
+      # A wide spread is the point: distinct values, not a narrow band.
+      assert samples |> Enum.uniq() |> length() > 100
+    end
+
+    test "two contenders at the same retry count usually draw DIFFERENT delays" do
+      # The lockstep failure, stated directly: under `(1 <<< n) + rand(3)`
+      # two contenders collided on the same millisecond about a third of
+      # the time. Full jitter over a 512ms interval makes that rare.
+      collisions =
+        Enum.count(1..1000, fn _ ->
+          Repo.retry_delay_in_ms(9) == Repo.retry_delay_in_ms(9)
+        end)
+
+      assert collisions < 50, "contenders still wake in lockstep (#{collisions}/1000 collided)"
+    end
+  end
+end

--- a/test/bedrock/internal/repo_transact_test.exs
+++ b/test/bedrock/internal/repo_transact_test.exs
@@ -19,6 +19,7 @@ defmodule Bedrock.Internal.RepoTransactTest do
   """
   use ExUnit.Case, async: true
 
+  alias Bedrock.Cluster.Link.RoutingCache
   alias Bedrock.Internal.Repo
   alias Bedrock.Internal.Repo.TransactionContext
 
@@ -391,6 +392,28 @@ defmodule Bedrock.Internal.RepoTransactTest do
       @moduledoc false
       def link!, do: Process.get(:stub_link_pid)
       def otp_name_for_worker(id), do: :"repo_transact_routing_worker_#{id}"
+      # The routing cache is read directly from ETS now, so the cluster
+      # must name the table just as a real cluster does.
+      # Fixed name: tests within a module run sequentially, and the
+      # lookup happens in the TransactionBuilder process, which cannot
+      # see the test's process dictionary.
+      def otp_name(:link_routing), do: :repo_transact_routing_cache
+    end
+
+    # A real routing cache, seeded per test. The read path no longer goes
+    # through the Link, so seeding the table IS how a "cache hit" is set
+    # up -- the stub link only serves misses, the TSL, and invalidation.
+    defp seed_routing_cache(entry) do
+      table = RoutingCluster.otp_name(:link_routing)
+      if :ets.whereis(table) != :undefined, do: :ets.delete(table)
+      RoutingCache.new(table)
+
+      case entry do
+        {start_key, end_key, raw_ref} -> RoutingCache.insert(table, start_key, end_key, raw_ref)
+        nil -> :ok
+      end
+
+      table
     end
 
     # A covering entry as the proxy serves it: shard bounds, tag, raw
@@ -430,31 +453,23 @@ defmodule Bedrock.Internal.RepoTransactTest do
     end
 
     # A one-entry Link cache: covers [start, end) or nothing.
-    defp link_loop(tsl, cached_entry, test_pid) do
+    defp link_loop(tsl, cached_entry, test_pid, table) do
       receive do
-        {:"$gen_call", from, {:get_covering_entry, key}} ->
-          case cached_entry do
-            {start_key, end_key, raw_ref} when key >= start_key and key < end_key ->
-              GenServer.reply(from, {:ok, {{start_key, end_key}, raw_ref}})
-
-            _ ->
-              GenServer.reply(from, {:error, :not_cached})
-          end
-
-          link_loop(tsl, cached_entry, test_pid)
-
         {:"$gen_call", from, :get_transaction_system_layout} ->
           GenServer.reply(from, {:ok, tsl})
-          link_loop(tsl, cached_entry, test_pid)
+          link_loop(tsl, cached_entry, test_pid, table)
 
-        {:"$gen_cast", {:cache_routing_entry, entry}} ->
+        {:"$gen_cast", {:cache_routing_entry, {start_key, end_key, raw_ref} = entry}} ->
+          RoutingCache.insert(table, start_key, end_key, raw_ref)
+
           send(test_pid, {:routing_cached, entry})
-          link_loop(tsl, entry, test_pid)
+          link_loop(tsl, entry, test_pid, table)
 
         {:"$gen_call", from, :invalidate_routing} ->
+          RoutingCache.clear(table)
           GenServer.reply(from, :ok)
           send(test_pid, :routing_invalidated)
-          link_loop(tsl, nil, test_pid)
+          link_loop(tsl, nil, test_pid, table)
       end
     end
 
@@ -474,7 +489,8 @@ defmodule Bedrock.Internal.RepoTransactTest do
         end)
 
       tsl = %{epoch: 1, sequencer: spawn_stub_sequencer(), proxies: [proxy]}
-      link = spawn(fn -> link_loop(tsl, nil, test_pid) end)
+      table = seed_routing_cache(nil)
+      link = spawn(fn -> link_loop(tsl, nil, test_pid, table) end)
       Process.put(:stub_link_pid, link)
 
       result = Repo.transact(RoutingCluster, TestRepo, fn -> Repo.get(TestRepo, "some_key") end, [])
@@ -494,7 +510,8 @@ defmodule Bedrock.Internal.RepoTransactTest do
 
       # No proxies at all: a proxy fetch would fail loudly.
       tsl = %{epoch: 1, sequencer: spawn_stub_sequencer(), proxies: []}
-      link = spawn(fn -> link_loop(tsl, cached_entry(covering_entry()), test_pid) end)
+      table = seed_routing_cache(cached_entry(covering_entry()))
+      link = spawn(fn -> link_loop(tsl, cached_entry(covering_entry()), test_pid, table) end)
       Process.put(:stub_link_pid, link)
 
       result = Repo.transact(RoutingCluster, TestRepo, fn -> Repo.get(TestRepo, "some_key") end, [])
@@ -524,7 +541,8 @@ defmodule Bedrock.Internal.RepoTransactTest do
         end)
 
       tsl = %{epoch: 1, sequencer: spawn_stub_sequencer(), proxies: [proxy]}
-      link = spawn(fn -> link_loop(tsl, stale, test_pid) end)
+      table = seed_routing_cache(stale)
+      link = spawn(fn -> link_loop(tsl, stale, test_pid, table) end)
       Process.put(:stub_link_pid, link)
 
       result = Repo.transact(RoutingCluster, TestRepo, fn -> Repo.get(TestRepo, "some_key") end, [])
@@ -605,7 +623,8 @@ defmodule Bedrock.Internal.RepoTransactTest do
         end)
 
       tsl = %{epoch: 1, sequencer: spawn_stub_sequencer(), proxies: [proxy]}
-      link = spawn(fn -> link_loop(tsl, nil, test_pid) end)
+      table = seed_routing_cache(nil)
+      link = spawn(fn -> link_loop(tsl, nil, test_pid, table) end)
       Process.put(:stub_link_pid, link)
 
       result = Repo.transact(RoutingCluster, TestRepo, fn -> Repo.get(TestRepo, "some_key") end, [])
@@ -629,7 +648,8 @@ defmodule Bedrock.Internal.RepoTransactTest do
       Process.register(materializer, RoutingCluster.otp_name_for_worker("wkr1"))
 
       tsl = %{epoch: 1, sequencer: spawn_stub_sequencer(), proxies: []}
-      link = spawn(fn -> link_loop(tsl, cached_entry(covering_entry()), test_pid) end)
+      table = seed_routing_cache(cached_entry(covering_entry()))
+      link = spawn(fn -> link_loop(tsl, cached_entry(covering_entry()), test_pid, table) end)
       Process.put(:stub_link_pid, link)
 
       assert_raise RuntimeError, ~r/retry limit/, fn ->
@@ -652,7 +672,8 @@ defmodule Bedrock.Internal.RepoTransactTest do
       # list and fail. Lazy routing means this commit-only (read-free)
       # transaction never asks.
       tsl = %{epoch: 1, sequencer: spawn_stub_sequencer(), proxies: []}
-      link = spawn(fn -> link_loop(tsl, nil, test_pid) end)
+      table = seed_routing_cache(nil)
+      link = spawn(fn -> link_loop(tsl, nil, test_pid, table) end)
       Process.put(:stub_link_pid, link)
 
       assert Repo.transact(RoutingCluster, TestRepo, fn -> :no_reads end, []) == :no_reads


### PR DESCRIPTION
Ticket: `bedrock-62e`. Found while chasing a reported slowdown in the class-scheduling demo's "dans" section.

## The defect

```elixir
base_delay = 1 <<< retry_count
jitter = :rand.uniform(3)          # one to three milliseconds
```

A ceiling that doubles, with 1–3ms of jitter. Transactions contending on one key fail at nearly the same instant, compute nearly the same delay, and **wake together** — so they collide again, and the round trip repeats at twice the delay. The work is trivial; the wall clock is set by whichever contender climbs furthest up the ladder.

## Measured

100 concurrent signups against one seat counter, ten independent rounds, fresh class each round:

| | median | **max** | total |
|---|---|---|---|
| before | 285ms / 540ms | **1058ms / 3057ms** | 4761ms / 7161ms |
| after | 210ms / 202ms | **387ms / 320ms** | 2327ms / 2054ms |

Before, samples snap to a ladder — `280, 540, 1058, 3057` — every contender climbing the same rungs. After, they spread and the tail collapses **2.7–9.5×**.

## The fix is FDB's

Full jitter: the delay is a uniform draw from the **whole** interval below the ceiling, and only the *ceiling* grows.

- `NativeAPI.actor.cpp:4436` — `returnedBackoff *= deterministicRandom()->random01();`
- `:4446` — `backoff = std::min(backoff * CLIENT_KNOBS->BACKOFF_GROWTH_RATE, ...)`
- `ClientKnobs.cpp:67-69` — 10ms initial, 1s max, growth 2.0

The ceiling schedule here is **unchanged**. What changed is drawing from all of it rather than a 3ms band at its top. Never zero, so a retry cannot become a spin.

## Not a regression

Bisected: 198ms at `0.5.3`, 150ms at `0.6.0`, 283ms at `0.6.1`-era, 277ms pre-merge, 281ms today. Pickaxe dates the schedule to `602f0c8a`. It has always been this way and was simply never measured.

## Tests

`retry_delay_in_ms/1` extracted as a pure function and tested for properties rather than values: ceiling still doubles, cap holds, never below 1ms, delays **spread across the interval** rather than clustering at the top, and two contenders at the same retry count rarely draw the same delay (`<50/1000`, vs ~1-in-3 under the old 3ms band).

## What remains, deliberately

The ~200ms floor is the real cost: 100 transactions contending on one key must serialize, so ~2ms per commit × 100. The backoff fix moves the workload from backoff-dominated to actually doing the work; it does not make contention free.

## Gates

2769 tests + 13 doctests + 158 properties · `credo --strict` clean · dialyzer 0 errors · formatted.

---

# Second commit: read the routing cache from ETS, not through the Link

Separate concern, same PR because it surfaced from the same investigation. **This is not what made the demo slow** — that was the backoff above.

## The defect

Every transaction on the node looks up every key, and each cached lookup was a `GenServer.call` into the Link: one process serializing the node's entire read path.

| lookup | 1-way | 16-way |
|---|---|---|
| `GenServer.call` (before) | 0.79µs | 0.86µs |
| ETS read (after) | 0.06µs | **0.04µs** |

The call *flattens* under concurrency because calls queue; the ETS read gets **faster** as readers are added.

## The change

The lookup leaves the server. The Link still **owns** the table — one writer keeps invalidation ordered against the pushes that trigger it, and the reply to a synchronous invalidate still means the stale entries are gone — but readers read it directly. FDB's shape: `DatabaseContext locationCache` is a structure the calling context reads, not a server it asks.

The index is keyed by **end** key, so a lookup is a ceiling search plus a start-key check. `Bedrock.end_of_keyspace/0` is the one **inclusive** end — the sentinel above every real key rather than a boundary — and `:ets.next/2` is strictly-greater, so it would step past the range that owns it. That case is tried as an exact hit first.

A missing table reads as a **miss**, not a raise: if the Link hasn't started or has restarted, the caller falls back to a proxy and the node warms up again. A dead cache must never be worse than an empty one.

## Tests

`RoutingCache` is checked **differentially against `LayoutIndex`** — same ranges into both, then compare answers, including 500 randomized probes — so the semantics cannot drift. Plus: the sentinel is inclusive in both, gaps miss in both, and a lookup from a non-owner process needs no message.

Dialyzer caught the consequence in the caller: with the read no longer a call, there's no `unavailable`/`timeout` arm left to handle. That dead clause is gone.

## Honest note

Two transient full-suite failures across ~8 runs while benchmarks were loading the machine. Not reproducible by seed — seed 2222 failed once, then passed three times. I could not capture the test name before it stopped reproducing, so I'm flagging it rather than attributing it to the known flaky test (`bedrock-s9x`).

## Gates

2773 tests + 13 doctests + 158 properties · `credo --strict` clean · dialyzer 0 errors · formatted.

---

# Third commit: hold an open batch only while batches are actually filling

## The defect

The proxy closed its batch on a **zero timeout**, which fires as soon as the mailbox empties. With request/response clients that is immediately — so the batch closed at one transaction and `max_latency_in_ms` was never reached.

| offered concurrency | 1 | 8 | 32 | 128 |
|---|---|---|---|---|
| mean batch size | 1.00 | 1.03 | 1.15 | 1.41 |

`max_per_batch: 10` was never approached. Essentially every transaction paid a full finalization round — resolver plus log push, measured at **~3.8ms mean**.

## Experiments

Uncontended writes to distinct keys, two runs averaged:

| policy | conc=1 | conc=8 | conc=32 | conc=128 | p50 @128 |
|---|---|---|---|---|---|
| close now (today) | 1768/s | 4125/s | 6749/s | 7586/s | 15–17ms |
| fixed 1ms hold | 490/s ⬇3.6× | 3977/s | 15598/s | 24137/s | 5–6ms |
| **demand-adaptive** | **1952/s** | **4237/s** | **17044/s** | **25962/s** | **4–6ms** |

A fixed hold buys 3.2× throughput at load and costs 3.6× at idle. Adapting on **whether recent batches filled** gets both: an idle proxy sees batches of one, keeps its average low, and waits zero — the property the zero timeout got right.

Note latency improves as well as throughput: batching removes more queueing than the deliberate wait adds (p50 at 128-way: 16ms → 5ms).

A sweep found larger holds strictly worse — 8ms cost **12×** at idle and *lost* throughput under load versus 1ms — so the hold is 1ms, which is also FDB's `COMMIT_TRANSACTION_BATCH_INTERVAL_MIN`.

## The mechanism

Two pure functions and one state field — **56 lines**, of which most is commentary:

```elixir
def observe_batch(average, n), do: (1 - @smoothing) * average + @smoothing * n

def hold_in_ms(average) when average > @batching_threshold, do: @hold_in_ms
def hold_in_ms(_not_filling), do: 0
```

`max_latency_in_ms` and `max_per_batch` are unchanged and still cap the batch; this only decides whether waiting is worth it at all.

## Divergence from FDB, deliberate

FDB adapts the same knob from the other side: interval tracks a fraction of observed latency, smoothed, clamped `[1ms, 20ms]` (`CommitProxyServer.actor.cpp:2843-2849`, `ServerKnobs.cpp:701-704`). Its floor is 1ms, so an idle FDB commit always pays it. Ours can reach **zero**, because version advancement is guaranteed separately by the empty-transaction timeout.

## Contended workload

The case the whole investigation started from — 100 concurrent signups on one counter, 8 rounds: **total 1710ms** against 2112–2196ms with the backoff fix alone. Batch fill there sits at 1.44–1.69, which is honest: a conflict-serialized workload genuinely cannot fill batches.

## Gates

2783 tests + 13 doctests + 158 properties across seeds 4 / 808 / 12321 · `credo --strict` clean · dialyzer 0 errors · formatted.
