### PR TITLE
bedrock-bkt: key dialyzer PLT cache on resolved OTP/Elixir versions

### DIFF
--- a/.github/workflows/elixir_ci.yaml
+++ b/.github/workflows/elixir_ci.yaml
@@ -44,6 +44,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Install Elixir and Erlang
+      id: beam
       uses: erlef/setup-beam@v1
       with:
         elixir-version: ${{ matrix.elixir }}
@@ -88,13 +89,18 @@ jobs:
       run: mix credo --strict
 
     # Define how to cache the `plts` directory. After the first run,
-    # this speeds up dialyzer runs a lot.
+    # this speeds up dialyzer runs a lot. Keyed on setup-beam's *resolved*
+    # otp-version/elixir-version outputs (not matrix.otp/matrix.elixir,
+    # which are the requested spec, e.g. "27.3") — a runner-image patch
+    # bump changes the resolved version and the PLT's on-disk format, so
+    # the key must change with it or dialyzer loads a PLT built by a
+    # different OTP patch and fails with "Old PLT file".
     - name: Cache PLTs
       id: cache-plts
       uses: actions/cache@v3
       with:
         path: plts
-        key: ${{ runner.os }}-${{ matrix.elixir }}-${{ matrix.otp }}-plts-v3-${{ hashFiles('**/mix.lock') }}
+        key: ${{ runner.os }}-${{ steps.beam.outputs.otp-version }}-${{ steps.beam.outputs.elixir-version }}-plts-v4-${{ hashFiles('**/mix.lock') }}
 
     - name: Dialyzer
       run: mix dialyzer


### PR DESCRIPTION
The dialyzer PLT cache in the Elixir CI workflow was keyed on the toolchain the matrix asks for, not the one installed. When the runner's newest matching OTP build changed, the key still hit and restored a PLT dialyzer refused to load. It now uses the versions `erlef/setup-beam` reports it resolved.

Ticket: bedrock-bkt
Closes bedrock-bkt.

## Why

`setup-beam` treats `otp-version: "27.3"` as a range and installs the newest matching build, so the toolchain behind a fixed matrix cell moves on its own. The old key held workflow literals and the `mix.lock` hash; nothing in it moved with the toolchain.

Dialyzer's PLT validity check is not a file-format check: it compares the dialyzer application version stored in the PLT, and an md5 of the running `erl_bif_types.beam` and `erl_types.beam`, against the current ones. A patch release touching either beam invalidates every PLT built before it. Dialyxir's staleness check hashes only `mix.lock` and the app list, so on a cache hit with an unchanged lock it declares the PLT current and hands it to dialyzer, which throws `Old PLT file plts/dialyzer.plt`.

PR #223's 2026-09-03 run hit that: the OTP 27.3 and 29.0 jobs failed after a cache hit, while 28.3 passed from the same 2026-08-28 save. Deleting cache entries 7106643988 and 7106652589 cleared the run, not the cause.

## What changed

The setup-beam step gets `id: beam`, and the PLT cache key interpolates its `otp-version` and `elixir-version` outputs, which report the exact installed versions. The suffix moves from `plts-v3` to `plts-v4`. The `deps`/`_build` cache keeps the matrix literals; it holds no PLTs.

## How it works

The key now moves whenever the thing the PLT is built against moves. `setup-beam` resolves the range once and reports what it installed, so a runner that starts serving OTP 27.3.1 in place of 27.3.0 produces a different key on the next run.

```
before   Linux-27.3-1.17.3-plts-v3-<mix.lock hash>      unchanged by a patch bump
after    Linux-27.3.1-1.17.3-plts-v4-<mix.lock hash>    changes with the build
```

A changed key misses, and dialyxir rebuilds the PLT against the toolchain actually present. There are no `restore-keys` on this cache, so a miss cannot fall back to a prefix match and hand back the stale PLT the key was meant to retire. The one-time `v4` bump retires the entries saved under the old scheme.

## Verification

All four CI jobs pass here; actionlint reports the same warnings as on develop.

