### PR TITLE
Replace unused-module finder with a transitive dead-code hunter

### DIFF
--- a/.claude/skills/hunt-dead-code/SKILL.md
+++ b/.claude/skills/hunt-dead-code/SKILL.md
@@ -1,0 +1,162 @@
+---
+name: hunt-dead-code
+description: Find and remove transitively dead code - modules reachable only from other dead modules and their own tests. Use when hunting unused code, cleaning up abandoned subsystems, or auditing what the codebase no longer needs.
+---
+
+# Hunt Dead Code
+
+Dead means **unreachable from the declared roots**, where tests are not roots. A
+module reachable only from other dead modules and from its own tests is dead, no
+matter how many incoming edges it has.
+
+That transitivity is the point. Counting incoming references cannot find a
+cluster of modules that reference each other but that nothing outside reaches --
+every member has callers, so every member looks alive. `ChunkWriter` is the easy
+version of this (a leaf, zero incoming edges); an abandoned three-module
+subsystem with its own test suite is the version that hides.
+
+The governing rule: **static analysis proposes, the compiler and test suite
+dispose.** Never delete on the analyzer's say-so. It cannot resolve dynamic
+dispatch, and this codebase is full of it.
+
+## 1. Run the analyzer
+
+```bash
+elixir .claude/skills/hunt-dead-code/scripts/dead_code.exs
+```
+
+`--json` for machine-readable output, `--root DIR` to analyze elsewhere.
+
+It reports five things, in descending order of confidence:
+
+| Section | Confidence | Action |
+|---|---|---|
+| Dead clusters | High -- verify then delete | Work one cluster at a time |
+| Tests to delete outright | High | Delete with their cluster |
+| Tests needing surgical edits | High | Remove only the dead `describe` blocks |
+| Unused public API | Advisory | Human judgement, never auto-delete |
+| Unreferenced / test-only functions | Advisory | Read each one |
+
+## 2. Triage before touching anything
+
+For each cluster, rule out every false-positive class in
+[reference.md](reference.md) before proceeding. The short version:
+
+- Is it referenced from inside a `quote` block anywhere? (analyzer handles this,
+  but confirm for anything surprising)
+- Is it a behaviour impl selected by config or by an atom at runtime?
+- Is it named as a bare atom, in a config file, or in a `priv/` schema?
+- Is it attached as a telemetry handler?
+- Is it a supervision-tree child built from capabilities?
+- Does `git log --follow` show it arriving recently as scaffolding for
+  in-flight work?
+
+```bash
+rg 'ModuleName|:module_name' --type elixir --type markdown
+git log --oneline --follow -- path/to/module.ex
+```
+
+A cluster that survives triage is a **candidate**, not a corpse.
+
+## 3. Ticket and branch
+
+Every code change gets a ticket (see CLAUDE.md).
+
+```bash
+bw create "Remove dead <cluster name>" -p P3
+git checkout -b <ticket-id>-remove-<slug>
+```
+
+One cluster per ticket. Clusters are independent; batching them makes a red gate
+ambiguous about which removal caused it.
+
+## 4. Delete the whole unit
+
+A cluster's members only make sense together -- delete them together, along with:
+
+- every test file listed under **Tests to delete outright**
+- the dead `describe` / `test` blocks in files under **Tests needing surgical
+  edits** (leave the rest of the file intact)
+- any now-unused `alias` lines left behind in surviving files
+- entries in `mix.exs` `docs/0` (`extras`, `skip_code_autolink_to`) that named
+  the deleted modules
+- guide prose in `guides/` that documents the removed behaviour
+
+```bash
+git rm lib/path/to/module.ex test/path/to/module_test.exs
+```
+
+## 5. Run the verification gate
+
+This is what actually proves deadness. Run all of it.
+
+```bash
+mix compile --force --warnings-as-errors
+mix quality          # format --check-formatted, credo --strict, dialyzer
+mix test
+```
+
+Then the distributed durability suite, which exercises the runtime wiring that
+static analysis and unit tests both miss -- the recovery phases, the supervision
+tree, the control plane. This is where a wrongly-removed dynamically-dispatched
+module surfaces.
+
+```bash
+# once per machine
+MIX_ENV=test mix minio_server.download --arch darwin-arm64 --version latest
+
+BEDROCK_INCLUDE_DISTRIBUTED=1 mix test --include distributed \
+  test/bedrock/distributed/minio_durability_test.exs
+```
+
+Skipping the distributed suite for control-plane, recovery, or supervision-tree
+clusters makes the gate meaningless for exactly the code most likely to be
+dynamically wired.
+
+## 6. Land it, or record why it lives
+
+**Green** -- the removal is proven. Commit, close the ticket, sync.
+
+**Red** -- the module was alive and the analyzer could not see how. Do not patch
+the analyzer for the special case. Revert the deletion and add the entry point to
+`roots.exs` **with the reason it is reachable**:
+
+```elixir
+roots: [
+  {"lib/bedrock/some/module.ex", "Attached as a telemetry handler by Foo.start/0"}
+]
+```
+
+This is the ratchet, and it is the most valuable thing the skill produces. Each
+false positive becomes a permanent, justified root: the noise floor drops for
+good, and `roots.exs` accumulates into documentation of the dynamic-wiring
+surface -- knowledge this codebase records nowhere else. An analyzer tweak would
+have bought a quieter report and taught no one anything.
+
+## Handling the advisory sections
+
+**Unused public API.** Bedrock is a published package, so a public module can
+never be *proven* dead from inside it -- a downstream user may call it. The
+analyzer flags public modules with no internal caller and stops there. Decide per
+module whether it is intended API or drift. Removing one is a breaking change:
+it needs its own ticket and a CHANGELOG entry.
+
+**Unreferenced public functions** (name appears in no lib or test file) is the
+stronger tier. **Test-only functions** (name appears only in tests) are dead by
+this skill's definition, but that is also the exact shape of a helper kept
+deliberately for testing -- read each one before removing it.
+
+Both tiers are name-based and arity-insensitive. They miss nothing that is
+called, but they do flag things reached by dynamic dispatch, protocols, and
+macro-generated calls. Treat them as a reading list, not a work queue.
+
+## Files
+
+- `scripts/dead_code.exs` -- the analyzer
+- `roots.exs` -- declared roots; the ratchet, grown over time
+- `reference.md` -- false-positive taxonomy and why `mix xref` is not enough
+
+> `.claude/` is gitignored in this repo, so `roots.exs` is local-only. The
+> justifications accumulated there are real project knowledge and will not
+> survive a fresh clone. If that becomes a problem, move the manifest somewhere
+> tracked and point the analyzer's `manifest_path` at it.

--- a/.claude/skills/hunt-dead-code/reference.md
+++ b/.claude/skills/hunt-dead-code/reference.md
@@ -1,0 +1,150 @@
+# Dead-code detection: what defeats it
+
+Reference for the triage step in [SKILL.md](SKILL.md). Every class below was
+confirmed in this codebase, not hypothesised.
+
+## Why not `mix xref`
+
+`mix xref graph` is the obvious foundation and it is the wrong one, for a
+specific and fatal reason: **it cannot see through `quote`.**
+
+`lib/bedrock/cluster.ex` contains 14 call sites to `Bedrock.Internal.ClusterSupervisor`.
+Every one is inside `quote do` in `__using__`, so the reference is injected into
+the *downstream user's* module -- code that does not exist in this repository.
+The compiler records no edge from `cluster.ex` to `cluster_supervisor.ex`.
+`repo.ex` -> `Internal.Repo` is the same story.
+
+Reachability over the xref graph therefore reports the live runtime guts of the
+library as dead:
+
+```
+ClusterSupervisor, Internal.Repo, all 8 of internal/transaction_builder/,
+every tracing.ex  -- 20 files, all alive, all flagged
+```
+
+A tool built on xref would confidently tell you to delete the engine.
+
+The analyzer builds its graph from **source AST** instead, walking into `quote`
+blocks like any other node. That over-approximates liveness, which is the
+correct direction of error: missing some dead code costs a little tidiness,
+deleting live code costs a production incident.
+
+Measured on this repo:
+
+| Graph | Reported dead | Of which false positives |
+|---|---|---|
+| Zero in-degree | 19 | finds only leaves; blind to clusters |
+| xref reachability | 28 | 20 |
+| AST reachability (quote-aware) | 4 | 0 confirmed so far |
+
+## The false-positive classes
+
+### 1. `quote` / `__using__` injection
+
+Handled by the analyzer. Listed here because it is the largest class and worth
+recognising by eye.
+
+```elixir
+defmacro __using__(opts) do
+  quote do
+    alias Bedrock.Internal.ClusterSupervisor
+    def fetch_config, do: ClusterSupervisor.fetch_config(__MODULE__)
+  end
+end
+```
+
+### 2. `__MODULE__.Submodule`
+
+Recovery phases chain by naming the next phase relative to the enclosing module:
+
+```elixir
+# lib/bedrock/control_plane/director/recovery.ex:343
+def run_recovery_attempt(t, context, next_phase_module \\ __MODULE__.TSLValidationPhase)
+```
+
+The alias head is not an atom, so a naive `__aliases__` walk drops it and the
+entire recovery phase chain looks dead. The analyzer resolves `__MODULE__`
+against the enclosing module.
+
+### 3. Behaviour impls chosen at runtime
+
+`Bedrock.Encoding` has three impls, `Bedrock.ObjectStorage` has two, and which
+one runs is a config atom. Nothing references the impl module statically:
+
+```elixir
+backend = ObjectStorage.backend(LocalFilesystem, root: path)
+```
+
+The analyzer adds an edge from a behaviour to each of its implementors, so
+declaring `@behaviour` keeps an impl alive. **This means an impl of a dead
+behaviour is correctly dead, but an impl of a live behaviour is always live** --
+including genuinely abandoned ones. Check impls by hand.
+
+### 4. Telemetry handlers
+
+Attached at runtime by name, with a capture that hides the reference:
+
+```elixir
+:telemetry.attach_many(handler_id, events, &__MODULE__.handler/4, nil)
+```
+
+Whatever calls `Tracing.start/0` is the real root. If that caller is itself only
+reachable dynamically, the whole tracing module looks dead.
+
+### 5. Supervision children built from config
+
+`ClusterSupervisor.children_for_capabilities/3` maps capability atoms to modules
+through `module_for_capability/1`. That lookup table does name its modules
+statically, so these edges survive -- but a child added by config alone, or by
+`Module.concat`, would not.
+
+```
+lib/mix/bedrock.ex:49            |> Module.concat()
+lib/bedrock/service/manifest.ex  worker_name |> String.split(".") |> Module.concat()
+```
+
+Anything reachable only through a `Module.concat` is invisible to every static
+tool. `manifest.ex` reconstructs worker modules from persisted strings.
+
+### 6. Mix tasks
+
+CLI-invoked, never aliased. Everything under `lib/mix/` is rooted automatically.
+
+## Things that are *not* evidence of life
+
+- **An incoming reference from a test.** Tests are not roots. A module whose
+  only callers are its own test and a sibling's test is dead -- that is precisely
+  the `ChunkWriter` case.
+- **An incoming reference from another dead module.** Deadness is transitive;
+  that is the whole reason for computing reachability instead of in-degree.
+- **A `@moduledoc` describing planned functionality.** `ChunkWriter`'s moduledoc
+  documents a full usage example and cites a future compaction ticket. It is
+  still dead. Intent is not a caller.
+- **Being mentioned in `guides/`.** Documentation of a dead module is a docs bug,
+  not a reference. Delete the prose with the code.
+
+## Sub-file granularity
+
+A test file that exercises both live and dead modules cannot be deleted
+wholesale. `test/bedrock/object_storage/chunk_reader_test.exs` tests the live
+`ChunkReader` and carries one block for the dead `ChunkWriter`:
+
+```elixir
+describe "integration with ChunkWriter" do
+```
+
+The analyzer classifies test files by **subject** -- the module its own name
+points at (`ChunkWriterTest` -> `ChunkWriter`) -- rather than by everything they
+touch, because a test that builds a fixture from a live storage backend is not
+thereby testing that backend.
+
+## Calibration case
+
+`Bedrock.ObjectStorage.ChunkWriter` is the reference example. Expected findings:
+
+- module: dead, zero incoming edges
+- `chunk_writer_test.exs`: delete outright, subject is dead
+- `chunk_reader_test.exs`: surgical edit, one `describe` block
+- `ChunkReader` alongside it: **live** (`demux/shard_server.ex`)
+
+If a change to the analyzer breaks any of those four, the change is wrong.

--- a/.claude/skills/hunt-dead-code/roots.exs
+++ b/.claude/skills/hunt-dead-code/roots.exs
@@ -1,0 +1,45 @@
+# Declared roots for the transitive dead-code analyzer.
+#
+# A root is code that is reachable from outside this repository -- by a
+# downstream user, by the BEAM, by a CLI, or by runtime wiring that no static
+# analysis can follow. Everything not transitively reachable from a root is a
+# deletion candidate.
+#
+# THIS FILE IS THE RATCHET. When the analyzer proposes a cluster and the
+# verification gate proves it live, the fix is not to tweak the analyzer -- it
+# is to add the entry point here with the reason it is reachable. The noise
+# floor then drops permanently, and this file accumulates into documentation of
+# the dynamic-wiring surface, which is knowledge the codebase records nowhere
+# else.
+#
+# Each root is {path, reason}. Write the reason for someone who does not
+# already know why the module is alive.
+
+%{
+  # Reached from outside the library. Because Bedrock is a published package,
+  # these can never be *proven* dead from inside it -- the analyzer reports
+  # uncalled ones as advisory instead of proposing deletion.
+  public_api: [
+    "lib/bedrock.ex",
+    "lib/bedrock/cluster.ex",
+    "lib/bedrock/directory.ex",
+    "lib/bedrock/durability.ex",
+    "lib/bedrock/encoding.ex",
+    "lib/bedrock/high_contention_allocator.ex",
+    "lib/bedrock/key.ex",
+    "lib/bedrock/key_range.ex",
+    "lib/bedrock/key_selector.ex",
+    "lib/bedrock/keyspace.ex",
+    "lib/bedrock/object_storage.ex",
+    "lib/bedrock/repo.ex",
+    "lib/bedrock/system_keys.ex",
+    "lib/bedrock/telemetry.ex",
+    "lib/bedrock/type_coercion.ex"
+  ],
+
+  # Reachable, but not by any edge the graph can see. Mix tasks are added
+  # automatically (anything under lib/mix/) and do not need listing here.
+  roots: [
+    # -- add confirmed false positives here, with the reason --
+  ]
+}

--- a/.claude/skills/hunt-dead-code/scripts/dead_code.exs
+++ b/.claude/skills/hunt-dead-code/scripts/dead_code.exs
@@ -1,0 +1,673 @@
+#!/usr/bin/env elixir
+#
+# Transitive dead-code analyzer.
+#
+# "Dead" means: unreachable from the declared roots, where tests are NOT roots.
+# A module reachable only from other dead modules and from its own tests is dead,
+# however many incoming edges it has. That transitivity is the whole point --
+# in-degree counting cannot find a self-referencing cluster that nothing outside
+# it reaches.
+#
+# The reference graph is built from source AST, not from `mix xref`, because
+# xref cannot see through `quote`. In a library that exposes `__using__` macros,
+# the calls that keep the runtime guts alive are injected into the *caller's*
+# module and never appear as an edge here. Building from AST over-approximates
+# liveness, which is the direction you want: missing some dead code is cheap,
+# deleting live code is not.
+#
+# Usage:
+#   elixir .claude/skills/hunt-dead-code/scripts/dead_code.exs [--json] [--root DIR]
+
+defmodule DeadCode.Source do
+  @moduledoc "Parses one source file into the facts the graph needs."
+
+  defstruct [:path, :modules, :aliases, :refs, :behaviours, :functions, :impls]
+
+  def parse(path, root) do
+    rel = Path.relative_to(path, root)
+
+    case path |> File.read!() |> Code.string_to_quoted() do
+      {:ok, ast} ->
+        modules = modules(ast)
+        primary = List.first(modules)
+        aliases = aliases(ast)
+
+        %__MODULE__{
+          path: rel,
+          modules: modules,
+          aliases: aliases,
+          refs: refs(ast, aliases, primary),
+          behaviours: behaviours(ast, aliases),
+          functions: functions(ast, primary),
+          impls: impls(ast)
+        }
+
+      {:error, _} ->
+        %__MODULE__{path: rel, modules: [], aliases: %{}, refs: [], behaviours: [], functions: [], impls: []}
+    end
+  end
+
+  defp dotted(parts), do: Enum.join(parts, ".")
+
+  # Every module defined in the file, outermost first. Nested `defmodule`s are
+  # qualified against their enclosing module the way the compiler does.
+  def modules(ast) do
+    {_, {mods, _}} =
+      Macro.traverse(
+        ast,
+        {[], []},
+        fn
+          {:defmodule, _, [{:__aliases__, _, parts} | _]} = node, {mods, stack} when is_list(parts) ->
+            name =
+              if stack == [],
+                do: dotted(parts),
+                else: dotted([List.last(stack) | Enum.map(parts, &to_string/1)])
+
+            {node, {mods ++ [name], stack ++ [name]}}
+
+          node, acc ->
+            {node, acc}
+        end,
+        fn
+          {:defmodule, _, _} = node, {mods, stack} ->
+            {node, {mods, Enum.drop(stack, -1)}}
+
+          node, acc ->
+            {node, acc}
+        end
+      )
+
+    mods
+  end
+
+  # alias Foo.Bar / alias Foo.Bar, as: Baz / alias Foo.{Bar, Baz}
+  # Treated as file-global rather than lexically scoped. That over-links, which
+  # over-approximates liveness -- the safe direction.
+  def aliases(ast) do
+    {_, table} =
+      Macro.prewalk(ast, %{}, fn
+        {:alias, _, [{{:., _, [{:__aliases__, _, base}, :{}]}, _, children}]} = node, acc
+        when is_list(base) and is_list(children) ->
+          if Enum.all?(base, &is_atom/1) do
+            table =
+              Enum.reduce(children, acc, fn
+                {:__aliases__, _, parts}, a when is_list(parts) ->
+                  if Enum.all?(parts, &is_atom/1),
+                    do: Map.put(a, to_string(List.last(parts)), dotted(base ++ parts)),
+                    else: a
+
+                _, a ->
+                  a
+              end)
+
+            {node, table}
+          else
+            {node, acc}
+          end
+
+        {:alias, _, [{:__aliases__, _, parts}, opts]} = node, acc when is_list(parts) ->
+          if Enum.all?(parts, &is_atom/1) do
+            case Keyword.get(List.wrap(opts), :as) do
+              {:__aliases__, _, [as]} when is_atom(as) ->
+                {node, Map.put(acc, to_string(as), dotted(parts))}
+
+              _ ->
+                {node, Map.put(acc, to_string(List.last(parts)), dotted(parts))}
+            end
+          else
+            {node, acc}
+          end
+
+        {:alias, _, [{:__aliases__, _, parts}]} = node, acc when is_list(parts) ->
+          if Enum.all?(parts, &is_atom/1),
+            do: {node, Map.put(acc, to_string(List.last(parts)), dotted(parts))},
+            else: {node, acc}
+
+        node, acc ->
+          {node, acc}
+      end)
+
+    table
+  end
+
+  # Every module referenced anywhere -- inside `quote` blocks included, which is
+  # exactly what xref misses.
+  def refs(ast, aliases, primary) do
+    {_, refs} =
+      Macro.prewalk(ast, [], fn
+        # `__MODULE__.Submodule` -- how recovery phases chain to one another.
+        {:__aliases__, _, [{:__MODULE__, _, _} | rest]} = node, acc when is_list(rest) ->
+          if primary && Enum.all?(rest, &is_atom/1),
+            do: {node, [dotted([primary | Enum.map(rest, &to_string/1)]) | acc]},
+            else: {node, acc}
+
+        {:__aliases__, _, parts} = node, acc when is_list(parts) ->
+          if Enum.all?(parts, &is_atom/1) do
+            full = dotted(parts)
+            head = to_string(List.first(parts))
+
+            # A bare `Foo` may be an alias for something longer; record both the
+            # literal name and the expansion so either can resolve.
+            expanded =
+              case Map.get(aliases, head) do
+                nil -> []
+                base -> [dotted([base | Enum.drop(parts, 1) |> Enum.map(&to_string/1)])]
+              end
+
+            {node, [full | expanded] ++ acc}
+          else
+            {node, acc}
+          end
+
+        node, acc ->
+          {node, acc}
+      end)
+
+    Enum.uniq(refs)
+  end
+
+  def behaviours(ast, aliases) do
+    {_, bs} =
+      Macro.prewalk(ast, [], fn
+        {:@, _, [{:behaviour, _, [{:__aliases__, _, parts}]}]} = node, acc when is_list(parts) ->
+          if Enum.all?(parts, &is_atom/1) do
+            head = to_string(List.first(parts))
+            full = dotted(parts)
+            expanded = if base = Map.get(aliases, head), do: [base], else: []
+            {node, [full | expanded] ++ acc}
+          else
+            {node, acc}
+          end
+
+        node, acc ->
+          {node, acc}
+      end)
+
+    Enum.uniq(bs)
+  end
+
+  @def_kinds [:def, :defmacro, :defguard, :defdelegate]
+
+  # Public function definitions, as {module, name, arity}. Default arguments
+  # widen one definition into a range of arities.
+  def functions(ast, primary) do
+    {_, fns} =
+      Macro.prewalk(ast, [], fn
+        {kind, _, [head | _]} = node, acc when kind in @def_kinds ->
+          case fn_head(head) do
+            {name, args} ->
+              defaults = Enum.count(args, &match?({:\\, _, _}, &1))
+              total = length(args)
+              arities = (total - defaults)..total//1
+              {node, Enum.map(arities, &{primary, name, &1}) ++ acc}
+
+            nil ->
+              {node, acc}
+          end
+
+        node, acc ->
+          {node, acc}
+      end)
+
+    Enum.uniq(fns)
+  end
+
+  defp fn_head({:when, _, [inner | _]}), do: fn_head(inner)
+  defp fn_head({name, _, args}) when is_atom(name) and is_list(args), do: {name, args}
+  defp fn_head({name, _, nil}) when is_atom(name), do: {name, []}
+  defp fn_head(_), do: nil
+
+  # Names carrying `@impl` -- behaviour callbacks, dispatched by something else.
+  def impls(ast) do
+    {_, {names, _}} =
+      Macro.prewalk(ast, {[], false}, fn
+        {:@, _, [{:impl, _, _}]} = node, {names, _} ->
+          {node, {names, true}}
+
+        {kind, _, [head | _]} = node, {names, pending} when kind in @def_kinds ->
+          case {fn_head(head), pending} do
+            {{name, _}, true} -> {node, {[name | names], false}}
+            _ -> {node, {names, pending}}
+          end
+
+        node, acc ->
+          {node, acc}
+      end)
+
+    Enum.uniq(names)
+  end
+
+  # Every function name invoked, captured, or named as an atom anywhere in the
+  # file. Name-only (arity-insensitive) on purpose: this feeds a conservative
+  # "is this name mentioned at all" check.
+  def called_names(ast) do
+    {_, names} =
+      Macro.prewalk(ast, [], fn
+        {{:., _, [_, name]}, _, _} = node, acc when is_atom(name) ->
+          {node, [name | acc]}
+
+        {:&, _, [{:/, _, [{name, _, _}, _]}]} = node, acc when is_atom(name) ->
+          {node, [name | acc]}
+
+        {name, _, args} = node, acc when is_atom(name) and is_list(args) ->
+          {node, [name | acc]}
+
+        node, acc when is_atom(node) ->
+          {node, [node | acc]}
+
+        node, acc ->
+          {node, acc}
+      end)
+
+    MapSet.new(names)
+  end
+end
+
+defmodule DeadCode.Graph do
+  @moduledoc "Module reference graph and reachability over it."
+
+  def build(sources) do
+    owner =
+      for s <- sources, m <- s.modules, into: %{} do
+        {m, s.path}
+      end
+
+    edges =
+      for s <- sources,
+          r <- s.refs,
+          tgt = Map.get(owner, r),
+          tgt != nil,
+          tgt != s.path,
+          uniq: true,
+          do: {s.path, tgt}
+
+    # A module implementing a behaviour is kept alive by whatever dispatches
+    # that behaviour, so treat the behaviour as pointing back at the impl.
+    impl_edges =
+      for s <- sources,
+          b <- s.behaviours,
+          src = Map.get(owner, b),
+          src != nil,
+          src != s.path,
+          uniq: true,
+          do: {src, s.path}
+
+    all = edges ++ impl_edges
+
+    %{
+      owner: owner,
+      adj: Enum.group_by(all, &elem(&1, 0), &elem(&1, 1)),
+      rev: Enum.group_by(all, &elem(&1, 1), &elem(&1, 0)),
+      nodes: sources |> Enum.map(& &1.path) |> MapSet.new()
+    }
+  end
+
+  def reachable(graph, roots) do
+    Stream.iterate({MapSet.new(roots), roots}, fn {seen, frontier} ->
+      next =
+        frontier
+        |> Enum.flat_map(&Map.get(graph.adj, &1, []))
+        |> Enum.reject(&MapSet.member?(seen, &1))
+        |> Enum.uniq()
+
+      {MapSet.union(seen, MapSet.new(next)), next}
+    end)
+    |> Enum.find(fn {_, frontier} -> frontier == [] end)
+    |> elem(0)
+  end
+
+  # Weakly-connected components among the dead nodes. A cluster is the unit of
+  # deletion: its members only make sense together, so they live or die together.
+  def clusters(graph, dead) do
+    dead_set = MapSet.new(dead)
+
+    neighbours = fn n ->
+      (Map.get(graph.adj, n, []) ++ Map.get(graph.rev, n, []))
+      |> Enum.filter(&MapSet.member?(dead_set, &1))
+    end
+
+    {clusters, _} =
+      Enum.reduce(Enum.sort(dead), {[], MapSet.new()}, fn node, {acc, seen} ->
+        if MapSet.member?(seen, node) do
+          {acc, seen}
+        else
+          component = flood([node], MapSet.new([node]), neighbours)
+          {[Enum.sort(component) | acc], MapSet.union(seen, MapSet.new(component))}
+        end
+      end)
+
+    Enum.sort_by(clusters, &{-length(&1), List.first(&1)})
+  end
+
+  defp flood([], seen, _), do: MapSet.to_list(seen)
+
+  defp flood(frontier, seen, neighbours) do
+    next =
+      frontier
+      |> Enum.flat_map(neighbours)
+      |> Enum.reject(&MapSet.member?(seen, &1))
+      |> Enum.uniq()
+
+    flood(next, MapSet.union(seen, MapSet.new(next)), neighbours)
+  end
+end
+
+defmodule DeadCode.Report do
+  def line(s), do: IO.puts(s)
+  def rule, do: IO.puts(String.duplicate("=", 76))
+  def thin, do: IO.puts(String.duplicate("-", 76))
+end
+
+defmodule DeadCode.CLI do
+  alias DeadCode.Graph
+  alias DeadCode.Report
+  alias DeadCode.Source
+
+  def main(argv) do
+    {opts, _, _} = OptionParser.parse(argv, strict: [json: :boolean, root: :string])
+    root = Keyword.get(opts, :root, File.cwd!())
+
+    manifest_path = Path.join(root, ".claude/skills/hunt-dead-code/roots.exs")
+
+    manifest =
+      if File.exists?(manifest_path) do
+        {m, _} = Code.eval_file(manifest_path)
+        m
+      else
+        %{roots: [], public_api: []}
+      end
+
+    lib = Path.wildcard(Path.join(root, "lib/**/*.ex"))
+    support = Path.wildcard(Path.join(root, "test/support/**/*.ex"))
+    tests = Path.wildcard(Path.join(root, "test/**/*_test.exs"))
+
+    lib_sources = Enum.map(lib, &Source.parse(&1, root))
+    support_sources = Enum.map(support, &Source.parse(&1, root))
+    test_sources = Enum.map(tests, &Source.parse(&1, root))
+
+    graph = Graph.build(lib_sources)
+
+    declared = manifest |> Map.get(:roots, []) |> Enum.map(&elem(&1, 0))
+    public_api = Map.get(manifest, :public_api, [])
+
+    mix_tasks = graph.nodes |> Enum.filter(&String.starts_with?(&1, "lib/mix/"))
+
+    roots =
+      (declared ++ public_api ++ mix_tasks)
+      |> Enum.uniq()
+      |> Enum.filter(&MapSet.member?(graph.nodes, &1))
+
+    live = Graph.reachable(graph, roots)
+    dead = graph.nodes |> Enum.reject(&MapSet.member?(live, &1)) |> Enum.sort()
+    clusters = Graph.clusters(graph, dead)
+
+    dead_modules =
+      for s <- lib_sources, s.path in dead, m <- s.modules, into: MapSet.new(), do: m
+
+    test_index = classify_tests(test_sources ++ support_sources, dead_modules, graph.owner)
+    unused_public = unused_public_api(graph, public_api, live)
+    dead_fns = dead_public_functions(lib_sources, test_sources, support_sources, dead)
+
+    if Keyword.get(opts, :json) do
+      emit_json(clusters, test_index, unused_public, dead_fns)
+    else
+      emit_text(graph, clusters, test_index, unused_public, dead_fns, roots, live)
+    end
+  end
+
+  # A test file dies wholesale when its *subject* is dead -- the module its own
+  # name points at. Judging by "every module it touches" would spare
+  # chunk_writer_test.exs, which also touches a live storage backend to build a
+  # fixture; that backend is scaffolding, not the thing under test.
+  #
+  # A file that survives but still references dead modules needs a surgical
+  # edit: chunk_reader_test.exs tests a live module and carries one
+  # `describe "integration with ChunkWriter"` block that has to come out.
+  defp classify_tests(test_sources, dead_modules, owner) do
+    for s <- test_sources, reduce: %{fully_dead: [], partial: []} do
+      acc ->
+        touched =
+          s.refs
+          |> Enum.filter(&Map.has_key?(owner, &1))
+          |> Enum.uniq()
+
+        dead_refs = Enum.filter(touched, &MapSet.member?(dead_modules, &1))
+        subject = subject_module(s)
+
+        cond do
+          dead_refs == [] ->
+            acc
+
+          subject && MapSet.member?(dead_modules, subject) ->
+            %{acc | fully_dead: [{s.path, subject} | acc.fully_dead]}
+
+          # No identifiable subject, but everything it touches is dead.
+          subject == nil and touched == dead_refs ->
+            %{acc | fully_dead: [{s.path, List.first(dead_refs)} | acc.fully_dead]}
+
+          true ->
+            %{acc | partial: [{s.path, dead_refs} | acc.partial]}
+        end
+    end
+  end
+
+  # Bedrock.ObjectStorage.ChunkWriterTest -> Bedrock.ObjectStorage.ChunkWriter
+  defp subject_module(%{modules: []}), do: nil
+
+  defp subject_module(%{modules: [primary | _]}) do
+    case String.replace_suffix(primary, "Test", "") do
+      ^primary -> nil
+      "" -> nil
+      stripped -> stripped
+    end
+  end
+
+  # Public modules can never be *proven* dead from inside the library -- a
+  # downstream user may call them. Report the ones with no internal caller as
+  # advisory, for human judgement, and keep them out of the deletion set.
+  defp unused_public_api(graph, public_api, live) do
+    public_api
+    |> Enum.filter(&MapSet.member?(graph.nodes, &1))
+    |> Enum.filter(fn path ->
+      callers =
+        graph
+        |> Map.get(:rev, %{})
+        |> Map.get(path, [])
+        |> Enum.filter(&MapSet.member?(live, &1))
+
+      callers == []
+    end)
+    |> Enum.sort()
+  end
+
+  @otp_callbacks ~w(
+    init handle_call handle_cast handle_info handle_continue terminate code_change
+    child_spec start_link start format_status run handle_event callback_mode
+  )a
+
+  # Advisory only, and split into two tiers because they warrant different
+  # confidence. Behaviour and OTP callbacks are excluded throughout: something
+  # dispatches them by name.
+  #
+  #   :never  -- the name appears in no other file at all. Strongest signal.
+  #   :tests  -- the name appears only in test files. Dead by the definition
+  #              this tool works to (reachable only from its own tests), but
+  #              also the shape of a helper kept deliberately for testing, so
+  #              it needs a human read rather than a blanket delete.
+  defp dead_public_functions(lib_sources, test_sources, support_sources, dead_paths) do
+    dead_set = MapSet.new(dead_paths)
+    live_sources = Enum.reject(lib_sources, &MapSet.member?(dead_set, &1.path))
+
+    prod_mentions = mention_index(lib_sources)
+    test_mentions = mention_index(test_sources ++ support_sources)
+
+    candidates =
+      for s <- live_sources,
+          {mod, name, arity} <- s.functions,
+          mod != nil,
+          name not in @otp_callbacks,
+          name not in s.impls,
+          not String.starts_with?(to_string(name), "__"),
+          not mentioned_elsewhere?(prod_mentions, s.path, name) do
+        tier = if mentioned_elsewhere?(test_mentions, s.path, name), do: :tests, else: :never
+        {tier, s.path, "#{mod}.#{name}/#{arity}"}
+      end
+      |> Enum.uniq()
+
+    for tier <- [:never, :tests], into: %{} do
+      grouped =
+        candidates
+        |> Enum.filter(&(elem(&1, 0) == tier))
+        |> Enum.group_by(&elem(&1, 1), &elem(&1, 2))
+
+      {tier, grouped}
+    end
+  end
+
+  defp mention_index(sources) do
+    for s <- sources, into: %{} do
+      ast =
+        case s.path |> File.read!() |> Code.string_to_quoted() do
+          {:ok, parsed} -> parsed
+          _ -> {:__block__, [], []}
+        end
+
+      {s.path, Source.called_names(ast)}
+    end
+  end
+
+  defp mentioned_elsewhere?(mentions, own_path, name) do
+    Enum.any?(mentions, fn {path, names} ->
+      path != own_path and MapSet.member?(names, name)
+    end)
+  end
+
+  defp emit_text(graph, clusters, tests, unused_public, dead_fns, roots, live) do
+    Report.rule()
+    Report.line("TRANSITIVE DEAD CODE")
+    Report.rule()
+
+    Report.line(
+      "modules: #{MapSet.size(graph.nodes)}   roots: #{length(roots)}   " <>
+        "live: #{MapSet.size(live)}   dead: #{MapSet.size(graph.nodes) - MapSet.size(live)}"
+    )
+
+    Report.line("")
+    Report.line("## Dead clusters (#{length(clusters)}) -- each is one deletion unit")
+    Report.thin()
+
+    if clusters == [] do
+      Report.line("  none")
+    else
+      clusters
+      |> Enum.with_index(1)
+      |> Enum.each(fn {cluster, i} ->
+        Report.line("")
+        Report.line("[#{i}] #{length(cluster)} module(s)")
+        Enum.each(cluster, &Report.line("      #{&1}"))
+      end)
+    end
+
+    Report.line("")
+    Report.line("## Tests to delete outright (#{length(tests.fully_dead)})")
+    Report.thin()
+
+    if tests.fully_dead == [] do
+      Report.line("  none")
+    else
+      tests.fully_dead
+      |> Enum.sort()
+      |> Enum.each(fn {p, subject} -> Report.line("  #{p}  (subject: #{subject})") end)
+    end
+
+    Report.line("")
+    Report.line("## Tests needing surgical edits (#{length(tests.partial)})")
+    Report.line("   (exercise both live and dead modules -- remove only the dead parts)")
+    Report.thin()
+
+    if tests.partial == [] do
+      Report.line("  none")
+    else
+      tests.partial
+      |> Enum.sort()
+      |> Enum.each(fn {p, hits} ->
+        Report.line("  #{p}")
+        Enum.each(hits, &Report.line("      dead ref: #{&1}"))
+      end)
+    end
+
+    Report.line("")
+    Report.line("## Unused public API (#{length(unused_public)}) -- ADVISORY, human judgement")
+    Report.line("   Cannot be proven dead from inside a library; downstream users may call these.")
+    Report.thin()
+
+    if unused_public == [],
+      do: Report.line("  none"),
+      else: Enum.each(unused_public, &Report.line("  #{&1}"))
+
+    emit_fn_tier(
+      dead_fns[:never] || %{},
+      "Public functions referenced nowhere at all",
+      "   Not called, captured, or named as an atom in any lib or test file."
+    )
+
+    emit_fn_tier(
+      dead_fns[:tests] || %{},
+      "Public functions referenced only by tests",
+      "   Dead by this tool's definition, but also the shape of a helper kept\n" <>
+        "   deliberately for testing. Read each one before removing."
+    )
+
+    Report.line("")
+    Report.rule()
+    Report.line("Nothing here is proven dead until the verification gate passes.")
+    Report.line("See SKILL.md -- delete the cluster, then run the gate.")
+    Report.rule()
+  end
+
+  defp emit_fn_tier(grouped, title, note) do
+    total = grouped |> Map.values() |> List.flatten() |> length()
+    Report.line("")
+    Report.line("## #{title} (#{total}) -- ADVISORY")
+    Report.line(note)
+    Report.line("   Dynamic dispatch, protocol impls, and macro-generated calls all defeat")
+    Report.line("   this check. Verify before removing.")
+    Report.thin()
+
+    if map_size(grouped) == 0 do
+      Report.line("  none")
+    else
+      grouped
+      |> Enum.sort()
+      |> Enum.each(fn {path, fns} ->
+        Report.line("  #{path}")
+        fns |> Enum.sort() |> Enum.each(&Report.line("      #{&1}"))
+      end)
+    end
+  end
+
+  # Uses the stdlib JSON module, so the script needs no project deps loaded and
+  # runs under plain `elixir`. JSON arrived in Elixir 1.18; mix.exs still allows
+  # 1.17, so say so plainly rather than failing with UndefinedFunctionError.
+  defp emit_json(clusters, tests, unused_public, dead_fns) do
+    if Code.ensure_loaded?(JSON) do
+      %{
+        "clusters" => clusters,
+        "tests_to_delete" =>
+          Enum.map(tests.fully_dead, fn {p, s} -> %{"path" => p, "subject" => s} end),
+        "tests_to_edit" =>
+          Enum.map(tests.partial, fn {p, h} -> %{"path" => p, "dead_refs" => h} end),
+        "unused_public_api" => unused_public,
+        "unreferenced_functions" => dead_fns[:never] || %{},
+        "test_only_functions" => dead_fns[:tests] || %{}
+      }
+      |> JSON.encode!()
+      |> IO.puts()
+    else
+      IO.puts(:stderr, "--json needs Elixir 1.18+ (stdlib JSON). Re-run without it for the text report.")
+      System.halt(1)
+    end
+  end
+end
+
+DeadCode.CLI.main(System.argv())

--- a/.gitignore
+++ b/.gitignore
@@ -38,7 +38,15 @@ bedrock-*.tar
 .vscode/
 
 # AI tools
-.claude/
+# Local agent state stays out of the repo, with one exception: skills that are
+# project tooling rather than personal configuration. Those are versioned so
+# everyone gets the same analysis, and so the knowledge in them survives a fresh
+# clone. Re-include has to be spelled out a level at a time -- git will not
+# descend into an excluded directory to find a negation.
+.claude/*
+!.claude/skills/
+.claude/skills/*
+!.claude/skills/hunt-dead-code/
 CLAUDE.md
 AGENTS.md
 .gitattributes


### PR DESCRIPTION
Closes bedrock-a4n.

Replaces the `find-unused-modules` skill with `hunt-dead-code`, which finds
code that is dead *transitively* — reachable only from other dead code and from
its own tests.

## Why the old skill could not do this

It reported modules with **zero incoming references**. That structurally cannot
find the thing we actually want to remove: a cluster of modules that reference
each other but that nothing outside reaches. Every member has callers, so every
member looks alive. It found `ChunkWriter` only because `ChunkWriter` happens to
be a leaf.

The new skill computes reachability from declared roots, with tests excluded
from the root set. A module reachable only from other dead modules and its own
tests comes out dead however many callers it has.

## Why the graph is not built from `mix xref`

`mix xref` cannot see references inside `quote`. In this codebase that is not an
edge case — it is how the library is wired. `cluster.ex` has 14 call sites to
`ClusterSupervisor`, every one inside `quote do` in `__using__`, so the
reference only materializes in a downstream user's module and the compiler
records no edge. `repo.ex` → `Internal.Repo` is the same.

Measured on this repo:

| Graph | Reported dead | False positives |
|---|---|---|
| Zero in-degree (old skill) | 19 | finds only leaves; blind to clusters |
| xref reachability | 28 | **20** |
| AST reachability (quote-aware) | 4 | 0 confirmed |

An xref-based tool would confidently propose deleting `ClusterSupervisor`,
`Internal.Repo`, all 8 modules of `internal/transaction_builder/`, and every
`tracing.ex` — the live runtime guts of the library. The analyzer builds from
source AST instead, which over-approximates liveness: missing some dead code
costs a little tidiness, deleting live code costs an incident.

## What it currently reports

```
lib/bedrock/control_plane/director/changing_parameters.ex
lib/bedrock/control_plane/rate_keeper.ex          (3-line empty stub)
lib/bedrock/data_plane/proxy.ex
lib/bedrock/object_storage/chunk_writer.ex
```

Plus advisory lists: 3 public modules with no internal caller, 118 public
functions referenced nowhere at all, and 163 referenced only by tests.

**Nothing is removed in this PR.** The analyzer proposes; the compiler, test
suite and distributed durability suite dispose. Each removal gets its own
ticket.

## The ratchet

When the gate proves a candidate live, the fix is *not* to tweak the analyzer —
it is to record the entry point in `roots.exs` with the reason it is reachable.
The noise floor then drops permanently, and the manifest accumulates into
documentation of the dynamic-wiring surface, which this codebase records nowhere
else.

## Note on `.gitignore`

`.claude/` is gitignored here by policy, along with `CLAUDE.md` and `AGENTS.md`.
This makes the narrowest possible exception — `hunt-dead-code` only — because it
is project tooling rather than personal configuration: everyone should get the
same analysis, and the justifications accumulated in `roots.exs` need to survive
a fresh clone. `settings.local.json`, `worktrees/` and the other skills stay
ignored. Easy to widen or revert if you would rather keep the policy absolute.

The old skill was never tracked, so its removal does not appear in this diff —
it was deleted from the working checkout.

## Verification

Pre-commit hook ran `credo --strict`, `compile` and `dialyzer` — all clean.
Analyzer calibration verified: `ChunkWriter` dead, `chunk_writer_test.exs` a
wholesale delete, `chunk_reader_test.exs` flagged for surgical edit of its one
`describe` block, and `ChunkReader`, `ClusterSupervisor`, `transaction_builder`
and `tracing` all correctly **live**.