### PR TITLE
Drop deleted ChunkWriter from LocalFilesystem moduledoc

### DIFF
--- a/lib/bedrock/object_storage/local_filesystem.ex
+++ b/lib/bedrock/object_storage/local_filesystem.ex
@@ -13,7 +13,7 @@ defmodule Bedrock.ObjectStorage.LocalFilesystem do
 
   That matters most for `put_if_not_exists/4`, the writer for chunks,
   snapshots and the bootstrap record. Its callers in the data plane
-  (`Demux.ShardServer`, `ChunkWriter`, `Snapshot`) read `:already_exists`
+  (`Demux.ShardServer`, `Snapshot`) read `:already_exists`
   as success, so a key claimed by a short object would report success to
   everyone forever and could never be rewritten. The bootstrap callers
   (`ClusterBootstrap.Discovery`, recovery's `PersistencePhase`) instead


### PR DESCRIPTION
Closes bedrock-jzh.

Doc-only. The `put_if_not_exists/4` caller list in `LocalFilesystem`'s moduledoc still named `ChunkWriter`, which #220 (bedrock-d3k) deleted. Verified the surviving callers by grep: `Demux.ShardServer`, `Snapshot`, `ClusterBootstrap.Discovery`, `PersistencePhase` — all still listed accurately.

Found while auditing the tracker for tickets whose work had merged without being closed (15 closed, 23 stale worktrees removed).