### PR TITLE
Enforce the segment pool ceiling the recycler always documented

### DIFF
--- a/lib/bedrock/data_plane/log/shale/segment.ex
+++ b/lib/bedrock/data_plane/log/shale/segment.ex
@@ -74,7 +74,7 @@ defmodule Bedrock.DataPlane.Log.Shale.Segment do
     end
   end
 
-  @spec return_to_recycler(t(), SegmentRecycler.server()) :: :ok
+  @spec return_to_recycler(t(), SegmentRecycler.server()) :: :ok | {:error, File.posix()}
   def return_to_recycler(segment, segment_recycler), do: SegmentRecycler.check_in(segment_recycler, segment.path)
 
   @doc """

--- a/lib/bedrock/data_plane/log/shale/segment_recycler.ex
+++ b/lib/bedrock/data_plane/log/shale/segment_recycler.ex
@@ -14,10 +14,14 @@ defmodule Bedrock.DataPlane.Log.Shale.SegmentRecycler do
   def check_out(segment_recycler, new_path), do: GenServer.call(segment_recycler, {:check_out, new_path})
 
   @doc """
-  Return a segment to the recycler. The recycler will attempt to delete the
-  segment if it has too many on-hand.
+  Return a segment to the recycler. The recycler will delete the segment
+  if it is already holding `max_available` of them.
+
+  Returns the unlink's error if that deletion fails; callers that match
+  on `:ok` will crash the log and re-recover, which is the same exposure
+  the rename this replaced always had.
   """
-  @spec check_in(server(), path :: String.t()) :: :ok
+  @spec check_in(server(), path :: String.t()) :: :ok | {:error, File.posix()}
   def check_in(segment_recycler, segment), do: GenServer.call(segment_recycler, {:check_in, segment})
 
   @spec child_spec(term()) :: Supervisor.child_spec()
@@ -83,21 +87,32 @@ defmodule Bedrock.DataPlane.Log.Shale.SegmentRecycler do
             max_available :: pos_integer()
           ) :: {:ok, State.t()} | {:error, atom()}
     def new(path_to_dir, size, min_available, max_available) do
-      if File.dir?(path_to_dir) do
-        segments = find_existing_preallocated_files(path_to_dir)
-        highest_id = find_highest_id(segments)
+      cond do
+        # min == max leaves no slack for a returned segment to land in:
+        # a checkout drops the pool to max - 1, the min-refill allocates a
+        # replacement, and the check-in then finds the pool full and
+        # unlinks. Every cycle costs a fresh allocation and recycles
+        # nothing — the module's whole purpose, silently off. Refuse the
+        # config instead of quietly degrading under it.
+        min_available >= max_available ->
+          {:error, :max_available_must_exceed_min_available}
 
-        {:ok,
-         %State{
-           path: path_to_dir,
-           segments: segments,
-           size: size,
-           next_id: highest_id + 1,
-           min_available: min_available,
-           max_available: max_available
-         }}
-      else
-        {:error, :path_is_not_a_directory}
+        not File.dir?(path_to_dir) ->
+          {:error, :path_is_not_a_directory}
+
+        true ->
+          segments = find_existing_preallocated_files(path_to_dir)
+          highest_id = find_highest_id(segments)
+
+          {:ok,
+           %State{
+             path: path_to_dir,
+             segments: segments,
+             size: size,
+             next_id: highest_id + 1,
+             min_available: min_available,
+             max_available: max_available
+           }}
       end
     end
 
@@ -131,8 +146,21 @@ defmodule Bedrock.DataPlane.Log.Shale.SegmentRecycler do
       end
     end
 
+    # The pool is a cache, not a ledger: every preallocated file is
+    # interchangeable, so at the cap the cheapest correct move is to
+    # unlink the segment being returned rather than rename it in and
+    # evict another. Without this, a trim burst — `trim_durable_segments/1`
+    # splitting off many segments at once when a durability watermark
+    # jumps — checks them all in back-to-back with no intervening
+    # checkout, and the pool keeps every one of them at `size` bytes
+    # apiece for the life of the worker.
     @spec check_in(State.t(), path_to_file :: String.t()) ::
-            {:ok, State.t()} | {:error, :file_is_not_closed}
+            {:ok, State.t()} | {:error, File.posix()}
+    def check_in(%{segments: segments, max_available: max_available} = t, path_to_file)
+        when length(segments) >= max_available do
+      with :ok <- File.rm(path_to_file), do: {:ok, t}
+    end
+
     def check_in(t, path_to_file) do
       new_path_to_file = Path.join(t.path, generate_unused_file_name(t.next_id))
 

--- a/test/bedrock/data_plane/log/shale/recovery_test.exs
+++ b/test/bedrock/data_plane/log/shale/recovery_test.exs
@@ -18,7 +18,7 @@ defmodule Bedrock.DataPlane.Log.Shale.RecoveryTest do
 
   setup %{tmp_dir: tmp_dir} do
     {:ok, recycler} =
-      start_supervised({SegmentRecycler, path: tmp_dir, min_available: 1, max_available: 1, segment_size: 1024 * 1024})
+      start_supervised({SegmentRecycler, path: tmp_dir, min_available: 1, max_available: 2, segment_size: 1024 * 1024})
 
     state = %State{
       mode: :locked,

--- a/test/bedrock/data_plane/log/shale/segment_recycler_test.exs
+++ b/test/bedrock/data_plane/log/shale/segment_recycler_test.exs
@@ -1,0 +1,137 @@
+defmodule Bedrock.DataPlane.Log.Shale.SegmentRecyclerTest do
+  use ExUnit.Case, async: true
+
+  alias Bedrock.DataPlane.Log.Shale.SegmentRecycler
+  alias Bedrock.DataPlane.Log.Shale.SegmentRecycler.Logic
+
+  # The pool is a disk-backed cache of preallocated 64 MiB files. Its
+  # ceiling is the only thing standing between a trim burst and hundreds
+  # of megabytes pinned for the life of the worker, so these tests assert
+  # the ceiling holds against bursts, not just against the steady
+  # one-in-one-out cadence a running log produces.
+  @moduletag :tmp_dir
+
+  @segment_size 1024
+  @max_available 3
+
+  setup %{tmp_dir: dir} do
+    {:ok, state} = Logic.new(dir, @segment_size, 1, @max_available)
+    %{dir: dir, state: state}
+  end
+
+  # A stand-in for a retired WAL segment: check_in either renames it into
+  # the pool or unlinks it, so the contents are irrelevant and the size
+  # need not be realistic.
+  defp retired_segment(dir, name) do
+    path = Path.join(dir, name)
+    :ok = File.write(path, "retired")
+    path
+  end
+
+  defp check_in_all(state, dir, names) do
+    Enum.reduce(names, state, fn name, acc ->
+      {:ok, acc} = Logic.check_in(acc, retired_segment(dir, name))
+      acc
+    end)
+  end
+
+  defp pooled_files(dir), do: Logic.find_existing_preallocated_files(dir)
+
+  describe "check_in/2 below the cap" do
+    test "pools the segment under a preallocated name", %{dir: dir, state: state} do
+      path = retired_segment(dir, "wal_a")
+
+      {:ok, state} = Logic.check_in(state, path)
+
+      assert [pooled] = state.segments
+      assert File.exists?(pooled)
+      assert Path.basename(pooled) =~ ~r/^preallocated\./
+      refute File.exists?(path), "check_in must rename the retired segment, not copy it"
+    end
+
+    test "accumulates up to max_available", %{dir: dir, state: state} do
+      state = check_in_all(state, dir, ["wal_a", "wal_b", "wal_c"])
+
+      assert length(state.segments) == @max_available
+      assert length(pooled_files(dir)) == @max_available
+    end
+  end
+
+  describe "check_in/2 at the cap" do
+    test "deletes the returned segment instead of pooling it", %{dir: dir, state: state} do
+      state = check_in_all(state, dir, ["wal_a", "wal_b", "wal_c"])
+      assert length(state.segments) == @max_available
+
+      surplus = retired_segment(dir, "wal_surplus")
+      {:ok, state} = Logic.check_in(state, surplus)
+
+      assert length(state.segments) == @max_available,
+             "pool must not grow past max_available"
+
+      refute File.exists?(surplus), "the surplus segment must be unlinked, not left on disk"
+      assert length(pooled_files(dir)) == @max_available
+    end
+
+    # The ratchet only bites on a burst: trim_durable_segments/1 can split
+    # off many segments at once when a durability watermark jumps, and
+    # checks them all in back-to-back with no intervening checkout.
+    test "a burst of consecutive check-ins never exceeds max_available", %{dir: dir, state: state} do
+      surplus_count = 5
+      names = Enum.map(1..(@max_available + surplus_count), &"wal_#{&1}")
+
+      state = check_in_all(state, dir, names)
+
+      assert length(state.segments) == @max_available
+      assert length(pooled_files(dir)) == @max_available
+
+      assert Path.wildcard(Path.join(dir, "wal_*")) == [],
+             "every checked-in segment must be either pooled or unlinked"
+    end
+  end
+
+  describe "new/4 configuration" do
+    test "refuses a pool with no slack between min and max", %{tmp_dir: dir} do
+      assert {:error, :max_available_must_exceed_min_available} = Logic.new(dir, @segment_size, 1, 1)
+      assert {:error, :max_available_must_exceed_min_available} = Logic.new(dir, @segment_size, 3, 2)
+    end
+
+    test "accepts a pool with slack", %{tmp_dir: dir} do
+      assert {:ok, %{min_available: 2, max_available: 3}} = Logic.new(dir, @segment_size, 2, 3)
+    end
+  end
+
+  # The Logic tests above never run the min-refill, which is the other
+  # half of the cycle: a live recycler must hold the ceiling while
+  # ensure_min_available keeps putting segments back.
+  describe "the running recycler" do
+    setup %{tmp_dir: dir} do
+      {:ok, recycler} =
+        SegmentRecycler.start_link(
+          path: dir,
+          min_available: 2,
+          max_available: @max_available,
+          segment_size: @segment_size
+        )
+
+      %{recycler: recycler}
+    end
+
+    test "refuses to start with no slack", %{tmp_dir: dir} do
+      Process.flag(:trap_exit, true)
+
+      assert {:error, :max_available_must_exceed_min_available} =
+               SegmentRecycler.start_link(path: dir, min_available: 1, max_available: 1, segment_size: @segment_size)
+    end
+
+    test "holds the ceiling across a burst and still serves checkouts", %{dir: dir, recycler: recycler} do
+      for i <- 1..8, do: :ok = SegmentRecycler.check_in(recycler, retired_segment(dir, "wal_#{i}"))
+
+      assert length(pooled_files(dir)) <= @max_available
+
+      # The pool is still usable afterwards — deletion must never starve
+      # the very checkout the pool exists to serve.
+      assert :ok = SegmentRecycler.check_out(recycler, Path.join(dir, "wal_next"))
+      assert File.exists?(Path.join(dir, "wal_next"))
+    end
+  end
+end


### PR DESCRIPTION
Closes bedrock-61c.3 (epic bedrock-61c).

`SegmentRecycler.check_in/2`'s docstring has always promised to delete a returned segment when the pool is full. `max_available` was fetched, threaded into `State`, and never compared against anything.

Steady state hides it — one checkout per roll and one check-in per trim keeps the pool oscillating at the cap. A **trim burst** does not: `trim_durable_segments/1` splits off every segment below a jumped durability watermark and checks them all in back-to-back with no intervening checkout, so the pool keeps each at `segment_size` for the life of the worker. At the 64 MiB production size a ten-segment burst pins 640 MiB that is never released.

### Changes
- at the cap, unlink the returned segment instead of pooling it
- reject `min_available >= max_available` at construction — with no slack a checkout drops the pool to `max - 1`, the min-refill allocates a replacement, and the check-in then unlinks, so every cycle costs an allocation and recycles nothing. Silent degradation becomes a startup error. (`recovery_test.exs` used exactly `1/1`; updated to `1/2`.)
- correct two specs that promised `:: :ok` — `check_in/2` can now fail on the unlink

### Trade
A later burst re-allocates what an earlier one used to leave lying around. A metadata-only `fallocate` is the right price for not pinning the disk.

### Verification
2803 tests, 0 failures. Credo and dialyzer clean.

Adversarially audited by a cold agent, which confirmed delete-safety (every returned file is closed first, and `rm` is path-equivalent to the old `rename` for every reader) and that the tests are boundary-sensitive — mutating `>=` to `>` fails two of them. It also surfaced two pre-existing bugs, filed separately as bedrock-m7j and bedrock-20c.