### PR TITLE
bedrock-xfc: isolate Raft protocol test DETS tables

### DIFF
--- a/test/bedrock/control_plane/coordinator/disk_raft_log_protocol_test.exs
+++ b/test/bedrock/control_plane/coordinator/disk_raft_log_protocol_test.exs
@@ -6,13 +6,39 @@ defmodule Bedrock.ControlPlane.Coordinator.DiskRaftLogProtocolTest do
 
   @moduletag :tmp_dir
 
-  def with_log(%{tmp_dir: tmp_dir} = context) do
-    log = DiskRaftLog.new(log_dir: tmp_dir, table_name: :protocol_test)
+  def with_log(%{tmp_dir: tmp_dir, test: test} = context) do
+    # DETS names are shared across the VM. A previous test's automatic close
+    # may still be pending, so each test needs its own name as well as its file.
+    table_name = :"#{__MODULE__}.#{test}"
+    log = DiskRaftLog.new(log_dir: tmp_dir, table_name: table_name)
     {:ok, log} = DiskRaftLog.open(log)
 
-    on_exit(fn -> DiskRaftLog.close(log) end)
-
+    # DETS closes the table when this test process exits. An on_exit callback
+    # runs in another process and cannot close this process's DETS handle.
     {:ok, Map.put(context, :log, log)}
+  end
+
+  test "fixtures keep separate logs when a previous table is still open", %{tmp_dir: tmp_dir} do
+    {:ok, %{log: first}} =
+      with_log(%{tmp_dir: Path.join(tmp_dir, "first"), test: :first_fixture})
+
+    try do
+      {:ok, _} = Log.append_transactions(first, {0, 0}, [{{1, 1}, {1, :first}}])
+
+      {:ok, %{log: second}} =
+        with_log(%{tmp_dir: Path.join(tmp_dir, "second"), test: :second_fixture})
+
+      try do
+        assert Log.newest_transaction_id(second) == {0, 0}
+        assert {:ok, _} = Log.append_transactions(second, {0, 0}, [{{2, 1}, {2, :second}}])
+        assert Log.transactions_to(first, :newest) == [{{1, 1}, {1, :first}}]
+        assert Log.transactions_to(second, :newest) == [{{2, 1}, {2, :second}}]
+      after
+        DiskRaftLog.close(second)
+      end
+    after
+      DiskRaftLog.close(first)
+    end
   end
 
   defp create_test_chain(log) do


### PR DESCRIPTION
The latest `develop` CI failed before a Raft range-query test could begin: its fixture returned `{:error, :incompatible_arguments}` while opening the log ([original run](https://github.com/bedrock-kv/bedrock/actions/runs/33976924772)). This change gives each protocol test its own DETS table name so it can open its log even while an earlier test's table is still closing.

Think of a DETS table name as a label on an open file. Every test had its own temporary file, but all of them used the label `:protocol_test`. If test A's label still points to file A when test B asks to use it for file B, DETS rejects the request: one open label cannot refer to two different files.

Tests running one at a time does not guarantee that DETS has finished processing the previous test process's exit. The old `on_exit` callback did not guarantee that either: ExUnit runs it in another process, and [DETS only allows a process that opened a table to close its handle](https://www.erlang.org/doc/apps/stdlib/dets.html#close/1). DETS automatically closes the table when its opening process exits.

The fixture now derives its table name from the test module and test name. For example, test A and test B get different labels as well as different files. The ineffective fixture cleanup callback is removed; normal DETS owner-exit cleanup remains responsible for closing the table. The change is confined to the protocol test file.

The new regression deliberately keeps the first fixture open while opening the second. Before the fix, it fails with the same `:incompatible_arguments` error at `with_log/1`. After the fix, both logs open, the second starts empty, and writes to either log stay separate. This reproduces the conflicting-table condition deterministically; it does not claim to reproduce the original CI scheduler timing. A baseline of 100 repeated protocol-suite runs did not hit that natural timing failure.

Validation:

- Regression observed red before the fixture fix and green afterward; all 53 protocol tests pass on both toolchains below.
- Elixir 1.19.4 / OTP 28.3: full suite passed (17 doctests, 158 properties, 2,892 tests; 2 excluded).
- Elixir 1.17.3 / OTP 27.3.3: the full suite hit the existing `bedrock-s9x` TransactionBuilder process-exit timeout on both runs with seed `346337` (17 doctests, 158 properties, 2,894 tests; 1 failure, 2 excluded). The 53 protocol tests passed. That TransactionBuilder test passes in isolation with the same seed; the full-suite failures are recorded on its existing ticket. This uses the locally available OTP patch, not CI's exact 27.3, and runs on macOS rather than Linux.
- Formatting, strict Credo, and Dialyzer passed, including the commit hook.
- Independent cold agent review completed before pushing: no actionable findings.
