### PR TITLE
Roll the WAL on the Demux's configured cut interval, not the default

### DIFF
--- a/lib/bedrock/data_plane/log/shale/demux_control.ex
+++ b/lib/bedrock/data_plane/log/shale/demux_control.ex
@@ -12,7 +12,8 @@ defmodule Bedrock.DataPlane.Log.Shale.DemuxControl do
     Demux.Server.start_link(
       cluster: t.cluster,
       object_storage: t.object_storage,
-      log: self()
+      log: self(),
+      cut_interval_us: State.cut_interval_us(t)
     )
   end
 

--- a/lib/bedrock/data_plane/log/shale/pushing.ex
+++ b/lib/bedrock/data_plane/log/shale/pushing.ex
@@ -24,7 +24,6 @@ defmodule Bedrock.DataPlane.Log.Shale.Pushing do
   """
   import Bedrock.DataPlane.Log.Telemetry
 
-  alias Bedrock.DataPlane.Demux
   alias Bedrock.DataPlane.Log.Shale.Segment
   alias Bedrock.DataPlane.Log.Shale.State
   alias Bedrock.DataPlane.Log.Shale.Writer
@@ -198,7 +197,7 @@ defmodule Bedrock.DataPlane.Log.Shale.Pushing do
   end
 
   defp maybe_roll_and_append(t, encoded_transaction, version) do
-    if crosses_cut_boundary?(t.active_segment, version) do
+    if crosses_cut_boundary?(t, t.active_segment, version) do
       # Roll on the cut cadence, not just on byte size: the active
       # segment is trim-immune, so a low-traffic log that never fills a
       # segment would otherwise hold its entire history in one
@@ -262,11 +261,13 @@ defmodule Bedrock.DataPlane.Log.Shale.Pushing do
   end
 
   # Same version arithmetic as the Demux's deterministic cuts: a segment
-  # holds exactly one cut bucket of versions.
-  defp crosses_cut_boundary?(nil, _version), do: false
+  # holds exactly one cut bucket of versions. The width comes from the
+  # log's own state — the same value `DemuxControl` starts the Demux
+  # with — so the two boundaries cannot drift apart.
+  defp crosses_cut_boundary?(_t, nil, _version), do: false
 
-  defp crosses_cut_boundary?(%{min_version: min_version}, version) do
-    interval = Demux.Server.default_cut_interval_us()
+  defp crosses_cut_boundary?(t, %{min_version: min_version}, version) do
+    interval = State.cut_interval_us(t)
 
     div(Version.to_integer(version), interval) > div(Version.to_integer(min_version), interval)
   end

--- a/lib/bedrock/data_plane/log/shale/server.ex
+++ b/lib/bedrock/data_plane/log/shale/server.ex
@@ -60,6 +60,7 @@ defmodule Bedrock.DataPlane.Log.Shale.Server do
     object_storage = Keyword.fetch!(opts, :object_storage)
     start_unlocked = Keyword.get(opts, :start_unlocked, false)
     reject_pushes_above_lag_us = Keyword.get(opts, :reject_pushes_above_lag_us)
+    cut_interval_us = opts |> Keyword.get(:params, %{}) |> cut_interval_us_from_params()
 
     %{
       id: {__MODULE__, id},
@@ -75,17 +76,35 @@ defmodule Bedrock.DataPlane.Log.Shale.Server do
              path,
              object_storage,
              start_unlocked,
-             reject_pushes_above_lag_us
+             reject_pushes_above_lag_us,
+             cut_interval_us
            },
            [name: otp_name]
          ]}
     }
   end
 
+  # The cut interval rides the manifest, which is what makes it survive a
+  # restart: the Foreman rebuilds a crashed worker from its manifest
+  # alone, so an interval held only in State would revert to the default
+  # and the log would resume rolling on boundaries the chunks it already
+  # wrote were not cut on. Anything but a positive integer is "unset" —
+  # manifest params are JSON, so a string or a zero is a config mistake,
+  # not an instruction.
+  @spec cut_interval_us_from_params(map()) :: pos_integer() | nil
+  defp cut_interval_us_from_params(%{"cut_interval_us" => us}) when is_integer(us) and us > 0, do: us
+  defp cut_interval_us_from_params(_params), do: nil
+
   @impl true
-  @spec init({module(), atom(), Log.id(), pid(), Path.t(), module(), boolean(), non_neg_integer() | nil}) ::
+  @spec init(
+          {module(), atom(), Log.id(), pid(), Path.t(), module(), boolean(), non_neg_integer() | nil,
+           pos_integer() | nil}
+        ) ::
           {:ok, State.t(), {:continue, :initialization}}
-  def init({cluster, otp_name, id, foreman, path, object_storage, start_unlocked, reject_pushes_above_lag_us}) do
+  def init(
+        {cluster, otp_name, id, foreman, path, object_storage, start_unlocked, reject_pushes_above_lag_us,
+         cut_interval_us}
+      ) do
     initial_mode = if start_unlocked, do: :running, else: :locked
 
     {:ok,
@@ -99,6 +118,7 @@ defmodule Bedrock.DataPlane.Log.Shale.Server do
        foreman: foreman,
        object_storage: object_storage,
        reject_pushes_above_lag_us: reject_pushes_above_lag_us,
+       cut_interval_us: cut_interval_us,
        available_after: Version.zero(),
        oldest_version: Version.zero(),
        last_version: Version.zero()

--- a/lib/bedrock/data_plane/log/shale/state.ex
+++ b/lib/bedrock/data_plane/log/shale/state.ex
@@ -4,6 +4,7 @@ defmodule Bedrock.DataPlane.Log.Shale.State do
   """
 
   alias Bedrock.ControlPlane.Director
+  alias Bedrock.DataPlane.Demux
   alias Bedrock.DataPlane.Log.Shale.Segment
   alias Bedrock.DataPlane.Log.Shale.SegmentRecycler
   alias Bedrock.DataPlane.Log.Shale.Writer
@@ -28,6 +29,7 @@ defmodule Bedrock.DataPlane.Log.Shale.State do
           object_storage: module() | nil,
           demux: pid() | nil,
           demux_supervisor: pid() | nil,
+          cut_interval_us: pos_integer() | nil,
           min_durable_version: Bedrock.version() | nil,
           #
           last_version: Bedrock.version(),
@@ -67,6 +69,7 @@ defmodule Bedrock.DataPlane.Log.Shale.State do
             object_storage: nil,
             demux: nil,
             demux_supervisor: nil,
+            cut_interval_us: nil,
             min_durable_version: nil,
             #
             last_version: nil,
@@ -88,4 +91,20 @@ defmodule Bedrock.DataPlane.Log.Shale.State do
               default_pull_limit: 100,
               max_pull_limit: 500
             }
+
+  @doc """
+  The cut-interval width this log operates on, in microseconds of
+  version-time.
+
+  The single resolution point for the default. The WAL's segment-roll
+  boundary and the Demux's cut boundary are the SAME boundary — a
+  segment holds exactly one cut bucket, which is what lets trimming drop
+  history at the cut cadence even though the active segment is
+  trim-immune. Two independent reads of "the default" would hold only by
+  coincidence, and would diverge the moment a log's Demux were
+  configured with a different width.
+  """
+  @spec cut_interval_us(t()) :: pos_integer()
+  def cut_interval_us(%__MODULE__{cut_interval_us: nil}), do: Demux.Server.default_cut_interval_us()
+  def cut_interval_us(%__MODULE__{cut_interval_us: cut_interval_us}), do: cut_interval_us
 end

--- a/test/bedrock/data_plane/log/shale/demux_control_test.exs
+++ b/test/bedrock/data_plane/log/shale/demux_control_test.exs
@@ -1,0 +1,47 @@
+defmodule Bedrock.DataPlane.Log.Shale.DemuxControlTest do
+  use ExUnit.Case, async: true
+
+  alias Bedrock.DataPlane.Demux
+  alias Bedrock.DataPlane.Log.Shale.DemuxControl
+  alias Bedrock.DataPlane.Log.Shale.State
+  alias Bedrock.ObjectStorage
+  alias Bedrock.ObjectStorage.LocalFilesystem
+
+  # DemuxControl is the single place a log's Demux is started from, which
+  # is precisely why the cut interval has to travel through it: the log's
+  # WAL roll boundary and the Demux's cut boundary are the same boundary,
+  # and nothing else is positioned to keep them equal.
+  @moduletag :tmp_dir
+
+  defp state_in_tmp_dir(%{tmp_dir: dir}, overrides) do
+    struct!(
+      %State{
+        cluster: Bedrock.Cluster,
+        path: dir,
+        object_storage: ObjectStorage.backend(LocalFilesystem, root: Path.join(dir, "object_storage"))
+      },
+      overrides
+    )
+  end
+
+  describe "start/1" do
+    test "hands the Demux the log's configured cut interval", ctx do
+      interval = div(Demux.Server.default_cut_interval_us(), 5)
+      state = state_in_tmp_dir(ctx, cut_interval_us: interval)
+
+      {:ok, demux} = DemuxControl.start(state)
+      on_exit(fn -> DemuxControl.teardown(demux) end)
+
+      assert :sys.get_state(demux).cut_interval_us == interval
+    end
+
+    test "falls back to the default when the log has no configured interval", ctx do
+      state = state_in_tmp_dir(ctx, cut_interval_us: nil)
+
+      {:ok, demux} = DemuxControl.start(state)
+      on_exit(fn -> DemuxControl.teardown(demux) end)
+
+      assert :sys.get_state(demux).cut_interval_us == Demux.Server.default_cut_interval_us()
+    end
+  end
+end

--- a/test/bedrock/data_plane/log/shale/pull_boundary_test.exs
+++ b/test/bedrock/data_plane/log/shale/pull_boundary_test.exs
@@ -23,7 +23,7 @@ defmodule Bedrock.DataPlane.Log.Shale.PullBoundaryTest do
     {:ok, pid} =
       GenServer.start_link(
         Server,
-        {cluster, otp_name, id, foreman, path, object_storage, true, nil},
+        {cluster, otp_name, id, foreman, path, object_storage, true, nil, nil},
         name: otp_name
       )
 

--- a/test/bedrock/data_plane/log/shale/pushing_test.exs
+++ b/test/bedrock/data_plane/log/shale/pushing_test.exs
@@ -384,6 +384,55 @@ defmodule Bedrock.DataPlane.Log.Shale.PushingTest do
       assert length(state.segments) == 2
       assert state.active_segment.min_version == Version.from_integer(4 * interval + 1)
     end
+
+    # The roll boundary exists to match the Demux's cut boundary exactly —
+    # a segment holds one cut bucket, which is what lets trimming drop
+    # history at the cut cadence despite the active segment being
+    # trim-immune. The Demux's bucket width is configurable, so reading
+    # the module default here would silently break that correspondence
+    # for any log whose Demux was configured otherwise.
+    defp state_with_cut_interval(dir, recycler, cut_interval_us) do
+      %State{
+        mode: :running,
+        path: dir,
+        segment_recycler: recycler,
+        writer: nil,
+        active_segment: nil,
+        segments: [],
+        last_version: Version.from_integer(0),
+        cut_interval_us: cut_interval_us
+      }
+    end
+
+    test "rolls on a configured interval narrower than the default", %{dir: dir, recycler: recycler} do
+      interval = div(Demux.Server.default_cut_interval_us(), 5)
+      state = state_with_cut_interval(dir, recycler, interval)
+
+      state = write!(state, 1_000)
+      assert state.segments == []
+
+      # Crosses the configured boundary while still inside bucket 0 at the
+      # default width — only a state-driven interval can see this roll.
+      state = write!(state, interval + 1)
+
+      assert [_predecessor] = state.segments
+      assert state.active_segment.min_version == Version.from_integer(interval + 1)
+    end
+
+    test "does not roll at the default boundary when configured wider", %{dir: dir, recycler: recycler} do
+      default = Demux.Server.default_cut_interval_us()
+      state = state_with_cut_interval(dir, recycler, default * 4)
+
+      state = write!(state, 1_000)
+
+      # Crosses the DEFAULT boundary but not the configured one.
+      state = write!(state, default + 1)
+
+      assert state.segments == [],
+             "the roll must follow the configured cut interval, not the module default"
+
+      assert state.active_segment.min_version == Version.from_integer(1_000)
+    end
   end
 
   describe "rollover publishes only after the successor cursor is durable" do

--- a/test/bedrock/data_plane/log/shale/server_test.exs
+++ b/test/bedrock/data_plane/log/shale/server_test.exs
@@ -2,6 +2,7 @@ defmodule Bedrock.DataPlane.Log.Shale.ServerTest do
   use ExUnit.Case, async: false
 
   alias Bedrock.Cluster
+  alias Bedrock.DataPlane.Demux
   alias Bedrock.DataPlane.Demux.ShardServer
   alias Bedrock.DataPlane.Log.Shale.Segment
   alias Bedrock.DataPlane.Log.Shale.Server
@@ -51,6 +52,37 @@ defmodule Bedrock.DataPlane.Log.Shale.ServerTest do
                id: {Server, ^expected_id},
                start: {GenServer, :start_link, [Server, _, [name: ^expected_name]]}
              } = spec
+    end
+
+    # The interval has to ride the manifest, not just live in State: the
+    # Foreman rebuilds a restarted worker purely from opts, so an
+    # init-only field would silently revert to the default after a crash
+    # and the log would resume rolling on different boundaries than the
+    # chunks it already wrote were cut on.
+    defp init_state(opts) do
+      %{start: {GenServer, :start_link, [Server, init_arg, _]}} = Server.child_spec(opts)
+      {:ok, state, _continue} = Server.init(init_arg)
+      state
+    end
+
+    test "carries a cut interval from the manifest params", %{server_opts: opts} do
+      state = init_state(Keyword.put(opts, :params, %{"cut_interval_us" => 1_000_000}))
+
+      assert State.cut_interval_us(state) == 1_000_000
+    end
+
+    test "falls back to the default when the manifest says nothing", %{server_opts: opts} do
+      assert State.cut_interval_us(init_state(opts)) ==
+               Demux.Server.default_cut_interval_us()
+    end
+
+    test "ignores a manifest cut interval that is not a positive integer", %{server_opts: opts} do
+      for bad <- [0, -1, "5000000", nil] do
+        state = init_state(Keyword.put(opts, :params, %{"cut_interval_us" => bad}))
+
+        assert State.cut_interval_us(state) == Demux.Server.default_cut_interval_us(),
+               "#{inspect(bad)} must not be accepted as an interval"
+      end
     end
 
     test "raises error when cluster option is missing" do

--- a/test/bedrock/data_plane/log/shale/simple_pull_test.exs
+++ b/test/bedrock/data_plane/log/shale/simple_pull_test.exs
@@ -23,7 +23,7 @@ defmodule Bedrock.DataPlane.Log.Shale.SimplePullTest do
     {:ok, pid} =
       GenServer.start_link(
         Server,
-        {cluster, otp_name, id, foreman, path, object_storage, true, nil},
+        {cluster, otp_name, id, foreman, path, object_storage, true, nil, nil},
         name: otp_name
       )
 


### PR DESCRIPTION
Closes bedrock-61c.1 (epic bedrock-61c).

The WAL's segment-roll boundary and the Demux's cut boundary are the **same boundary** — a segment holds exactly one cut bucket, which is what lets trimming drop history at the cut cadence even though the active segment is trim-immune. Both modules document this.

They agreed only by coincidence:
- `Pushing.crosses_cut_boundary?/2` read `Demux.Server.default_cut_interval_us/0` directly
- `DemuxControl.start/1` — documented as the single place a log's Demux is started from, where *"initialization and recovery reset must agree on every option"* — never passed `:cut_interval_us` at all

Both sides defaulted, so both matched, and the Demux's documented `:cut_interval_us` option was unreachable from a log.

### Changes
- `State.cut_interval_us/1` is the single resolution point for the default
- `DemuxControl` hands that value to the Demux; `Pushing` measures the roll against the same value
- carried on the **manifest params**, not `State` alone: the Foreman rebuilds a restarted worker from its manifest, so an init-only field would revert to the default after a crash and the log would resume rolling on boundaries its already-written chunks were not cut on — reintroducing across a restart exactly the drift this closes in-process

### Scope
This is a coupling fix. No production behaviour changes today, because until now nothing could configure the width. A drift's cost is **retention, not durability**: a segment spanning several cuts stays un-trimmable until the last cut covering it lands. The trim floor is the Demux watermark alone and eligibility is content-derived, so an unaligned segment is never trimmed early.

### Verification
2802 tests, 0 failures. Credo and dialyzer clean.

Adversarially audited by a cold agent, which found no off-by-one at the bucket boundary, confirmed no explicit `nil` can reach `div/2`, verified the recovery-reset and relock paths preserve the interval, and confirmed three of the four new tests fail against the pre-fix code.