### PR TITLE
Make recomputing health and waking waiters one act

### DIFF
--- a/lib/bedrock/service/foreman/impl.ex
+++ b/lib/bedrock/service/foreman/impl.ex
@@ -91,7 +91,10 @@ defmodule Bedrock.Service.Foreman.Impl do
       |> try_to_start_worker(t.cluster, t.object_storage)
       |> advertise_running_worker(t.cluster)
 
-    t = update_workers(t, &Map.put(&1, id, worker_info))
+    t =
+      t
+      |> update_workers(&Map.put(&1, id, worker_info))
+      |> settle_health()
 
     {t, worker_info.otp_name}
   end
@@ -111,7 +114,7 @@ defmodule Bedrock.Service.Foreman.Impl do
         t =
           t
           |> update_workers(&Map.delete(&1, worker_id))
-          |> recompute_health()
+          |> settle_health()
 
         {t, result}
     end
@@ -126,7 +129,7 @@ defmodule Bedrock.Service.Foreman.Impl do
            }}
   def do_remove_workers(t, worker_ids) do
     {updated_state, results} = process_worker_removals(t, worker_ids)
-    final_state = recompute_health(updated_state)
+    final_state = settle_health(updated_state)
     {final_state, results}
   end
 
@@ -242,8 +245,7 @@ defmodule Bedrock.Service.Foreman.Impl do
   def do_worker_health(t, worker_id, health) do
     t
     |> put_health_for_worker(worker_id, health)
-    |> recompute_health()
-    |> notify_waiting_for_healthy()
+    |> settle_health()
   end
 
   @spec do_spin_up(State.t()) :: State.t()
@@ -261,12 +263,15 @@ defmodule Bedrock.Service.Foreman.Impl do
     # therefore had no path to :ok at all, and wait_for_healthy/2 could
     # not return on one.
     #
-    # No waiters can exist yet to notify: this runs in the :spin_up
-    # handle_continue, which precedes every mailbox message, so the
-    # handle_call that is the only writer of waiting_for_healthy cannot
-    # have run. A caller whose request is already queued finds health
-    # settled when it is finally served.
-    |> recompute_health()
+    # settle_health/1 rather than a bare recompute, though no waiter can
+    # exist here yet: this runs in the :spin_up handle_continue, which
+    # precedes every mailbox message, so the handle_call that is the only
+    # writer of waiting_for_healthy cannot have run. The notify is a
+    # no-op today and is here anyway, because "provably no waiters" is a
+    # property of the current call ordering rather than of this code —
+    # routing every health change through one function is what keeps the
+    # pairing from being forgotten if that ordering ever changes.
+    |> settle_health()
   end
 
   # An unstartable directory is silent by nature: with no manifest there
@@ -331,6 +336,19 @@ defmodule Bedrock.Service.Foreman.Impl do
       |> merge_worker_info_into_workers(workers)
     end)
   end
+
+  @doc """
+  Recomputes the foreman's verdict and wakes anyone waiting on it.
+
+  One act, not two. A caller parked in `wait_for_healthy/2` waits with no
+  timeout by default, so a path that recomputes without notifying leaves
+  it asleep through the exact moment its condition became true. Every
+  health change goes through here so that pairing cannot be forgotten at
+  a call site — which is how worker removal came to flip the verdict to
+  `:ok` and tell nobody.
+  """
+  @spec settle_health(State.t()) :: State.t()
+  def settle_health(t), do: t |> recompute_health() |> notify_waiting_for_healthy()
 
   @spec recompute_health(State.t()) :: State.t()
   def recompute_health(t) do

--- a/lib/bedrock/service/foreman/state.ex
+++ b/lib/bedrock/service/foreman/state.ex
@@ -13,7 +13,7 @@ defmodule Bedrock.Service.Foreman.State do
           otp_name: atom(),
           path: Path.t(),
           object_storage: term(),
-          waiting_for_healthy: [pid()],
+          waiting_for_healthy: [GenServer.from()],
           workers: %{Worker.id() => WorkerInfo.t()}
         }
   defstruct [
@@ -68,7 +68,7 @@ defmodule Bedrock.Service.Foreman.State do
           State.t()
   def update_waiting_for_healthy(t, updater), do: %{t | waiting_for_healthy: updater.(t.waiting_for_healthy)}
 
-  @spec put_waiting_for_healthy(State.t(), [pid()]) :: State.t()
+  @spec put_waiting_for_healthy(State.t(), [GenServer.from()]) :: State.t()
   def put_waiting_for_healthy(t, waiting_for_healthy), do: %{t | waiting_for_healthy: waiting_for_healthy}
 
   @spec put_health_for_worker(State.t(), Worker.id(), Worker.health()) :: State.t()

--- a/test/bedrock/service/foreman/settle_health_test.exs
+++ b/test/bedrock/service/foreman/settle_health_test.exs
@@ -1,0 +1,136 @@
+defmodule Bedrock.Service.Foreman.SettleHealthTest do
+  use ExUnit.Case, async: true
+
+  alias Bedrock.Service.Foreman.Impl
+  alias Bedrock.Service.Foreman.State
+  alias Bedrock.Service.Foreman.WorkerInfo
+
+  # Recomputing the verdict and waking the callers waiting on it are one
+  # act, not two. Every place that does the first must do the second —
+  # otherwise a caller parked in wait_for_healthy/2 (default timeout
+  # :infinity) sleeps through the very moment its condition came true.
+
+  defmodule SettleTestCluster do
+    @moduledoc false
+    def name, do: "settle_test_cluster"
+    def otp_name_for_worker(id), do: :"settle_test_worker_#{id}"
+    def otp_name(:worker_supervisor), do: :settle_test_worker_supervisor
+    def otp_name(:link), do: :settle_test_link
+    def otp_name(:foreman), do: :settle_test_foreman
+  end
+
+  defp failed_worker(id) do
+    %WorkerInfo{
+      id: id,
+      path: "/nonexistent/#{id}",
+      otp_name: :"settle_test_worker_#{id}",
+      health: {:failed_to_start, :manifest_does_not_exist}
+    }
+  end
+
+  defp healthy_worker(id) do
+    %WorkerInfo{
+      id: id,
+      path: "/nonexistent/#{id}",
+      otp_name: :"settle_test_worker_#{id}",
+      health: {:ok, self()}
+    }
+  end
+
+  defp state_with(workers, waiting) do
+    %State{
+      cluster: SettleTestCluster,
+      capabilities: [:log],
+      health: {:failed_to_start, :at_least_one_failed_to_start},
+      otp_name: :settle_test_foreman,
+      path: "/nonexistent",
+      waiting_for_healthy: waiting,
+      workers: Map.new(workers, &{&1.id, &1})
+    }
+  end
+
+  describe "do_remove_worker/2" do
+    # Removing the last failing worker is exactly when a parked caller's
+    # condition becomes true, and exactly when it was never told.
+    test "wakes waiters when removal makes the foreman healthy" do
+      tag = make_ref()
+      state = state_with([healthy_worker("aaaa"), failed_worker("bbbb")], [{self(), tag}])
+
+      {settled, _result} = Impl.do_remove_worker(state, "bbbb")
+
+      assert settled.health == :ok
+      assert settled.waiting_for_healthy == []
+      assert_receive {^tag, :ok}
+    end
+
+    test "leaves waiters parked while the foreman is still unhealthy" do
+      tag = make_ref()
+      state = state_with([failed_worker("aaaa"), failed_worker("bbbb")], [{self(), tag}])
+
+      {settled, _result} = Impl.do_remove_worker(state, "bbbb")
+
+      # Deliberately not asserting WHICH unhealthy verdict: that depends
+      # on the fold, which bedrock-287 corrects on a separate branch.
+      # What matters here is that a waiter is only woken by :ok.
+      refute settled.health == :ok
+      assert settled.waiting_for_healthy == [{self(), tag}]
+      refute_receive {^tag, :ok}, 50
+    end
+
+    test "removing an absent worker changes nothing" do
+      tag = make_ref()
+      state = state_with([failed_worker("aaaa")], [{self(), tag}])
+
+      assert {^state, {:error, :worker_not_found}} = Impl.do_remove_worker(state, "zzzz")
+      refute_receive {^tag, :ok}, 50
+    end
+  end
+
+  describe "do_new_worker/4" do
+    # The same gap in the optimistic direction: adding a worker changes
+    # the set the verdict summarises, so a worker that fails to start
+    # must be able to take the foreman OUT of :ok. Left unsettled, a
+    # fresh node reports healthy while hosting a dead worker, and
+    # do_wait_for_healthy/2 short-circuits :ok immediately.
+    test "a worker that fails to start takes the foreman out of :ok" do
+      # max_children: 0 makes every start_child fail, which is the
+      # simplest honest way to get {:failed_to_start, _} from the real
+      # code path rather than a hand-built worker_info.
+      start_supervised!(
+        {DynamicSupervisor,
+         strategy: :one_for_one, max_children: 0, name: SettleTestCluster.otp_name(:worker_supervisor)}
+      )
+
+      dir = Path.join(System.tmp_dir!(), "settle_new_worker_#{System.unique_integer([:positive])}")
+      File.mkdir_p!(dir)
+      on_exit(fn -> File.rm_rf!(dir) end)
+
+      state = %{state_with([], []) | path: dir, health: :ok}
+
+      {settled, _ref} = Impl.do_new_worker(state, "eeeeeeee", :log, %{})
+
+      assert [%{health: {:failed_to_start, _}}] = Map.values(settled.workers)
+
+      refute settled.health == :ok,
+             "a foreman hosting a worker that failed to start must not report healthy"
+    end
+  end
+
+  describe "do_remove_workers/2" do
+    test "wakes waiters when a batch removal makes the foreman healthy" do
+      tag = make_ref()
+
+      state =
+        state_with(
+          [healthy_worker("aaaa"), failed_worker("bbbb"), failed_worker("cccc")],
+          [{self(), tag}]
+        )
+
+      {settled, _results} = Impl.do_remove_workers(state, ["bbbb", "cccc"])
+
+      assert settled.health == :ok
+      assert settled.waiting_for_healthy == []
+      assert_receive {^tag, :ok}
+    end
+  end
+end


### PR DESCRIPTION
Closes bedrock-n5h, under epic bedrock-gu0. **Stacked on #218**, itself stacked on #213. GitHub retargets as each merges.

`do_remove_worker/2` and `do_remove_workers/2` recomputed the verdict but never called `notify_waiting_for_healthy/1`. Only `do_worker_health/3` paired them — by hand.

So removing the last failing worker flipped health to `:ok` and told nobody. A caller parked in `wait_for_healthy/2` (default timeout `:infinity`) slept through the exact moment its condition became true.

### The audit found the same gap in the opposite direction

`do_new_worker/4` is a **fourth** writer of `t.workers` and recomputed nothing at all. A fresh node folds an empty worker set to `:ok`, so adding a worker that then fails to start left the foreman reporting healthy while hosting a dead one — and `do_wait_for_healthy/2` short-circuits `:ok` immediately. Nothing corrected it, since recompute is otherwise reachable only from a worker's own health cast and Shale never sends one.

I had written a docstring claiming *"every health change goes through here"* while only three of four writers did. Rather than weaken the claim, this PR makes it true: `settle_health/1` now covers all four.

### Why a helper rather than four fixed call sites

The pairing stops being something a call site can forget. Forgetting it is precisely how three of the four came to differ from each other.

Spin-up uses it too, though no waiter can exist there — it runs in the `:spin_up` `handle_continue`, which precedes every mailbox message. The notify is a no-op today and is there anyway, because "provably no waiters" is a property of the current call ordering rather than of that code.

### Verification

2821 tests, 0 failures. `mix compile --warnings-as-errors`, format, credo and dialyzer all clean. Two of the four original tests fail against the pre-fix code; the `do_new_worker` test fails against the un-fixed version of that path.

Audited by a cold agent, which confirmed no double-reply is possible (the list clear rides in the same returned state as the reply), verified the spin-up no-waiters claim independently, and proved `do_new_worker`'s staleness using the real function rather than a graft.

### Follow-ups filed

- **bedrock-gu0.1** — `waiting_for_healthy` is never pruned, so a timed-out caller leaks and later receives a stale reply.
- **bedrock-uvk** — the audit also **identified the flaky test** I had seen once and could not name: `ShardServerTest`'s retry-telemetry case missing its 1.5s `assert_receive` budget under full-suite load. Reproduced once in 20 full-suite runs, never in 10 isolated runs of that file. It is not bedrock-s9x.
