### PR TITLE
233: Preserve exact durable versions in compaction snapshots

### DIFF
--- a/guides/deep-dives/architecture/implementations/olivine.md
+++ b/guides/deep-dives/architecture/implementations/olivine.md
@@ -30,7 +30,9 @@ The stream puller hands each batch to the server through a synchronous ingest ca
 
 ## Compaction and Snapshots
 
-Background compaction rewrites the data and index files without blocking reads or ingestion, cutting over atomically when the compacted files are ready. After a successful compaction, olivine optionally uploads the result to object storage as the shard's snapshot bundle — the bootstrap point for cold-started replacements.
+Background compaction rewrites the data and index files without blocking reads or ingestion, cutting over atomically when the compacted files are ready. The compactor selects the exact retained index at the durable version, which is at or below KCV. It never snapshots the applied tip under an older version: even fully committed mutations after the durable boundary must be replayed from that boundary, including atomic operations. Cutover restores this historical baseline and rejoins the stream after it.
+
+After a successful compaction, olivine optionally uploads the result to object storage as the shard's snapshot bundle — the bootstrap point for cold-started replacements. It captures the compacted bytes before ingestion resumes and uploads those immutable bytes asynchronously. Idle spin-down uses the same exact-version compactor and uploads its scratch files before retiring.
 
 ## Key Components
 

--- a/lib/bedrock/data_plane/materializer/olivine/database.ex
+++ b/lib/bedrock/data_plane/materializer/olivine/database.ex
@@ -7,6 +7,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Database do
   alias Bedrock.DataPlane.Materializer.Olivine.DataDatabase
   alias Bedrock.DataPlane.Materializer.Olivine.Index.Page
   alias Bedrock.DataPlane.Materializer.Olivine.IndexDatabase
+  alias Bedrock.DataPlane.Materializer.Olivine.IndexManager
 
   @type t :: {DataDatabase.t(), IndexDatabase.t()}
   @type locator :: DataDatabase.locator()
@@ -120,31 +121,33 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Database do
   Compacts the database files by building new files with sequential data layout.
 
   Accepts a writer module and writer state for pluggable output format.
+  Selects the exact durable index from the captured manager, so the snapshot
+  contents and advertised replay boundary always describe the same state.
+  Applied mutations after that boundary must be replayed, even if committed.
   Returns the writer result, compacted pages, and durable version.
 
   This is run in a background task and should not block normal operations.
   """
   @spec compact(
           t(),
-          complete_page_map :: %{Page.id() => {Page.t(), Page.id()}},
+          index_manager :: IndexManager.t(),
           writer_module :: module(),
           writer :: CompactionWriter.t()
         ) ::
           {:ok, CompactionWriter.result(), compacted_pages :: %{Page.id() => {Page.t(), Page.id()}},
            durable_version :: Bedrock.version()}
           | {:error, term()}
-  def compact({data_db, index_db}, complete_page_map, writer_module, writer) do
+  def compact({data_db, index_db}, index_manager, writer_module, writer) do
     durable_version = IndexDatabase.durable_version(index_db)
 
-    # Build compacted data, updating writer state
-    {compacted_pages, writer} = build_compacted_data(data_db, complete_page_map, writer_module, writer)
+    with {:ok, complete_page_map} <- IndexManager.get_complete_page_map(index_manager, durable_version) do
+      {compacted_pages, writer} = build_compacted_data(data_db, complete_page_map, writer_module, writer)
+      index_record = IndexDatabase.build_snapshot_record(durable_version, compacted_pages)
 
-    # Write snapshot index record
-    index_record = IndexDatabase.build_snapshot_record(durable_version, compacted_pages)
-
-    with {:ok, writer} <- writer_module.write_index(writer, index_record),
-         {:ok, result} <- writer_module.finish(writer) do
-      {:ok, result, compacted_pages, durable_version}
+      with {:ok, writer} <- writer_module.write_index(writer, index_record),
+           {:ok, result} <- writer_module.finish(writer) do
+        {:ok, result, compacted_pages, durable_version}
+      end
     end
   end
 

--- a/lib/bedrock/data_plane/materializer/olivine/index_manager.ex
+++ b/lib/bedrock/data_plane/materializer/olivine/index_manager.ex
@@ -262,11 +262,26 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.IndexManager do
 
   @doc """
   Extracts the complete page_map from the current version's index.
-  Used during compaction to get all current pages.
+  For a durable snapshot, use the exact-version variant instead.
   """
   @spec get_complete_page_map(t()) :: %{Page.id() => {Page.t(), Page.id()}}
   def get_complete_page_map(%{versions: [{_, {current_index, _}} | _]}), do: current_index.page_map
   def get_complete_page_map(%{versions: []}), do: %{}
+
+  @doc """
+  Extracts the complete page map at an exact retained version.
+
+  Compaction must pair the durable boundary with its own index, never the
+  applied tip or a nearby version. Window advancement retains that boundary.
+  """
+  @spec get_complete_page_map(t(), Bedrock.version()) ::
+          {:ok, modified_pages()} | {:error, :version_not_retained}
+  def get_complete_page_map(%{versions: versions}, version) do
+    case List.keyfind(versions, version, 0) do
+      {^version, {index, _modified_pages}} -> {:ok, index.page_map}
+      nil -> {:error, :version_not_retained}
+    end
+  end
 
   @spec index_for_version(version_list(), Bedrock.version()) :: Index.t() | nil
   defp index_for_version(versions, target), do: find_target(versions, target)

--- a/lib/bedrock/data_plane/materializer/olivine/logic.ex
+++ b/lib/bedrock/data_plane/materializer/olivine/logic.ex
@@ -435,8 +435,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Logic do
   @spec start_compaction(State.t()) :: {:ok, Task.t()}
   def start_compaction(%State{} = state) do
     database = state.database
-    # Get complete current page_map from index
-    complete_page_map = IndexManager.get_complete_page_map(state.index_manager)
+    index_manager = state.index_manager
     caller = self()
 
     durable_version = Database.durable_version(database)
@@ -458,7 +457,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Logic do
 
         with {:ok, writer} <- SplitFileWriter.new(compact_data_path, compact_idx_path),
              {:ok, result, compacted_pages, durable_version} <-
-               Database.compact(database, complete_page_map, SplitFileWriter, writer) do
+               Database.compact(database, index_manager, SplitFileWriter, writer) do
           duration = System.monotonic_time(:microsecond) - start_time
 
           send(caller, {
@@ -517,14 +516,13 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Logic do
 
   def upload_snapshot_before_spindown(%State{snapshot: snapshot} = t) do
     {data_db, index_db} = t.database
-    complete_page_map = IndexManager.get_complete_page_map(t.index_manager)
     spindown_data_path = data_db.file_name ++ ~c".spindown"
     spindown_idx_path = index_db.file_name ++ ~c".spindown"
 
     result =
       with {:ok, writer} <- SplitFileWriter.new(spindown_data_path, spindown_idx_path),
            {:ok, files, _compacted_pages, durable_version} <-
-             Database.compact(t.database, complete_page_map, SplitFileWriter, writer),
+             compact_for_spindown(t, writer),
            _ = :file.close(files.data_fd),
            _ = :file.close(files.idx_fd),
            version_int = Version.to_integer(durable_version),
@@ -544,12 +542,25 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Logic do
     result
   end
 
+  defp compact_for_spindown(t, writer) do
+    case Database.compact(t.database, t.index_manager, SplitFileWriter, writer) do
+      {:ok, _, _, _} = result ->
+        result
+
+      {:error, _} = error ->
+        :file.close(writer.data_fd)
+        :file.close(writer.idx_fd)
+        error
+    end
+  end
+
   @doc """
   Optionally uploads a snapshot to ObjectStorage after compaction.
 
   This is a fire-and-forget operation. If snapshot is not configured,
-  this is a no-op. If configured, spawns an async task to read the data and
-  index files and upload them directly as a bundle (iodata).
+  this is a no-op. If configured, captures the compacted bytes before returning
+  to ingestion, then uploads that immutable bundle in an async task. The live
+  paths may be appended to or replaced as soon as this call returns.
 
   The task logs success or failure but does not affect the caller.
   """
@@ -567,18 +578,25 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Logic do
   def maybe_upload_snapshot(%State{snapshot: snapshot}, data_path, idx_path, durable_version) do
     version_int = Version.to_integer(durable_version)
 
-    Task.start(fn ->
-      # Read files and upload as iodata (no intermediate bundle file)
-      with {:ok, data} <- File.read(to_string(data_path)),
-           {:ok, idx} <- File.read(to_string(idx_path)),
-           :ok <- Snapshot.write(snapshot, version_int, [data, idx]) do
-        Logger.info("Snapshot uploaded to ObjectStorage", version: version_int)
-      else
-        {:error, reason} ->
-          Logger.warning("Snapshot upload failed", version: version_int, reason: inspect(reason))
-      end
-    end)
+    # The server cannot mutate these files during its cutover callback.
+    # Never hand the async task live paths: they may represent a different
+    # version by the time it runs.
+    with {:ok, data} <- File.read(to_string(data_path)),
+         {:ok, idx} <- File.read(to_string(idx_path)) do
+      Task.start(fn ->
+        case Snapshot.write(snapshot, version_int, [data, idx]) do
+          :ok -> Logger.info("Snapshot uploaded to ObjectStorage", version: version_int)
+          {:error, reason} -> log_snapshot_upload_failure(version_int, reason)
+        end
+      end)
+    else
+      {:error, reason} -> log_snapshot_upload_failure(version_int, reason)
+    end
 
     :ok
+  end
+
+  defp log_snapshot_upload_failure(version, reason) do
+    Logger.warning("Snapshot upload failed", version: version, reason: inspect(reason))
   end
 end

--- a/test/bedrock/data_plane/materializer/olivine/compaction_cutover_test.exs
+++ b/test/bedrock/data_plane/materializer/olivine/compaction_cutover_test.exs
@@ -11,6 +11,8 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.CompactionCutoverTest do
   """
   use ExUnit.Case, async: true
 
+  alias Bedrock.DataPlane.Materializer.Olivine.Database
+  alias Bedrock.DataPlane.Materializer.Olivine.IndexManager
   alias Bedrock.DataPlane.Materializer.Olivine.Logic
   alias Bedrock.DataPlane.Materializer.Olivine.Server
   alias Bedrock.DataPlane.Transaction
@@ -175,6 +177,48 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.CompactionCutoverTest do
     resumed_from = Version.increment(durable_version)
     assert_receive {:pulled, ^resumed_from}, 15_000
     assert_pulls_monotonic(resumed_from)
+  end
+
+  test "a committed atomic suffix present before compaction is replayed once", %{tmp_dir: tmp_dir} do
+    {:ok, shard_server} = ReplayShardServer.start_link(self())
+    {:ok, log_stub} = StubLog.start_link(shard_server)
+    pid = start_worker(tmp_dir)
+    unlock_with_stream(pid, log_stub)
+    v100 = Version.from_integer(100)
+    v200 = Version.from_integer(200)
+
+    :ok = ReplayShardServer.append(shard_server, v100, slice(v100, <<10>>))
+    await_value(pid, v100, <<10>>)
+
+    # Pin the durable boundary while retaining the newer committed suffix
+    # in memory, just as window advancement does in production.
+    :sys.replace_state(pid, fn state ->
+      {data, _} = state.database
+
+      {:ok, database, _} =
+        Database.advance_durable_version(
+          state.database,
+          v100,
+          Version.zero(),
+          data.file_offset,
+          [IndexManager.get_complete_page_map(state.index_manager)]
+        )
+
+      %{state | database: database}
+    end)
+
+    atomic = Transaction.encode(%{mutations: [{:atomic, :add, "key", <<5>>}], commit_version: v200})
+    :ok = ReplayShardServer.append(shard_server, v200, atomic)
+    await_value(pid, v200, <<15>>)
+    {:ok, task} = Logic.start_compaction(:sys.get_state(pid))
+    assert_receive {:compaction_ready, _, _, _, _, _, _, _, ^v100, _, _, _} = cutover, 10_000
+    Task.await(task)
+    flush_pulls()
+    send(pid, cutover)
+    resumed_from = Version.increment(v100)
+    assert_receive {:pulled, ^resumed_from}, 15_000
+    await_value(pid, v200, <<15>>)
+    await_value(pid, v100, <<10>>)
   end
 
   test "a superseded puller's queued ingest is acknowledged and discarded",

--- a/test/bedrock/data_plane/materializer/olivine/compaction_version_test.exs
+++ b/test/bedrock/data_plane/materializer/olivine/compaction_version_test.exs
@@ -1,0 +1,257 @@
+defmodule Bedrock.DataPlane.Materializer.Olivine.CompactionVersionTest do
+  use ExUnit.Case, async: true
+
+  alias Bedrock.DataPlane.Materializer.Olivine.Database
+  alias Bedrock.DataPlane.Materializer.Olivine.Index
+  alias Bedrock.DataPlane.Materializer.Olivine.IndexDatabase
+  alias Bedrock.DataPlane.Materializer.Olivine.IndexManager
+  alias Bedrock.DataPlane.Materializer.Olivine.Logic
+  alias Bedrock.DataPlane.Materializer.Olivine.State
+  alias Bedrock.DataPlane.Transaction
+  alias Bedrock.DataPlane.Version
+  alias Bedrock.ObjectStorage
+  alias Bedrock.ObjectStorage.LocalFilesystem
+  alias Bedrock.ObjectStorage.Snapshot
+
+  for output <- [:compaction, :spindown] do
+    @tag :tmp_dir
+    test "#{output} cold replacement excludes an uncommitted tail", %{tmp_dir: path} do
+      state = baseline(path, "old")
+      state = apply_at(state, 200, [{:set, "a", "future"}])
+      assert value(state, 200) == "future"
+      restored = restore(unquote(output), state, path)
+
+      assert restored.index_manager.current_version == Version.from_integer(100)
+      assert value(restored, 100) == "old"
+      assert {:ok, rolled_back} = Logic.unlock_after_recovery(state, Version.from_integer(100), [])
+      assert value(rolled_back, 100) == "old"
+      assert rolled_back.index_manager.current_version == restored.index_manager.current_version
+      Database.close(restored.database)
+      Database.close(state.database)
+    end
+
+    @tag :tmp_dir
+    test "#{output} keeps an empty durable baseline empty", %{tmp_dir: path} do
+      live = Path.join(path, "live")
+      File.mkdir_p!(live)
+      {:ok, database} = Database.open(unique_name(), Path.join(live, "db"), pool_size: 1)
+      state = %State{database: database, index_manager: IndexManager.new(), known_committed_version: Version.zero()}
+      state = apply_at(state, 200, [{:set, "a", "future"}])
+      restored = restore(unquote(output), state, path)
+      assert restored.index_manager.current_version == Version.zero()
+      assert File.read!(Path.join([path, "replacement", "data"])) == ""
+      [{_, {index, _}}] = restored.index_manager.versions
+      assert Enum.all?(index.page_map, fn {_, {page, _}} -> Index.Page.key_count(page) == 0 end)
+      Database.close(restored.database)
+      Database.close(state.database)
+    end
+
+    @tag :tmp_dir
+    test "#{output} committed atomic suffix is replayed exactly once", %{tmp_dir: path} do
+      state = baseline(path, <<10>>)
+      mutation = [{:atomic, :add, "a", <<5>>}]
+      state = apply_at(state, 200, mutation)
+      state = %{state | known_committed_version: Version.from_integer(200)}
+      assert value(state, 200) == <<15>>
+      restored = restore(unquote(output), state, path)
+      assert restored.index_manager.current_version == Version.from_integer(100)
+
+      replayed = apply_at(restored, 200, mutation)
+      assert value(replayed, 200) == <<15>>
+      assert value(replayed, 100) == <<10>>
+      Database.close(replayed.database)
+      Database.close(state.database)
+    end
+  end
+
+  @tag :tmp_dir
+  test "async upload captures its immutable baseline before returning to ingestion", %{tmp_dir: path} do
+    state = baseline(path, "old")
+    backend = ObjectStorage.backend(LocalFilesystem, root: Path.join(path, "objects"))
+    snapshot = Snapshot.new(backend, "1")
+    data_path = Path.join(path, "upload-data")
+    idx_path = Path.join(path, "upload-idx")
+    version = Version.from_integer(100)
+
+    File.write!(
+      idx_path,
+      IndexDatabase.build_snapshot_record(version, IndexManager.get_complete_page_map(state.index_manager))
+    )
+
+    # A Unix FIFO holds the first file capture open until explicitly released.
+    # Its writer-open handshake proves the reader entered capture; this does
+    # not depend on winning a race with an asynchronously scheduled task.
+    assert {_, 0} = System.cmd("mkfifo", [data_path])
+    parent = self()
+
+    producer =
+      spawn(fn ->
+        {:ok, file} = :file.open(String.to_charlist(data_path), [:raw, :write, :binary])
+        send(parent, :capture_started)
+
+        receive do
+          :release -> :file.write(file, "oldkeepkeep")
+        end
+
+        :file.close(file)
+      end)
+
+    caller =
+      spawn(fn ->
+        result = Logic.maybe_upload_snapshot(%{state | snapshot: snapshot}, data_path, idx_path, version)
+        send(parent, {:upload_returned, result})
+      end)
+
+    on_exit(fn ->
+      Process.exit(caller, :kill)
+      Process.exit(producer, :kill)
+    end)
+
+    assert_receive :capture_started, 5_000
+    refute_receive {:upload_returned, _}
+    send(producer, :release)
+    assert_receive {:upload_returned, :ok}, 5_000
+
+    # The server can now advance or replace its live files. The uploaded
+    # bundle must still describe the version captured before this return.
+    File.rm!(data_path)
+    File.write!(data_path, "future")
+    File.write!(idx_path, "new live index")
+    assert {:ok, 100, _} = await_snapshot(snapshot)
+    replacement = Path.join(path, "replacement")
+    File.mkdir_p!(replacement)
+    assert :ok = Logic.maybe_load_snapshot(replacement, snapshot)
+    restored = open_replacement(replacement)
+    assert restored.index_manager.current_version == version
+    assert value(restored, 100) == "old"
+    Database.close(restored.database)
+    Database.close(state.database)
+  end
+
+  defp await_snapshot(snapshot, attempts \\ 100)
+  defp await_snapshot(_snapshot, 0), do: {:error, :timed_out}
+
+  defp await_snapshot(snapshot, attempts) do
+    case Snapshot.read_latest(snapshot) do
+      {:error, :not_found} ->
+        Process.sleep(10)
+        await_snapshot(snapshot, attempts - 1)
+
+      result ->
+        result
+    end
+  end
+
+  @tag :tmp_dir
+  test "repeated window advancement retains the exact durable index", %{tmp_dir: path} do
+    state = baseline(path, "old")
+    state = %{state | index_manager: %{state.index_manager | window_lag_time_μs: 0}}
+    {:ok, state} = Logic.advance_window(state)
+    assert Enum.map(state.index_manager.versions, &elem(&1, 0)) == [Version.from_integer(100)]
+    state = apply_at(state, 200, [{:set, "a", "committed"}])
+    state = %{state | known_committed_version: Version.from_integer(200)}
+    {:ok, state} = Logic.advance_window(state)
+    assert Database.durable_version(state.database) == Version.from_integer(200)
+    assert Enum.map(state.index_manager.versions, &elem(&1, 0)) == [Version.from_integer(200)]
+
+    assert {:error, :version_not_retained} =
+             IndexManager.get_complete_page_map(state.index_manager, Version.from_integer(150))
+
+    state = apply_at(state, 300, [{:set, "a", "future"}])
+    {:ok, state} = Logic.advance_window(state)
+    assert Database.durable_version(state.database) == Version.from_integer(200)
+    restored = restore(:compaction, state, path)
+    assert value(restored, 200) == "committed"
+    Database.close(restored.database)
+    Database.close(state.database)
+  end
+
+  @tag :tmp_dir
+  test "missing exact durable baseline produces neither compacted index nor uploaded snapshot", %{tmp_dir: path} do
+    state = baseline(path, "old")
+    state = apply_at(state, 200, [{:set, "a", "future"}])
+
+    assert {:error, :version_not_retained} =
+             IndexManager.get_complete_page_map(state.index_manager, Version.from_integer(150))
+
+    versions = Enum.reject(state.index_manager.versions, fn {v, _} -> v == Version.from_integer(100) end)
+    state = %{state | index_manager: %{state.index_manager | versions: versions}}
+
+    assert {:error, :version_not_retained} =
+             IndexManager.get_complete_page_map(state.index_manager, Version.from_integer(100))
+
+    {:ok, task} = Logic.start_compaction(state)
+    assert_receive {:compaction_failed, :version_not_retained}, 5_000
+    Task.await(task)
+    refute_receive {:compaction_ready, _, _, _, _, _, _, _, _, _, _, _}
+    backend = ObjectStorage.backend(LocalFilesystem, root: Path.join(path, "objects"))
+    snapshot = Snapshot.new(backend, "1")
+    assert {:error, :version_not_retained} = Logic.upload_snapshot_before_spindown(%{state | snapshot: snapshot})
+    assert {:error, :not_found} = Snapshot.read_latest(snapshot)
+    refute File.exists?(Path.join([path, "live", "data.spindown"]))
+    refute File.exists?(Path.join([path, "live", "idx.spindown"]))
+    Database.close(state.database)
+  end
+
+  defp baseline(path, value) do
+    live = Path.join(path, "live")
+    File.mkdir_p!(live)
+    {:ok, database} = Database.open(unique_name(), Path.join(live, "db"), pool_size: 1)
+
+    state = %State{
+      database: database,
+      index_manager: IndexManager.new(),
+      known_committed_version: Version.from_integer(100)
+    }
+
+    state = apply_at(state, 100, [{:set, "a", value}, {:set, "b", "keep"}, {:set, "c", "keep"}])
+    state = %{state | index_manager: %{state.index_manager | window_lag_time_μs: 0}}
+    {:ok, state} = Logic.advance_window(state)
+    state
+  end
+
+  defp apply_at(state, version, mutations) do
+    txn = Transaction.encode(%{mutations: mutations, commit_version: Version.from_integer(version)})
+    {:ok, state, _} = Logic.apply_transactions(state, [txn])
+    state
+  end
+
+  defp value(state, version) do
+    {:ok, page} = IndexManager.page_for_key(state.index_manager, "a", Version.from_integer(version))
+    {:ok, locator} = Index.Page.locator_for_key(page, "a")
+    {:ok, value} = Database.load_value(state.database, locator)
+    value
+  end
+
+  defp restore(:compaction, state, path) do
+    {:ok, task} = Logic.start_compaction(state)
+    assert_receive {:compaction_ready, _, _, dp, ip, _, _, _, advertised, _, _, _}, 5_000
+    Task.await(task)
+    assert advertised <= state.known_committed_version
+    recovered = Path.join(path, "replacement")
+    File.mkdir_p!(recovered)
+    File.cp!(to_string(dp), Path.join(recovered, "data"))
+    File.cp!(to_string(ip), Path.join(recovered, "idx"))
+    open_replacement(recovered)
+  end
+
+  defp restore(:spindown, state, path) do
+    backend = ObjectStorage.backend(LocalFilesystem, root: Path.join(path, "objects"))
+    snapshot = Snapshot.new(backend, "1")
+    assert :ok = Logic.upload_snapshot_before_spindown(%{state | snapshot: snapshot})
+    assert {:ok, advertised, _} = Snapshot.read_latest(snapshot)
+    assert advertised <= Version.to_integer(state.known_committed_version)
+    recovered = Path.join(path, "replacement")
+    File.mkdir_p!(recovered)
+    assert :ok = Logic.maybe_load_snapshot(recovered, snapshot)
+    open_replacement(recovered)
+  end
+
+  defp open_replacement(path) do
+    {:ok, database} = Database.open(unique_name(), Path.join(path, "db"), pool_size: 1)
+    {:ok, index_manager} = IndexManager.recover_from_database(database)
+    %State{database: database, index_manager: index_manager}
+  end
+
+  defp unique_name, do: :"compaction_version_#{System.unique_integer([:positive])}"
+end


### PR DESCRIPTION
Olivine's compactor copied the newest in-memory page map into fresh files but stamped them with the durable version, which trails the applied tip. A cold-started replacement then read post-durable state under a durable label, and the cutover replay re-applied atomics already in the compacted bytes. The compactor now selects the retained index at exactly the durable version.

Ticket: bedrock-wjt
Closes #233

## Why

Compacted files are a snapshot plus a replay boundary: the version they advertise is where the stream rejoins. Both callers handed the compactor the applied tip of the retained version list, while the label came from the durable version, which eviction clamps to the known committed version. The files therefore held state from above the boundary while claiming to sit on it.

A cold-started replacement seeds its version list from that label, so an uncommitted value at 200 became committed history at 100. The cutover rejoins the stream at the same boundary; sets replay idempotently, but an atomic add reads the value out of the index it lands on, so a committed increment already in the snapshot was applied twice. Separately, the post-compaction upload handed live paths to an async task that ran after ingestion had resumed.

## What changed

- An exact-version page-map lookup on `IndexManager`, returning `{:error, :version_not_retained}`. It is deliberately not the nearest match at or below: compacting an older index under the durable label would make the replay skip transactions.
- `Database.compact/4` now takes the index manager, resolves that baseline itself, and short-circuits before writing.
- Spin-down closes its scratch writer on that error, and the uploader reads both files synchronously so the task holds bytes rather than paths.

Not done: labelling the files with the applied version, which would put post-KCV state on disk.

## How it works

The invariant is that the oldest retained version entry sits at exactly the durable version. Window advancement moves both in one step: the eviction version trims the retained list and becomes the new durable version. Fresh, recovered, and post-cutover managers each start with a single entry at that boundary.

A counter durable at 100, with a committed `add <<5>>` applied at 200:

| | compacted value | after replaying 200 |
|---|---|---|
| before | `<<15>>` | `<<20>>` |
| after | `<<10>>` | `<<15>>` |

The suffix that leaves the files is the suffix the stream re-delivers. A missing baseline aborts compaction and spin-down before anything is written; the uploader captures its bytes inside the cutover callback, before the server can accept another ingest.

## Verification

New tests drive compaction and spin-down against a real database and object store: cold replacement keeps the version-100 value, a committed atomic suffix replays once, window advancement keeps the durable entry exact, and a missing baseline yields neither index nor upload. A FIFO proves the uploader captures bytes before returning; reverting only that change fails it. CI is green, S3 suite included.

#276 (bedrock-3v1) fixes the same defect on the #253 stack with a different shape. The two heads conflict in `index_manager.ex`, `logic.ex`, and the cutover test, so whichever lands second must rebase.

Follow-up: bedrock-947, compaction is not yet scheduled. Follow-up: bedrock-q67.21.5, idle timeout not wired through recruitment. Follow-up: bedrock-ngl, timeout path bypasses the advancement guard. Follow-up: bedrock-0lx, rewind inherits the live id allocator.
