### PR TITLE
234: Preserve ordered mutations through batching and recovery

### DIFF
--- a/lib/bedrock/data_plane/commit_proxy/finalization.ex
+++ b/lib/bedrock/data_plane/commit_proxy/finalization.ex
@@ -733,6 +733,7 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization do
     initial_mutations_by_log = Map.new(log_ids, &{&1, []})
 
     plan.transactions
+    |> Enum.sort_by(fn {index, _entry} -> index end)
     |> Enum.reduce_while(
       {:ok, initial_mutations_by_log},
       fn {idx, entry}, {:ok, acc} ->

--- a/lib/bedrock/data_plane/materializer/olivine/index_update.ex
+++ b/lib/bedrock/data_plane/materializer/olivine/index_update.ex
@@ -169,6 +169,13 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.IndexUpdate do
   end
 
   defp apply_mutation({:clear_range, start_key, end_key}, _target_version, index_update) do
+    # Range discovery sees the base pages; staged inserts may extend beyond
+    # their old bounds and must be cleared before handling those pages.
+    index_update = %{
+      index_update
+      | pending_operations: clear_pending_keys_in_range(index_update.pending_operations, start_key, end_key)
+    }
+
     case collect_range_pages_via_chain_following(index_update.index, start_key, end_key) do
       [] ->
         index_update
@@ -238,11 +245,11 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.IndexUpdate do
           length(first_keys_to_clear) + length(last_keys_to_clear) +
             middle_keys_count + length(page_0_keys_to_clear)
 
+        index_update = delete_pages(index_update, middle_page_ids_excluding_page_zero)
+
         %{
           index_update
-          | index: Index.delete_pages(index_update.index, middle_page_ids_excluding_page_zero),
-            id_allocator: IdAllocator.recycle_ids(index_update.id_allocator, middle_page_ids_excluding_page_zero),
-            pending_operations: final_operations,
+          | pending_operations: final_operations,
             keys_removed: index_update.keys_removed + total_keys_removed
         }
     end
@@ -272,6 +279,15 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.IndexUpdate do
         database: database,
         keys_changed: index_update.keys_changed + 1
     }
+  end
+
+  defp clear_pending_keys_in_range(pending_operations, start_key, end_key) do
+    Map.new(pending_operations, fn {page_id, operations} ->
+      {page_id,
+       Map.new(operations, fn {key, operation} ->
+         {key, if(key >= start_key and key <= end_key, do: :clear, else: operation)}
+       end)}
+    end)
   end
 
   @spec collect_range_pages_via_chain_following(Index.t(), binary(), binary()) :: [Page.id()]
@@ -395,14 +411,34 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.IndexUpdate do
       # Inline update_page logic - page 0 becoming empty doesn't change tree structure
       {_old_page, next_id} = Map.get(index_update.index.page_map, page_id)
       updated_page_map = Map.put(index_update.index.page_map, page_id, {updated_page, next_id})
-      %{index_update | index: %{index_update.index | page_map: updated_page_map}}
-    else
+
       %{
         index_update
-        | index: Index.delete_pages(index_update.index, [page_id]),
-          id_allocator: IdAllocator.recycle_id(index_update.id_allocator, page_id)
+        | index: %{index_update.index | page_map: updated_page_map},
+          modified_page_ids: MapSet.put(index_update.modified_page_ids, page_id)
       }
+    else
+      delete_pages(index_update, [page_id])
     end
+  end
+
+  defp delete_pages(index_update, []), do: index_update
+
+  defp delete_pages(index_update, page_ids) do
+    index = Index.delete_pages(index_update.index, page_ids)
+    # Recovery follows next pointers, so predecessor-only changes are durable
+    # mutations too. Deleted pages themselves need no tombstones.
+    modified_page_ids =
+      Enum.reduce(index.page_map, index_update.modified_page_ids, fn {id, page}, modified ->
+        if Map.get(index_update.index.page_map, id) == page, do: modified, else: MapSet.put(modified, id)
+      end)
+
+    %{
+      index_update
+      | index: index,
+        id_allocator: IdAllocator.recycle_ids(index_update.id_allocator, page_ids),
+        modified_page_ids: MapSet.difference(modified_page_ids, MapSet.new(page_ids))
+    }
   end
 
   defp handle_oversized_page_from_segments(index_update, page_id, original_page, segments, key_count, _rightmost_key) do
@@ -455,6 +491,22 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.IndexUpdate do
 
   @spec get_current_value_for_atomic_op(t(), Bedrock.key(), Bedrock.version()) :: binary()
   defp get_current_value_for_atomic_op(index_update, key, _target_version) do
+    page_id = Tree.page_for_key(index_update.index.tree, key)
+
+    case index_update.pending_operations |> Map.get(page_id, %{}) |> Map.get(key) do
+      :clear ->
+        <<>>
+
+      {:set, locator} ->
+        {:ok, value} = Database.load_value(index_update.database, locator)
+        value
+
+      nil ->
+        get_indexed_value_for_atomic_op(index_update, key)
+    end
+  end
+
+  defp get_indexed_value_for_atomic_op(index_update, key) do
     case Index.locator_for_key(index_update.index, key) do
       {:ok, _page, locator} ->
         case Database.load_value(index_update.database, locator) do

--- a/test/bedrock/data_plane/materializer/olivine/mutation_order_test.exs
+++ b/test/bedrock/data_plane/materializer/olivine/mutation_order_test.exs
@@ -1,0 +1,301 @@
+defmodule Bedrock.DataPlane.Materializer.Olivine.MutationOrderTest do
+  use ExUnit.Case, async: true
+
+  alias Bedrock.DataPlane.CommitProxy.Batch
+  alias Bedrock.DataPlane.CommitProxy.Finalization
+  alias Bedrock.DataPlane.CommitProxy.ResolverLayout
+  alias Bedrock.DataPlane.CommitProxy.RoutingData
+  alias Bedrock.DataPlane.Materializer.Olivine.Database
+  alias Bedrock.DataPlane.Materializer.Olivine.Index
+  alias Bedrock.DataPlane.Materializer.Olivine.Index.Page
+  alias Bedrock.DataPlane.Materializer.Olivine.IndexManager
+  alias Bedrock.DataPlane.Transaction
+  alias Bedrock.DataPlane.Version
+  alias Bedrock.Test.DataPlane.FinalizationTestSupport, as: Support
+
+  @cases [
+    add_add: [{:atomic, :add, "key", <<1>>}, {:atomic, :add, "key", <<1>>}],
+    set_atomic: [{:set, "key", <<5>>}, {:atomic, :add, "key", <<2>>}],
+    clear_atomic: [{:clear, "key"}, {:atomic, :add, "key", <<2>>}],
+    set_range: [{:set, "newkey", <<5>>}, {:clear_range, "new", "newz"}],
+    range_set: [{:clear_range, "j", "l"}, {:set, "key", <<5>>}],
+    range_atomic: [{:clear_range, "j", "l"}, {:atomic, :add, "key", <<2>>}]
+  ]
+
+  for {name, mutations} <- @cases do
+    test "sequential oracle: #{name}", %{tmp_dir: dir} do
+      check_history(dir, [[{:set, "key", <<9>>}], unquote(Macro.escape(mutations))])
+    end
+  end
+
+  @moduletag :tmp_dir
+
+  test "staged inserts and clears span existing pages and newly split pages", %{tmp_dir: dir} do
+    seed = for n <- 1..800, do: {:set, key(n), <<9>>}
+    inserts = for n <- 1..800, do: {:set, key(n) <> "x", <<3>>}
+
+    mutations =
+      inserts ++
+        [
+          {:clear_range, key(100), key(700) <> "w"},
+          {:atomic, :add, key(400), <<2>>},
+          {:set, key(600), <<7>>},
+          {:atomic, :add, key(799) <> "x", <<2>>}
+        ]
+
+    check_history(dir, [seed, mutations])
+  end
+
+  test "all three-operation histories agree with the sequential oracle", %{tmp_dir: dir} do
+    operations = [{:set, "key", <<5>>}, {:clear, "key"}, {:clear_range, "j", "l"}, {:atomic, :add, "key", <<2>>}]
+    histories = for first <- operations, second <- operations, third <- operations, do: [first, second, third]
+
+    for {history, n} <- Enum.with_index(histories), seed <- [[], [{:set, "key", <<9>>}]] do
+      history_dir = Path.join(dir, "#{n}-#{length(seed)}")
+      File.mkdir_p!(history_dir)
+      check_history(history_dir, [seed, history])
+    end
+  end
+
+  test "range clears persist empty page zero and removed page links", %{tmp_dir: dir} do
+    seed = for n <- 1..800, do: {:set, key(n), <<9>>}
+    check_history(dir, [seed, [{:clear_range, "k", "l"}]])
+  end
+
+  test "separate durable advances preserve predecessor-only deletion and recycled page IDs", %{tmp_dir: dir} do
+    path = Path.join(dir, "incremental")
+    seed = for n <- 1..800, do: {:set, key(n), <<9>>}
+    {manager, db, expected} = durable_step(IndexManager.new(), open_database(path), %{}, seed, path)
+    [{_, {index, _}} | _] = manager.versions
+    assert map_size(index.page_map) > 2
+    {removed_page, _} = Map.fetch!(index.page_map, 1)
+    removed_keys = Page.keys(removed_page)
+    {predecessor, 1} = Map.fetch!(index.page_map, 0)
+    clears = Enum.map(removed_keys, &{:clear, &1})
+    {manager, db, expected} = durable_step(manager, db, expected, clears, path)
+    [{_, {index, _}} | _] = manager.versions
+    assert {^predecessor, next} = Map.fetch!(index.page_map, 0)
+    refute next == 1
+    refute Map.has_key?(index.page_map, 1)
+    for key <- removed_keys, do: assert({:error, :not_found} = Index.locator_for_key(index, key))
+
+    inserts = for n <- 1..800, do: {:set, "r" <> key(n), <<3>>}
+    {manager, db, _} = durable_step(manager, db, expected, inserts, path)
+    [{_, {index, _}} | _] = manager.versions
+    assert Map.has_key?(index.page_map, 1)
+    :ok = Database.close(db)
+  end
+
+  test "newly created atomic values observe earlier additions", %{tmp_dir: dir} do
+    check_history(dir, [[{:atomic, :add, "counter", <<1>>}, {:atomic, :add, "counter", <<1>>}]])
+  end
+
+  for aborted <- [[], [15]] do
+    test "commit proxy combines distinct clients in arrival order with aborts #{inspect(aborted)}", %{tmp_dir: dir} do
+      aborted = unquote(aborted)
+      test_pid = self()
+      clients = for n <- 1..40, do: [{:set, "key", <<n>>}, {:atomic, :add, "key", <<1>>}]
+
+      batch =
+        Enum.reduce(
+          Enum.with_index(clients),
+          Batch.new_batch(0, Version.zero(), Version.from_integer(1)),
+          fn {mutations, client}, batch ->
+            Batch.add_transaction(
+              batch,
+              Transaction.encode(%{mutations: mutations}),
+              fn reply -> send(test_pid, {:client, client, reply}) end,
+              :user
+            )
+          end
+        )
+
+      routing =
+        RoutingData.from_snapshot(%{
+          shard_layout: %{<<255, 255>> => {0, <<>>}},
+          log_map: %{0 => :log},
+          log_services: %{},
+          replication_factor: 1
+        })
+
+      test_pid = self()
+
+      n_aborts = length(aborted)
+      n_oks = 40 - n_aborts
+
+      assert {:ok, ^n_aborts, ^n_oks} =
+               Finalization.finalize_batch(batch,
+                 epoch: 1,
+                 sequencer: :sequencer,
+                 resolver_layout: %ResolverLayout.Single{resolver_ref: :resolver},
+                 metadata_apply_fn: Support.metadata_apply_fn(routing),
+                 resolver_fn: fn _, _, last, version, transactions, _, _ ->
+                   assert length(transactions) == 40
+                   {:ok, aborted, Support.tiling_window(last, version)}
+                 end,
+                 batch_log_push_fn: fn _, transactions_by_log, _, _ ->
+                   send(test_pid, {:logged, Map.fetch!(transactions_by_log, :log)})
+                   :ok
+                 end,
+                 sequencer_notify_fn: fn _, _, _, _ -> :ok end
+               )
+
+      for client <- 0..39 do
+        if client in aborted do
+          assert_receive {:client, ^client, {:error, :aborted}}
+        else
+          version = Version.from_integer(1)
+          assert_receive {:client, ^client, {:ok, ^version, ^client}}
+        end
+      end
+
+      refute_receive {:client, _, _}
+
+      clients =
+        clients
+        |> Enum.with_index()
+        |> Enum.reject(fn {_, client} -> client in aborted end)
+        |> Enum.flat_map(&elem(&1, 0))
+
+      assert_receive {:logged, encoded}
+      assert encoded |> Transaction.mutations!() |> Enum.to_list() == clients
+      check_encoded_history(dir, [encoded], [clients])
+    end
+  end
+
+  defp key(n), do: "k" <> String.pad_leading(Integer.to_string(n), 4, "0")
+
+  defp check_history(dir, history) do
+    encoded =
+      history
+      |> Enum.with_index(1)
+      |> Enum.map(fn {mutations, n} ->
+        Transaction.encode(%{mutations: mutations, commit_version: Version.from_integer(n)})
+      end)
+
+    check_encoded_history(dir, encoded, history)
+  end
+
+  defp check_encoded_history(dir, encoded, history) do
+    path = Path.join(dir, "db")
+    db = open_database(path)
+
+    {manager, db, expected} =
+      encoded
+      |> Enum.zip(history)
+      |> Enum.reduce({IndexManager.new(), db, %{}}, fn {tx, mutations}, {manager, db, expected} ->
+        expected = interpret(expected, mutations)
+        {manager, db} = IndexManager.apply_transaction(manager, tx, db)
+        assert values(manager, db) == expected
+        {manager, db, expected}
+      end)
+
+    pages = manager.output_queue |> :queue.to_list() |> Enum.map(&elem(&1, 3))
+
+    {:ok, db, _} =
+      Database.advance_durable_version(
+        db,
+        manager.current_version,
+        Version.zero(),
+        manager.last_version_ended_at_offset,
+        pages
+      )
+
+    :ok = Database.close(db)
+    db = open_database(path)
+    {:ok, recovered} = IndexManager.recover_from_database(db)
+    assert values(recovered, db) == expected
+    :ok = Database.close(db)
+
+    replay_db = open_database(Path.join(dir, "replay"))
+    {replayed, replay_db} = IndexManager.apply_transactions(IndexManager.new(), encoded, replay_db)
+    assert values(replayed, replay_db) == expected
+    :ok = Database.close(replay_db)
+  end
+
+  defp durable_step(manager, db, expected, mutations, path) do
+    version = Version.from_integer(Version.to_integer(manager.current_version) + 1)
+    tx = Transaction.encode(%{commit_version: version, mutations: mutations})
+    {manager, db} = IndexManager.apply_transaction(manager, tx, db)
+    expected = interpret(expected, mutations)
+    assert values(manager, db) == expected
+    [{_, {_, pages}} | _] = manager.versions
+
+    {:ok, db, _} =
+      Database.advance_durable_version(
+        db,
+        version,
+        Database.durable_version(db),
+        manager.last_version_ended_at_offset,
+        [pages]
+      )
+
+    :ok = Database.close(db)
+    db = open_database(path)
+    {:ok, manager} = IndexManager.recover_from_database(db)
+    assert manager.current_version == version
+    assert values(manager, db) == expected
+    {manager, db, expected}
+  end
+
+  defp open_database(path) do
+    {:ok, db} = Database.open(__MODULE__, path)
+
+    on_exit(fn ->
+      try do
+        Database.close(db)
+      catch
+        _, _ -> :ok
+      end
+    end)
+
+    db
+  end
+
+  defp values(manager, db) do
+    [{_, {index, _}} | _] = manager.versions
+
+    {entries, visited} = chain_entries(index.page_map, 0, MapSet.new())
+    assert MapSet.size(visited) == map_size(index.page_map)
+    keys = Enum.map(entries, &elem(&1, 0))
+    assert keys == Enum.sort(Enum.uniq(keys))
+
+    Map.new(entries, fn {key, locator} ->
+      assert {:ok, _, ^locator} = Index.locator_for_key(index, key)
+      {:ok, value} = Database.load_value(db, locator)
+      {key, value}
+    end)
+  end
+
+  defp chain_entries(pages, id, visited) do
+    refute MapSet.member?(visited, id)
+    {page, next} = Map.fetch!(pages, id)
+    visited = MapSet.put(visited, id)
+
+    if next == 0 do
+      {Page.key_locators(page), visited}
+    else
+      {remaining, visited} = chain_entries(pages, next, visited)
+      {Page.key_locators(page) ++ remaining, visited}
+    end
+  end
+
+  # Deliberately independent of production atomics, index routing and mutation helpers.
+  defp interpret(state, mutations) do
+    Enum.reduce(mutations, state, fn
+      {:set, key, value}, state ->
+        Map.put(state, key, value)
+
+      {:clear, key}, state ->
+        Map.delete(state, key)
+
+      {:clear_range, first, last}, state ->
+        Map.reject(state, fn {key, _} -> key >= first and key < last end)
+
+      {:atomic, :add, key, <<operand>>}, state ->
+        <<value>> = Map.get(state, key, <<0>>)
+        current = value
+        Map.put(state, key, <<rem(current + operand, 256)>>)
+    end)
+  end
+end

--- a/test/bedrock/data_plane/materializer/olivine/mutation_order_test.exs
+++ b/test/bedrock/data_plane/materializer/olivine/mutation_order_test.exs
@@ -208,6 +208,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.MutationOrderTest do
     :ok = Database.close(db)
 
     replay_db = open_database(Path.join(dir, "replay"))
+    assert Database.durable_version(replay_db) == Version.zero()
     {replayed, replay_db} = IndexManager.apply_transactions(IndexManager.new(), encoded, replay_db)
     assert values(replayed, replay_db) == expected
     :ok = Database.close(replay_db)
@@ -239,7 +240,8 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.MutationOrderTest do
   end
 
   defp open_database(path) do
-    {:ok, db} = Database.open(__MODULE__, path)
+    File.mkdir_p!(path)
+    {:ok, db} = Database.open(__MODULE__, Path.join(path, "db"))
 
     on_exit(fn ->
       try do


### PR DESCRIPTION
Olivine applies a transaction's mutations as one page-grouped batch, but atomics and range clears read the pre-batch index rather than the batch's own staged writes, so a later mutation could miss an earlier one. Staged writes now come first, page deletions mark the predecessor's changed chain pointer durable, and the proxy emits transactions in arrival order.

Ticket: bedrock-8cx
Closes #234

## Why

Mutations fold into a pending map of `page_id => %{key => {:set, locator} | :clear}` and pages materialise only once the batch is folded, which is what makes large transactions cheap. An atomic read its value from the index as it stood before the transaction, so two adds of 1 on an absent counter both saw the empty value and both stored 1. A range clear walks the base chain and clears only the keys it finds there, missing any key staged by an earlier set.

The proxy also concatenates a batch's transactions into one stream per log by iterating a map keyed by arrival index, and Elixir maps iterate in key order only to 32 entries, then in hash order.

Durability testing exposed a third defect: unlinking a page rewrote the predecessor's next pointer without marking that predecessor modified, and the delta comes from the modified set alone, so clearing an index's 800 keys resurrected all 800 on reopen.

## What changed

- An atomic reads the pending map for its page first, falling through to the index only on a miss.
- A range clear rewrites every pending entry inside the range to a clear before page discovery runs.
- One helper now handles deletions, recycling ids and marking any page whose pointer or contents changed, including an emptied page 0.
- `Finalization` sorts by arrival index before building the log stream.

The inclusive range end is unchanged and the new predicate matches the existing two, so #236 (bedrock-q67.19) must flip all three.

## How it works

```elixir
[{:atomic, :add, "counter", <<1>>},   # index miss, stores <<1>>
 {:atomic, :add, "counter", <<1>>},   # reads the staged <<1>>, stores <<2>>
 {:set, "newkey", "value"},
 {:clear_range, "new", "newz"}]       # flips the staged set to :clear
```

Page 0 then materialises with the counter at 2 and no `newkey`. Clearing a key the page never held is a no-op, and the staged value is readable at once from the write buffer.

Clearing page 1 in a chain `0 -> 1 -> 2 -> 3` rewrites page 0's pointer to 2, and the diff puts page 0 in the delta, so recovery skips to page 2 rather than loading page 1's stale copy.

## Verification

Every history is checked against an independent sequential `Map` interpreter, then persisted, recovered, and replayed. Coverage spans the six ordering pairs from the acceptance criteria, all 64 three-operation histories, an 800-key page-spanning case, the full-clear resurrection, durable advances with a recycled page id, and a 40-client `finalize_batch` run past the 32-entry threshold. Evidence: `/tmp/issue234-amended-red.log`, `/tmp/bedrock-issue-team-20260905/234-final-audit.md`.

CI (run 34001484285) is red only on OTP 27.3 / Elixir 1.17.3, six failures from the new test file: `@moduletag :tmp_dir` sits below the `for` block generating those six tests, and 1.17 resolves per-test tags before merging module context, so they receive `tmp_dir: true` and `Path.join` raises. Moving the attribute above the block fixes it.

Follow-up: bedrock-q67.19 (#236), exclusive range-clear end.
