### PR TITLE
Report the recycler's failures instead of masking them

### DIFF
--- a/lib/bedrock/data_plane/log/shale/segment_recycler.ex
+++ b/lib/bedrock/data_plane/log/shale/segment_recycler.ex
@@ -222,8 +222,13 @@ defmodule Bedrock.DataPlane.Log.Shale.SegmentRecycler do
         {:ok, state} ->
           reply(state, :ok, continue: :ensure_min_available)
 
+        # Refill on the failure path too. An exhausted pool is the one
+        # moment a refill is most needed, and nothing else drives
+        # :ensure_min_available — so a pool that ever reached zero could
+        # never recover, and every later checkout would fail even after
+        # whatever caused the exhaustion had cleared.
         {:error, _reason} = error ->
-          reply(state, error)
+          reply(state, error, continue: :ensure_min_available)
       end
     end
 
@@ -243,7 +248,12 @@ defmodule Bedrock.DataPlane.Log.Shale.SegmentRecycler do
       |> Logic.ensure_min_available(state.min_available)
       |> case do
         {:ok, state} -> noreply(state)
-        {:error, reason} -> stop(reason, :shutdown)
+        # stop/2 is stop(state, reason). Transposed, this exited with
+        # :shutdown — an orderly-looking stop — and installed the real
+        # cause as the state, discarding exactly the :enospc / :emfile /
+        # :enomem distinction Shale's classify_resource_error/1 exists to
+        # act on.
+        {:error, reason} -> stop(state, reason)
       end
     end
   end

--- a/test/bedrock/data_plane/log/shale/segment_recycler_server_test.exs
+++ b/test/bedrock/data_plane/log/shale/segment_recycler_server_test.exs
@@ -1,0 +1,69 @@
+defmodule Bedrock.DataPlane.Log.Shale.SegmentRecyclerServerTest do
+  use ExUnit.Case, async: true
+
+  alias Bedrock.DataPlane.Log.Shale.SegmentRecycler.Logic
+  alias Bedrock.DataPlane.Log.Shale.SegmentRecycler.Server
+
+  # The GenServer clauses around the pool, tested as pure callbacks: both
+  # defects here are in how a failure is reported, and both are invisible
+  # to a test that only exercises the happy path.
+  @moduletag :tmp_dir
+
+  @segment_size 1024
+
+  defp state(dir, opts \\ []) do
+    {:ok, state} = Logic.new(dir, @segment_size, 1, 4)
+    struct!(state, opts)
+  end
+
+  describe "handle_continue(:ensure_min_available, _)" do
+    # Replies.stop/2 is stop(state, reason) :: {:stop, reason, state}.
+    # Called as stop(reason, :shutdown) the recycler exits with the
+    # reason ':shutdown' — which reads as an orderly stop — and installs
+    # the real cause as its own state, discarding it. Shale has a
+    # classify_resource_error/1 precisely to tell :enospc / :emfile /
+    # :enomem apart; that distinction was being thrown away here.
+    test "stops with the real allocation failure, not with :shutdown", %{tmp_dir: dir} do
+      state = state(dir, segments: [], min_available: 1)
+      on_exit(fn -> File.chmod(dir, 0o755) end)
+      :ok = File.chmod(dir, 0o500)
+
+      assert {:stop, reason, returned_state} = Server.handle_continue(:ensure_min_available, state)
+
+      refute reason == :shutdown,
+             "the exit reason must carry the allocation failure, not mask it as an orderly stop"
+
+      assert reason == :eacces
+      assert returned_state == state, "the state must survive the stop, not be replaced by the reason"
+    end
+
+    test "carries on when the pool can be refilled", %{tmp_dir: dir} do
+      assert {:noreply, refilled} = Server.handle_continue(:ensure_min_available, state(dir, segments: []))
+
+      assert length(refilled.segments) == 1
+    end
+  end
+
+  describe "handle_call({:check_out, _}, _, _)" do
+    test "schedules a refill after a successful checkout", %{tmp_dir: dir} do
+      {:ok, state} = Logic.ensure_min_available(state(dir), 1)
+
+      assert {:reply, :ok, _state, {:continue, :ensure_min_available}} =
+               Server.handle_call({:check_out, Path.join(dir, "wal_a")}, self(), state)
+    end
+
+    # An exhausted pool is the one moment a refill is most needed, and it
+    # was the one moment nothing scheduled it. Nothing else drives
+    # :ensure_min_available, so a pool that ever reached zero could not
+    # refill itself — every later checkout fails and
+    # Segment.allocate_from_recycler!/4 raises. Reachable once allocation
+    # can fail transiently: a full disk that later clears leaves the pool
+    # stuck at zero even after space returns.
+    test "schedules a refill after an exhausted checkout too", %{tmp_dir: dir} do
+      state = state(dir, segments: [])
+
+      assert {:reply, {:error, :unavailable}, _state, {:continue, :ensure_min_available}} =
+               Server.handle_call({:check_out, Path.join(dir, "wal_a")}, self(), state)
+    end
+  end
+end


### PR DESCRIPTION
Closes bedrock-m7j and bedrock-20c.

Two defects in `SegmentRecycler.Server`, both in how a failure is *reported*, and both invisible to a test that only walks the happy path.

### 1. Transposed `stop/2` arguments discarded the cause
`Replies.stop/2` is `stop(state, reason)`. `handle_continue` called it as `stop(reason, :shutdown)`, exiting with `:shutdown` and installing the real cause as the GenServer's state.

The payoff is **narrower than it first appears**, and the audit is why this PR says so. The reason does *not* reach Shale's `classify_resource_error/1` — that only sees the return value of `start_link/1`, and `init/1` can fail only with `:path_is_not_a_directory`. An allocation failure happens in the post-`init` continue, after `proc_lib` has acked `{:ok, pid}`, so it reaches the log as an async link EXIT that kills it either way.

What the fix genuinely buys: gen_server **suppresses error_info for `:shutdown`**, so the crash report was silent and the cause was thrown away. Now `:enospc` or `:eacces` appears in the log, and the `State` struct survives to `terminate/2`. A log whose disk filled no longer looks like it shut down politely.

### 2. No refill after an exhausted checkout
`Logic.check_out/2` returns `{:error, :unavailable}` exactly when the pool is empty — so the one moment a refill was most needed was the one moment nothing scheduled it, and nothing else drives that continue. Not reachable today (every path that lowers the pool is immediately followed by the refill, which stops the process if it cannot restore the floor); reachable the moment allocation can fail transiently, e.g. a full disk that later clears.

### Neither fix changes what happens to the owning log
The audit specifically tried to break this and could not. `:shutdown` is special to *supervisors* and to gen_server's error logging, **not** to link propagation — only `:normal` is — and Shale does not trap exits, so the log died on an allocation failure before this commit too. Shale's `child_spec` sets no `restart:` key, so it is `:permanent`, and `supervisor.erl` restarts and counts permanent children identically for `:shutdown` and for a posix reason. Fix 2 cannot loop and cannot introduce a new kill path.

### Verification
2799 tests, 0 failures. `mix compile --warnings-as-errors`, credo and dialyzer clean. Both failure-path tests fail against the pre-fix code; the two happy-path tests pass in both states and are guards, not pins.

Two follow-ups the audit surfaced, filed separately: bedrock-sfu (`Calls.call/3` does not normalize posix exit reasons, so a crashed callee raises instead of returning `:unavailable` — reachable via this change) and bedrock-vih (a failed preallocation leaves a zero-length file that the next incarnation adopts as a full 64 MiB segment).