### PR TITLE
Publish local objects atomically, never claim a key with a partial one

### DIFF
--- a/lib/bedrock/object_storage/chunk.ex
+++ b/lib/bedrock/object_storage/chunk.ex
@@ -229,7 +229,8 @@ defmodule Bedrock.ObjectStorage.Chunk do
          dir_size = header.directory_size,
          true <- byte_size(rest) >= dir_size,
          <<dir_binary::binary-size(^dir_size), data::binary>> = rest,
-         {:ok, directory} <- decode_directory(dir_binary, header.txn_count) do
+         {:ok, directory} <- decode_directory(dir_binary, header.txn_count),
+         true <- data_section_complete?(directory, data) do
       {:ok, %{header: header, directory: directory, data: data}}
     else
       false -> {:error, :truncated_chunk}
@@ -239,6 +240,26 @@ defmodule Bedrock.ObjectStorage.Chunk do
 
   def decode(_) do
     {:error, :truncated_chunk}
+  end
+
+  # The directory is a map of extents into the data section; a chunk whose
+  # data stops short of them is torn, not merely odd. Checking it here
+  # keeps truncation a decode error: without it the header and directory
+  # parse cleanly, decode reports success, and the missing bytes surface
+  # only as an ArgumentError out of binary_part/3 in
+  # `extract_transactions/1` — at read time, far from the write.
+  #
+  # An empty directory is rejected rather than waved through: `encode/1`
+  # refuses to emit one (`{:error, :empty_chunk}`), so a chunk claiming
+  # zero transactions is corrupt however well-formed its header looks —
+  # and accepting it would decode as an empty chunk and read as a silent
+  # replay gap.
+  defp data_section_complete?([], _data), do: false
+
+  defp data_section_complete?(directory, data) do
+    required = Enum.reduce(directory, 0, fn %{offset: offset, length: length}, acc -> max(acc, offset + length) end)
+
+    byte_size(data) >= required
   end
 
   @doc """

--- a/lib/bedrock/object_storage/local_filesystem.ex
+++ b/lib/bedrock/object_storage/local_filesystem.ex
@@ -5,6 +5,49 @@ defmodule Bedrock.ObjectStorage.LocalFilesystem do
   This backend stores objects as files on the local filesystem, useful for
   development and testing. The directory structure mirrors the object keys.
 
+  ## Write atomicity
+
+  Readers are written against S3's contract: an object is complete or it
+  is absent, and `put_if_not_exists/4` claims a key only by publishing a
+  whole object.
+
+  That matters most for `put_if_not_exists/4`, the writer for chunks,
+  snapshots and the bootstrap record. Its callers in the data plane
+  (`Demux.ShardServer`, `ChunkWriter`, `Snapshot`) read `:already_exists`
+  as success, so a key claimed by a short object would report success to
+  everyone forever and could never be rewritten. The bootstrap callers
+  (`ClusterBootstrap.Discovery`, recovery's `PersistencePhase`) instead
+  treat it as a lost race, which is only sound if the winner's object is
+  whole.
+
+  Every write therefore goes to a scratch file in the target's own
+  directory, is fsynced, and is published in one step — `rename` for
+  `put/4`, `link` for `put_if_not_exists/4` (rename would clobber an
+  existing object and so cannot express create-only). A failure at any
+  point removes the scratch file and leaves the key untouched, so a
+  retry can still take it.
+
+  ## Scratch files left by a killed writer
+
+  In-process failures clean up after themselves. A process killed
+  between the scratch write and the publish cannot, so its scratch file
+  survives — full size, hidden from `list/3`, and reclaimed by nothing.
+  That is the deliberate trade: before, the same crash left wreckage
+  visible under the real key, where it was permanent and poisonous;
+  now it is inert but invisible. Reclaiming it needs a sweep that can
+  tell a dead scratch file from a live writer's, which is a separate
+  piece of work (bedrock-ck3).
+
+  ## Durability boundary
+
+  Object content is fsynced before publication, but the parent
+  DIRECTORY is not: Erlang's `:file.open/2` refuses a directory with
+  `:eisdir`, so the directory entry cannot be synced from the BEAM
+  without a NIF. On power loss a just-published object may therefore be
+  absent rather than short. Absent is a state the writers already handle;
+  short under a permanently-claimed key is the one that could not be
+  recovered from.
+
   ## Configuration
 
   - `:root` - Required. The root directory for storing objects.
@@ -20,13 +63,32 @@ defmodule Bedrock.ObjectStorage.LocalFilesystem do
 
   alias Bedrock.ObjectStorage
 
+  # Scratch files live in the target's own directory, so publishing is a
+  # rename or link within one filesystem — the only way it is atomic. The
+  # leading dot and the prefix keep them out of `list/3`. No key `Keys`
+  # builds can begin with this prefix (they are `c/`, `s/` and a
+  # base36 suffix), though the bootstrap key is free-form app-env text,
+  # so that remains a convention rather than something enforced here.
+  @scratch_prefix ".bedrock-tmp."
+
+  # Exhausting these means the same node, pid and unique-integer collided
+  # repeatedly, which is not a real filesystem state — surfacing :eexist
+  # beats looping.
+  @scratch_attempts 5
+
   @impl true
   def put(config, key, data, _opts \\ []) do
     root = Keyword.fetch!(config, :root)
     path = build_path(root, key)
 
-    with :ok <- ensure_parent_dir(path) do
-      File.write(path, data)
+    with :ok <- ensure_parent_dir(path),
+         {:ok, scratch} <- write_scratch(path, data) do
+      # rename consumes the scratch name on success, so there is nothing
+      # to clean up there; on failure it is still ours to remove.
+      case :file.rename(scratch, path) do
+        :ok -> :ok
+        {:error, reason} -> discard_scratch(scratch, reason)
+      end
     end
   end
 
@@ -72,22 +134,37 @@ defmodule Bedrock.ObjectStorage.LocalFilesystem do
     root = Keyword.fetch!(config, :root)
     path = build_path(root, key)
 
-    with :ok <- ensure_parent_dir(path) do
-      case :file.open(path, [:write, :binary, :exclusive]) do
-        {:ok, fd} ->
-          try do
-            :ok = :file.write(fd, data)
-            :ok
-          after
-            :file.close(fd)
-          end
+    # Advisory short-circuit; `link` in claim_key/2 is still what decides.
+    # This only avoids writing and fsyncing an entire payload to discover
+    # the key was already taken — not a rare path, since re-putting an
+    # existing chunk or snapshot is the ordinary idempotent outcome.
+    if File.exists?(path) do
+      {:error, :already_exists}
+    else
+      claim_key(path, data)
+    end
+  end
 
-        {:error, :eexist} ->
-          {:error, :already_exists}
+  # Link, not rename: rename would clobber an existing object, so it
+  # cannot express create-only. `link` fails with :eexist exactly when the
+  # key is taken, and when it succeeds it publishes an object that is
+  # already whole and synced — the same all-or-nothing claim S3 gives with
+  # `if_none_match: "*"`.
+  @spec claim_key(Path.t(), iodata()) :: :ok | {:error, :already_exists | File.posix()}
+  defp claim_key(path, data) do
+    with :ok <- ensure_parent_dir(path),
+         {:ok, scratch} <- write_scratch(path, data) do
+      result =
+        case :file.make_link(scratch, path) do
+          :ok -> :ok
+          {:error, :eexist} -> {:error, :already_exists}
+          {:error, reason} -> {:error, reason}
+        end
 
-        {:error, reason} ->
-          {:error, reason}
-      end
+      # link leaves the scratch name in place whether or not it
+      # succeeded, so it is always ours to remove.
+      _ = File.rm(scratch)
+      result
     end
   end
 
@@ -136,6 +213,67 @@ defmodule Bedrock.ObjectStorage.LocalFilesystem do
     |> File.mkdir_p()
   end
 
+  # Write the whole object to a scratch file and fsync it, so that
+  # whatever gets published is complete and on disk BEFORE it is
+  # reachable under its key. Any failure cleans up after itself and
+  # surfaces as an error: a half-written scratch file must never be left
+  # to be mistaken for an object, and the key must stay unclaimed so a
+  # retry can still take it.
+  @spec write_scratch(Path.t(), iodata()) :: {:ok, Path.t()} | {:error, File.posix()}
+  defp write_scratch(path, data) do
+    # :exclusive makes the kernel arbitrate the scratch name, which is the
+    # only thing that can. A root directory is routinely shared by more
+    # than one node — the default one (`ObjectStorage.Config`) is derived
+    # from the system tmp dir and carries nothing node-specific — and
+    # :erlang.unique_integer/1 is unique only WITHIN a node: two VMs
+    # readily produce the same values. Two writers landing on one scratch
+    # name would interleave their bytes into a single inode and then
+    # publish the splice, which is the exact failure this module exists
+    # to prevent. Node and OS pid make a collision unlikely; :exclusive
+    # makes it impossible, and a retry costs a filename.
+    case open_scratch(path, @scratch_attempts) do
+      {:ok, fd, scratch} ->
+        result = with :ok <- :file.write(fd, data), do: :file.sync(fd)
+        _ = :file.close(fd)
+        finish_scratch(result, scratch)
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  @spec open_scratch(Path.t(), pos_integer()) :: {:ok, :file.io_device(), Path.t()} | {:error, File.posix()}
+  defp open_scratch(_path, 0), do: {:error, :eexist}
+
+  defp open_scratch(path, attempts_left) do
+    scratch =
+      Path.join(
+        Path.dirname(path),
+        "#{@scratch_prefix}#{Path.basename(path)}.#{node()}.#{System.pid()}.#{:erlang.unique_integer([:positive])}"
+      )
+
+    case :file.open(scratch, [:write, :binary, :raw, :exclusive]) do
+      {:ok, fd} -> {:ok, fd, scratch}
+      {:error, :eexist} -> open_scratch(path, attempts_left - 1)
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp finish_scratch(:ok, scratch), do: {:ok, scratch}
+
+  defp finish_scratch({:error, reason}, scratch) do
+    _ = File.rm(scratch)
+    {:error, reason}
+  end
+
+  @spec discard_scratch(Path.t(), term()) :: {:error, term()}
+  defp discard_scratch(scratch, reason) do
+    _ = File.rm(scratch)
+    {:error, reason}
+  end
+
+  defp scratch_file?(path), do: path |> Path.basename() |> String.starts_with?(@scratch_prefix)
+
   # List state: {root, dirs_to_visit, files_collected, prefix, remaining_limit}
   defp init_list_state(root, prefix_path, prefix, limit) do
     if File.dir?(prefix_path) do
@@ -178,7 +316,9 @@ defmodule Bedrock.ObjectStorage.LocalFilesystem do
           |> Enum.map(&Path.join(dir, &1))
           |> Enum.split_with(&File.regular?/1)
 
-        sorted_files = Enum.sort(files)
+        # A scratch file is a write in progress or the wreckage of one.
+        # It is never an object, and must not be reported as a key.
+        sorted_files = files |> Enum.reject(&scratch_file?/1) |> Enum.sort()
         sorted_subdirs = subdirs |> Enum.filter(&may_contain_prefix?(&1, root, prefix)) |> Enum.sort()
 
         list_next({root, sorted_subdirs ++ rest_dirs, sorted_files, prefix, limit})

--- a/test/bedrock/object_storage/chunk_test.exs
+++ b/test/bedrock/object_storage/chunk_test.exs
@@ -93,6 +93,28 @@ defmodule Bedrock.ObjectStorage.ChunkTest do
     test "returns error for truncated chunk" do
       assert {:error, :truncated_chunk} = Chunk.decode(<<1, 2, 3>>)
     end
+
+    # A tear PAST the directory used to slip through: the header and
+    # directory both parse, so decode reported success, and the missing
+    # bytes only surfaced as an ArgumentError from binary_part/3 inside
+    # extract_transactions/1 — at read time, deep in a materializer
+    # catch-up or a recovery replay, far from whatever wrote it.
+    test "returns error when the data section is short of the directory" do
+      transactions = [{100, String.duplicate("a", 64)}, {200, String.duplicate("b", 64)}]
+      {:ok, binary} = Chunk.encode(transactions)
+
+      torn = binary_part(binary, 0, byte_size(binary) - 32)
+
+      assert {:error, :truncated_chunk} = Chunk.decode(torn)
+    end
+
+    test "accepts a chunk whose data section is exactly complete" do
+      transactions = [{100, String.duplicate("a", 64)}, {200, String.duplicate("b", 64)}]
+      {:ok, binary} = Chunk.encode(transactions)
+
+      assert {:ok, chunk} = Chunk.decode(binary)
+      assert Chunk.extract_transactions(chunk) == transactions
+    end
   end
 
   describe "extract_transactions/1" do

--- a/test/bedrock/object_storage/local_filesystem_atomicity_test.exs
+++ b/test/bedrock/object_storage/local_filesystem_atomicity_test.exs
@@ -1,0 +1,185 @@
+defmodule Bedrock.ObjectStorage.LocalFilesystemAtomicityTest do
+  use ExUnit.Case, async: true
+
+  alias Bedrock.ObjectStorage
+  alias Bedrock.ObjectStorage.LocalFilesystem
+
+  # Readers of this store are written against S3's contract: one atomic
+  # PUT, so an object is complete or absent, and put-if-not-exists claims
+  # a key only by publishing a whole object. A local backend that creates
+  # the key first and fills it second can strand a permanently short
+  # object under a key nothing may ever rewrite — put_if_not_exists is
+  # the only writer for both chunks and snapshots, and both callers read
+  # :already_exists as success.
+
+  setup do
+    root = Path.join(System.tmp_dir!(), "atomicity_test_#{:erlang.unique_integer([:positive])}")
+    File.mkdir_p!(root)
+    on_exit(fn -> File.rm_rf!(root) end)
+
+    {:ok, backend: ObjectStorage.backend(LocalFilesystem, root: root), root: root}
+  end
+
+  defp all_files(root) do
+    root
+    |> Path.join("**")
+    |> Path.wildcard(match_dot: true)
+    |> Enum.filter(&File.regular?/1)
+    |> Enum.map(&Path.relative_to(&1, root))
+    |> Enum.sort()
+  end
+
+  describe "no intermediate state is observable" do
+    test "a completed put leaves exactly one file", %{backend: backend, root: root} do
+      :ok = ObjectStorage.put(backend, "c/0/obj", "payload")
+
+      assert all_files(root) == ["c/0/obj"],
+             "scratch files must not survive a successful put"
+    end
+
+    test "a completed put_if_not_exists leaves exactly one file", %{backend: backend, root: root} do
+      :ok = ObjectStorage.put_if_not_exists(backend, "c/0/obj", "payload")
+
+      assert all_files(root) == ["c/0/obj"]
+    end
+
+    test "scratch files are never visible to list/3", %{backend: backend, root: root} do
+      :ok = ObjectStorage.put(backend, "c/0/obj", "payload")
+
+      # A scratch file left behind by a killed writer, in the same
+      # directory the real object lives in.
+      File.write!(Path.join(root, "c/0/.bedrock-tmp.obj.999"), "half a pay")
+
+      assert backend |> ObjectStorage.list("c/") |> Enum.to_list() == ["c/0/obj"]
+    end
+
+    test "scratch files are never visible to get/2", %{backend: backend, root: root} do
+      File.mkdir_p!(Path.join(root, "c/0"))
+      File.write!(Path.join(root, "c/0/.bedrock-tmp.obj.999"), "half a pay")
+
+      assert {:error, :not_found} = ObjectStorage.get(backend, "c/0/obj")
+    end
+
+    # Scratch names must be arbitrated by the filesystem, not by a
+    # node-local counter. A root directory is routinely shared by more
+    # than one node — the default one is derived from the system tmp dir
+    # and carries nothing node-specific — and :erlang.unique_integer/1
+    # repeats freely across VMs. Two writers on one scratch name would
+    # interleave into a single inode and publish the splice.
+    test "concurrent writers to one key never splice their payloads", %{backend: backend, root: root} do
+      payloads = for i <- 1..16, do: String.duplicate(<<?a + i>>, 64_000)
+
+      results =
+        payloads
+        |> Task.async_stream(&ObjectStorage.put_if_not_exists(backend, "c/0/contended", &1),
+          max_concurrency: 16,
+          ordered: false
+        )
+        |> Enum.map(fn {:ok, result} -> result end)
+
+      assert Enum.count(results, &(&1 == :ok)) == 1,
+             "exactly one writer may claim the key"
+
+      assert Enum.all?(results, &(&1 in [:ok, {:error, :already_exists}])),
+             "a lost race is :already_exists, never a torn-write error: #{inspect(Enum.uniq(results))}"
+
+      {:ok, published} = ObjectStorage.get(backend, "c/0/contended")
+
+      assert published in payloads,
+             "the published object must be exactly one writer's payload, not a splice"
+
+      assert all_files(root) == ["c/0/contended"]
+    end
+
+    test "concurrent writers to distinct keys all succeed", %{backend: backend, root: root} do
+      results =
+        1..16
+        |> Task.async_stream(&ObjectStorage.put_if_not_exists(backend, "c/0/k#{&1}", "payload-#{&1}"),
+          max_concurrency: 16,
+          ordered: false
+        )
+        |> Enum.map(fn {:ok, result} -> result end)
+
+      assert Enum.all?(results, &(&1 == :ok)), "distinct keys must not contend: #{inspect(results)}"
+      assert length(all_files(root)) == 16
+    end
+  end
+
+  describe "put_if_not_exists/4 claims a key only with a whole object" do
+    test "refuses a key that already holds an object", %{backend: backend} do
+      :ok = ObjectStorage.put_if_not_exists(backend, "c/0/obj", "first")
+
+      assert {:error, :already_exists} = ObjectStorage.put_if_not_exists(backend, "c/0/obj", "second")
+      assert {:ok, "first"} = ObjectStorage.get(backend, "c/0/obj")
+    end
+
+    # The key point: a leftover scratch file is NOT a claim. Under the
+    # old create-then-write shape the claim was the empty target file
+    # itself, which no retry could ever displace.
+    test "succeeds when only a stale scratch file is present", %{backend: backend, root: root} do
+      File.mkdir_p!(Path.join(root, "c/0"))
+      File.write!(Path.join(root, "c/0/.bedrock-tmp.obj.999"), "wreckage")
+
+      assert :ok = ObjectStorage.put_if_not_exists(backend, "c/0/obj", "payload")
+      assert {:ok, "payload"} = ObjectStorage.get(backend, "c/0/obj")
+    end
+
+    # Re-putting an existing object is the ordinary idempotent outcome for
+    # chunks and snapshots, so the rejection must not cost a full payload
+    # write and fsync first.
+    test "rejecting a taken key does not write the payload", %{backend: backend, root: root} do
+      :ok = ObjectStorage.put_if_not_exists(backend, "c/0/obj", "first")
+      before = all_files(root)
+
+      assert {:error, :already_exists} =
+               ObjectStorage.put_if_not_exists(backend, "c/0/obj", String.duplicate("x", 1_000_000))
+
+      assert all_files(root) == before, "a rejected claim must leave no scratch file behind"
+      assert {:ok, "first"} = ObjectStorage.get(backend, "c/0/obj")
+    end
+  end
+
+  describe "write failures surface instead of raising" do
+    # ENOSPC is the realistic trigger. An unwritable parent directory
+    # reaches the same code path: the scratch open fails, and the caller
+    # must get an error rather than a MatchError — and must not leave a
+    # claimed key behind.
+    test "an unwritable directory returns an error and claims nothing", %{backend: backend, root: root} do
+      dir = Path.join(root, "c/0")
+      File.mkdir_p!(dir)
+      on_exit(fn -> File.chmod(dir, 0o755) end)
+      :ok = File.chmod(dir, 0o500)
+
+      assert {:error, _reason} = ObjectStorage.put_if_not_exists(backend, "c/0/obj", "payload")
+
+      :ok = File.chmod(dir, 0o755)
+      assert all_files(root) == [], "a failed write must leave no key and no scratch file"
+
+      # And the key is still claimable once the fault clears.
+      assert :ok = ObjectStorage.put_if_not_exists(backend, "c/0/obj", "payload")
+    end
+
+    test "put/4 on an unwritable directory returns an error", %{backend: backend, root: root} do
+      dir = Path.join(root, "c/0")
+      File.mkdir_p!(dir)
+      on_exit(fn -> File.chmod(dir, 0o755) end)
+      :ok = File.chmod(dir, 0o500)
+
+      assert {:error, _reason} = ObjectStorage.put(backend, "c/0/obj", "payload")
+    end
+
+    test "put/4 leaves the previous object intact when the new write fails", %{backend: backend, root: root} do
+      :ok = ObjectStorage.put(backend, "c/0/obj", "original")
+      dir = Path.join(root, "c/0")
+      on_exit(fn -> File.chmod(dir, 0o755) end)
+      :ok = File.chmod(dir, 0o500)
+
+      assert {:error, _reason} = ObjectStorage.put(backend, "c/0/obj", "replacement")
+
+      :ok = File.chmod(dir, 0o755)
+
+      assert {:ok, "original"} = ObjectStorage.get(backend, "c/0/obj"),
+             "a failed overwrite must not destroy the object it was replacing"
+    end
+  end
+end


### PR DESCRIPTION
Closes bedrock-ghd.

Readers of the object store are written against S3's contract: an object is complete or absent, and `put_if_not_exists` claims a key only by publishing a whole object. The local backend did not honour that — unlike the S3 backend, which uses one `put_object` with `if_none_match: "*"`.

`put_if_not_exists` opened the key with `:exclusive` and wrote to it as a **second step**, so between the two the key existed at zero length. A crash there claimed the key permanently: every later attempt gets `:eexist`, and the data-plane callers (`Demux.ShardServer`, `ChunkWriter`, `Snapshot`) read `{:error, :already_exists}` as success — so a short object would report success to everyone forever and could never be rewritten. `olivine/logic.ex` already warned that put-if-not-exists *"makes the poisoned bundle permanent"*; the backend could manufacture one on its own.

### Approach
Write to a scratch file in the target's own directory, fsync, publish in one step — `rename` for `put/4`, `link` for `put_if_not_exists/4` (rename clobbers, so it cannot express create-only). Failures remove the scratch and leave the key unclaimed, and write errors are returned rather than raised — the old `:ok = :file.write(fd, data)` turned ENOSPC into a MatchError with a poisoned key left behind.

### Two things the audit caught that I'd got wrong
- **The scratch name must be kernel-arbitrated.** `:erlang.unique_integer/1` is unique only *within* a node, and the default root is derived from the system tmp dir with nothing node-specific in it. Two nodes sharing a root could pick the same scratch name, interleave into one inode, and publish the splice — the exact failure this change exists to prevent. The auditor reproduced it: 878 spurious `{:error, :not_found}` results from a *PUT* in one paired run, which would `CaseClauseError` in `Discovery.write_bootstrap/4`. Scratch files are now created `:exclusive` and carry `node()` and the OS pid.
- **The idempotent path got 60× slower** (3 ms → 179 ms over 20 duplicate 32 MB puts), because the payload was written and fsynced before `:eexist` was discovered. Re-putting an existing chunk is the *ordinary* outcome, so there's now an advisory short-circuit; `link` still decides.

### Accepted trade, documented
A process killed between the write and the publish leaves a full-size scratch file that is inert but invisible, where the same crash previously left wreckage visible under the real key — permanent and poisonous. Reclaiming it needs a sweep that can tell a dead scratch from a live writer's; filed as bedrock-ck3.

Content is fsynced; the parent **directory** is not — Erlang's `:file.open` refuses a directory with `:eisdir`, so the entry cannot be synced from the BEAM without a NIF. I probed this rather than assuming. On power loss a just-published object may be *absent* rather than *short*; absent the writers already handle.

### Also: truncation becomes a decode error
`Chunk.decode/1` validated the header and directory but never the data section against the directory's extents, so a tear past the directory decoded as `{:ok, chunk}` and only failed as an `ArgumentError` from `binary_part/3` at read time, deep in a materializer catch-up. An empty directory is rejected too — `encode/1` refuses to emit one, so a header claiming zero transactions is corrupt however well-formed it looks.

### Coverage, stated plainly
That no key is ever claimed by a partial object is established **structurally** — one atomic publish — not by any test; proving it needs fault injection between write and publish. Three tests pin the old bugs; the rest guard observable consequences (one winner under contention with no splice, no scratch visible or left behind, a failed write that neither claims the key nor destroys what it was replacing). The cross-node collision is likewise closed structurally and cannot be exercised from one VM.

### Verification
2809 tests, 0 failures. `mix compile --warnings-as-errors` clean — the audit caught that my helper placement broke it, which CI (`elixir_ci.yaml:75`) would have failed on. Credo and dialyzer clean.