### PR TITLE
Settle the foreman's health at spin-up

### DIFF
--- a/lib/bedrock/service/foreman/impl.ex
+++ b/lib/bedrock/service/foreman/impl.ex
@@ -253,6 +253,20 @@ defmodule Bedrock.Service.Foreman.Impl do
     |> load_workers_from_disk()
     |> start_workers_that_are_stopped()
     |> relay_current_tsl()
+    # Spin-up is where the foreman learns what it has and starts it, so
+    # it is where the verdict has to be settled. Without this the state
+    # keeps the :starting it was constructed with: recompute_health/1 is
+    # otherwise reachable only from a worker's own health cast, and the
+    # sole sender is Olivine — Shale never reports. A log-only node
+    # therefore had no path to :ok at all, and wait_for_healthy/2 could
+    # not return on one.
+    #
+    # No waiters can exist yet to notify: this runs in the :spin_up
+    # handle_continue, which precedes every mailbox message, so the
+    # handle_call that is the only writer of waiting_for_healthy cannot
+    # have run. A caller whose request is already queued finds health
+    # settled when it is finally served.
+    |> recompute_health()
   end
 
   # An unstartable directory is silent by nature: with no manifest there

--- a/test/bedrock/service/foreman/spin_up_health_test.exs
+++ b/test/bedrock/service/foreman/spin_up_health_test.exs
@@ -1,0 +1,123 @@
+defmodule Bedrock.Service.Foreman.SpinUpHealthTest do
+  use ExUnit.Case, async: true
+
+  alias Bedrock.Service.Foreman.Impl
+  alias Bedrock.Service.Foreman.State
+
+  # Spin-up is where a foreman learns what it has and starts it. If the
+  # verdict is not recomputed there, the foreman keeps the :starting it
+  # was born with no matter how the boot actually went — and since
+  # recompute_health/1 is otherwise reachable only from a worker's own
+  # health cast, and Shale never sends one, a log-only node would sit at
+  # :starting forever.
+  @moduletag :tmp_dir
+
+  defmodule SpinUpTestCluster do
+    @moduledoc false
+    def name, do: "spin_up_test_cluster"
+    def otp_name_for_worker(id), do: :"spin_up_test_worker_#{id}"
+    def otp_name(:worker_supervisor), do: :spin_up_test_worker_supervisor
+    def otp_name(:link), do: :spin_up_test_link
+    def otp_name(:foreman), do: :spin_up_test_foreman
+  end
+
+  defmodule SpinUpTestWorker do
+    @moduledoc false
+    use Bedrock.Service.WorkerBehaviour, kind: :log
+    use GenServer
+
+    def child_spec(opts), do: %{id: {__MODULE__, opts[:id]}, start: {__MODULE__, :start_link, [opts]}}
+    def start_link(opts), do: GenServer.start_link(__MODULE__, opts, name: opts[:otp_name])
+
+    @impl GenServer
+    def init(opts), do: {:ok, opts}
+  end
+
+  defp write_worker(dir, id) do
+    path = Path.join(dir, id)
+    File.mkdir_p!(path)
+
+    File.write!(
+      Path.join(path, "manifest.json"),
+      ~s({"id":"#{id}","cluster":"spin_up_test_cluster",) <>
+        ~s("worker":"Bedrock.Service.Foreman.SpinUpHealthTest.SpinUpTestWorker","params":{}})
+    )
+  end
+
+  defp base_state(dir, overrides \\ []) do
+    struct!(
+      %State{
+        cluster: SpinUpTestCluster,
+        capabilities: [:log],
+        health: :starting,
+        otp_name: :spin_up_test_foreman,
+        path: dir,
+        waiting_for_healthy: [],
+        workers: %{}
+      },
+      overrides
+    )
+  end
+
+  describe "do_spin_up/1" do
+    test "computes a verdict rather than leaving the birth state", %{tmp_dir: dir} do
+      state = Impl.do_spin_up(base_state(dir))
+
+      refute state.health == :starting,
+             "spin-up must reach a verdict; :starting is what the foreman was born with"
+
+      assert state.health == :ok
+    end
+
+    # The empty case is the log-only node in miniature: nothing will ever
+    # cast a health report, so if spin-up does not settle the verdict
+    # nothing else will.
+    test "an empty working directory settles at :ok", %{tmp_dir: dir} do
+      assert %{health: :ok} = Impl.do_spin_up(base_state(dir))
+    end
+
+    test "a directory of other components' data does not make the foreman unhealthy", %{tmp_dir: dir} do
+      File.mkdir_p!(Path.join(dir, "object_storage"))
+      File.mkdir_p!(Path.join(dir, "raft"))
+
+      assert %{health: :ok} = Impl.do_spin_up(base_state(dir))
+    end
+
+    # The headline scenario, not the empty-directory one: a log worker
+    # that really starts. Shale never reports its own health, so before
+    # this change nothing would ever have moved the verdict off :starting
+    # on a node like this.
+    test "a worker that actually starts drives the verdict to :ok", %{tmp_dir: dir} do
+      start_supervised!(
+        {DynamicSupervisor, strategy: :one_for_one, name: SpinUpTestCluster.otp_name(:worker_supervisor)}
+      )
+
+      write_worker(dir, "aaaaaaaa")
+
+      state = Impl.do_spin_up(base_state(dir))
+
+      assert %{health: :ok} = state
+      assert [%{id: "aaaaaaaa", health: {:ok, pid}}] = Map.values(state.workers)
+      assert Process.alive?(pid)
+    end
+
+    test "a worker whose directory cannot produce one leaves the foreman unhealthy", %{tmp_dir: dir} do
+      start_supervised!(
+        {DynamicSupervisor, strategy: :one_for_one, name: SpinUpTestCluster.otp_name(:worker_supervisor)}
+      )
+
+      write_worker(dir, "aaaaaaaa")
+      # A manifest naming a module that is not a worker at all.
+      File.mkdir_p!(Path.join(dir, "bbbbbbbb"))
+
+      File.write!(
+        Path.join(dir, "bbbbbbbb/manifest.json"),
+        ~s({"id":"bbbbbbbb","cluster":"spin_up_test_cluster","worker":"Enum","params":{}})
+      )
+
+      assert %{health: health} = Impl.do_spin_up(base_state(dir))
+
+      refute health == :ok, "a worker that cannot start must not be reported as healthy"
+    end
+  end
+end


### PR DESCRIPTION
Closes bedrock-mxt. **Stacked on #213** — it also edits `do_spin_up/1`. GitHub will retarget this to `develop` when #213 merges.

`do_spin_up/1` loaded workers from disk, started them, and relayed the layout — but never recomputed health. `recompute_health/1` is reachable only from `do_worker_health/3`, `do_remove_worker/2` and `do_remove_workers/2`, so after a successful boot the state kept the `:starting` from `State.new_state/1`, however cleanly every worker started.

The consequence is worst where there is no other path to a verdict: the only sender of `{:worker_health, ...}` is `Materializer.Olivine.Server`, and **Shale never calls `Foreman.report_health/3`**. On a node with only the `:log` capability nothing would ever trigger the sole remaining recompute, so `wait_for_healthy/2` could not return `:ok` — not slowly, but never.

### Two corrections the audit forced
- **I dropped the `notify_waiting_for_healthy/1` call.** My justification for it — "a caller can park before spin-up runs" — is provably false: this runs in the `:spin_up` `handle_continue`, which precedes every mailbox message, so the `handle_call` that is the only writer of `waiting_for_healthy` cannot have run. The list is always `[]` here. A caller whose request is already queued finds health settled when it is served. The line was dead code with a false comment; the comment now explains why no notify is needed.
- **The tests only covered the empty-directory path**, so the headline scenario was untested. There is now a test with a log worker that really starts, driving the verdict to `:ok`, plus one where a worker cannot start and the foreman must not report healthy. Four of five tests fail against the pre-fix code.

### What `:ok` means here is weaker than the docstring promises
`try_to_start_worker/3` concludes `{:ok, pid}` once the process registers its name. For Olivine that is after `init/1`, which returns immediately and defers real work to a `:finish_startup` continue — so a materializer whose startup will fail can be counted healthy and then die, and the foreman never learns, because it holds no monitor on its workers. Filed as bedrock-z2e (P2). Previously such a node reached `:ok` only via the worker's own post-startup report, which was stronger; for log workers, which never report at all, there was no path to `:ok` whatsoever, which was worse.

Also filed: bedrock-jq8 — `try_to_start_workers/3` has an unreachable `{:error, _}` clause and would `CaseClauseError` the whole foreman on a `Task.async_stream` `{:exit, _}`, which its default 5s timeout makes reachable under load.

### Verification
2816 tests, 0 failures. `mix compile --warnings-as-errors`, credo, dialyzer and format clean.

The verdict this settles is only as trustworthy as the fold that produces it — bedrock-287 (#214) fixes that fold's order-dependence on its own branch.