### PR TITLE
Make the foreman's health verdict independent of worker order

### DIFF
--- a/lib/bedrock/service/foreman/health.ex
+++ b/lib/bedrock/service/foreman/health.ex
@@ -4,16 +4,51 @@ defmodule Bedrock.Service.Foreman.Health do
   alias Bedrock.Service.Foreman
   alias Bedrock.Service.Foreman.WorkerInfo
 
+  @doc """
+  Summarises a set of workers into one foreman verdict.
+
+  The verdict describes a SET, so it cannot depend on the order the
+  members arrive in — `recompute_health/1` folds `Map.values/1`, whose
+  order follows however worker ids happen to sort. Stated as precedence
+  over the whole collection rather than as a pairwise fold, which is what
+  makes the independence obvious:
+
+    * any worker failed to start — the foreman is failed, and no number
+      of healthy siblings may soften that
+    * any health we do not recognise — `:unknown`, because "we cannot
+      tell" must not be reported as progress
+    * any worker still stopped — `:starting`
+    * otherwise every worker is running, so `:ok` (vacuously so when
+      there are no workers at all)
+  """
   @spec compute_health_from_worker_info([WorkerInfo.t()]) :: Foreman.health()
   def compute_health_from_worker_info(worker_info) do
-    worker_info
-    |> Enum.map(& &1.health)
-    |> Enum.reduce(:ok, fn
-      {:ok, _}, :ok -> :ok
-      {:ok, _}, _ -> :starting
-      {:failed_to_start, _}, :ok -> :starting
-      {:failed_to_start, _}, _ -> {:failed_to_start, :at_least_one_failed_to_start}
-      _, _ -> :unknown
-    end)
+    healths = Enum.map(worker_info, & &1.health)
+
+    cond do
+      Enum.any?(healths, &match?({:failed_to_start, _}, &1)) ->
+        {:failed_to_start, :at_least_one_failed_to_start}
+
+      Enum.any?(healths, &(not recognised?(&1))) ->
+        :unknown
+
+      Enum.any?(healths, &(&1 == :stopped)) ->
+        :starting
+
+      true ->
+        :ok
+    end
   end
+
+  # Deliberately `term()`, not `WorkerInfo.health()`: this exists to
+  # catch a value that is NOT one of those three, and typing the argument
+  # as the very type that excludes them would make the catch-all
+  # statically unreachable. It is reachable in fact —
+  # `Foreman.report_health/3` accepts `Worker.health()`, which includes
+  # `{:error, :timeout | :unavailable}`, and that lands in this field.
+  @spec recognised?(term()) :: boolean()
+  defp recognised?({:ok, _pid}), do: true
+  defp recognised?(:stopped), do: true
+  defp recognised?({:failed_to_start, _reason}), do: true
+  defp recognised?(_health), do: false
 end

--- a/lib/bedrock/service/foreman/state.ex
+++ b/lib/bedrock/service/foreman/state.ex
@@ -1,6 +1,7 @@
 defmodule Bedrock.Service.Foreman.State do
   @moduledoc false
   alias Bedrock.Cluster
+  alias Bedrock.Service.Foreman
   alias Bedrock.Service.Foreman.State
   alias Bedrock.Service.Foreman.WorkerInfo
   alias Bedrock.Service.Worker
@@ -8,7 +9,7 @@ defmodule Bedrock.Service.Foreman.State do
   @type t :: %__MODULE__{
           cluster: Cluster.t(),
           capabilities: [Cluster.capability()],
-          health: :starting | :ok | :error,
+          health: Foreman.health(),
           otp_name: atom(),
           path: Path.t(),
           object_storage: term(),
@@ -57,10 +58,10 @@ defmodule Bedrock.Service.Foreman.State do
         ) :: State.t()
   def update_workers(t, updater), do: %{t | workers: updater.(t.workers)}
 
-  @spec update_health(State.t(), (:starting | :ok | :error -> :starting | :ok | :error)) :: State.t()
+  @spec update_health(State.t(), (Foreman.health() -> Foreman.health())) :: State.t()
   def update_health(t, updater), do: %{t | health: updater.(t.health)}
 
-  @spec put_health(State.t(), :starting | :ok | :error) :: State.t()
+  @spec put_health(State.t(), Foreman.health()) :: State.t()
   def put_health(t, health), do: %{t | health: health}
 
   @spec update_waiting_for_healthy(State.t(), ([GenServer.from()] -> [GenServer.from()])) ::

--- a/test/bedrock/service/foreman/health_test.exs
+++ b/test/bedrock/service/foreman/health_test.exs
@@ -1,0 +1,99 @@
+defmodule Bedrock.Service.Foreman.HealthTest do
+  use ExUnit.Case, async: true
+
+  import Bedrock.Service.Foreman.Health, only: [compute_health_from_worker_info: 1]
+
+  # The verdict summarises a SET of workers, so it must not depend on the
+  # order they happen to arrive in. `recompute_health/1` folds
+  # `Map.values(t.workers)`, and for small maps Erlang returns keys in
+  # term order — so an order-sensitive fold makes the foreman's health a
+  # function of how worker ids happen to sort.
+
+  defp ok, do: %{health: {:ok, self()}}
+  defp failed, do: %{health: {:failed_to_start, :manifest_does_not_exist}}
+  defp stopped, do: %{health: :stopped}
+  defp unrecognised, do: %{health: {:error, :timeout}}
+
+  describe "compute_health_from_worker_info/1" do
+    test "no workers is healthy" do
+      assert compute_health_from_worker_info([]) == :ok
+    end
+
+    test "all running is healthy" do
+      assert compute_health_from_worker_info([ok(), ok(), ok()]) == :ok
+    end
+
+    test "a stopped worker is still starting" do
+      assert compute_health_from_worker_info([ok(), stopped()]) == :starting
+    end
+
+    test "a single failure is reported however many healthy workers surround it" do
+      assert compute_health_from_worker_info([failed()]) ==
+               {:failed_to_start, :at_least_one_failed_to_start}
+
+      assert compute_health_from_worker_info([ok(), failed()]) ==
+               {:failed_to_start, :at_least_one_failed_to_start}
+
+      assert compute_health_from_worker_info([failed(), ok()]) ==
+               {:failed_to_start, :at_least_one_failed_to_start}
+    end
+
+    # The specific regression: `{:ok, _}, _ -> :starting` overwrote an
+    # already-recorded failure, so [bad, ok] reported :starting — a
+    # wedged worker indistinguishable from a slow boot.
+    test "a healthy worker never clears a recorded failure" do
+      assert compute_health_from_worker_info([failed(), failed(), ok()]) ==
+               {:failed_to_start, :at_least_one_failed_to_start}
+
+      assert compute_health_from_worker_info([failed(), ok(), ok(), ok()]) ==
+               {:failed_to_start, :at_least_one_failed_to_start}
+    end
+
+    test "failure outranks merely starting" do
+      assert compute_health_from_worker_info([stopped(), failed()]) ==
+               {:failed_to_start, :at_least_one_failed_to_start}
+
+      assert compute_health_from_worker_info([failed(), stopped()]) ==
+               {:failed_to_start, :at_least_one_failed_to_start}
+    end
+
+    # Reachable in fact, not just in theory: Foreman.report_health/3
+    # accepts Worker.health(), which includes {:error, :timeout}, and
+    # that value lands straight in this field.
+    test "an unrecognized health is not silently treated as progress" do
+      assert compute_health_from_worker_info([ok(), unrecognised()]) == :unknown
+
+      # The discriminating order: a healthy worker AFTER the unknown one
+      # used to overwrite the verdict back to :starting.
+      assert compute_health_from_worker_info([unrecognised(), ok()]) == :unknown
+    end
+
+    # The property the fold has to satisfy, stated directly.
+    test "the verdict is invariant under permutation" do
+      for workers <- [
+            [ok(), failed(), stopped()],
+            [ok(), ok(), failed()],
+            [stopped(), ok()],
+            [failed(), failed()],
+            [ok(), ok(), ok()],
+            [stopped(), stopped(), ok(), failed()],
+            [ok(), unrecognised()],
+            [unrecognised(), stopped(), ok()],
+            [failed(), unrecognised(), ok()]
+          ] do
+        expected = compute_health_from_worker_info(workers)
+
+        for permutation <- permutations(workers) do
+          assert compute_health_from_worker_info(permutation) == expected,
+                 "order changed the verdict for #{inspect(Enum.map(workers, & &1.health))}"
+        end
+      end
+    end
+  end
+
+  defp permutations([]), do: [[]]
+
+  defp permutations(list) do
+    for element <- list, rest <- permutations(list -- [element]), do: [element | rest]
+  end
+end


### PR DESCRIPTION
Closes bedrock-287.

`compute_health_from_worker_info/1` was a pairwise fold whose clause `{:ok, _}, _ -> :starting` overwrote an already-recorded failure, so the verdict depended on the order workers arrived in:

| input | old | new |
|---|---|---|
| `[ok, bad, bad]` | `{:failed_to_start, _}` | `{:failed_to_start, _}` |
| `[bad, bad, ok]` | `:starting` | `{:failed_to_start, _}` |
| `[ok, bad]` | `:starting` | `{:failed_to_start, _}` |
| `[bad]` | `:starting` | `{:failed_to_start, _}` |

`recompute_health/1` folds `Map.values(t.workers)`, and small Erlang maps iterate in term order — so whether a wedged worker was reported came down to how worker ids sort. Exhaustively: over every multiset of size 1–3 drawn from the four reachable health shapes, **18 distinct multisets change verdict under permutation**. The last row is the starkest — a foreman hosting exactly one worker, and that worker failed to start, reported `:starting`.

A second bug shared the clause list: `:stopped` matched only the catch-all, so a still-starting worker yielded `:unknown`.

### Approach
State the verdict as precedence over the whole collection rather than as a pairwise fold, so order-independence is structural instead of something to re-derive clause by clause.

### No caller can observe a difference in what anything actually reads
The `:ok` / not-`:ok` partition is **identical** before and after: the old fold could only reach `:ok` via `{:ok, _}, :ok` and never re-entered it once it left, so both versions return `:ok` exactly when every worker is running. Both consumers (`do_wait_for_healthy/2`, `notify_waiting_for_healthy/1`) match `:ok` literally.

`:unknown` is kept and is **not** dead code — `Foreman.report_health/3` accepts `Worker.health()`, which includes `{:error, :timeout | :unavailable}`, and that reaches this field.

### Verification
2803 tests, 0 failures. Credo and dialyzer clean.

Adversarially audited by a cold agent, which reproduced both bugs against the pre-fix code by exhaustive enumeration, proved the `:ok` partition is unchanged, and confirmed 5 of the 8 new tests fail against it. Its findings are applied here: `recognised?/1` is spec'd `term()` (typing it `WorkerInfo.health()` would make the branch it exists for statically unreachable), `State`'s health typespec is corrected, and two weak tests were strengthened — my `:unknown` test had used the one ordering that does not discriminate.

Two follow-ups filed: bedrock-n5h (removal recomputes health without waking waiters) and bedrock-1a6 (the verdict has no reader at all, which is why these bugs went unnoticed).