### PR TITLE
Prevent missing Olivine reads after right-edge page splits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Unreleased
+
+- **Olivine keeps append-only workloads readable after page splits.** Keys
+  above every stored page boundary now extend the actual rightmost page
+  instead of returning to page 0 and overlapping later ranges. Recovery
+  validates complete snapshots and the recovered page chain, rejecting
+  damaged indexes explicitly instead of silently routing reads through an
+  ambiguous page map.
+
 ## 0.7.0 — 2026-08-28
 
 This release moves cluster metadata out of the broadcast layout and into the
@@ -384,13 +393,6 @@ describes; the broadcast carries only this epoch's wiring.
   restarts its stream from the compacted durable boundary, so transactions
   ingested while compaction ran are re-delivered instead of vanishing until
   the next recovery.
-
-- **Olivine keeps append-only workloads readable after page splits.** Keys
-  above every stored page boundary now extend the actual rightmost page
-  instead of returning to page 0 and overlapping later ranges. Recovery
-  validates complete snapshots and the recovered page chain, rejecting
-  damaged indexes explicitly instead of silently routing reads through an
-  ambiguous page map.
 
 - **Guides reflect the new data plane.** The durability-foundation, recovery,
   data-plane, and async-persistence guides describe the shipped design —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -385,6 +385,13 @@ describes; the broadcast carries only this epoch's wiring.
   ingested while compaction ran are re-delivered instead of vanishing until
   the next recovery.
 
+- **Olivine keeps append-only workloads readable after page splits.** Keys
+  above every stored page boundary now extend the actual rightmost page
+  instead of returning to page 0 and overlapping later ranges. Recovery
+  validates complete snapshots and the recovered page chain, rejecting
+  damaged indexes explicitly instead of silently routing reads through an
+  ambiguous page map.
+
 - **Guides reflect the new data plane.** The durability-foundation, recovery,
   data-plane, and async-persistence guides describe the shipped design —
   KCV-gated cuts, Demux streaming, reconciliation, trimming — rather than its

--- a/lib/bedrock/data_plane/materializer/olivine/index.ex
+++ b/lib/bedrock/data_plane/materializer/olivine/index.ex
@@ -131,7 +131,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Index do
   """
   @spec load_from(Database.t(), keyword()) ::
           {:ok, t(), Page.id(), [Page.id()], non_neg_integer()}
-          | {:error, :missing_pages}
+          | {:error, :missing_pages | {:corrupt_index, term()}}
   def load_from({_data_db, index_db}, opts \\ []) do
     {:ok, durable_version} = IndexDatabase.load_durable_version(index_db)
     max_keys = Keyword.get(opts, :max_keys_per_page, @default_max_keys_per_page)
@@ -142,12 +142,10 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Index do
     else
       needed_page_ids = MapSet.new([0])
 
-      case load_needed_pages(index_db, %{}, %{}, needed_page_ids, durable_version) do
-        {:ok, final_page_map} ->
-          build_index_from_page_map(final_page_map, max_keys, target_keys)
-
-        {:error, :missing_pages} ->
-          {:error, :missing_pages}
+      with {:ok, final_page_map} <-
+             load_needed_pages(index_db, %{}, %{}, needed_page_ids, MapSet.new(), durable_version),
+           :ok <- validate_recovered_page_map(final_page_map) do
+        build_index_from_page_map(final_page_map, max_keys, target_keys)
       end
     end
   end
@@ -160,46 +158,93 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Index do
           page_map :: %{Page.id() => {Page.t(), Page.id()}},
           all_pages_seen :: %{Page.id() => {Page.t(), Page.id()}},
           needed_page_ids :: MapSet.t(Page.id()),
+          visited_versions :: MapSet.t(Bedrock.version()),
           Bedrock.version()
-        ) :: {:ok, %{Page.id() => {Page.t(), Page.id()}}} | {:error, :missing_pages}
-  defp load_needed_pages(index_db, page_map, all_pages_seen, needed_page_ids, current_version) do
+        ) ::
+          {:ok, %{Page.id() => {Page.t(), Page.id()}}}
+          | {:error, :missing_pages | {:corrupt_index, term()}}
+  defp load_needed_pages(index_db, page_map, all_pages_seen, needed_page_ids, visited_versions, current_version) do
     cond do
       MapSet.size(needed_page_ids) == 0 ->
+        # Incremental blocks are a page-version store, not an audit log. Once
+        # the live chain is complete, older blocks are intentionally unused;
+        # requiring them would make obsolete history part of availability.
         {:ok, page_map}
 
       current_version == nil || current_version == Version.zero() ->
-        missing = Enum.reject(needed_page_ids, &Map.has_key?(all_pages_seen, &1))
+        finish_loading_pages(page_map, all_pages_seen, needed_page_ids)
 
-        case missing do
-          [] ->
-            final_page_map = Enum.reduce(needed_page_ids, page_map, &Map.put_new(&2, &1, all_pages_seen[&1]))
-            {:ok, final_page_map}
-
-          [0] ->
-            {:ok, Map.put(page_map, 0, {Page.new(0, []), 0})}
-
-          _ ->
-            {:error, :missing_pages}
-        end
+      MapSet.member?(visited_versions, current_version) ->
+        {:error, {:corrupt_index, {:version_cycle, current_version}}}
 
       true ->
-        load_needed_pages_from_version(index_db, page_map, all_pages_seen, needed_page_ids, current_version)
+        load_needed_pages_from_version(
+          index_db,
+          page_map,
+          all_pages_seen,
+          needed_page_ids,
+          visited_versions,
+          current_version
+        )
     end
   end
 
-  defp load_needed_pages_from_version(index_db, page_map, all_pages_seen, needed_page_ids, current_version) do
+  defp finish_loading_pages(page_map, all_pages_seen, needed_page_ids) do
+    {final_page_map, unresolved_page_ids} =
+      process_version_pages(all_pages_seen, page_map, needed_page_ids, all_pages_seen)
+
+    case MapSet.to_list(unresolved_page_ids) do
+      [] ->
+        {:ok, final_page_map}
+
+      [0] when map_size(all_pages_seen) == 0 ->
+        {:ok, Map.put(page_map, 0, {Page.new(0, []), 0})}
+
+      [0] ->
+        {:error, {:corrupt_index, :missing_page_zero}}
+
+      _ ->
+        {:error, :missing_pages}
+    end
+  end
+
+  defp load_needed_pages_from_version(
+         index_db,
+         page_map,
+         all_pages_seen,
+         needed_page_ids,
+         visited_versions,
+         current_version
+       ) do
     case IndexDatabase.load_page_block(index_db, current_version) do
       {:ok, version_pages, next_version} ->
-        updated_all_pages = Map.merge(version_pages, all_pages_seen)
+        with :ok <- validate_previous_version(current_version, next_version),
+             :ok <- validate_snapshot_page_map(version_pages, next_version) do
+          updated_all_pages = Map.merge(version_pages, all_pages_seen)
 
-        {updated_page_map, updated_needed} =
-          process_version_pages(version_pages, page_map, needed_page_ids, updated_all_pages)
+          {updated_page_map, updated_needed} =
+            process_version_pages(updated_all_pages, page_map, needed_page_ids, updated_all_pages)
 
-        load_needed_pages(index_db, updated_page_map, updated_all_pages, updated_needed, next_version)
+          load_needed_pages(
+            index_db,
+            updated_page_map,
+            updated_all_pages,
+            updated_needed,
+            MapSet.put(visited_versions, current_version),
+            next_version
+          )
+        end
 
       {:error, :not_found} ->
-        load_needed_pages(index_db, page_map, all_pages_seen, needed_page_ids, Version.zero())
+        {:error, {:corrupt_index, {:missing_version, current_version}}}
     end
+  end
+
+  defp validate_previous_version(_current_version, nil), do: :ok
+  defp validate_previous_version(current_version, previous_version) when previous_version < current_version, do: :ok
+
+  defp validate_previous_version(current_version, previous_version) do
+    {:error, {:corrupt_index, {:invalid_previous_version, current_version, previous_version}}}
   end
 
   defp process_version_pages(version_pages, page_map, needed_page_ids, updated_all_pages) do
@@ -208,11 +253,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Index do
 
   defp process_version_pages_loop(version_pages, page_map, needed_page_ids, updated_all_pages) do
     version_page_ids = MapSet.new(Map.keys(version_pages))
-
-    to_process =
-      needed_page_ids
-      |> MapSet.intersection(version_page_ids)
-      |> find_additional_needed_pages(page_map, updated_all_pages, version_page_ids)
+    to_process = MapSet.intersection(needed_page_ids, version_page_ids)
 
     case MapSet.size(to_process) do
       0 ->
@@ -232,20 +273,6 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Index do
     end
   end
 
-  defp find_additional_needed_pages(initial_set, page_map, all_pages_seen, version_page_ids) do
-    Enum.reduce(all_pages_seen, initial_set, fn
-      {_id, {_page, next_id}}, acc when next_id != 0 ->
-        if MapSet.member?(version_page_ids, next_id) and not Map.has_key?(page_map, next_id) do
-          MapSet.put(acc, next_id)
-        else
-          acc
-        end
-
-      _, acc ->
-        acc
-    end)
-  end
-
   defp process_needed_page(page_id, acc_map, acc_needed, updated_all_pages) do
     {resolved_page, resolved_next_id} = Map.get(updated_all_pages, page_id)
     new_map = Map.put(acc_map, page_id, {resolved_page, resolved_next_id})
@@ -261,24 +288,113 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Index do
     {new_map, final_needed}
   end
 
+  # The page map is not sufficient to repair an invalid index safely. A stale
+  # duplicate can have a greater locator after compaction, and a clear can
+  # remove the routed copy while leaving an older copy on an overlapping page.
+  # Fail closed so recovery never selects a stale value or resurrects a key.
+  defp validate_recovered_page_map(page_map) do
+    case validate_page_map(page_map) do
+      :ok -> :ok
+      {:error, reason} -> {:error, {:corrupt_index, reason}}
+    end
+  end
+
+  # A snapshot block is a complete page map, unlike an incremental block,
+  # whose unreachable pages may be stale versions intentionally ignored by
+  # the loader. Validate complete membership before selective loading can
+  # hide an orphan page or synthesize a missing page 0.
+  defp validate_snapshot_page_map(page_map, nil), do: validate_recovered_page_map(page_map)
+  defp validate_snapshot_page_map(_page_map, _previous_version), do: :ok
+
+  defp validate_page_map(page_map) do
+    with :ok <- validate_page_ids(page_map),
+         {:ok, pages} <- page_chain(page_map),
+         :ok <- validate_reachable_page_count(pages, page_map) do
+      validate_global_key_order(pages)
+    end
+  end
+
+  defp validate_page_ids(page_map) do
+    Enum.reduce_while(page_map, :ok, fn {map_page_id, {page, _next_id}}, :ok ->
+      embedded_page_id = Page.id(page)
+
+      if map_page_id == embedded_page_id do
+        {:cont, :ok}
+      else
+        {:halt, {:error, {:page_id_mismatch, map_page_id, embedded_page_id}}}
+      end
+    end)
+  end
+
+  defp page_chain(page_map) do
+    case Map.fetch(page_map, 0) do
+      {:ok, {page, next_id}} ->
+        collect_page_chain(page_map, next_id, MapSet.new([0]), [page])
+
+      :error ->
+        {:error, :missing_page_zero}
+    end
+  end
+
+  defp collect_page_chain(_page_map, 0, _seen, pages), do: {:ok, Enum.reverse(pages)}
+
+  defp collect_page_chain(page_map, page_id, seen, pages) do
+    cond do
+      MapSet.member?(seen, page_id) ->
+        {:error, {:cycle, page_id}}
+
+      not Map.has_key?(page_map, page_id) ->
+        {:error, {:missing_page, page_id}}
+
+      true ->
+        {page, next_id} = Map.fetch!(page_map, page_id)
+        collect_page_chain(page_map, next_id, MapSet.put(seen, page_id), [page | pages])
+    end
+  end
+
+  defp validate_reachable_page_count(pages, page_map) do
+    reachable_count = length(pages)
+    stored_count = map_size(page_map)
+
+    if reachable_count == stored_count do
+      :ok
+    else
+      {:error, {:unreachable_pages, stored_count - reachable_count}}
+    end
+  end
+
+  defp validate_global_key_order(pages) do
+    pages
+    |> Enum.reduce_while({:ok, nil}, fn page, {:ok, previous_key} ->
+      case validate_page_keys(Page.keys(page), previous_key) do
+        {:ok, _previous_key} = state -> {:cont, state}
+        {:error, _reason} = error -> {:halt, error}
+      end
+    end)
+    |> case do
+      {:ok, _previous_key} -> :ok
+      {:error, _reason} = error -> error
+    end
+  end
+
+  defp validate_page_keys([], previous_key), do: {:ok, previous_key}
+
+  defp validate_page_keys([key | keys], previous_key) do
+    cond do
+      key == previous_key ->
+        {:error, :duplicate_keys}
+
+      previous_key != nil and key < previous_key ->
+        {:error, :keys_out_of_order}
+
+      true ->
+        validate_page_keys(keys, key)
+    end
+  end
+
   @spec build_index_from_page_map(%{Page.id() => {Page.t(), Page.id()}}, pos_integer(), pos_integer()) ::
           {:ok, t(), Page.id(), [Page.id()], non_neg_integer()}
   defp build_index_from_page_map(page_map, max_keys_per_page, target_keys_per_page) do
-    case verify_page_chain(page_map) do
-      :ok ->
-        :ok
-
-      {:error, {:broken_chain, missing_page_id}} ->
-        require Logger
-
-        Logger.error("Page chain is broken: page #{missing_page_id} is referenced but not in page_map")
-
-      {:error, {:cycle, page_id}} ->
-        require Logger
-
-        Logger.error("Page chain has a cycle at page #{page_id}")
-    end
-
     tree = Tree.from_page_map(page_map)
     page_ids = page_map |> Map.keys() |> MapSet.new()
     max_id = if MapSet.size(page_ids) > 0, do: Enum.max(page_ids), else: 0
@@ -309,32 +425,6 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Index do
     }
 
     {:ok, index, max_id, free_ids, total_key_count}
-  end
-
-  defp verify_page_chain(page_map) do
-    case Map.get(page_map, 0) do
-      nil ->
-        :ok
-
-      {_page, next_id} ->
-        verify_chain_walk(page_map, next_id, MapSet.new([0]))
-    end
-  end
-
-  defp verify_chain_walk(_page_map, 0, _visited), do: :ok
-
-  defp verify_chain_walk(page_map, page_id, visited) do
-    cond do
-      MapSet.member?(visited, page_id) ->
-        {:error, {:cycle, page_id}}
-
-      not Map.has_key?(page_map, page_id) ->
-        {:error, {:broken_chain, page_id}}
-
-      true ->
-        {_page, next_id} = page_map[page_id]
-        verify_chain_walk(page_map, next_id, MapSet.put(visited, page_id))
-    end
   end
 
   defp calculate_free_ids(0, _all_existing_page_ids), do: []

--- a/lib/bedrock/data_plane/materializer/olivine/index/tree.ex
+++ b/lib/bedrock/data_plane/materializer/olivine/index/tree.ex
@@ -48,8 +48,9 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Index.Tree do
 
   Tree structure: key = last_key, value = page_id
 
-  When a key is beyond all pages in the tree, returns page 0 (which acts as
-  the catch-all page extending to infinity).
+  When a key is beyond all stored page boundaries, returns the rightmost
+  page. New maximum keys must extend that page; page 0 is only the rightmost
+  page before the first split.
   """
   @spec page_for_key(t(), Bedrock.key()) :: page_id()
   def page_for_key(tree, key) do
@@ -57,7 +58,16 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Index.Tree do
 
     case :gb_trees.next(iter) do
       {_last_key, page_id, _next_iter} -> page_id
-      _none -> 0
+      _none -> rightmost_page_id(tree)
+    end
+  end
+
+  defp rightmost_page_id(tree) do
+    if :gb_trees.is_empty(tree) do
+      0
+    else
+      {_last_key, page_id} = :gb_trees.largest(tree)
+      page_id
     end
   end
 

--- a/lib/bedrock/data_plane/materializer/olivine/index_manager.ex
+++ b/lib/bedrock/data_plane/materializer/olivine/index_manager.ex
@@ -70,24 +70,27 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.IndexManager do
   end
 
   @spec recover_from_database(database :: Database.t()) ::
-          {:ok, t()} | {:error, :missing_pages}
+          {:ok, t()} | {:error, :missing_pages | {:corrupt_index, term()}}
   def recover_from_database({_data_db, _index_db} = database) do
     durable_version = Database.durable_version(database)
 
     case Index.load_from(database) do
       {:ok, initial_index, max_id, free_ids, n_keys} ->
+        {data_db, _index_db} = database
+
         index_manager = %__MODULE__{
           versions: [{durable_version, {initial_index, %{}}}],
           current_version: durable_version,
           window_size_in_microseconds: 5_000_000,
           id_allocator: IdAllocator.new(max_id, free_ids),
+          last_version_ended_at_offset: data_db.file_offset,
           n_keys: n_keys
         }
 
         {:ok, index_manager}
 
-      {:error, :missing_pages} ->
-        {:error, :missing_pages}
+      {:error, _reason} = error ->
+        error
     end
   end
 

--- a/lib/mix/tasks/bedrock.analyze_index.ex
+++ b/lib/mix/tasks/bedrock.analyze_index.ex
@@ -118,6 +118,10 @@ defmodule Mix.Tasks.Bedrock.AnalyzeIndex do
       {:error, :missing_pages} ->
         Mix.shell().info("Index has missing pages")
         System.halt(1)
+
+      {:error, {:corrupt_index, reason}} ->
+        Mix.shell().error("Index is corrupt: #{inspect(reason)}")
+        System.halt(1)
     end
   end
 

--- a/test/bedrock/data_plane/materializer/olivine/index_manager_property_test.exs
+++ b/test/bedrock/data_plane/materializer/olivine/index_manager_property_test.exs
@@ -225,8 +225,8 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.IndexManagerPropertyTest do
         found_page_id = Tree.page_for_key(tree, test_key)
         page_ids = Enum.map(pages, &Page.id/1)
 
-        assert is_integer(found_page_id) and found_page_id >= 0 and (found_page_id in page_ids or found_page_id == 0),
-               "page_for_key should return a valid page_id that exists in tree or 0 (rightmost page)"
+        assert is_integer(found_page_id) and found_page_id in page_ids,
+               "page_for_key should return a page_id that exists in the tree"
       end
     end
   end
@@ -329,8 +329,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.IndexManagerPropertyTest do
         assert find_rightmost_page(tree) == Page.id(page)
 
         found_page_id = Tree.page_for_key(tree, test_key)
-        # Key can map to the page itself or to page 0 (rightmost) if beyond page's range
-        assert found_page_id == Page.id(page) or found_page_id == 0
+        assert found_page_id == Page.id(page)
       end
     end
   end

--- a/test/bedrock/data_plane/materializer/olivine/index_tree_test.exs
+++ b/test/bedrock/data_plane/materializer/olivine/index_tree_test.exs
@@ -23,8 +23,8 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Index.TreeTest do
       # Key "j" should go to page 2 (contains "g" to "m")
       assert Tree.page_for_key(tree, "j") == 2
 
-      # Key "z" (beyond all pages) should go to rightmost page (always 0)
-      assert Tree.page_for_key(tree, "z") == 0
+      # Key "z" (beyond all pages) should extend the actual rightmost page.
+      assert Tree.page_for_key(tree, "z") == 2
     end
   end
 
@@ -43,8 +43,8 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Index.TreeTest do
       # In gap-free design, all keys map to a page
       # "key0" would go in page 1
       assert Tree.page_for_key(tree, "key0") == 1
-      # "key4" beyond all pages goes to rightmost (0)
-      assert Tree.page_for_key(tree, "key4") == 0
+      # "key4" beyond all pages stays on the only (and therefore rightmost) page.
+      assert Tree.page_for_key(tree, "key4") == 1
     end
 
     test "adds page 0 with no keys to tree" do

--- a/test/bedrock/data_plane/materializer/olivine/page_chain_recovery_bug_test.exs
+++ b/test/bedrock/data_plane/materializer/olivine/page_chain_recovery_bug_test.exs
@@ -3,6 +3,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.PageChainRecoveryBugTest do
 
   alias Bedrock.DataPlane.Materializer.Olivine.Database
   alias Bedrock.DataPlane.Materializer.Olivine.Index
+  alias Bedrock.DataPlane.Materializer.Olivine.Index.Page
   alias Bedrock.DataPlane.Materializer.Olivine.IndexManager
   alias Bedrock.DataPlane.Transaction
   alias Bedrock.DataPlane.Version
@@ -37,11 +38,428 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.PageChainRecoveryBugTest do
 
   defp data_size_in_bytes({data_db, _index_db}), do: data_db.file_offset
 
+  defp persist_page_map(database, page_map, version, previous_version \\ nil) do
+    {:ok, database, _metadata} =
+      Database.advance_durable_version(
+        database,
+        version,
+        previous_version || version,
+        data_size_in_bytes(database),
+        [page_map]
+      )
+
+    Database.close(database)
+  end
+
   describe "page chain recovery bug" do
     @tag :tmp_dir
 
     setup context do
       setup_tmp_dir(context)
+    end
+
+    test "increasing single-key transactions remain readable after page splits", %{tmp_dir: tmp_dir} do
+      file_path = Path.join(tmp_dir, "increasing_keys.dets")
+      {:ok, database} = Database.open(:increasing_keys, file_path)
+
+      [first_key | _] = keys = for i <- 1..600, do: "key_#{String.pad_leading("#{i}", 4, "0")}"
+      last_key = List.last(keys)
+
+      transactions =
+        keys
+        |> Enum.with_index(1)
+        |> Enum.map(fn {key, version} -> create_transaction([{:set, key, key}], version) end)
+
+      {index_manager, database} =
+        IndexManager.apply_transactions(IndexManager.new(), transactions, database)
+
+      [{_version, {index, _modified_pages}} | _] = index_manager.versions
+
+      assert map_size(index.page_map) > 1
+
+      missing_keys =
+        Enum.reject(keys, fn key ->
+          match?({:ok, _page, _locator}, Index.locator_for_key(index, key))
+        end)
+
+      assert missing_keys == []
+
+      assert {:ok, pages} = Index.pages_for_range(index, first_key, last_key <> <<0>>)
+      assert Enum.flat_map(pages, &Page.keys/1) == keys
+
+      Database.close(database)
+    end
+
+    test "rejects overlapping recovered pages with duplicate keys", %{tmp_dir: tmp_dir} do
+      file_path = Path.join(tmp_dir, "overlapping_pages.dets")
+      {:ok, database} = Database.open(:overlapping_pages, file_path)
+      version = Version.from_integer(10_000_000)
+      locator = <<0::64>>
+
+      persist_page_map(
+        database,
+        %{
+          0 => {Page.new(0, [{"a", locator}]), 1},
+          1 => {Page.new(1, [{"a", locator}, {"m", locator}]), 0}
+        },
+        version
+      )
+
+      {:ok, recovered_database} = Database.open(:overlapping_pages_recovery, file_path)
+
+      assert {:error, {:corrupt_index, :duplicate_keys}} =
+               IndexManager.recover_from_database(recovered_database)
+
+      Database.close(recovered_database)
+    end
+
+    test "rejects globally out-of-order recovered pages", %{tmp_dir: tmp_dir} do
+      file_path = Path.join(tmp_dir, "out_of_order_pages.dets")
+      {:ok, database} = Database.open(:out_of_order_pages, file_path)
+      version = Version.from_integer(10_000_000)
+      locator = <<0::64>>
+
+      persist_page_map(
+        database,
+        %{
+          0 => {Page.new(0, [{"a", locator}, {"z", locator}]), 1},
+          1 => {Page.new(1, [{"m", locator}]), 0}
+        },
+        version
+      )
+
+      {:ok, recovered_database} = Database.open(:out_of_order_pages_recovery, file_path)
+
+      assert {:error, {:corrupt_index, :keys_out_of_order}} =
+               IndexManager.recover_from_database(recovered_database)
+
+      Database.close(recovered_database)
+    end
+
+    test "rejects a cyclic recovered page chain", %{tmp_dir: tmp_dir} do
+      file_path = Path.join(tmp_dir, "cyclic_pages.dets")
+      {:ok, database} = Database.open(:cyclic_pages, file_path)
+      version = Version.from_integer(10_000_000)
+      locator = <<0::64>>
+
+      persist_page_map(
+        database,
+        %{
+          0 => {Page.new(0, [{"a", locator}]), 1},
+          1 => {Page.new(1, [{"b", locator}]), 1}
+        },
+        version
+      )
+
+      {:ok, recovered_database} = Database.open(:cyclic_pages_recovery, file_path)
+
+      assert {:error, {:corrupt_index, {:cycle, 1}}} =
+               IndexManager.recover_from_database(recovered_database)
+
+      Database.close(recovered_database)
+    end
+
+    test "rejects orphan pages in a complete snapshot", %{tmp_dir: tmp_dir} do
+      file_path = Path.join(tmp_dir, "orphan_pages.dets")
+      {:ok, database} = Database.open(:orphan_pages, file_path)
+      version = Version.from_integer(10_000_000)
+      locator = <<0::64>>
+
+      persist_page_map(
+        database,
+        %{
+          0 => {Page.new(0, [{"a", locator}]), 0},
+          1 => {Page.new(1, [{"z", locator}]), 0}
+        },
+        version
+      )
+
+      {:ok, recovered_database} = Database.open(:orphan_pages_recovery, file_path)
+
+      assert {:error, {:corrupt_index, {:unreachable_pages, 1}}} =
+               IndexManager.recover_from_database(recovered_database)
+
+      Database.close(recovered_database)
+    end
+
+    test "rejects a non-empty snapshot without page 0", %{tmp_dir: tmp_dir} do
+      file_path = Path.join(tmp_dir, "missing_page_zero.dets")
+      {:ok, database} = Database.open(:missing_page_zero, file_path)
+      version = Version.from_integer(10_000_000)
+      locator = <<0::64>>
+
+      persist_page_map(database, %{1 => {Page.new(1, [{"z", locator}]), 0}}, version)
+
+      {:ok, recovered_database} = Database.open(:missing_page_zero_recovery, file_path)
+
+      assert {:error, {:corrupt_index, :missing_page_zero}} =
+               IndexManager.recover_from_database(recovered_database)
+
+      Database.close(recovered_database)
+    end
+
+    test "rejects an empty complete snapshot", %{tmp_dir: tmp_dir} do
+      file_path = Path.join(tmp_dir, "empty_snapshot.dets")
+      {:ok, database} = Database.open(:empty_snapshot, file_path)
+      version = Version.from_integer(10_000_000)
+
+      persist_page_map(database, %{}, version)
+
+      {:ok, recovered_database} = Database.open(:empty_snapshot_recovery, file_path)
+
+      assert {:error, {:corrupt_index, :missing_page_zero}} =
+               IndexManager.recover_from_database(recovered_database)
+
+      Database.close(recovered_database)
+    end
+
+    test "rejects non-empty incremental history that never defines page 0", %{tmp_dir: tmp_dir} do
+      file_path = Path.join(tmp_dir, "missing_page_zero_incremental.dets")
+      {:ok, database} = Database.open(:missing_page_zero_incremental, file_path)
+      version = Version.from_integer(10_000_000)
+      locator = <<0::64>>
+
+      persist_page_map(
+        database,
+        %{1 => {Page.new(1, [{"z", locator}]), 0}},
+        version,
+        Version.zero()
+      )
+
+      {:ok, recovered_database} =
+        Database.open(:missing_page_zero_incremental_recovery, file_path)
+
+      assert {:error, {:corrupt_index, :missing_page_zero}} =
+               IndexManager.recover_from_database(recovered_database)
+
+      Database.close(recovered_database)
+    end
+
+    test "rejects unresolved incremental history with a missing predecessor", %{tmp_dir: tmp_dir} do
+      file_path = Path.join(tmp_dir, "missing_predecessor.dets")
+      {:ok, database} = Database.open(:missing_predecessor, file_path)
+      missing_version = Version.from_integer(10_000_000)
+      durable_version = Version.from_integer(20_000_000)
+
+      persist_page_map(database, %{}, durable_version, missing_version)
+
+      {:ok, recovered_database} = Database.open(:missing_predecessor_recovery, file_path)
+
+      assert {:error, {:corrupt_index, {:missing_version, ^missing_version}}} =
+               IndexManager.recover_from_database(recovered_database)
+
+      Database.close(recovered_database)
+    end
+
+    test "does not load an unused predecessor after the live chain is resolved", %{tmp_dir: tmp_dir} do
+      file_path = Path.join(tmp_dir, "unused_predecessor.dets")
+      {:ok, database} = Database.open(:unused_predecessor, file_path)
+      missing_version = Version.from_integer(10_000_000)
+      durable_version = Version.from_integer(20_000_000)
+
+      persist_page_map(database, %{0 => {Page.new(0, []), 0}}, durable_version, missing_version)
+
+      {:ok, recovered_database} = Database.open(:unused_predecessor_recovery, file_path)
+
+      assert {:ok, recovered_index_manager} = IndexManager.recover_from_database(recovered_database)
+      [{_version, {recovered_index, _modified_pages}} | _] = recovered_index_manager.versions
+      assert Map.keys(recovered_index.page_map) == [0]
+
+      Database.close(recovered_database)
+    end
+
+    test "resolves the live chain through pages cached from a newer block", %{tmp_dir: tmp_dir} do
+      file_path = Path.join(tmp_dir, "newer_cached_pages.dets")
+      {:ok, database} = Database.open(:newer_cached_pages, file_path)
+      missing_version = Version.from_integer(10_000_000)
+      root_version = Version.from_integer(20_000_000)
+      durable_version = Version.from_integer(30_000_000)
+      locator = <<0::64>>
+
+      {:ok, database, _metadata} =
+        Database.advance_durable_version(
+          database,
+          root_version,
+          missing_version,
+          data_size_in_bytes(database),
+          [%{0 => {Page.new(0, [{"a", locator}]), 3}}]
+        )
+
+      newer_pages = %{
+        3 => {Page.new(3, [{"d", locator}]), 5},
+        5 => {Page.new(5, [{"e", locator}]), 4},
+        4 => {Page.new(4, [{"g", locator}]), 0}
+      }
+
+      {:ok, database, _metadata} =
+        Database.advance_durable_version(
+          database,
+          durable_version,
+          root_version,
+          data_size_in_bytes(database),
+          [newer_pages]
+        )
+
+      Database.close(database)
+      {:ok, recovered_database} = Database.open(:newer_cached_pages_recovery, file_path)
+
+      assert {:ok, recovered_index_manager} = IndexManager.recover_from_database(recovered_database)
+      [{_version, {recovered_index, _modified_pages}} | _] = recovered_index_manager.versions
+
+      assert recovered_index.page_map |> Map.keys() |> Enum.sort() == [0, 3, 4, 5]
+      assert {:ok, pages} = Index.pages_for_range(recovered_index, "a", "h")
+      assert Enum.flat_map(pages, &Page.keys/1) == ["a", "d", "e", "g"]
+
+      Database.close(recovered_database)
+    end
+
+    test "ignores stale snapshot pages bypassed by a newer page chain", %{tmp_dir: tmp_dir} do
+      file_path = Path.join(tmp_dir, "deleted_middle_pages.dets")
+      {:ok, database} = Database.open(:deleted_middle_pages, file_path)
+      snapshot_version = Version.from_integer(10_000_000)
+      durable_version = Version.from_integer(20_000_000)
+      locator = <<0::64>>
+
+      snapshot_pages = %{
+        0 => {Page.new(0, [{"a", locator}]), 1},
+        1 => {Page.new(1, [{"b", locator}]), 2},
+        2 => {Page.new(2, [{"c", locator}]), 3},
+        3 => {Page.new(3, [{"d", locator}]), 4},
+        4 => {Page.new(4, [{"e", locator}]), 0}
+      }
+
+      {:ok, database, _metadata} =
+        Database.advance_durable_version(
+          database,
+          snapshot_version,
+          snapshot_version,
+          data_size_in_bytes(database),
+          [snapshot_pages]
+        )
+
+      # A range clear deleted pages 1 and 2. The newer page-0 pointer is the
+      # authoritative live chain; the older snapshot copies remain on disk.
+      {:ok, database, _metadata} =
+        Database.advance_durable_version(
+          database,
+          durable_version,
+          snapshot_version,
+          data_size_in_bytes(database),
+          [%{0 => {Page.new(0, [{"a", locator}]), 3}}]
+        )
+
+      Database.close(database)
+      {:ok, recovered_database} = Database.open(:deleted_middle_pages_recovery, file_path)
+
+      assert {:ok, recovered_index_manager} = IndexManager.recover_from_database(recovered_database)
+      [{_version, {recovered_index, _modified_pages}} | _] = recovered_index_manager.versions
+
+      assert recovered_index.page_map |> Map.keys() |> Enum.sort() == [0, 3, 4]
+      assert {:ok, pages} = Index.pages_for_range(recovered_index, "a", "f")
+      assert Enum.flat_map(pages, &Page.keys/1) == ["a", "d", "e"]
+
+      Database.close(recovered_database)
+    end
+
+    test "follows a new sibling from a non-leftmost incremental page split", %{tmp_dir: tmp_dir} do
+      file_path = Path.join(tmp_dir, "incremental_middle_split.dets")
+      {:ok, database} = Database.open(:incremental_middle_split, file_path)
+      snapshot_version = Version.from_integer(10_000_000)
+      durable_version = Version.from_integer(20_000_000)
+      locator = <<0::64>>
+
+      snapshot_pages = %{
+        0 => {Page.new(0, [{"a", locator}]), 1},
+        1 => {Page.new(1, [{"b", locator}]), 2},
+        2 => {Page.new(2, [{"c", locator}]), 3},
+        3 => {Page.new(3, [{"d", locator}]), 4},
+        4 => {Page.new(4, [{"g", locator}]), 0}
+      }
+
+      {:ok, database, _metadata} =
+        Database.advance_durable_version(
+          database,
+          snapshot_version,
+          snapshot_version,
+          data_size_in_bytes(database),
+          [snapshot_pages]
+        )
+
+      # Splitting page 3 creates page 5 between it and unchanged page 4.
+      split_pages = %{
+        3 => {Page.new(3, [{"d", locator}]), 5},
+        5 => {Page.new(5, [{"e", locator}]), 4}
+      }
+
+      {:ok, database, _metadata} =
+        Database.advance_durable_version(
+          database,
+          durable_version,
+          snapshot_version,
+          data_size_in_bytes(database),
+          [split_pages]
+        )
+
+      Database.close(database)
+      {:ok, recovered_database} = Database.open(:incremental_middle_split_recovery, file_path)
+
+      assert {:ok, recovered_index_manager} = IndexManager.recover_from_database(recovered_database)
+      [{_version, {recovered_index, _modified_pages}} | _] = recovered_index_manager.versions
+
+      assert recovered_index.page_map |> Map.keys() |> Enum.sort() == [0, 1, 2, 3, 4, 5]
+      assert {:ok, pages} = Index.pages_for_range(recovered_index, "a", "h")
+      assert Enum.flat_map(pages, &Page.keys/1) == ["a", "b", "c", "d", "e", "g"]
+
+      Database.close(recovered_database)
+    end
+
+    test "rejects cyclic incremental history without looping", %{tmp_dir: tmp_dir} do
+      file_path = Path.join(tmp_dir, "cyclic_history.dets")
+      {:ok, database} = Database.open(:cyclic_history, file_path)
+      older_version = Version.from_integer(10_000_000)
+      durable_version = Version.from_integer(20_000_000)
+
+      {:ok, database, _metadata} =
+        Database.advance_durable_version(
+          database,
+          older_version,
+          durable_version,
+          data_size_in_bytes(database),
+          [%{}]
+        )
+
+      {:ok, database, _metadata} =
+        Database.advance_durable_version(
+          database,
+          durable_version,
+          older_version,
+          data_size_in_bytes(database),
+          [%{}]
+        )
+
+      Database.close(database)
+      {:ok, recovered_database} = Database.open(:cyclic_history_recovery, file_path)
+
+      assert {:error, {:corrupt_index, {:invalid_previous_version, ^older_version, ^durable_version}}} =
+               IndexManager.recover_from_database(recovered_database)
+
+      Database.close(recovered_database)
+    end
+
+    test "rejects snapshots whose map key and embedded page ID disagree", %{tmp_dir: tmp_dir} do
+      file_path = Path.join(tmp_dir, "page_id_mismatch.dets")
+      {:ok, database} = Database.open(:page_id_mismatch, file_path)
+      version = Version.from_integer(10_000_000)
+      locator = <<0::64>>
+
+      persist_page_map(database, %{0 => {Page.new(7, [{"a", locator}]), 0}}, version)
+
+      {:ok, recovered_database} = Database.open(:page_id_mismatch_recovery, file_path)
+
+      assert {:error, {:corrupt_index, {:page_id_mismatch, 0, 7}}} =
+               IndexManager.recover_from_database(recovered_database)
+
+      Database.close(recovered_database)
     end
 
     test "recovers all pages in chain when durable version is empty", %{tmp_dir: tmp_dir} do

--- a/test/bedrock/data_plane/materializer/olivine/snapshot_loading_test.exs
+++ b/test/bedrock/data_plane/materializer/olivine/snapshot_loading_test.exs
@@ -13,6 +13,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.SnapshotLoadingTest do
 
   import ExUnit.CaptureLog
 
+  alias Bedrock.DataPlane.Materializer.Olivine.Index.Page
   alias Bedrock.DataPlane.Materializer.Olivine.IndexDatabase
   alias Bedrock.DataPlane.Materializer.Olivine.Logic
   alias Bedrock.DataPlane.Materializer.Olivine.State
@@ -94,7 +95,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.SnapshotLoadingTest do
       # Create a valid snapshot in ObjectStorage
       data_content = "snapshot data content"
       version = <<0, 0, 0, 0, 0, 0, 0, 42>>
-      pages_map = %{}
+      pages_map = %{0 => {Page.new(0, []), 0}}
 
       index_record = IndexDatabase.build_snapshot_record(version, pages_map)
       index_binary = IO.iodata_to_binary(index_record)
@@ -166,7 +167,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.SnapshotLoadingTest do
       # Create a valid snapshot with proper index structure
       data_content = ""
       version = <<0, 0, 0, 0, 0, 0, 0, 100>>
-      pages_map = %{}
+      pages_map = %{0 => {Page.new(0, []), 0}}
 
       index_record = IndexDatabase.build_snapshot_record(version, pages_map)
       index_binary = IO.iodata_to_binary(index_record)
@@ -218,7 +219,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.SnapshotLoadingTest do
 
       # Write a snapshot to ObjectStorage (should not be used)
       version = <<0, 0, 0, 0, 0, 0, 0, 999>>
-      pages_map = %{}
+      pages_map = %{0 => {Page.new(0, []), 0}}
       index_record = IndexDatabase.build_snapshot_record(version, pages_map)
       :ok = Snapshot.write(snapshot, 999, IO.iodata_to_binary(index_record))
 


### PR DESCRIPTION
## Why

Olivine routes a key through a tree whose boundaries are the last key on each index page. Page 0 begins as the only page, but after the first split it becomes the **leftmost** page.

When a key sorted beyond every stored boundary, the old fallback still returned page 0. That sent new maximum keys back to the left edge, creating overlapping page ranges and an out-of-order page chain. The value bytes were written successfully, but point reads could route to the wrong page and range reads could omit committed keys.

For example, after a split:

```text
page 0: a..f
page 1: g..m
```

A write for `z` must extend page 1. Sending it to page 0 produces `a..f,z` before `g..m`, so the global index is no longer ordered.

The regression test reproduces this with 600 increasing keys written as 600 separate transactions, matching append-heavy metadata workloads.

## What changed

- Keys beyond the largest boundary now route to the page stored at `:gb_trees.largest/1`, which is the actual rightmost page.
- Unit and property expectations now require routing to an existing rightmost page rather than assuming page 0.
- Recovery validates the reconstructed index before accepting it:
  - page 0 exists;
  - map keys agree with embedded page IDs;
  - the page chain has no missing links or cycles;
  - every recovered page is reachable from page 0;
  - keys are globally ordered and unique across page boundaries;
  - required version records exist and predecessor versions descend correctly.
- Complete snapshots are validated before selective loading can hide orphan pages.
- `IndexManager` restores the recovered data-file offset, and the index analyzer reports structured corruption errors.

## How it works

### Routing new maximum keys

Normal lookups still choose the first page boundary greater than or equal to the key. Only the no-boundary case changes:

```text
key e  -> boundary f -> page 0
key k  -> boundary m -> page 1
key z  -> no boundary -> largest boundary m -> page 1
```

This keeps increasing writes on the right edge, where subsequent splits preserve global ordering.

### Reconstructing recovery state

Index history stores changed page versions, so recovery builds a newest-known view while walking backward through version blocks. It starts with page 0 and follows only the page IDs required by the live chain.

After each block is loaded, recovery closes that required frontier against every newer page version already seen. This handles both sides of incremental history safely:

- **Non-leftmost split:** an older page points to a sibling created in a newer block, such as `3 -> 5 -> 4`. Once page 3 becomes reachable, recovery follows the cached page 5 and continues to page 4.
- **Range deletion:** a newer chain bypasses deleted pages, such as changing `0 -> 1 -> 2 -> 3 -> 4` into `0 -> 3 -> 4`. The stale copies of pages 1 and 2 remain historical data, but recovery never admits them because the live chain does not reference them.

Once the live chain is complete, older unused blocks are not an availability dependency. If a predecessor is still required to resolve the chain, however, a missing or cyclic history is reported as corruption.

### Handling already-damaged indexes

Recovery fails closed with `{:corrupt_index, reason}` rather than guessing how to repair an overlapping page map. Automatic repair is unsafe here: compaction can change locator ordering, and a clear can leave only a stale duplicate behind. Choosing a survivor could therefore return an older value or resurrect a deleted key.

## Testing

- `mix test test/bedrock/data_plane/materializer/olivine` — 319 tests, 23 properties
- `mix test` — 2,848 tests, 158 properties, 17 doctests
- `mix format --check-formatted`
- `mix credo --strict`
- `mix dialyzer`

A final cold review of exact commit `2c2356d0` found no blockers. Independent adversarial probes covered non-leftmost splits, range deletions, newer cached pages, missing history, and corrupt snapshots.

Closes #158