### PR TITLE
Watch hosted workers, so a dead one stops being reported as running

### DIFF
--- a/lib/bedrock/service/foreman/impl.ex
+++ b/lib/bedrock/service/foreman/impl.ex
@@ -85,11 +85,18 @@ defmodule Bedrock.Service.Foreman.Impl do
   @spec do_new_worker(State.t(), Worker.id(), :log | :materializer, params :: map()) ::
           {State.t(), Worker.ref()}
   def do_new_worker(t, id, kind, params \\ %{}) do
+    # An id already in the map means a retried creation — a director that
+    # timed out and asked again. The entry is about to be overwritten, so
+    # release its monitor first or the ref leaks: nothing else can reach
+    # it once the entry is gone.
+    release_monitor(Map.get(t.workers, id))
+
     worker_info =
       id
       |> initialize_new_worker(worker_for_kind(kind), params, t.path, t.cluster)
       |> try_to_start_worker(t.cluster, t.object_storage)
       |> advertise_running_worker(t.cluster)
+      |> monitor_worker()
 
     t =
       t
@@ -189,10 +196,24 @@ defmodule Bedrock.Service.Foreman.Impl do
   @spec remove_worker_completely(WorkerInfo.t(), module(), String.t()) ::
           :ok | {:error, {:failed_to_remove_directory, File.posix(), Path.t()}}
   defp remove_worker_completely(worker_info, cluster, base_path) do
+    # Release the monitor before terminating, with :flush so an already
+    # queued :DOWN is discarded. A deliberate removal is not a death, and
+    # must not be reported as one.
+    release_monitor(worker_info)
+
     with :ok <- terminate_worker_process(worker_info, cluster),
          :ok <- unadvertise_worker(worker_info, cluster) do
       cleanup_worker_directory(worker_info, base_path)
     end
+  end
+
+  @spec release_monitor(WorkerInfo.t() | nil) :: :ok
+  defp release_monitor(nil), do: :ok
+  defp release_monitor(%{monitor_ref: nil}), do: :ok
+
+  defp release_monitor(%{monitor_ref: ref}) do
+    Process.demonitor(ref, [:flush])
+    :ok
   end
 
   @spec terminate_worker_process(WorkerInfo.t(), module()) :: :ok | {:error, :not_found}
@@ -241,12 +262,128 @@ defmodule Bedrock.Service.Foreman.Impl do
   @spec do_wait_for_healthy(State.t(), GenServer.from()) :: State.t()
   def do_wait_for_healthy(t, from), do: add_pid_to_waiting_for_healthy(t, from)
 
+  @doc """
+  Records that a monitored worker's process is gone.
+
+  The process is gone right now, so `:stopped` is what is true right now
+  — and it is the state the worker held before it ever started, so no
+  health value the fold does not already understand.
+
+  It may not stay true. Workers are `:transient` under a
+  DynamicSupervisor, so an abnormal exit is restarted under the same OTP
+  name, and leaving the worker at `:stopped` would drop a LIVE worker out
+  of the roll call `do_get_all_running_services/1` advertises to the
+  coordinator — the original bug's mirror image. Adopting that
+  replacement cannot happen here, because the `:DOWN` always beats the
+  restart: it is delivered the instant the process dies, while the
+  supervisor must first handle its own `EXIT`. The caller therefore
+  schedules `do_worker_recheck/3`, and the worker id is returned for
+  exactly that purpose.
+
+  A `:DOWN` whose ref matches no worker is ignored, which is the ordinary
+  case for one the foreman deliberately removed:
+  `remove_worker_completely/3` demonitors with `:flush`, so a queued
+  `:DOWN` is discarded before it can be mistaken for a death.
+  """
+  @spec do_worker_down(State.t(), reference(), term()) ::
+          {State.t(), Worker.id() | :no_such_worker}
+  def do_worker_down(t, ref, reason) do
+    case Enum.find(t.workers, fn {_id, worker_info} -> worker_info.monitor_ref == ref end) do
+      nil -> {t, :no_such_worker}
+      {worker_id, _worker_info} -> {resettle_worker(t, worker_id, reason), worker_id}
+    end
+  end
+
+  @spec resettle_worker(State.t(), Worker.id(), term()) :: State.t()
+  defp resettle_worker(t, worker_id, reason) do
+    Logger.warning("Bedrock foreman: worker #{worker_id} died (#{inspect(reason)})")
+
+    t
+    |> update_workers(
+      &Map.update!(&1, worker_id, fn info ->
+        info |> WorkerInfo.put_health(:stopped) |> WorkerInfo.put_monitor_ref(nil)
+      end)
+    )
+    |> settle_health()
+  end
+
+  @doc """
+  Adopts the replacement a supervisor started for a worker that died.
+
+  Split from `do_worker_down/3` because the two events race and the
+  `:DOWN` always wins: it is delivered the instant the process dies,
+  while the supervisor must first handle its own `EXIT` and only then
+  start a child. Re-resolving at `:DOWN` time therefore finds nothing
+  almost every time, which would leave a worker the supervisor DID
+  restart parked at `:stopped` — dropping a live worker out of the roll
+  call `do_get_all_running_services/1` advertises from, which is the
+  original bug's mirror image.
+
+  Only a worker still `:stopped` is adopted, so this can never overwrite
+  a health the worker reported for itself in the meantime. Attempts are
+  bounded: a `:transient` child that exited normally is never coming
+  back, and retrying forever would mean a timer per dead worker for the
+  life of the node. A restart slower than that window therefore leaves a
+  live worker recorded as `:stopped` until the next spin-up
+  (bedrock-gu0.2) — stale toward unhealthy, which is the safe direction.
+  """
+  @spec do_worker_recheck(State.t(), Worker.id(), non_neg_integer()) ::
+          {State.t(), :done | :retry}
+  def do_worker_recheck(t, worker_id, attempts_left) do
+    with %{health: :stopped, otp_name: otp_name} <- Map.get(t.workers, worker_id),
+         pid when is_pid(pid) <- Process.whereis(otp_name) do
+      Logger.info("Bedrock foreman: worker #{worker_id} was replaced; adopting #{inspect(pid)}")
+
+      t =
+        t
+        |> update_workers(
+          &Map.update!(&1, worker_id, fn info ->
+            info |> WorkerInfo.put_health({:ok, pid}) |> monitor_worker()
+          end)
+        )
+        |> settle_health()
+
+      {t, :done}
+    else
+      _ when attempts_left > 0 -> {t, :retry}
+      _ -> {t, :done}
+    end
+  end
+
   @spec do_worker_health(State.t(), Worker.id(), WorkerInfo.health()) :: State.t()
   def do_worker_health(t, worker_id, health) do
     t
     |> put_health_for_worker(worker_id, health)
+    |> rewatch_worker(worker_id, Map.get(t.workers, worker_id))
     |> settle_health()
   end
+
+  # A worker reporting its own health can name a DIFFERENT process than
+  # the one being watched. Olivine's replacement casts {:ok, self()} the
+  # moment its startup completes, which for a small shard beats the
+  # recheck timer — and `do_worker_recheck/3` only adopts a worker still
+  # `:stopped`, so it would then retry to exhaustion and give up. The new
+  # pid would be left carrying a stale ref or none at all, no further
+  # :DOWN would ever arrive for it, and the worker would be back in
+  # exactly the state this whole change exists to eliminate.
+  @spec rewatch_worker(State.t(), Worker.id(), WorkerInfo.t() | nil) :: State.t()
+  defp rewatch_worker(t, worker_id, previous) do
+    update_workers(
+      t,
+      &Map.update!(&1, worker_id, fn info ->
+        if watching?(previous, info.health) do
+          info
+        else
+          release_monitor(previous)
+          info |> WorkerInfo.put_monitor_ref(nil) |> monitor_worker()
+        end
+      end)
+    )
+  end
+
+  @spec watching?(WorkerInfo.t() | nil, WorkerInfo.health()) :: boolean()
+  defp watching?(%{monitor_ref: ref, health: {:ok, pid}}, {:ok, pid}) when is_reference(ref), do: true
+  defp watching?(_previous, _health), do: false
 
   @spec do_spin_up(State.t()) :: State.t()
   def do_spin_up(t) do
@@ -333,9 +470,29 @@ defmodule Bedrock.Service.Foreman.Impl do
       |> Enum.filter(&(&1.health == :stopped))
       |> try_to_start_workers(t.cluster, t.object_storage)
       |> advertise_running_workers(t.cluster)
+      |> Enum.map(&monitor_worker/1)
       |> merge_worker_info_into_workers(workers)
     end)
   end
+
+  @doc """
+  Watches a running worker so its death is observable.
+
+  A worker's health is otherwise recorded once, at start, and never
+  revisited — so `{:ok, pid}` outlives the process it names. The foreman
+  would go on relaying layout pushes to a dead worker, advertising it to
+  the coordinator as a running service, and folding it into a verdict of
+  `:ok`.
+
+  The monitor must be taken by the foreman itself. Starting happens
+  inside a `Task.async_stream`, and a monitor established there would
+  belong to the task and die with it.
+  """
+  @spec monitor_worker(WorkerInfo.t()) :: WorkerInfo.t()
+  def monitor_worker(%{health: {:ok, pid}, monitor_ref: nil} = worker_info),
+    do: WorkerInfo.put_monitor_ref(worker_info, Process.monitor(pid))
+
+  def monitor_worker(worker_info), do: worker_info
 
   @doc """
   Recomputes the foreman's verdict and wakes anyone waiting on it.

--- a/lib/bedrock/service/foreman/server.ex
+++ b/lib/bedrock/service/foreman/server.ex
@@ -103,8 +103,40 @@ defmodule Bedrock.Service.Foreman.Server do
   def handle_info({:tsl_updated, transaction_system_layout}, t),
     do: t |> do_relay_tsl(transaction_system_layout) |> noreply()
 
+  # How long to keep looking for the replacement a supervisor starts for
+  # a worker that died, and how often. The :DOWN beats the restart every
+  # time, so the first look is always too early; these bound how long a
+  # restarted worker can stay recorded as :stopped.
+  @recheck_interval_ms 25
+  @recheck_attempts 20
+
+  # A hosted worker's process is gone. Without this the monitor's :DOWN
+  # would fall into the catch-all below and the foreman would go on
+  # naming a dead process as running.
+  @impl true
+  def handle_info({:DOWN, ref, :process, _pid, reason}, t) do
+    case do_worker_down(t, ref, reason) do
+      {t, :no_such_worker} -> noreply(t)
+      {t, worker_id} -> t |> schedule_recheck(worker_id, @recheck_attempts) |> noreply()
+    end
+  end
+
+  # The worker died; see whether its supervisor has since replaced it.
+  @impl true
+  def handle_info({:worker_recheck, worker_id, attempts_left}, t) do
+    case do_worker_recheck(t, worker_id, attempts_left) do
+      {t, :done} -> noreply(t)
+      {t, :retry} -> t |> schedule_recheck(worker_id, attempts_left - 1) |> noreply()
+    end
+  end
+
   @impl true
   def handle_info(_, t), do: noreply(t)
+
+  defp schedule_recheck(t, worker_id, attempts_left) do
+    Process.send_after(self(), {:worker_recheck, worker_id, attempts_left}, @recheck_interval_ms)
+    t
+  end
 
   @impl true
   def handle_continue(:spin_up, t), do: t |> do_spin_up() |> noreply()

--- a/lib/bedrock/service/foreman/worker_info.ex
+++ b/lib/bedrock/service/foreman/worker_info.ex
@@ -16,11 +16,15 @@ defmodule Bedrock.Service.Foreman.WorkerInfo do
     :path,
     :health,
     :manifest,
-    :otp_name
+    :otp_name,
+    :monitor_ref
   ]
 
   @spec put_health(t(), health()) :: t()
   def put_health(t, health), do: %{t | health: health}
+
+  @spec put_monitor_ref(t(), reference() | nil) :: t()
+  def put_monitor_ref(t, monitor_ref), do: %{t | monitor_ref: monitor_ref}
 
   @spec put_manifest(t(), Manifest.t()) :: t()
   def put_manifest(t, manifest), do: %{t | manifest: manifest}

--- a/test/bedrock/service/foreman/worker_death_test.exs
+++ b/test/bedrock/service/foreman/worker_death_test.exs
@@ -1,0 +1,302 @@
+defmodule Bedrock.Service.Foreman.WorkerDeathTest do
+  use ExUnit.Case, async: false
+
+  alias Bedrock.ObjectStorage
+  alias Bedrock.ObjectStorage.LocalFilesystem
+  alias Bedrock.Service.Foreman.Server
+
+  # A worker's health is recorded once, when it starts, and never
+  # revisited. Nothing monitors the process, so {:ok, pid} outlives the
+  # process it names: the foreman goes on reporting a dead worker as
+  # running, relaying layout pushes to it, and — since the verdict is a
+  # fold over these values — reporting itself healthy.
+  alias Bedrock.Service.WorkerBehaviour
+
+  @moduletag :tmp_dir
+
+  defmodule DeathTestCluster do
+    @moduledoc false
+    def name, do: "death_test_cluster"
+    def otp_name_for_worker(id), do: :"death_test_worker_#{id}"
+    def otp_name(:worker_supervisor), do: :death_test_worker_supervisor
+    def otp_name(:link), do: :death_test_link
+    def otp_name(:foreman), do: :death_test_foreman
+  end
+
+  defmodule DeathTestWorker do
+    @moduledoc false
+    use WorkerBehaviour, kind: :log
+    use GenServer
+
+    def child_spec(opts), do: %{id: {__MODULE__, opts[:id]}, start: {__MODULE__, :start_link, [opts]}}
+    def start_link(opts), do: GenServer.start_link(__MODULE__, opts, name: opts[:otp_name])
+
+    @impl GenServer
+    def init(opts), do: {:ok, opts}
+  end
+
+  # Olivine-shaped: init/1 returns immediately and the real startup runs
+  # in a continue, which then casts the worker's own health to the
+  # foreman. That cast names a pid, and for a small shard it lands well
+  # inside the recheck window — so it, not the recheck, is what adopts a
+  # replacement.
+  defmodule SelfReportingWorker do
+    @moduledoc false
+    use WorkerBehaviour, kind: :materializer
+    use GenServer
+
+    alias Bedrock.Service.Foreman
+
+    def child_spec(opts), do: %{id: {__MODULE__, opts[:id]}, start: {__MODULE__, :start_link, [opts]}}
+    def start_link(opts), do: GenServer.start_link(__MODULE__, opts, name: opts[:otp_name])
+
+    @impl GenServer
+    def init(opts), do: {:ok, opts, {:continue, :report}}
+
+    @impl GenServer
+    def handle_continue(:report, opts) do
+      Foreman.report_health(opts[:foreman], opts[:id], {:ok, self()})
+      {:noreply, opts}
+    end
+  end
+
+  defp write_self_reporting_worker(dir, id) do
+    path = Path.join(dir, id)
+    File.mkdir_p!(path)
+
+    File.write!(
+      Path.join(path, "manifest.json"),
+      ~s({"id":"#{id}","cluster":"death_test_cluster",) <>
+        ~s("worker":"Bedrock.Service.Foreman.WorkerDeathTest.SelfReportingWorker","params":{}})
+    )
+  end
+
+  defp write_worker(dir, id) do
+    path = Path.join(dir, id)
+    File.mkdir_p!(path)
+
+    File.write!(
+      Path.join(path, "manifest.json"),
+      ~s({"id":"#{id}","cluster":"death_test_cluster",) <>
+        ~s("worker":"Bedrock.Service.Foreman.WorkerDeathTest.DeathTestWorker","params":{}})
+    )
+  end
+
+  defp start_foreman(dir) do
+    start_supervised!({DynamicSupervisor, strategy: :one_for_one, name: DeathTestCluster.otp_name(:worker_supervisor)})
+
+    foreman =
+      start_supervised!(%{
+        id: Server,
+        start:
+          {GenServer, :start_link,
+           [
+             Server,
+             %{
+               cluster: DeathTestCluster,
+               path: dir,
+               capabilities: [:log],
+               otp_name: DeathTestCluster.otp_name(:foreman),
+               object_storage: ObjectStorage.backend(LocalFilesystem, root: Path.join(dir, "object_storage"))
+             },
+             [name: DeathTestCluster.otp_name(:foreman)]
+           ]}
+      })
+
+    # Force the :spin_up continue to have run.
+    :pong = GenServer.call(foreman, :ping)
+    foreman
+  end
+
+  defp worker_health(foreman, id), do: :sys.get_state(foreman).workers[id].health
+
+  # A normal exit leaves a :transient child down for good.
+  defp stop_for_good(pid) do
+    ref = Process.monitor(pid)
+    GenServer.stop(pid, :normal)
+    assert_receive {:DOWN, ^ref, :process, ^pid, _}
+  end
+
+  # The supervisor's restart is concurrent with our :DOWN; wait for the
+  # name to be held by someone other than the process that just died.
+  defp wait_for_replacement(original, attempts \\ 100) do
+    case Process.whereis(DeathTestCluster.otp_name_for_worker("aaaaaaaa")) do
+      pid when is_pid(pid) and pid != original ->
+        pid
+
+      _ when attempts > 0 ->
+        Process.sleep(10)
+        wait_for_replacement(original, attempts - 1)
+
+      _ ->
+        flunk("the supervisor never replaced the worker")
+    end
+  end
+
+  # Adoption happens on a timer, because the :DOWN always arrives before
+  # the supervisor has started the replacement.
+  defp wait_for_adoption(foreman, id, original, attempts \\ 100) do
+    case worker_health(foreman, id) do
+      {:ok, pid} when pid != original ->
+        pid
+
+      _ when attempts > 0 ->
+        Process.sleep(10)
+        wait_for_adoption(foreman, id, original, attempts - 1)
+
+      health ->
+        flunk("the foreman never adopted the replacement; health is #{inspect(health)}")
+    end
+  end
+
+  describe "a worker that dies" do
+    test "stops being reported as running", %{tmp_dir: dir} do
+      write_worker(dir, "aaaaaaaa")
+      foreman = start_foreman(dir)
+
+      assert {:ok, pid} = worker_health(foreman, "aaaaaaaa")
+
+      ref = Process.monitor(pid)
+      Process.exit(pid, :kill)
+      assert_receive {:DOWN, ^ref, :process, ^pid, :killed}
+
+      # Settle the foreman's mailbox before observing it.
+      :pong = GenServer.call(foreman, :ping)
+
+      refute match?({:ok, ^pid}, worker_health(foreman, "aaaaaaaa")),
+             "the foreman must not go on naming a dead process as running"
+    end
+
+    # A normal exit does not restart a :transient child, so this worker
+    # really is gone and the foreman must say so.
+    test "that is not replaced takes the foreman out of :ok", %{tmp_dir: dir} do
+      write_worker(dir, "aaaaaaaa")
+      foreman = start_foreman(dir)
+
+      assert %{health: :ok} = :sys.get_state(foreman)
+      {:ok, pid} = worker_health(foreman, "aaaaaaaa")
+
+      stop_for_good(pid)
+      :pong = GenServer.call(foreman, :ping)
+
+      assert worker_health(foreman, "aaaaaaaa") == :stopped
+
+      refute :sys.get_state(foreman).health == :ok,
+             "a foreman whose only worker is gone must not report healthy"
+    end
+
+    test "that is not replaced is dropped from the running-services roll call", %{tmp_dir: dir} do
+      write_worker(dir, "aaaaaaaa")
+      foreman = start_foreman(dir)
+
+      {:ok, pid} = worker_health(foreman, "aaaaaaaa")
+      stop_for_good(pid)
+      :pong = GenServer.call(foreman, :ping)
+
+      assert {:ok, []} = GenServer.call(foreman, :get_all_running_services)
+    end
+  end
+
+  describe "a worker the supervisor replaces" do
+    # Workers are :transient, so an abnormal exit is restarted under the
+    # same OTP name. Reporting the replacement as gone would drop a LIVE
+    # worker out of the roll call the coordinator is advertised from —
+    # the original bug's mirror image.
+    test "is re-adopted rather than reported gone", %{tmp_dir: dir} do
+      write_worker(dir, "aaaaaaaa")
+      foreman = start_foreman(dir)
+
+      {:ok, original} = worker_health(foreman, "aaaaaaaa")
+
+      ref = Process.monitor(original)
+      Process.exit(original, :kill)
+      assert_receive {:DOWN, ^ref, :process, ^original, :killed}
+
+      wait_for_replacement(original)
+      replacement = wait_for_adoption(foreman, "aaaaaaaa", original)
+
+      assert replacement != original
+      assert Process.alive?(replacement)
+      assert :sys.get_state(foreman).health == :ok
+      assert {:ok, [{"aaaaaaaa", :log, _}]} = GenServer.call(foreman, :get_all_running_services)
+    end
+
+    test "is monitored again, so a second death is still observed", %{tmp_dir: dir} do
+      write_worker(dir, "aaaaaaaa")
+      foreman = start_foreman(dir)
+
+      {:ok, original} = worker_health(foreman, "aaaaaaaa")
+      ref = Process.monitor(original)
+      Process.exit(original, :kill)
+      assert_receive {:DOWN, ^ref, :process, ^original, :killed}
+      wait_for_replacement(original)
+      replacement = wait_for_adoption(foreman, "aaaaaaaa", original)
+
+      assert :sys.get_state(foreman).workers["aaaaaaaa"].monitor_ref
+
+      stop_for_good(replacement)
+      :pong = GenServer.call(foreman, :ping)
+
+      assert worker_health(foreman, "aaaaaaaa") == :stopped
+    end
+  end
+
+  describe "a worker that reports its own health" do
+    # The self-report beats the recheck timer, so IT is what adopts the
+    # replacement. If adopting that way does not also take a monitor, the
+    # worker goes unwatched from then on — no further :DOWN can arrive,
+    # and the foreman is back to naming a dead process as running, with
+    # no timer left to correct it.
+    test "is still watched after its replacement reports in", %{tmp_dir: dir} do
+      write_self_reporting_worker(dir, "bbbbbbbb")
+      foreman = start_foreman(dir)
+
+      {:ok, original} = worker_health(foreman, "bbbbbbbb")
+
+      ref = Process.monitor(original)
+      Process.exit(original, :kill)
+      assert_receive {:DOWN, ^ref, :process, ^original, :killed}
+
+      replacement = wait_for_adoption(foreman, "bbbbbbbb", original)
+      assert Process.alive?(replacement)
+
+      assert :sys.get_state(foreman).workers["bbbbbbbb"].monitor_ref,
+             "adopting via a self-report must take a monitor too, or the worker goes unwatched"
+
+      # The real proof: a second death is still observed.
+      stop_for_good(replacement)
+      :pong = GenServer.call(foreman, :ping)
+
+      refute match?({:ok, ^replacement}, worker_health(foreman, "bbbbbbbb")),
+             "the foreman must not name the second dead process as running"
+    end
+  end
+
+  describe "a worker the foreman removes" do
+    # A deliberate removal is not a death. The entry is gone before the
+    # exit signal lands, so a stray :DOWN would be dropped anyway — what
+    # the demonitor actually buys is not leaving a monitor behind that
+    # nothing can ever reach again, since the entry holding its ref is
+    # deleted.
+    test "does not resurface as a death, and leaves no monitor behind", %{tmp_dir: dir} do
+      write_worker(dir, "aaaaaaaa")
+      foreman = start_foreman(dir)
+
+      {:ok, pid} = worker_health(foreman, "aaaaaaaa")
+      {:monitors, before} = Process.info(foreman, :monitors)
+      assert {:process, pid} in before
+
+      assert :ok = GenServer.call(foreman, {:remove_worker, "aaaaaaaa"})
+      :pong = GenServer.call(foreman, :ping)
+
+      state = :sys.get_state(foreman)
+      assert state.workers == %{}
+      assert state.health == :ok
+
+      {:monitors, remaining} = Process.info(foreman, :monitors)
+
+      refute {:process, pid} in remaining,
+             "removal must release the monitor, not orphan it"
+    end
+  end
+end


### PR DESCRIPTION
Closes bedrock-z2e, under epic bedrock-gu0.

A worker's health was recorded once, when it started, and never revisited. Nothing monitored the process, so `{:ok, pid}` outlived the process it named — and there was no monitor, no `trap_exit` and no `:DOWN` clause anywhere under `service/foreman`: the catch-all `handle_info/2` would have swallowed one regardless.

That stale value is load-bearing in three places:

| consumer | consequence |
|---|---|
| `do_relay_tsl/2` | layout pushes go to a dead pid — and that push is how a worker learns it has been **displaced** |
| `do_get_all_running_services/1` | the coordinator keeps being told a dead process is an available service |
| the health verdict | a fold over these values, so the foreman reports `:ok` while hosting a corpse |

The third is what made the verdict settled in #218/#219 untrustworthy. The second was not in the ticket — my failing tests found it.

### The interesting part: `:stopped` is not simply the right answer

Workers are `:transient`, so an abnormal exit is **restarted** under the same OTP name. Marking a dead worker `:stopped` and leaving it there would drop a *live* worker out of the roll call — trading a dead-process-reported-running bug for a live-process-reported-gone bug.

Adopting the replacement at `:DOWN` time doesn't work either: the `:DOWN` is delivered the instant the process dies, while the supervisor must first handle its own `EXIT`. It lost that race in every test run. So adoption is a bounded recheck on a timer, and only a worker still `:stopped` is adopted — it can never overwrite health the worker reported for itself.

### What the audit caught, and why my tests missed it

There are **two** adopters, not one. A worker that reports its own health names a pid, and that report can name a different process than the one being watched: Olivine's replacement casts `{:ok, self()}` as soon as startup completes, which for a small shard beats the recheck. Health would flip to the new pid with `monitor_ref: nil`, the recheck would decline to adopt an already-`{:ok}` worker and retry to exhaustion, and **nothing would ever watch the replacement again** — no further `:DOWN`, no timer left to correct it.

That is this bug restored in full, in the dangerous direction, for the one worker kind that self-reports. My tests all used a Shale-shaped worker that never reports, which is exactly why they passed. There is now a self-reporting worker in the suite, and it fails without the fix.

The audit also showed my removal test pinned nothing — deleting the demonitor left all six green, because the entry is gone before a stray `:DOWN` can land. The test now asserts on the foreman's actual monitor set, and the comment says what the demonitor really buys: not orphaning a monitor whose ref is about to be deleted with its entry. `do_new_worker/4` releases the same way before overwriting an entry, which a director retrying a timed-out creation will do.

### Verification
2869 tests, 0 failures. `mix compile --warnings-as-errors`, format, credo and dialyzer clean. The audit ran the new file 20x and the full suite 3x with no flakiness.

### Left open, both filed
- **bedrock-gu0.2** — a restart slower than the ~525 ms recheck window leaves a live worker recorded `:stopped`. Having Shale report its own health, as Olivine does, is the smallest fix.
- **bedrock-gu0.3** — an adopted worker is not handed the layout it missed while dead, so it cannot judge its own displacement until the next push. Narrowed by this change (those pushes previously went to a dead pid), not introduced by it.
