### PR TITLE
A worker directory is one with a manifest; report the ones that are not

### DIFF
--- a/lib/bedrock/service/foreman/impl.ex
+++ b/lib/bedrock/service/foreman/impl.ex
@@ -5,6 +5,7 @@ defmodule Bedrock.Service.Foreman.Impl do
 
   import Bedrock.Service.Foreman.StartingWorkers,
     only: [
+      abandoned_paths_from_disk: 1,
       worker_info_from_path: 2,
       try_to_start_workers: 3,
       try_to_start_worker: 3,
@@ -248,9 +249,36 @@ defmodule Bedrock.Service.Foreman.Impl do
   @spec do_spin_up(State.t()) :: State.t()
   def do_spin_up(t) do
     t
+    |> report_abandoned_directories()
     |> load_workers_from_disk()
     |> start_workers_that_are_stopped()
     |> relay_current_tsl()
+  end
+
+  # An unstartable directory is silent by nature: with no manifest there
+  # is no worker process, so nothing can report its own health and
+  # nothing can retire itself. Left unreported it is invisible — retried
+  # and re-failed on every boot while holding its disk. Say it out loud
+  # at the one moment an operator is looking, and name the paths so the
+  # cleanup is a copy-paste. Reporting only; a WAL is real data and the
+  # foreman does not delete on a guess.
+  @spec report_abandoned_directories(State.t()) :: State.t()
+  defp report_abandoned_directories(t) do
+    case abandoned_paths_from_disk(t.path) do
+      [] ->
+        t
+
+      paths ->
+        Logger.warning(
+          "Bedrock foreman: #{length(paths)} abandoned working " <>
+            "#{if length(paths) == 1, do: "directory", else: "directories"} under #{t.path} " <>
+            "(no manifest, so they cannot be started and cannot retire themselves). " <>
+            "They will be ignored on every boot until removed by hand: " <>
+            Enum.map_join(paths, ", ", &Path.basename/1)
+        )
+
+        t
+    end
   end
 
   # Cold boot composes with self-detection only if resurrected workers

--- a/lib/bedrock/service/foreman/starting_workers.ex
+++ b/lib/bedrock/service/foreman/starting_workers.ex
@@ -8,6 +8,7 @@ defmodule Bedrock.Service.Foreman.StartingWorkers do
 
   alias Bedrock.Cluster
   alias Bedrock.Service.Foreman.WorkerInfo
+  alias Bedrock.Service.Foreman.WorkingDirectory
   alias Bedrock.Service.Manifest
   alias Bedrock.Service.Worker
 
@@ -19,11 +20,71 @@ defmodule Bedrock.Service.Foreman.StartingWorkers do
     |> Enum.map(&worker_info_for_id(Path.basename(&1), &1, otp_namer))
   end
 
+  # Directories the foreman's path holds that belong to other components.
+  # The cluster supervisor derives object_storage/ from the same :path it
+  # hands the foreman; the coordinator's raft/ is a sibling by the
+  # convention every deployment config follows. Neither is a worker, and
+  # neither is news.
+  @infrastructure_dirs ~w(object_storage raft)
+
+  @doc """
+  The worker directories under the foreman's path.
+
+  A worker directory is one holding a manifest — not merely one that
+  exists. The foreman's path is shared with other components, so "every
+  entry under path is a worker" is never true in a real deployment.
+
+  Presence of the manifest is the test, not readability: a directory
+  whose manifest is corrupt is a worker in trouble, and one whose
+  manifest cannot be stat'ed for any reason OTHER than absence is a
+  worker we cannot rule out. Both are enumerated so they surface as
+  `:failed_to_start`. Only a definite absence excludes a directory —
+  a live worker must never vanish from the foreman's view because of a
+  permissions mistake.
+  """
   @spec worker_paths_from_disk(Path.t()) :: [Path.t()]
   def worker_paths_from_disk(path) do
     path
     |> Path.join("*")
     |> Path.wildcard()
+    |> Enum.filter(&worker_directory?/1)
+  end
+
+  @doc """
+  Directories under the foreman's path that are neither workers nor
+  another component's, in sorted order.
+
+  These are the remains of workers that cannot be started: a worker whose
+  manifest is gone is unstartable, and because retirement runs THROUGH
+  the worker — `Foreman.worker_retired/2` from a live process holding the
+  id and foreman ref its manifest supplied — an unstartable directory can
+  never retire itself either. It will be re-attempted and re-fail on
+  every boot, holding its disk forever.
+
+  The foreman reports them rather than reclaiming them: the directory may
+  hold a WAL, and deleting data on a guess is not the foreman's call.
+  """
+  @spec abandoned_paths_from_disk(Path.t()) :: [Path.t()]
+  def abandoned_paths_from_disk(path) do
+    path
+    |> Path.join("*")
+    |> Path.wildcard()
+    |> Enum.reject(&(worker_directory?(&1) or Path.basename(&1) in @infrastructure_dirs))
+    |> Enum.filter(&File.dir?/1)
+    |> Enum.sort()
+  end
+
+  @spec worker_directory?(Path.t()) :: boolean()
+  defp worker_directory?(path) do
+    case File.stat(WorkingDirectory.manifest_path(path)) do
+      {:ok, _stat} -> true
+      # A definite "no manifest here": either nothing at that path, or
+      # the entry is a plain file so it has no children at all.
+      {:error, reason} when reason in [:enoent, :enotdir] -> false
+      # Anything else (EACCES on the directory, EIO) is ignorance, not
+      # absence — enumerate and let the start attempt report the truth.
+      {:error, _reason} -> true
+    end
   end
 
   @spec worker_info_for_id(Worker.id(), Path.t(), (Worker.id() -> Worker.otp_name())) ::

--- a/lib/bedrock/service/foreman/working_directory.ex
+++ b/lib/bedrock/service/foreman/working_directory.ex
@@ -5,10 +5,23 @@ defmodule Bedrock.Service.Foreman.WorkingDirectory do
   alias Bedrock.Service.Manifest
   alias Bedrock.Service.Worker
 
+  @manifest_file_name "manifest.json"
+
+  @doc """
+  The manifest's path within a worker's working directory.
+
+  The manifest is what makes a directory a worker directory: the foreman's
+  path also holds `object_storage/` and `raft/`, so enumeration keys off
+  this file's presence. Writer and reader must therefore agree on the
+  name exactly — hence one definition.
+  """
+  @spec manifest_path(Path.t()) :: Path.t()
+  def manifest_path(working_directory), do: Path.join(working_directory, @manifest_file_name)
+
   @spec initialize_working_directory(Path.t(), Manifest.t()) ::
           :ok | {:error, File.posix()}
   def initialize_working_directory(working_directory, manifest) do
-    path_to_manifest = Path.join(working_directory, "manifest.json")
+    path_to_manifest = manifest_path(working_directory)
 
     with :ok <- File.mkdir_p(working_directory),
          :ok <- manifest.worker.one_time_initialization(working_directory) do
@@ -32,7 +45,7 @@ defmodule Bedrock.Service.Foreman.WorkingDirectory do
              | :worker_module_failed_to_load
              | :worker_module_is_invalid}
   def read_and_validate_manifest(path, worker_id, cluster_name) do
-    with {:ok, manifest} <- load_from_file(Path.join(path, "manifest.json")),
+    with {:ok, manifest} <- load_from_file(manifest_path(path)),
          :ok <- check_manifest_id(manifest, worker_id),
          :ok <- check_manifest_cluster_name(manifest, cluster_name) do
       {:ok, manifest}

--- a/test/bedrock/service/foreman/worker_enumeration_test.exs
+++ b/test/bedrock/service/foreman/worker_enumeration_test.exs
@@ -1,0 +1,195 @@
+defmodule Bedrock.Service.Foreman.WorkerEnumerationTest do
+  use ExUnit.Case, async: true
+
+  alias Bedrock.Service.Foreman.Impl
+  alias Bedrock.Service.Foreman.StartingWorkers
+  alias Bedrock.Service.Foreman.State
+
+  defmodule EnumerationTestCluster do
+    @moduledoc false
+    def name, do: "enumeration_test_cluster"
+    def otp_name_for_worker(id), do: :"enumeration_test_worker_#{id}"
+    def otp_name(:worker_supervisor), do: :enumeration_test_worker_supervisor
+    def otp_name(:link), do: :enumeration_test_link
+    def otp_name(:foreman), do: :enumeration_test_foreman
+  end
+
+  # The foreman's path is not a private worker registry — the cluster
+  # supervisor derives object_storage/ from the same :path it hands the
+  # foreman, and the coordinator derives raft/ from the same base. Both
+  # are permanent siblings of the worker directories, so "every entry
+  # under path is a worker" is never true in a real deployment.
+  @moduletag :tmp_dir
+
+  defp worker_dir(dir, id, manifest_body) do
+    path = Path.join(dir, id)
+    :ok = File.mkdir_p(path)
+    :ok = File.write(Path.join(path, "manifest.json"), manifest_body)
+    path
+  end
+
+  defp bare_dir(dir, name) do
+    path = Path.join(dir, name)
+    :ok = File.mkdir_p(path)
+    path
+  end
+
+  defp enumerate(dir), do: dir |> StartingWorkers.worker_paths_from_disk() |> Enum.sort()
+
+  describe "worker_paths_from_disk/1" do
+    test "returns worker directories", %{tmp_dir: dir} do
+      a = worker_dir(dir, "aaaaaaaa", ~s({"id":"aaaaaaaa"}))
+      b = worker_dir(dir, "bbbbbbbb", ~s({"id":"bbbbbbbb"}))
+
+      assert enumerate(dir) == Enum.sort([a, b])
+    end
+
+    test "excludes the object_storage and raft siblings", %{tmp_dir: dir} do
+      worker = worker_dir(dir, "aaaaaaaa", ~s({"id":"aaaaaaaa"}))
+      bare_dir(dir, "object_storage")
+      bare_dir(dir, "raft")
+
+      assert enumerate(dir) == [worker]
+    end
+
+    test "excludes a directory with no manifest at all", %{tmp_dir: dir} do
+      worker = worker_dir(dir, "aaaaaaaa", ~s({"id":"aaaaaaaa"}))
+      bare_dir(dir, "ta2y6ro4")
+
+      assert enumerate(dir) == [worker]
+    end
+
+    test "excludes stray files", %{tmp_dir: dir} do
+      worker = worker_dir(dir, "aaaaaaaa", ~s({"id":"aaaaaaaa"}))
+      :ok = File.write(Path.join(dir, "bootstrap"), "not a worker")
+
+      assert enumerate(dir) == [worker]
+    end
+
+    # A present-but-unreadable manifest is a worker in trouble, not a
+    # non-worker. Silently dropping it would hide a real failure, so it
+    # must still be enumerated and surface downstream as :failed_to_start.
+    test "still returns a worker whose manifest is corrupt", %{tmp_dir: dir} do
+      corrupt = worker_dir(dir, "cccccccc", "{ this is not json")
+
+      assert enumerate(dir) == [corrupt]
+    end
+
+    # Absence is the only thing that excludes. A stat that fails for any
+    # other reason is ignorance, and a live worker holding a WAL must not
+    # disappear from the foreman's view because of a permissions mistake.
+    test "still returns a worker whose manifest cannot be stat'ed", %{tmp_dir: dir} do
+      unreadable = worker_dir(dir, "dddddddd", ~s({"id":"dddddddd"}))
+      on_exit(fn -> File.chmod(unreadable, 0o755) end)
+      :ok = File.chmod(unreadable, 0o000)
+
+      assert {:error, :eacces} = File.stat(Path.join(unreadable, "manifest.json"))
+      assert enumerate(dir) == [unreadable]
+    end
+
+    test "leaves excluded directories on disk", %{tmp_dir: dir} do
+      worker_dir(dir, "aaaaaaaa", ~s({"id":"aaaaaaaa"}))
+      orphan = bare_dir(dir, "ta2y6ro4")
+      storage = bare_dir(dir, "object_storage")
+
+      _ = enumerate(dir)
+
+      assert File.dir?(orphan), "enumeration must never delete; a WAL is real data"
+      assert File.dir?(storage)
+    end
+  end
+
+  describe "worker_info_from_path/2" do
+    test "admits only real workers to the worker map", %{tmp_dir: dir} do
+      worker_dir(dir, "aaaaaaaa", ~s({"id":"aaaaaaaa"}))
+      bare_dir(dir, "object_storage")
+      bare_dir(dir, "raft")
+      bare_dir(dir, "ta2y6ro4")
+
+      assert [%{id: "aaaaaaaa"}] = StartingWorkers.worker_info_from_path(dir, &:"worker_#{&1}")
+    end
+  end
+
+  describe "abandoned_paths_from_disk/1" do
+    test "reports a manifest-less directory", %{tmp_dir: dir} do
+      worker_dir(dir, "aaaaaaaa", ~s({"id":"aaaaaaaa"}))
+      orphan = bare_dir(dir, "ta2y6ro4")
+
+      assert StartingWorkers.abandoned_paths_from_disk(dir) == [orphan]
+    end
+
+    test "says nothing about another component's directories", %{tmp_dir: dir} do
+      worker_dir(dir, "aaaaaaaa", ~s({"id":"aaaaaaaa"}))
+      bare_dir(dir, "object_storage")
+      bare_dir(dir, "raft")
+
+      assert StartingWorkers.abandoned_paths_from_disk(dir) == []
+    end
+
+    test "says nothing about a healthy directory of workers", %{tmp_dir: dir} do
+      worker_dir(dir, "aaaaaaaa", ~s({"id":"aaaaaaaa"}))
+      worker_dir(dir, "bbbbbbbb", ~s({"id":"bbbbbbbb"}))
+
+      assert StartingWorkers.abandoned_paths_from_disk(dir) == []
+    end
+
+    test "does not report a worker whose manifest is merely corrupt", %{tmp_dir: dir} do
+      worker_dir(dir, "cccccccc", "{ this is not json")
+
+      assert StartingWorkers.abandoned_paths_from_disk(dir) == []
+    end
+
+    test "does not report stray files", %{tmp_dir: dir} do
+      :ok = File.write(Path.join(dir, "bootstrap"), "not a worker")
+
+      assert StartingWorkers.abandoned_paths_from_disk(dir) == []
+    end
+
+    test "reports every orphan, sorted", %{tmp_dir: dir} do
+      a = bare_dir(dir, "aflw25ra")
+      d = bare_dir(dir, "d4if54s2")
+      t = bare_dir(dir, "ta2y6ro4")
+
+      assert StartingWorkers.abandoned_paths_from_disk(dir) == Enum.sort([a, d, t])
+    end
+  end
+
+  # The report has to reach an operator at the moment one is looking, and
+  # boot is that moment: an unstartable directory produces no worker, so
+  # it has no other voice anywhere in the system.
+  describe "spin-up reporting" do
+    defp spin_up(dir) do
+      state = %State{
+        cluster: EnumerationTestCluster,
+        capabilities: [:log],
+        health: :ok,
+        otp_name: :enumeration_test_foreman,
+        path: dir,
+        waiting_for_healthy: [],
+        workers: %{}
+      }
+
+      ExUnit.CaptureLog.capture_log(fn -> Impl.do_spin_up(state) end)
+    end
+
+    test "names the abandoned directories at boot", %{tmp_dir: dir} do
+      bare_dir(dir, "ta2y6ro4")
+      bare_dir(dir, "aflw25ra")
+
+      log = spin_up(dir)
+
+      assert log =~ "abandoned working directories"
+      assert log =~ "ta2y6ro4"
+      assert log =~ "aflw25ra"
+      assert log =~ dir
+    end
+
+    test "stays quiet when there is nothing to report", %{tmp_dir: dir} do
+      worker_dir(dir, "aaaaaaaa", ~s({"id":"aaaaaaaa"}))
+      bare_dir(dir, "object_storage")
+      bare_dir(dir, "raft")
+
+      refute spin_up(dir) =~ "abandoned working"
+    end
+  end
+end


### PR DESCRIPTION
Closes bedrock-61c.2 (epic bedrock-61c).

`worker_paths_from_disk/1` globbed every entry under the foreman's path and called each a worker. That path is shared — the cluster supervisor derives `object_storage/` from the same `:path` it hands the foreman, and every deployment config puts the coordinator's `raft/` alongside it. Both landed in the worker map as `{:failed_to_start, :manifest_does_not_exist}`, as did the remains of workers whose manifests are gone.

### Why the orphans are stuck

Retirement runs **through** the worker: `Foreman.worker_retired/2` is called by a live process holding the id and foreman ref that its *manifest* supplied. A directory with no manifest starts no process, is never judged displaced, and can never retire itself. It is retried and re-failed on every boot while holding its disk, invisibly. On the cluster that prompted this, that is 129 MB across three directories untouched since a crash five days earlier.

### Changes
- key enumeration off the manifest's presence, single-sourced as `WorkingDirectory.manifest_path/1`
- **absence is the only thing that excludes.** A corrupt manifest is a worker in trouble; a manifest that cannot be stat'ed for any reason other than absence is a worker we cannot rule out. Both stay enumerated and surface as `:failed_to_start`, so no live worker vanishes from the foreman's view because of a permissions mistake (`File.exists?/1` returns `false` on `EACCES` — that hole is closed)
- report manifest-less directories by name at boot, and leave them alone

### Deliberately not reclaiming
The directory may hold a WAL, and deleting data on a guess is not the foreman's call. There is no automatic reclamation path and this PR does not add one — cleanup is the operator's, which is why the log names the paths.

### Verification
2811 tests, 0 failures. Credo and dialyzer clean.

Adversarially audited by a cold agent. It corrected an earlier draft of this change on two counts, both fixed here: the `EACCES` hole above, and an original rationale claiming the foreman was pinned unhealthy — that chain does not execute, because `do_spin_up/1` never calls `recompute_health/1`. That turned out to be a real pre-existing bug in its own right and is filed as bedrock-mxt, along with an order-dependent health fold as bedrock-287.