### PR TITLE
235: Preserve range visibility and detect phantom inserts

### DIFF
--- a/guides/deep-dives/architecture/infrastructure/transaction-builder.md
+++ b/guides/deep-dives/architecture/infrastructure/transaction-builder.md
@@ -48,6 +48,14 @@ Transaction Builder solves this by maintaining a local cache of all writes made 
 
 This local caching also provides significant performance benefits. Repeated reads of the same key within a transaction only hit the network once, with subsequent reads served from the local cache. For workloads that read and modify the same keys multiple times, this can dramatically reduce network overhead.
 
+## Range Reads and Observed Absence
+
+Plain key ranges use a half-open interval `[start, end)`. The builder merges pending writes and clears even when a materializer returns no rows. It continues across empty shards and pages hidden by local clears until the visible page is filled or the requested interval is exhausted.
+
+Ordinary range reads record the interval actually consumed, including gaps where no keys exist. A truncated page records through the last returned key; an exhausted interval records through its exclusive endpoint. The resolver checks this range against newer point writes as well as range writes, so two transactions cannot both reserve different keys based on the same observed empty range. Snapshot reads still see local writes but add no read conflicts and preserve conflicts recorded by earlier ordinary reads.
+
+Pairs of `first_greater_or_equal` selectors use the same plain-range path. Arbitrary offset selectors retain the existing materializer resolution path; their cross-shard resolution and conflict envelopes remain a separate limitation tracked by `bedrock-mi1`.
+
 ## Materializer Selection and Performance Optimization
 
 Transaction Builder maintains knowledge about which materializers handle which [key ranges](../../../glossary.md#key-range), enabling it to route read requests efficiently. This mapping is derived from the [transaction system layout](../../../glossary.md#transaction-system-layout) and is kept current as the cluster configuration changes.

--- a/lib/bedrock/data_plane/resolver/conflicts.ex
+++ b/lib/bedrock/data_plane/resolver/conflicts.ex
@@ -73,7 +73,7 @@ defmodule Bedrock.DataPlane.Resolver.Conflicts do
 
   defp do_check_conflicts([{v, existing_points, tree} | rest], points, ranges, version, acc) when v > version do
     # Check points first (fast path)
-    if MapSet.disjoint?(points, existing_points) do
+    if MapSet.disjoint?(points, existing_points) and not points_overlap_ranges?(existing_points, ranges) do
       # No point conflict - accumulate tree and continue
       new_acc = if tree, do: [tree | acc], else: acc
       do_check_conflicts(rest, points, ranges, version, new_acc)
@@ -83,6 +83,14 @@ defmodule Bedrock.DataPlane.Resolver.Conflicts do
   end
 
   defp do_check_conflicts(_, points, ranges, _version, acc), do: check_accumulated_conflicts(acc, points, ranges)
+
+  defp points_overlap_ranges?(_points, []), do: false
+
+  defp points_overlap_ranges?(points, ranges) do
+    Enum.any?(points, fn point ->
+      Enum.any?(ranges, fn {start_key, end_key} -> start_key <= point and point < end_key end)
+    end)
+  end
 
   defp check_accumulated_conflicts([], _points, _ranges), do: :ok
 

--- a/lib/bedrock/internal/transaction_builder/range_reads.ex
+++ b/lib/bedrock/internal/transaction_builder/range_reads.ex
@@ -41,20 +41,64 @@ defmodule Bedrock.Internal.TransactionBuilder.RangeReads do
            | {:error, :timeout | :unavailable | :version_too_new}
            | {:failure,
               %{(:timeout | :unavailable | :version_too_old | :no_servers_to_race | :layout_lookup_failed) => [pid()]}}}
-  def get_range(state, {min_key, max_key_ex} = range, batch_size, opts \\ []) do
-    storage_get_range_fn = Keyword.get(opts, :storage_get_range_fn, &Materializer.get_range/5)
+  def get_range(state, range, batch_size, opts \\ [])
+
+  def get_range(state, {min_key, max_key}, _batch_size, _opts) when min_key >= max_key, do: {state, {:ok, {[], false}}}
+
+  def get_range(state, {min_key, max_key}, batch_size, opts) do
+    source = Keyword.get(opts, :storage_get_range_fn, &Materializer.get_range/5)
 
     case ensure_read_version(state, opts) do
-      {:ok, state} ->
-        execute_range_query(
-          state,
-          min_key,
-          &storage_get_range_fn.(&1, min_key, max_key_ex, &2, limit: batch_size, timeout: &3),
-          fn _results -> range end
-        )
+      {:ok, state} -> scan(state, min_key, max_key, batch_size, source, opts, [])
+      {:failure, reasons} -> {state, {:failure, reasons}}
+    end
+  end
 
-      {:failure, failures_by_reason} ->
-        {state, {:failure, failures_by_reason}}
+  defp scan(state, cursor, end_key, remaining, source, opts, accumulated) do
+    operation = &source.(&1, cursor, end_key, &2, limit: remaining, timeout: &3)
+
+    case StorageRacing.race_storage_servers(state, cursor, operation) do
+      {state, {:ok, {{rows, source_more}, {shard_start, shard_end}}}}
+      when shard_start <= cursor and cursor < shard_end ->
+        proof_end = proof_end(rows, source_more, cursor, min(end_key, shard_end))
+
+        if proof_end <= cursor do
+          {state, {:failure, %{unavailable: []}}}
+        else
+          consume_page(state, rows, proof_end, {cursor, end_key, remaining}, source, opts, accumulated)
+        end
+
+      {state, {:ok, _invalid_coverage}} ->
+        {state, {:failure, %{unavailable: []}}}
+
+      {state, {:failure, reasons}} ->
+        {state, {:failure, reasons}}
+    end
+  end
+
+  defp proof_end([], true, cursor, _end_key), do: cursor
+  defp proof_end(_rows, false, _cursor, end_key), do: end_key
+  defp proof_end(rows, true, _cursor, end_key), do: min(end_key, rows |> List.last() |> elem(0) |> Key.key_after())
+
+  defp consume_page(state, rows, proof_end, {cursor, end_key, remaining}, source, opts, accumulated) do
+    visible = Tx.range_view(state.tx, rows, {cursor, proof_end})
+    {page, excess} = Enum.split(visible, remaining)
+    consumed_end = if excess == [], do: proof_end, else: page |> List.last() |> elem(0) |> Key.key_after()
+
+    tx =
+      if Keyword.get(opts, :snapshot, false),
+        do: state.tx,
+        else: Tx.add_read_conflict_range(state.tx, cursor, consumed_end)
+
+    state = %{state | tx: tx}
+    accumulated = Enum.reverse(page, accumulated)
+    remaining = remaining - length(page)
+
+    cond do
+      excess != [] -> {state, {:ok, {Enum.reverse(accumulated), true}}}
+      proof_end >= end_key -> {state, {:ok, {Enum.reverse(accumulated), false}}}
+      remaining == 0 -> {state, {:ok, {Enum.reverse(accumulated), true}}}
+      true -> scan(state, proof_end, end_key, remaining, source, opts, accumulated)
     end
   end
 
@@ -75,7 +119,17 @@ defmodule Bedrock.Internal.TransactionBuilder.RangeReads do
            | {:error, :timeout | :unavailable | :version_too_new}
            | {:failure,
               %{(:timeout | :unavailable | :version_too_old | :no_servers_to_race | :layout_lookup_failed) => [pid()]}}}
-  def get_range_selectors(state, start_selector, end_selector, batch_size, opts \\ []) do
+  def get_range_selectors(state, start_selector, end_selector, batch_size, opts \\ [])
+
+  def get_range_selectors(
+        state,
+        %KeySelector{key: start_key, or_equal: true, offset: 0},
+        %KeySelector{key: end_key, or_equal: true, offset: 0},
+        batch_size,
+        opts
+      ), do: get_range(state, {start_key, end_key}, batch_size, opts)
+
+  def get_range_selectors(state, start_selector, end_selector, batch_size, opts) do
     storage_get_range_fn = Keyword.get(opts, :storage_get_range_fn, &Materializer.get_range/5)
 
     case ensure_read_version(state, opts) do
@@ -84,7 +138,8 @@ defmodule Bedrock.Internal.TransactionBuilder.RangeReads do
           state,
           start_selector.key,
           &storage_get_range_fn.(&1, start_selector, end_selector, &2, limit: batch_size, timeout: &3),
-          &range_from_batch/1
+          &range_from_batch/1,
+          opts
         )
 
       {:failure, failures_by_reason} ->
@@ -94,7 +149,7 @@ defmodule Bedrock.Internal.TransactionBuilder.RangeReads do
 
   # Private helper functions
 
-  defp execute_range_query(state, racing_key, operation_fn, range_fn) do
+  defp execute_range_query(state, racing_key, operation_fn, range_fn, opts) do
     state
     |> StorageRacing.race_storage_servers(racing_key, operation_fn)
     |> case do
@@ -111,6 +166,11 @@ defmodule Bedrock.Internal.TransactionBuilder.RangeReads do
             shard_range
           )
 
+        updated_tx =
+          if Keyword.get(opts, :snapshot, false),
+            do: %{updated_tx | reads: state.tx.reads, range_reads: state.tx.range_reads},
+            else: updated_tx
+
         {%{state | tx: updated_tx}, {:ok, {merged_batch_results, has_more}}}
 
       {state, {:failure, failures_by_reason}} ->
@@ -118,5 +178,6 @@ defmodule Bedrock.Internal.TransactionBuilder.RangeReads do
     end
   end
 
-  defp range_from_batch([{min_key, _value} | rest]), do: {min_key, rest |> List.last() |> elem(0) |> Key.key_after()}
+  defp range_from_batch([{min_key, _value} | _] = rows),
+    do: {min_key, rows |> List.last() |> elem(0) |> Key.key_after()}
 end

--- a/lib/bedrock/internal/transaction_builder/tx.ex
+++ b/lib/bedrock/internal/transaction_builder/tx.ex
@@ -515,6 +515,30 @@ defmodule Bedrock.Internal.TransactionBuilder.Tx do
   # Private Helper Functions - Storage Merging
   # =============================================================================
 
+  @doc false
+  @spec range_view(t(), [{key(), value()}], {key(), key()}) :: [{key(), value()}]
+  def range_view(tx, storage_results, {start_key, end_key}) do
+    clear_ranges = Enum.filter(tx.mutations, &match?({:clear_range, _, _}, &1))
+
+    # Surviving pending writes were made after any range clear covering them.
+    # Apply range clears to storage first so later local sets remain visible.
+    storage_results =
+      storage_results
+      |> Enum.filter(fn {key, _} -> key >= start_key and key < end_key end)
+      |> filter_cleared_keys(clear_ranges)
+
+    {reversed, _} =
+      merge_ordered_results_bounded(
+        storage_results,
+        :gb_trees.iterator_from(start_key, tx.writes),
+        [],
+        [],
+        end_key
+      )
+
+    reversed |> filter_cleared_keys([]) |> Enum.reverse()
+  end
+
   # Helper functions for the enhanced merge_storage_range_with_writes
 
   defp scan_pending_writes(tx, start_key, end_key) when start_key >= end_key do

--- a/test/bedrock/data_plane/resolver/range_point_conflicts_test.exs
+++ b/test/bedrock/data_plane/resolver/range_point_conflicts_test.exs
@@ -1,0 +1,17 @@
+defmodule Bedrock.DataPlane.Resolver.RangePointConflictsTest do
+  use ExUnit.Case, async: true
+
+  alias Bedrock.DataPlane.Resolver.Conflicts
+  alias Bedrock.DataPlane.Version
+
+  test "range reads detect newer point writes with half-open boundaries" do
+    for point <- ["a", "b", "b\0", "c", "e", "f", "f\0", "g"],
+        read_version <- [99, 100, 101] do
+      conflicts = Conflicts.add_conflicts(Conflicts.new(), [{point, point <> <<0>>}], Version.from_integer(100))
+      expected = if point >= "b" and point < "f" and read_version < 100, do: :abort, else: :ok
+
+      assert Conflicts.check_conflicts(conflicts, [{"b", "f"}], Version.from_integer(read_version)) == expected,
+             "point=#{inspect(point)} read_version=#{read_version}"
+    end
+  end
+end

--- a/test/bedrock/internal/transaction_builder/range_reads_test.exs
+++ b/test/bedrock/internal/transaction_builder/range_reads_test.exs
@@ -1,0 +1,354 @@
+defmodule Bedrock.Internal.TransactionBuilder.RangeReadsTest do
+  use ExUnit.Case, async: true
+
+  alias Bedrock.DataPlane.Resolver
+  alias Bedrock.DataPlane.Transaction
+  alias Bedrock.DataPlane.Version
+  alias Bedrock.Internal.Repo.TransactionContext
+  alias Bedrock.Internal.TransactionBuilder
+  alias Bedrock.Internal.TransactionBuilder.RangeReads
+  alias Bedrock.Internal.TransactionBuilder.State
+  alias Bedrock.Internal.TransactionBuilder.Tx
+
+  defmodule Repo do
+    use Bedrock.Repo, cluster: UnusedCluster
+  end
+
+  # Only scheduling and storage are controlled here; the real builder encoder,
+  # Resolver.Server verdict and public Repo retry loop all execute.
+  defmodule ResolvingProxy do
+    @moduledoc false
+    use GenServer
+
+    def start_link(opts), do: GenServer.start_link(__MODULE__, opts)
+    def init(opts), do: {:ok, {opts, []}}
+    def handle_call({:commit, 1, tx, :user}, from, {opts, []}), do: {:noreply, {opts, [{from, tx}]}}
+
+    def handle_call({:commit, 1, tx, :user}, from, {opts, [{first, first_tx}]}) do
+      old = Version.from_integer(100)
+      next = Version.from_integer(200)
+      {:ok, aborted, _} = Resolver.resolve_transactions(opts[:resolver], 1, old, next, [first_tx, tx], [[], []])
+      {:ok, %{mutations: [{:set, key, value}]}} = Transaction.decode(first_tx)
+      Agent.update(opts[:store], fn _ -> {next, [{key, value}]} end)
+      GenServer.reply(first, {:ok, next, 0})
+      GenServer.reply(from, if(1 in aborted, do: {:error, :conflict}, else: {:ok, next, 1}))
+      {:noreply, {opts, []}}
+    end
+  end
+
+  @version Version.from_integer(100)
+
+  defp state(tx \\ Tx.new(), range \\ {"", "z"}) do
+    {start_key, end_key} = range
+    %State{read_version: @version, tx: tx, routing_fn: fn _ -> {:ok, {start_key, end_key, [self()]}} end}
+  end
+
+  defp empty_source(_server, _start, _end, _version, _opts), do: {:ok, {[], false}}
+
+  defp read(state, range, opts \\ []) do
+    RangeReads.get_range(
+      state,
+      range,
+      Keyword.get(opts, :batch_size, 10),
+      Keyword.put_new(opts, :storage_get_range_fn, &empty_source/5)
+    )
+  end
+
+  defp conflicts(state) do
+    {:ok, tx} = Transaction.decode(Tx.commit(state.tx, state.read_version))
+    tx.read_conflicts
+  end
+
+  test "empty storage merges pending writes and clears inside the requested range" do
+    tx =
+      Tx.new()
+      |> Tx.set("a", "outside")
+      |> Tx.set("c", "local")
+      |> Tx.set("d", "clear")
+      |> Tx.clear("d")
+      |> Tx.set("f", "outside")
+
+    {s, result} = read(state(tx), {"b", "f"})
+    assert result == {:ok, {[{"c", "local"}], false}}
+    assert conflicts(s) == {@version, [{"b", "f"}]}
+  end
+
+  test "an empty range result records the full requested absence" do
+    {s, {:ok, {[], false}}} = read(state(), {"b", "f"})
+    assert conflicts(s) == {@version, [{"b", "f"}]}
+  end
+
+  test "snapshot range merges local writes without introducing read conflicts" do
+    tx = Tx.new() |> Tx.add_read_conflict_key("existing") |> Tx.set("c", "local")
+    s = state(tx)
+    {after_read, result} = read(s, {"b", "f"}, snapshot: true)
+    assert result == {:ok, {[{"c", "local"}], false}}
+    assert after_read.tx.reads == s.tx.reads
+    assert after_read.tx.range_reads == s.tx.range_reads
+  end
+
+  test "nonempty snapshot results do not leak into conflict tracking" do
+    {s, result} =
+      read(state(), {"b", "f"},
+        snapshot: true,
+        storage_get_range_fn: fn _, _, _, _, _ -> {:ok, {[{"c", "stored"}], false}} end
+      )
+
+    assert result == {:ok, {[{"c", "stored"}], false}}
+    assert conflicts(s) == {nil, []}
+  end
+
+  test "public Repo put then range sees pending writes over empty storage" do
+    {:ok, builder} = TransactionBuilder.start_link(transaction_system_layout: %{epoch: 1, proxies: []})
+    :sys.replace_state(builder, fn _ -> state() end)
+    TransactionContext.put_builder(Repo, builder)
+    Repo.put("c", "local")
+    assert Enum.to_list(Repo.get_range({"b", "f"}, storage_get_range_fn: &empty_source/5)) == [{"c", "local"}]
+    GenServer.stop(builder)
+  end
+
+  test "two conditional inserts based on the same empty range cannot both resolve" do
+    resolver =
+      start_supervised!(
+        {Resolver.Server, cluster: __MODULE__, director: self(), key_range: {"", "z"}, epoch: 1, last_version: @version}
+      )
+
+    transactions =
+      for key <- ["c", "d"] do
+        {s, {:ok, {[], false}}} = read(state(), {"b", "f"})
+        s.tx |> Tx.set(key, "reserved") |> Tx.commit(@version)
+      end
+
+    assert {:ok, [1], _} =
+             Resolver.resolve_transactions(resolver, 1, @version, Version.from_integer(200), transactions, [[], []])
+  end
+
+  test "pending writes paginate without reading or conflicting past the returned limit" do
+    s = Tx.new() |> Tx.set("c", "1") |> Tx.set("d", "2") |> state()
+    {s, first} = read(s, {"b", "f"}, batch_size: 1)
+    assert first == {:ok, {[{"c", "1"}], true}}
+    assert conflicts(s) == {@version, [{"b", "c\0"}]}
+    {s, second} = read(s, {"c\0", "f"}, batch_size: 1)
+    assert second == {:ok, {[{"d", "2"}], false}}
+    assert conflicts(s) == {@version, [{"b", "f"}]}
+  end
+
+  test "pending writes before the first stored key appear in the ordered page" do
+    s = state(Tx.set(Tx.new(), "b", "local"))
+
+    {s, result} =
+      read(s, {"a", "f"},
+        batch_size: 1,
+        storage_get_range_fn: fn _, _, _, _, _ -> {:ok, {[{"c", "stored"}], true}} end
+      )
+
+    assert result == {:ok, {[{"b", "local"}], true}}
+    assert conflicts(s) == {@version, [{"a", "b\0"}]}
+  end
+
+  test "empty shards do not end a scan before subsequent covered shards" do
+    s = %{
+      state()
+      | routing_fn: fn key ->
+          if key < "m", do: {:ok, {"", "m", [:first]}}, else: {:ok, {"m", "z", [:second]}}
+        end
+    }
+
+    source = fn
+      :first, _, _, _, _ -> {:ok, {[], false}}
+      :second, _, _, _, _ -> {:ok, {[{"n", "stored"}], false}}
+    end
+
+    {s, result} = read(s, {"b", "x"}, storage_get_range_fn: source)
+    assert result == {:ok, {[{"n", "stored"}], false}}
+    assert conflicts(s) == {@version, [{"b", "x"}]}
+  end
+
+  test "a fully cleared storage page continues to the next storage page" do
+    s = state(Tx.clear(Tx.new(), "c"))
+
+    source = fn _, start_key, _, _, _ ->
+      if start_key <= "c", do: {:ok, {[{"c", "stored"}], true}}, else: {:ok, {[{"d", "stored"}], false}}
+    end
+
+    {s, result} = read(s, {"b", "f"}, batch_size: 1, storage_get_range_fn: source)
+    assert result == {:ok, {[{"d", "stored"}], false}}
+    assert conflicts(s) == {@version, [{"b", "f"}]}
+  end
+
+  test "empty query bounds add neither a read conflict nor a storage request" do
+    s = state()
+    source = fn _, _, _, _, _ -> flunk("empty query reached storage") end
+    {after_read, result} = read(s, {"c", "c"}, storage_get_range_fn: source)
+    assert result == {:ok, {[], false}}
+    assert after_read.tx == s.tx
+  end
+
+  test "local range clears hide storage but preserve later local sets" do
+    tx = Tx.new() |> Tx.clear_range("b", "f") |> Tx.set("c", "new")
+
+    {_s, result} =
+      read(state(tx), {"b", "f"},
+        storage_get_range_fn: fn _, _, _, _, _ -> {:ok, {[{"c", "old"}, {"d", "old"}], false}} end
+      )
+
+    assert result == {:ok, {[{"c", "new"}], false}}
+  end
+
+  test "local sets followed by range clears leave an empty observed interval" do
+    tx = Tx.new() |> Tx.set("c", "new") |> Tx.clear_range("b", "f")
+    {s, result} = read(state(tx), {"b", "f"})
+    assert result == {:ok, {[], false}}
+    assert conflicts(s) == {@version, [{"b", "f"}]}
+  end
+
+  test "bounded pagination agrees with an independent local mutation model" do
+    operations = [{:set, "b", "new"}, {:set, "d", "new"}, {:clear, "b"}, {:clear_range, "b", "e"}]
+
+    for one <- operations,
+        two <- operations,
+        three <- operations,
+        initial <- [%{}, %{"b" => "old", "c" => "old", "f" => "endpoint"}],
+        batch_size <- [1, 2, 3] do
+      {tx, model} =
+        Enum.reduce([one, two, three], {Tx.new(), initial}, fn
+          {:set, k, v}, {tx, model} ->
+            {Tx.set(tx, k, v), Map.put(model, k, v)}
+
+          {:clear, k}, {tx, model} ->
+            {Tx.clear(tx, k), Map.delete(model, k)}
+
+          {:clear_range, a, b}, {tx, model} ->
+            {Tx.clear_range(tx, a, b), Map.reject(model, fn {k, _} -> a <= k and k < b end)}
+        end)
+
+      source = fn _, start_key, end_key, _, opts ->
+        rows = initial |> Enum.filter(fn {k, _} -> start_key <= k and k < end_key end) |> Enum.sort()
+        {page, rest} = Enum.split(rows, opts[:limit])
+        {:ok, {page, rest != []}}
+      end
+
+      {actual, final_state} = collect_pages(state(tx), "a", "f", batch_size, source, [])
+      expected = model |> Enum.filter(fn {k, _} -> "a" <= k and k < "f" end) |> Enum.sort()
+      assert actual == expected, inspect({one, two, three, initial, batch_size})
+      assert conflicts(final_state) == {@version, [{"a", "f"}]}
+    end
+  end
+
+  defp collect_pages(s, cursor, end_key, size, source, acc) do
+    {s, {:ok, {rows, more}}} = read(s, {cursor, end_key}, batch_size: size, storage_get_range_fn: source)
+
+    if more do
+      assert rows != []
+      collect_pages(s, elem(List.last(rows), 0) <> <<0>>, end_key, size, source, acc ++ rows)
+    else
+      {acc ++ rows, s}
+    end
+  end
+
+  test "nonprogressing and invalid coverage responses are retryable failures" do
+    assert {_, {:failure, %{unavailable: []}}} =
+             read(state(), {"b", "f"}, storage_get_range_fn: fn _, _, _, _, _ -> {:ok, {[], true}} end)
+
+    assert {_, {:failure, %{unavailable: []}}} = read(state(Tx.new(), {"m", "z"}), {"b", "f"})
+  end
+
+  test "canonical selectors share empty-range merging and snapshot policy" do
+    first = Bedrock.KeySelector.first_greater_or_equal("b")
+    last = Bedrock.KeySelector.first_greater_or_equal("f")
+    s = state(Tx.set(Tx.new(), "c", "new"))
+
+    {after_read, result} =
+      RangeReads.get_range_selectors(s, first, last, 10, snapshot: true, storage_get_range_fn: &empty_source/5)
+
+    assert result == {:ok, {[{"c", "new"}], false}}
+    assert after_read.tx == s.tx
+    {after_read, _} = RangeReads.get_range_selectors(s, first, last, 10, storage_get_range_fn: &empty_source/5)
+    assert conflicts(after_read) == {@version, [{"b", "f"}]}
+  end
+
+  test "offset selector singleton snapshots do not crash or add conflicts" do
+    first = Bedrock.KeySelector.first_greater_than("b")
+    last = Bedrock.KeySelector.first_greater_than("f")
+    s = state()
+
+    {after_read, result} =
+      RangeReads.get_range_selectors(s, first, last, 10,
+        snapshot: true,
+        storage_get_range_fn: fn _, _, _, _, _ -> {:ok, {[{"c", "stored"}], false}} end
+      )
+
+    assert result == {:ok, {[{"c", "stored"}], false}}
+    assert after_read.tx.reads == s.tx.reads
+    assert after_read.tx.range_reads == s.tx.range_reads
+
+    assert {_, {:ok, {[], false}}} =
+             RangeReads.get_range_selectors(s, first, last, 10, snapshot: true, storage_get_range_fn: &empty_source/5)
+  end
+
+  test "public Repo retries the losing concurrent empty-range conditional insert" do
+    resolver =
+      start_supervised!(
+        {Resolver.Server, cluster: __MODULE__, director: self(), key_range: {"", "z"}, epoch: 1, last_version: @version}
+      )
+
+    store = start_supervised!({Agent, fn -> {@version, []} end})
+    proxy = start_supervised!({ResolvingProxy, resolver: resolver, store: store})
+    owner = self()
+
+    tasks =
+      for key <- ["c", "d"] do
+        Task.async(fn ->
+          Repo.transact(
+            fn ->
+              send(owner, {:attempt, key})
+              {version, rows} = Agent.get(store, & &1)
+              builder = TransactionContext.builder(Repo)
+
+              :sys.replace_state(builder, fn current ->
+                %{current | read_version: version, routing_fn: fn _ -> {:ok, {"", "z", [owner]}} end}
+              end)
+
+              source = fn _, _, _, _, _ -> {:ok, {rows, false}} end
+
+              case Enum.to_list(Repo.get_range({"b", "f"}, storage_get_range_fn: source)) do
+                [] ->
+                  Repo.put(key, "reserved")
+                  :inserted
+
+                [_] ->
+                  :occupied
+              end
+            end,
+            transaction_system_layout: %{epoch: 1, proxies: [proxy]},
+            retry_limit: 1
+          )
+        end)
+      end
+
+    assert tasks |> Enum.map(&Task.await/1) |> Enum.sort() == [:inserted, :occupied]
+    for _ <- 1..3, do: assert_receive({:attempt, _})
+    refute_receive {:attempt, _}
+    assert {_, [_]} = Agent.get(store, & &1)
+  end
+
+  test "snapshot scans through cleared pages preserve prior point and range conflicts" do
+    tx = Tx.new() |> Tx.add_read_conflict_key("a") |> Tx.add_read_conflict_range("w", "x") |> Tx.clear("c")
+
+    source = fn _, cursor, _, _, _ ->
+      if cursor <= "c", do: {:ok, {[{"c", "old"}], true}}, else: {:ok, {[{"d", "old"}], false}}
+    end
+
+    {after_read, result} = read(state(tx), {"b", "f"}, batch_size: 1, snapshot: true, storage_get_range_fn: source)
+    assert result == {:ok, {[{"d", "old"}], false}}
+    assert after_read.tx == tx
+  end
+
+  test "empty or reversed ranges do not acquire an unset read version" do
+    s = %{state() | read_version: nil}
+
+    for range <- [{"c", "c"}, {"f", "b"}] do
+      assert {^s, {:ok, {[], false}}} = read(s, range)
+    end
+  end
+end


### PR DESCRIPTION
An empty range result from storage returned before the transaction builder merged local writes or recorded a read conflict, so a transaction could not see its own pending write, and two transactions could both observe the same empty interval, insert different keys, and both commit. The reader is now a cursor-driven scan that merges pending writes over every page and records the interval it consumed.

Ticket: bedrock-oep
Closes #235

## Why

The plain-range path returned an empty, exhausted storage response untouched, skipping the merge helper that already handled empty storage. A pending put of `c` followed by a read of `[b, f)` over empty storage returned nothing, and with no conflict recorded, two transactions scanning that interval and reserving different keys were both admitted.

Removing it exposed more. The helper recorded a conflict only from the first returned key through the last, leaving absence around the rows unrecorded, and it started the pending-write iterator at the first stored key, dropping earlier local writes. A materializer's `more: false` means the shard has nothing further, not that the query is exhausted, so scans halted at the first shard boundary.

The resolver never compared a point write against a read range, only points against points and ranges against range writes, so even a correct range conflict failed to abort the reader.

## What changed

Range reads now walk a cursor from the start key toward the end key, one storage page at a time, merging each page through a new pure view function over the transaction's writes and clears and recording the consumed interval as a read conflict unless the read is a snapshot. Canonical selector pairs route through the same path, and the resolver also checks newer point writes against incoming read ranges.

Plain range reads no longer populate the local read cache per returned key; the recorded range covers them all, so a later point read of such a key goes back to storage. Arbitrary-offset selectors deliberately keep the old path and its empty-result early return, since their cross-shard semantics remain tracked under `bedrock-mi1`.

## How it works

Each page yields a proof end: how far it proves the interval's contents.

```
{rows, false}  -> min(end_key, shard_end)
{rows, true}   -> min(end_key, shard_end, key_after(last row))
{[], true}     -> no progress; retryable failure
```

The consumed end is the proof end when the visible page fits the batch budget, and just past the last emitted key when it was clipped, so a truncated page never claims absence beyond what it returned. An empty shard or a page hidden by a local clear advances the cursor and continues, instead of returning an empty page, which ends the Repo stream.

## Verification

Twenty focused tests cover empty and cleared pages, pagination, cross-shard continuation, snapshot policy, degenerate bounds, and a model check of 64 histories against a map. Integration tests drive a real builder, a real `Resolver.Server`, and the public retry loop: two conditional inserts on the same empty interval yield one success and one retry. A resolver matrix over eight points pins the half-open rule and fails on develop. All four CI jobs pass at `d8ae2513`.

Follow-up: #239 (bedrock-tux), end-to-end transaction history harness.
Follow-up: bedrock-mi1, offset selector cross-shard conflicts.
