### PR TITLE
gh-141: Guard fresh-cluster shard boundaries with regression tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ def deps do
 end
 ```
 
+Bedrock requires Elixir 1.17 or later. CI tests OTP 27, 28, and 29 with
+Elixir 1.17.3, 1.19.5, and 1.20.3 respectively; see the
+[CI matrix](.github/workflows/elixir_ci.yaml) for the exact versions.
+
 ## A taste
 
 Define a cluster and a repo, add them to your supervision tree, and you have a

--- a/test/bedrock/internal/transaction_builder/layout_index_test.exs
+++ b/test/bedrock/internal/transaction_builder/layout_index_test.exs
@@ -1,7 +1,45 @@
 defmodule Bedrock.Internal.TransactionBuilder.LayoutIndexTest do
   use ExUnit.Case, async: true
 
+  alias Bedrock.ControlPlane.Config
+  alias Bedrock.ControlPlane.Config.RecoveryAttempt
+  alias Bedrock.ControlPlane.Director.Recovery.InitializationPhase
   alias Bedrock.Internal.TransactionBuilder.LayoutIndex
+
+  for order <- [:forward, :reverse] do
+    @order order
+    test "the fresh cluster's touching shards stay distinct in #{@order} fetch order (gh-141)" do
+      attempt = RecoveryAttempt.new(Bedrock.Cluster, 1, DateTime.utc_now())
+      {initialized, _next_phase} = InitializationPhase.execute(attempt, %{cluster_config: Config.new([node()])})
+
+      # Use recovery's actual default layout so a copied fixture cannot drift.
+      # Different refs make routing to the wrong side of the boundary visible.
+      refs = %{0 => [{:metadata_materializer, node()}], 1 => [{:data_materializer, node()}]}
+      entries = Enum.sort(initialized.shard_layout)
+      entries = if @order == :reverse, do: Enum.reverse(entries), else: entries
+
+      index =
+        Enum.reduce(entries, LayoutIndex.new(), fn {end_key, {tag, start_key}}, index ->
+          LayoutIndex.insert(index, start_key, end_key, Map.fetch!(refs, tag))
+        end)
+
+      # The old bulk builder emitted a third, zero-width entry at 0xFF.
+      # OTP 28 accepted its duplicate tree key; OTP 29 rejected it.
+      assert :gb_trees.to_list(index.tree) == [
+               {<<0xFF>>, {<<>>, refs[1]}},
+               {Bedrock.end_of_keyspace(), {<<0xFF>>, refs[0]}}
+             ]
+
+      for key <- [<<>>, "banana", <<0xFE, 0xFF>>] do
+        assert LayoutIndex.lookup_key(index, key) == {:ok, {{<<>>, <<0xFF>>}, refs[1]}}
+      end
+
+      for key <- [<<0xFF>>, <<0xFF, 0>>, Bedrock.end_of_keyspace()] do
+        assert LayoutIndex.lookup_key(index, key) ==
+                 {:ok, {{<<0xFF>>, Bedrock.end_of_keyspace()}, refs[0]}}
+      end
+    end
+  end
 
   test "an empty index misses" do
     assert LayoutIndex.lookup_key(LayoutIndex.new(), "a") == :not_cached


### PR DESCRIPTION
The fresh-cluster failure in #141 is reproducible in 0.6.0. Current `develop` already avoids it: #194 replaced the bulk layout builder with an index that inserts one fetched shard at a time. This PR adds the missing regression coverage and documents the tested toolchains; it does not change runtime behavior or backport a fix to 0.6.x.

### Why

Think of the default layout as two neighboring rooms sharing a doorway at `0xFF`:

- User data occupies `[empty, 0xFF)`.
- Metadata starts at `0xFF` and runs to the end-of-keyspace sentinel.

The old builder collected both rooms' start and end points. The shared doorway appeared twice, so it invented a third room with no space inside: `[0xFF, 0xFF)`. That also gave the tree two entries with the same end key. OTP 28 accepted the malformed tree; OTP 29 rejects it with `:not_orddict`.

### What changed and how it works

The new tests call `InitializationPhase.execute/2` to obtain recovery's real default shards, then insert those entries through today's `LayoutIndex` API. Using the actual initialization result prevents a copied test fixture from drifting away from what a fresh cluster creates.

Both fetch orders are tested. The assertions require exactly two tree entries and use different materializer references to verify the routing: `"banana"` goes to the data shard, while the shared `0xFF` boundary belongs to metadata. Empty-key, neighboring byte values, and the existing inclusive end-of-keyspace sentinel behavior are covered too.

Today's `:gb_trees.enter/3` stores each shard under its own end key; there is no combined boundary list to duplicate. No deduplication patch is needed in this implementation. OTP 29 is already in CI. The README now states the minimum Elixir version and the three CI-tested Elixir/OTP pairings.

### Validation

- Historical red: extracted the unmodified `LayoutIndex` from `a22a1516`, supplied the report's default layout, and asserted exactly two tree entries. OTP 29.0.5 / Elixir 1.20.3 raises `:not_orddict`; OTP 28.3 / Elixir 1.19.4 fails with three entries instead of two.
- Current green: all 7 LayoutIndex tests pass on OTP 29.0.5 / Elixir 1.20.3. The new tests pass without a runtime change because #194 already removed the faulty builder; this is historical red/current green, not a newly fixed failure on `develop`.
- Full suite on that OTP 29 toolchain after rebasing onto `abc99faa`: 3,066 passed, 2 distributed tests excluded.
- Formatting, compilation with warnings as errors, strict Credo, and Dialyzer passed (zero errors).
- `mix deps.audit` passed. Separately, Hex reported advisories for the unchanged Mint lock; the discrepancy is tracked in `bedrock-783`.
- Cold agent review in a separate worktree: no actionable findings. Reviewer independently checked the issue, implementation history, assertions, and README against CI.

Addresses #141 on current `develop`. Release/backport policy for 0.6.x remains outside this PR.

Ticket: `bedrock-fae`; review: `bedrock-99z`.
