### PR TITLE
Give relay-chain receive assertions a window scheduling can't miss

### DIFF
--- a/test/bedrock/control_plane/distributor/placeholder_test.exs
+++ b/test/bedrock/control_plane/distributor/placeholder_test.exs
@@ -68,13 +68,19 @@ defmodule Bedrock.ControlPlane.Distributor.PlaceholderTest do
 
       task = async_get(placeholder, "apple", timeout: 5_000)
 
-      assert_receive {:"$gen_cast", {:coverage_demand, 1}}
-      assert_receive {:telemetry, [:bedrock, :distributor, :placeholder, :parked], %{count: 1}, %{tag: 1}}
+      # Receive windows in this file are generous (5s): every asserted
+      # message needs at least one other process — a Task, the
+      # placeholder, or a telemetry relay — scheduled before it can
+      # arrive, and the default 100ms window flakes under full-suite
+      # load (bedrock-n9w). assert_receive returns the moment the
+      # message arrives, so the width is free.
+      assert_receive {:"$gen_cast", {:coverage_demand, 1}}, 5_000
+      assert_receive {:telemetry, [:bedrock, :distributor, :placeholder, :parked], %{count: 1}, %{tag: 1}}, 5_000
 
       :ok = Placeholder.notify_covered(placeholder, 1, stub)
 
       assert {:ok, "red"} = Task.await(task, 5_000)
-      assert_receive {:telemetry, [:bedrock, :distributor, :placeholder, :drained], %{count: 1}, %{tag: 1}}
+      assert_receive {:telemetry, [:bedrock, :distributor, :placeholder, :drained], %{count: 1}, %{tag: 1}}, 5_000
     end
 
     test "parked key-selector get is drained with the resolved key-value" do
@@ -84,7 +90,7 @@ defmodule Bedrock.ControlPlane.Distributor.PlaceholderTest do
       selector = KeySelector.first_greater_or_equal("apple")
       task = Task.async(fn -> Materializer.get(placeholder, selector, @version, timeout: 5_000) end)
 
-      assert_receive {:"$gen_cast", {:coverage_demand, 1}}
+      assert_receive {:"$gen_cast", {:coverage_demand, 1}}, 5_000
       :ok = Placeholder.notify_covered(placeholder, 1, stub)
 
       assert {:ok, {"apple", "red"}} = Task.await(task, 5_000)
@@ -96,7 +102,7 @@ defmodule Bedrock.ControlPlane.Distributor.PlaceholderTest do
 
       task = Task.async(fn -> Materializer.get_range(placeholder, "a", "c", @version, timeout: 5_000) end)
 
-      assert_receive {:"$gen_cast", {:coverage_demand, 1}}
+      assert_receive {:"$gen_cast", {:coverage_demand, 1}}, 5_000
       :ok = Placeholder.notify_covered(placeholder, 1, stub)
 
       assert {:ok, {[{"apple", "red"}, {"banana", "yellow"}], false}} = Task.await(task, 5_000)
@@ -109,7 +115,7 @@ defmodule Bedrock.ControlPlane.Distributor.PlaceholderTest do
       task_a = async_get(placeholder, "apple", timeout: 5_000)
       task_b = async_get(placeholder, "cherry", timeout: 5_000)
 
-      assert_receive {:"$gen_cast", {:coverage_demand, 1}}
+      assert_receive {:"$gen_cast", {:coverage_demand, 1}}, 5_000
       :ok = Placeholder.notify_covered(placeholder, 1, stub)
 
       assert {:ok, "red"} = Task.await(task_a, 1_000)
@@ -127,7 +133,8 @@ defmodule Bedrock.ControlPlane.Distributor.PlaceholderTest do
       assert {:error, :unavailable} = Task.await(task, 5_000)
 
       assert_receive {:telemetry, [:bedrock, :distributor, :placeholder, :shed], %{count: 1},
-                      %{reason: :deadline_expired}}
+                      %{reason: :deadline_expired}},
+                     5_000
     end
 
     test "caller-supplied timeout below hold_ms bounds the parking budget" do
@@ -171,7 +178,7 @@ defmodule Bedrock.ControlPlane.Distributor.PlaceholderTest do
       :ok = Placeholder.notify_covered(placeholder, 1, stub)
 
       assert {:ok, "red"} = Materializer.get(placeholder, "apple", @version, timeout: 5_000)
-      assert_receive {:telemetry, [:bedrock, :distributor, :placeholder, :forwarded], %{count: 1}, %{tag: 1}}
+      assert_receive {:telemetry, [:bedrock, :distributor, :placeholder, :forwarded], %{count: 1}, %{tag: 1}}, 5_000
       refute_receive {:"$gen_cast", {:coverage_demand, _tag}}, 50
     end
 
@@ -182,7 +189,7 @@ defmodule Bedrock.ControlPlane.Distributor.PlaceholderTest do
       :ok = Placeholder.notify_covered(placeholder, 1, stub)
 
       task = async_get(placeholder, "pear", timeout: 5_000)
-      assert_receive {:"$gen_cast", {:coverage_demand, 2}}
+      assert_receive {:"$gen_cast", {:coverage_demand, 2}}, 5_000
 
       :ok = Placeholder.notify_covered(placeholder, 2, start_stub(%{"pear" => "green"}))
       assert {:ok, "green"} = Task.await(task, 5_000)
@@ -196,7 +203,7 @@ defmodule Bedrock.ControlPlane.Distributor.PlaceholderTest do
       task_a = async_get(placeholder, "apple", timeout: 5_000)
       task_b = async_get(placeholder, "banana", timeout: 5_000)
 
-      assert_receive {:"$gen_cast", {:coverage_demand, 1}}
+      assert_receive {:"$gen_cast", {:coverage_demand, 1}}, 5_000
       refute_receive {:"$gen_cast", {:coverage_demand, 1}}, 50
 
       stub = start_stub(%{"apple" => "red", "banana" => "yellow"})
@@ -211,8 +218,8 @@ defmodule Bedrock.ControlPlane.Distributor.PlaceholderTest do
       task_a = async_get(placeholder, "apple", timeout: 5_000)
       task_b = async_get(placeholder, "pear", timeout: 5_000)
 
-      assert_receive {:"$gen_cast", {:coverage_demand, 1}}
-      assert_receive {:"$gen_cast", {:coverage_demand, 2}}
+      assert_receive {:"$gen_cast", {:coverage_demand, 1}}, 5_000
+      assert_receive {:"$gen_cast", {:coverage_demand, 2}}, 5_000
 
       assert {:error, :unavailable} = Task.await(task_a, 1_000)
       assert {:error, :unavailable} = Task.await(task_b, 1_000)
@@ -225,19 +232,19 @@ defmodule Bedrock.ControlPlane.Distributor.PlaceholderTest do
       placeholder = start_placeholder()
 
       task = async_get(placeholder, "apple", timeout: 5_000)
-      # Generous budget: the default 100ms flakes under full-suite load.
-      assert_receive {:"$gen_cast", {:coverage_demand, 1}}, 1_000
+      assert_receive {:"$gen_cast", {:coverage_demand, 1}}, 5_000
 
       :ok = Placeholder.notify_coverage_failed(placeholder, 1, :no_capacity)
 
       assert {:error, :unavailable} = Task.await(task, 5_000)
 
       assert_receive {:telemetry, [:bedrock, :distributor, :placeholder, :shed], %{count: 1},
-                      %{tag: 1, reason: :no_capacity}}
+                      %{tag: 1, reason: :no_capacity}},
+                     5_000
 
       # Dedupe was cleared: a later request re-triggers the demand.
       retry_task = async_get(placeholder, "apple", timeout: 5_000)
-      assert_receive {:"$gen_cast", {:coverage_demand, 1}}
+      assert_receive {:"$gen_cast", {:coverage_demand, 1}}, 5_000
 
       stub = start_stub(%{"apple" => "red"})
       :ok = Placeholder.notify_covered(placeholder, 1, stub)

--- a/test/bedrock/control_plane/distributor/server_test.exs
+++ b/test/bedrock/control_plane/distributor/server_test.exs
@@ -287,7 +287,7 @@ defmodule Bedrock.ControlPlane.Distributor.ServerTest do
 
       # The covered tag is reserved only while its verification is in
       # flight; a current-epoch answer releases it without recruiting.
-      assert_receive {:assignment_verified, 0, "wkr_sys", :current}
+      assert_receive {:assignment_verified, 0, "wkr_sys", :current}, 5_000
       assert {:noreply, t3} = Server.handle_info({:assignment_verified, 0, "wkr_sys", :current}, t2)
       refute MapSet.member?(t3.recruiting, 0)
       assert MapSet.member?(t3.recruiting, 1)
@@ -313,8 +313,8 @@ defmodule Bedrock.ControlPlane.Distributor.ServerTest do
       refute MapSet.member?(t2.recruiting, 0)
 
       # A current-epoch answer means no publish, no adoption, no recruit.
-      assert_receive {:assignment_verified, 0, "wkr_sys", :current}
-      assert_receive {:assignment_verified, 1, _worker, verdict1}
+      assert_receive {:assignment_verified, 0, "wkr_sys", :current}, 5_000
+      assert_receive {:assignment_verified, 1, _worker, verdict1}, 5_000
 
       assert {:noreply, t3} =
                Server.handle_info({:assignment_verified, 0, {"wkr_sys", Atom.to_string(node())}, :current}, t2)
@@ -364,11 +364,11 @@ defmodule Bedrock.ControlPlane.Distributor.ServerTest do
 
       # The stale worker was locked into THIS epoch and unlocked at the
       # version IT reported.
-      assert_receive {:adopt_locked, {_name, _node}, 3}
-      assert_receive {:adopt_unlocked, version}
+      assert_receive {:adopt_locked, {_name, _node}, 3}, 5_000
+      assert_receive {:adopt_unlocked, version}, 5_000
       assert version == Version.from_integer(5)
 
-      assert_receive {:assignment_verified, 1, worker, {:adopted, ^adopted, _node, "wkr_stale"}}
+      assert_receive {:assignment_verified, 1, worker, {:adopted, ^adopted, _node, "wkr_stale"}}, 5_000
 
       assert {:noreply, t3} =
                Server.handle_info({:assignment_verified, 1, worker, {:adopted, adopted, node(), "wkr_stale"}}, t2)
@@ -417,7 +417,8 @@ defmodule Bedrock.ControlPlane.Distributor.ServerTest do
         ExUnit.CaptureLog.capture_log(fn ->
           assert {:noreply, t2} = Server.handle_continue(:startup_sweep, t)
 
-          assert_receive {:assignment_verified, 1, worker, {:error, {:materializer_lock_failed, :wedged_mid_lock, _}}}
+          assert_receive {:assignment_verified, 1, worker, {:error, {:materializer_lock_failed, :wedged_mid_lock, _}}},
+                         5_000
 
           assert {:noreply, t3} =
                    Server.handle_info(
@@ -571,8 +572,8 @@ defmodule Bedrock.ControlPlane.Distributor.ServerTest do
       # until the verdict clears it.
       assert {0, "wkr_back"} in Map.values(t2.assignment_monitors)
       assert t2.unreachable_counts == %{{0, "wkr_back"} => 1}
-      assert_receive :probed
-      assert_receive {:assignment_verified, 0, "wkr_back", :current}
+      assert_receive :probed, 5_000
+      assert_receive {:assignment_verified, 0, "wkr_back", :current}, 5_000
     end
 
     test "a verification verdict for a tag another mechanism re-owned is dropped" do
@@ -670,7 +671,7 @@ defmodule Bedrock.ControlPlane.Distributor.ServerTest do
         )
 
       assert {:noreply, _t} = Server.handle_cast({:coverage_demand, 7}, t)
-      assert_receive {:placeholder_got, {:covered, 7, {_otp_name, _node}}}
+      assert_receive {:placeholder_got, {:covered, 7, {_otp_name, _node}}}, 5_000
     end
 
     test "an uncovered tag is recorded as pending demand for recruitment" do
@@ -778,7 +779,7 @@ defmodule Bedrock.ControlPlane.Distributor.ServerTest do
 
       assert {:noreply, t} = Server.handle_cast({:coverage_demand, 9}, t)
       assert MapSet.member?(t.recruiting, 9)
-      assert_receive {:recruitment_complete, 9, {:error, _}}, 500
+      assert_receive {:recruitment_complete, 9, {:error, _}}, 5_000
 
       # Second demand while in flight: no second task.
       assert {:noreply, t2} = Server.handle_cast({:coverage_demand, 9}, t)
@@ -817,7 +818,7 @@ defmodule Bedrock.ControlPlane.Distributor.ServerTest do
                _ -> false
              end)
 
-      assert_receive {:placeholder_got, {:covered, 9, {_otp, _node}}}
+      assert_receive {:placeholder_got, {:covered, 9, {_otp, _node}}}, 5_000
       assert t2.snapshot.materializer_refs[9] == %{"wkr_new" => Atom.to_string(node())}
       refute MapSet.member?(t2.recruiting, 9)
 
@@ -872,7 +873,7 @@ defmodule Bedrock.ControlPlane.Distributor.ServerTest do
         ExUnit.CaptureLog.capture_log(fn ->
           assert {:noreply, t2} = Server.handle_info({:recruitment_complete, 9, {:error, :no_nodes}}, t)
 
-          assert_receive {:placeholder_got, {:coverage_failed, 9, :no_nodes}}
+          assert_receive {:placeholder_got, {:coverage_failed, 9, :no_nodes}}, 5_000
           assert Map.has_key?(t2.backoff, 9)
 
           # Backoff suppresses an immediate re-recruit.
@@ -919,13 +920,13 @@ defmodule Bedrock.ControlPlane.Distributor.ServerTest do
 
         # The crash arrives as a DOWN; the server must synthesize the
         # failed completion itself (handler-level: drive the DOWN).
-        assert_receive {:DOWN, ref, :process, _pid, {%RuntimeError{}, _}} = down
+        assert_receive {:DOWN, ref, :process, _pid, {%RuntimeError{}, _}} = down, 5_000
         assert Map.fetch!(t.recruit_task_refs, ref) == 9
 
         assert {:noreply, t2} = Server.handle_info(down, t)
         refute MapSet.member?(t2.recruiting, 9)
         assert t2.recruit_task_refs == %{}
-        assert_receive {:placeholder_got, {:coverage_failed, 9, {:recruit_task_crashed, _}}}
+        assert_receive {:placeholder_got, {:coverage_failed, 9, {:recruit_task_crashed, _}}}, 5_000
       end)
     end
 
@@ -1054,7 +1055,7 @@ defmodule Bedrock.ControlPlane.Distributor.ServerTest do
 
           # Park, don't forward; and the re-recruit is in flight. (The
           # stub forwards a cast: wait, don't demand prior arrival.)
-          assert_receive {:placeholder_got, {:uncovered, 7}}
+          assert_receive {:placeholder_got, {:uncovered, 7}}, 5_000
           assert MapSet.member?(t2.recruiting, 7)
           assert t2.snapshot.materializer_refs[7] == %{Placeholder.worker_id() => Atom.to_string(node())}
           assert t2.assignment_monitors == %{}
@@ -1095,7 +1096,7 @@ defmodule Bedrock.ControlPlane.Distributor.ServerTest do
           # The placeholder swap is published and the tag uncovered —
           # exactly like a heal — but NO recruit task starts.
           assert_received {:committed, _}
-          assert_receive {:placeholder_got, {:uncovered, 7}}
+          assert_receive {:placeholder_got, {:uncovered, 7}}, 5_000
           refute MapSet.member?(t2.recruiting, 7)
           assert t2.snapshot.materializer_refs[7] == %{Placeholder.worker_id() => Atom.to_string(node())}
 
@@ -1227,7 +1228,7 @@ defmodule Bedrock.ControlPlane.Distributor.ServerTest do
 
         # The placeholder must learn the survivor: it may still be
         # forwarding to the corpse from an earlier notify_covered.
-        assert_receive {:placeholder_got, {:covered, 7, _survivor_ref}}
+        assert_receive {:placeholder_got, {:covered, 7, _survivor_ref}}, 5_000
         refute_received {:placeholder_got, {:uncovered, 7}}
 
         assert t2.snapshot.materializer_refs[7] == %{"wkr_live" => node_string}
@@ -1421,7 +1422,7 @@ defmodule Bedrock.ControlPlane.Distributor.ServerTest do
           # ...the third escalates: retire the member, park, re-recruit.
           assert {:noreply, t3} = Server.handle_info({:reverify_assignment, 7, "wkr_gone"}, t)
           assert_received {:committed, _}
-          assert_receive {:placeholder_got, {:uncovered, 7}}
+          assert_receive {:placeholder_got, {:uncovered, 7}}, 5_000
           assert MapSet.member?(t3.recruiting, 7)
           assert t3.unreachable_counts == %{}
         end)
@@ -1447,7 +1448,7 @@ defmodule Bedrock.ControlPlane.Distributor.ServerTest do
       assert t2.unreachable_counts == %{{7, "wkr_alive"} => 2}
       assert Map.values(t2.assignment_monitors) == [{7, "wkr_alive"}]
 
-      assert_receive {:assignment_verified, 7, worker, :current}
+      assert_receive {:assignment_verified, 7, worker, :current}, 5_000
       assert {:noreply, t2b} = Server.handle_info({:assignment_verified, 7, worker, :current}, t2)
       assert t2b.unreachable_counts == %{}
       refute_received {:committed, _}
@@ -1480,7 +1481,7 @@ defmodule Bedrock.ControlPlane.Distributor.ServerTest do
       ExUnit.CaptureLog.capture_log(fn ->
         assert {:noreply, t2} = Server.handle_info({:DOWN, ref, :process, nil, :noproc}, t)
         assert_received {:committed, _}
-        assert_receive {:placeholder_got, {:uncovered, 7}}
+        assert_receive {:placeholder_got, {:uncovered, 7}}, 5_000
         assert MapSet.member?(t2.recruiting, 7)
       end)
     end


### PR DESCRIPTION
Closes bedrock-n9w.

### Why

`PlaceholderTest "at most one coverage demand per tag until covered"` failed on `main` (run 33218502281, OTP 27.3, the 0.7.0 release merge) and again in a local full-suite run two days later — both times as *"Assertion failed, no matching message after 100ms / The process mailbox is empty."*

The mailbox being **empty** is the tell. The demand was not lost, duplicated, or mis-addressed — it was late. Every assertion in this class waits on a chain the scheduler must run before the message can arrive: a `Task` spawn, then a `GenServer.call` into the placeholder, then the placeholder's cast back to the test (or a telemetry handler's `send`, or a spawned stub relaying). Three process hops against ExUnit's default 100ms window, on a CI box running the whole suite in parallel.

### The diagnosis is proven, not presumed

A spike made the race deterministic: suspend the placeholder with `:sys.suspend/1`, issue the gets, resume it 150ms later from a helper process. That reproduces the CI failure **byte-for-byte** — same message, same empty mailbox — and the identical scenario passes with a generous window. If late delivery had *not* reproduced the failure, the diagnosis would have been wrong and something real would have been hiding under the timeout. (The spike is not landed: it tests the assertion budget, not the product.)

Two prior data points calibrate the window. This file had already been bitten once — the coverage-failure test carried `, 1_000` with the comment *"the default 100ms flakes under full-suite load"* — one site hardened, fourteen siblings left bare, and a bare sibling is what failed `main`. And bedrock-uvk records a **1.5s** window being missed under full-suite load elsewhere. Hence 5s: an `assert_receive` window is free when the message is prompt; it only delays the report of an already-failing test.

### What changed

All 36 relay-chain `assert_receive` sites across `placeholder_test.exs` and `server_test.exs` now carry `, 5_000` (the repo's idiom is inline numeric windows — there is deliberately no global `assert_receive_timeout` override, matching how bedrock-yp2/bedrock-c4u fixed each mechanism at its sites). The previously-hardened `1_000` site is normalized into the class, and one comment at the first site records the mechanism.

### Deliberately untouched — different mechanisms, not oversights

- **`assert_received` sites** — the message was sent synchronously before the assertion; there is no wait to widen.
- **The `:noproc` `:DOWN` assert** — that monitor fires without any process running, so there is no relay to schedule; the races it *can* have are reason races, bedrock-yp2 territory (guards, not windows). The *other* `:DOWN` assert — whose monitored recruit task must be scheduled, run, and crash before the DOWN exists — is the relay class and IS widened.
- **`refute_receive` absence windows (50ms)** — dedupe is state-based in `signal_demand/2` (a `MapSet` check, not timing), so 50ms proves what it needs to; widening only slows the suite.
- **Timer-tick asserts** (`:poll_lock`, `:reverify_assignment`, `:retire_member`) — `Process.send_after` delivers from the timer wheel straight into the test process's own mailbox, no relay to schedule, with 20-40x margin over the tick intervals.

### Verification and review

Distributor tests repeated 30× green (`--repeat-until-failure 30`); full suite 2835 tests, 0 failures; `mix format --check-formatted`, `credo --strict`, and dialyzer all clean.

Cold-reviewed by a context-free agent before this PR was opened. Verdict: approve — every widened site verified as a pure existence assertion, the dedupe `refute_receive` interplay and the `hold_ms` deadline tests confirmed unweakened. The review also caught two exclusions of mine that did not survive scrutiny — the `RuntimeError` `:DOWN` (relay-class after all: the monitored task must run and crash) and the grandfathered 500ms recruitment window (undercut by the same bedrock-uvk datum that justified 5s) — both folded into the class above.
