### PR TITLE
bedrock-31d: App env overrides static use-config (Ecto-style init pattern)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## Unreleased
 
+- **Application environment now overrides a cluster's static `use` config.**
+  Previously any `config:` given to `use Bedrock.Cluster` short-circuited the
+  `otp_app` application environment entirely, so a cluster that shipped inline
+  defaults could not be adjusted from `config/runtime.exs` or `put_env` without
+  recompiling. The two are now layered the way `Ecto.Repo` layers them: the
+  static config supplies compile-time defaults, the application environment
+  overrides it key by key, and an optional `init/1` callback on the cluster
+  module gets the last word. Clusters that declare both `otp_app:` and
+  `config:` and rely on the static values winning must move those values into
+  the application environment (or `init/1`). An explicitly configured
+  `:path_to_descriptor` is also no longer discarded when the `otp_app` isn't a
+  loaded application.
+
 - **Olivine keeps append-only workloads readable after page splits.** Keys
   above every stored page boundary now extend the actual rightmost page
   instead of returning to page 0 and overlapping later ranges. Recovery

--- a/guides/deep-dives/architecture/infrastructure/cluster.md
+++ b/guides/deep-dives/architecture/infrastructure/cluster.md
@@ -68,6 +68,22 @@ end
 
 This approach provides flexibility for different deployment scenarios while maintaining consistent interface patterns.
 
+### Configuration Precedence
+
+When both options are given, the static `config:` supplies compile-time defaults and the `otp_app` application environment overrides them key by key, so `config/runtime.exs` takes effect without recompiling. A cluster module may also implement the optional `init/1` callback for the last mile:
+
+```elixir
+defmodule MyApp.Cluster do
+  use Bedrock.Cluster,
+    otp_app: :my_app,
+    name: "production_cluster",
+    config: [capabilities: [:coordination, :materializer, :log]]
+
+  @impl true
+  def init(config), do: {:ok, Keyword.put(config, :path_to_descriptor, System.fetch_env!("BEDROCK_DESCRIPTOR"))}
+end
+```
+
 ## Key Operations
 
 ### Configuration Access

--- a/lib/bedrock/cluster.ex
+++ b/lib/bedrock/cluster.ex
@@ -37,10 +37,27 @@ defmodule Bedrock.Cluster do
   @callback gateway_ping_timeout_in_ms() :: non_neg_integer()
   @callback name() :: String.t()
   @callback node_config() :: Keyword.t()
+
+  @doc """
+  A callback invoked whenever the node configuration is read, giving the
+  cluster module the last word over the resolved configuration.
+
+  The argument is the node configuration after the static `use` config has
+  been overridden by the `otp_app` application environment. It must return
+  `{:ok, keyword}` with the configuration to use.
+
+  Most runtime configuration belongs in `config/runtime.exs`; this callback
+  is for the last mile (secrets, per-run paths, values that can only be
+  computed on the node itself).
+  """
+  @callback init(config :: Keyword.t()) :: {:ok, Keyword.t()}
+
   @callback otp_name() :: atom()
   @callback otp_name(service :: atom()) :: atom()
   @callback path_to_descriptor() :: Path.t()
   @callback transaction_system_layout!() :: TransactionSystemLayout.t()
+
+  @optional_callbacks init: 1
 
   @doc false
   defmacro __using__(opts) do

--- a/lib/bedrock/internal/cluster_supervisor.ex
+++ b/lib/bedrock/internal/cluster_supervisor.ex
@@ -369,18 +369,33 @@ defmodule Bedrock.Internal.ClusterSupervisor do
     end
   end
 
+  @doc """
+  Resolve the node configuration for a cluster module.
+
+  The static `use` config supplies compile-time defaults, the `otp_app`
+  application environment overrides them key by key (so `config/runtime.exs`
+  takes effect without recompiling), and the module's optional `init/1`
+  callback gets the last word.
+  """
   @spec node_config(Cluster.t(), otp_app :: atom() | nil, static_config :: Keyword.t() | nil) ::
           Keyword.t()
   def node_config(module, otp_app, static_config) do
-    case static_config do
-      nil when otp_app != nil ->
-        Application.get_env(otp_app, module, [])
+    (static_config || [])
+    |> Keyword.merge(app_env_config(module, otp_app))
+    |> apply_cluster_init(module)
+  end
 
-      nil ->
-        []
+  @spec app_env_config(Cluster.t(), otp_app :: atom() | nil) :: Keyword.t()
+  defp app_env_config(_module, nil), do: []
+  defp app_env_config(module, otp_app), do: Application.get_env(otp_app, module, [])
 
-      config ->
-        config
+  @spec apply_cluster_init(Keyword.t(), Cluster.t()) :: Keyword.t()
+  defp apply_cluster_init(config, module) do
+    if function_exported?(module, :init, 1) do
+      {:ok, config} = module.init(config)
+      config
+    else
+      config
     end
   end
 

--- a/lib/bedrock/internal/cluster_supervisor.ex
+++ b/lib/bedrock/internal/cluster_supervisor.ex
@@ -391,6 +391,8 @@ defmodule Bedrock.Internal.ClusterSupervisor do
 
   @spec apply_cluster_init(Keyword.t(), Cluster.t()) :: Keyword.t()
   defp apply_cluster_init(config, module) do
+    # Every caller reaches us through the cluster module itself, so it is
+    # always loaded here; unlike Ecto we don't need a Code.ensure_loaded?/1.
     if function_exported?(module, :init, 1) do
       {:ok, config} = module.init(config)
       config
@@ -441,20 +443,17 @@ defmodule Bedrock.Internal.ClusterSupervisor do
   def path_to_descriptor(module, otp_app, static_config) do
     module
     |> node_config(otp_app, static_config)
-    |> Keyword.get(
-      :path_to_descriptor,
-      case otp_app do
-        nil ->
-          Cluster.default_descriptor_file_name()
+    |> Keyword.get_lazy(:path_to_descriptor, fn -> default_path_to_descriptor(otp_app) end)
+  end
 
-        app ->
-          Path.join(
-            Application.app_dir(app, "priv"),
-            Cluster.default_descriptor_file_name()
-          )
-      end
-    )
+  @spec default_path_to_descriptor(otp_app :: atom() | nil) :: Path.t()
+  defp default_path_to_descriptor(nil), do: Cluster.default_descriptor_file_name()
+
+  defp default_path_to_descriptor(otp_app) do
+    Path.join(Application.app_dir(otp_app, "priv"), Cluster.default_descriptor_file_name())
   rescue
-    _ -> Cluster.default_descriptor_file_name()
+    # app_dir/2 raises when the application isn't loaded, which is routine for
+    # the synthetic otp_apps used by tests, scripts and livebooks.
+    ArgumentError -> Cluster.default_descriptor_file_name()
   end
 end

--- a/test/bedrock/cluster_test.exs
+++ b/test/bedrock/cluster_test.exs
@@ -108,18 +108,65 @@ defmodule Bedrock.ClusterTest do
   end
 
   describe "__using__/1 precedence rules" do
-    test "config takes precedence over otp_app when both provided" do
+    test "otp_app environment overrides static config, key by key" do
       defmodule TestClusterPrecedence do
         @moduledoc false
         use Cluster,
           name: "test_precedence",
           otp_app: :test_app,
-          config: [capabilities: [:materializer]]
+          config: [capabilities: [:materializer], coordinator_ping_timeout_in_ms: 500]
       end
 
       Application.put_env(:test_app, TestClusterPrecedence, capabilities: [:coordination])
 
-      assert [:materializer] = TestClusterPrecedence.node_capabilities()
+      assert [:coordination] = TestClusterPrecedence.node_capabilities()
+      assert 500 = TestClusterPrecedence.coordinator_ping_timeout_in_ms()
+    end
+
+    test "static config stands when the otp_app environment is unset" do
+      defmodule TestClusterNoEnv do
+        @moduledoc false
+        use Cluster,
+          name: "test_no_env",
+          otp_app: :test_app,
+          config: [capabilities: [:materializer]]
+      end
+
+      assert [:materializer] = TestClusterNoEnv.node_capabilities()
+    end
+
+    test "otp_app environment set after compilation is picked up without recompiling" do
+      defmodule TestClusterRuntimeEnv do
+        @moduledoc false
+        use Cluster,
+          name: "test_runtime_env",
+          otp_app: :test_app,
+          config: [coordinator_ping_timeout_in_ms: 500]
+      end
+
+      assert 500 = TestClusterRuntimeEnv.coordinator_ping_timeout_in_ms()
+
+      Application.put_env(:test_app, TestClusterRuntimeEnv, coordinator_ping_timeout_in_ms: 1000)
+
+      assert 1000 = TestClusterRuntimeEnv.coordinator_ping_timeout_in_ms()
+    end
+
+    test "init/1 has the last word over both static config and the otp_app environment" do
+      defmodule TestClusterInit do
+        @moduledoc false
+        use Cluster,
+          name: "test_init",
+          otp_app: :test_app,
+          config: [coordinator_ping_timeout_in_ms: 500, capabilities: [:materializer]]
+
+        @impl true
+        def init(config), do: {:ok, Keyword.put(config, :coordinator_ping_timeout_in_ms, 42)}
+      end
+
+      Application.put_env(:test_app, TestClusterInit, coordinator_ping_timeout_in_ms: 1000)
+
+      assert 42 = TestClusterInit.coordinator_ping_timeout_in_ms()
+      assert [:materializer] = TestClusterInit.node_capabilities()
     end
   end
 

--- a/test/bedrock/cluster_test.exs
+++ b/test/bedrock/cluster_test.exs
@@ -151,6 +151,31 @@ defmodule Bedrock.ClusterTest do
       assert 1000 = TestClusterRuntimeEnv.coordinator_ping_timeout_in_ms()
     end
 
+    test "otp_app environment can inject a descriptor path for an otp_app that isn't loaded" do
+      defmodule TestClusterInjectedPath do
+        @moduledoc false
+        use Cluster,
+          name: "test_injected_path",
+          otp_app: :test_app,
+          config: [path_to_descriptor: "/static/bedrock.cluster"]
+      end
+
+      assert "/static/bedrock.cluster" = TestClusterInjectedPath.path_to_descriptor()
+
+      Application.put_env(:test_app, TestClusterInjectedPath, path_to_descriptor: "/per-run/bedrock.cluster")
+
+      assert "/per-run/bedrock.cluster" = TestClusterInjectedPath.path_to_descriptor()
+    end
+
+    test "falls back to the bare descriptor file name when the otp_app isn't loaded" do
+      defmodule TestClusterUnloadedApp do
+        @moduledoc false
+        use Cluster, name: "test_unloaded_app", otp_app: :test_app
+      end
+
+      assert "bedrock.cluster" = TestClusterUnloadedApp.path_to_descriptor()
+    end
+
     test "init/1 has the last word over both static config and the otp_app environment" do
       defmodule TestClusterInit do
         @moduledoc false

--- a/test/bedrock/internal/cluster_supervisor_test.exs
+++ b/test/bedrock/internal/cluster_supervisor_test.exs
@@ -11,6 +11,13 @@ defmodule Bedrock.Internal.ClusterSupervisorTest do
 
   defmock(Bedrock.MockCluster, for: Bedrock.Cluster)
 
+  # `init/1` is an optional callback, but Mox defines it on the mock anyway.
+  # Stub the pass-through that a cluster module without an override provides.
+  setup do
+    stub(Bedrock.MockCluster, :init, &{:ok, &1})
+    :ok
+  end
+
   # Test helpers
   defp expect_cluster_name(cluster, name) do
     expect(cluster, :name, fn -> name end)


### PR DESCRIPTION
A cluster module that passed any inline `config:` to `use Bedrock.Cluster` ignored its `otp_app` application environment completely, so nothing in `config/runtime.exs` could adjust it without a recompile. Configuration is now layered the way `Ecto.Repo` layers it: static config as defaults, the application environment over it, an optional `init/1` callback last.

Ticket: bedrock-31d

## Why

Every configuration accessor generated on a cluster module funnels through one resolver in `Bedrock.Internal.ClusterSupervisor`, which the supervisor also reads at start. That resolver picked a single source: when static config was present it was returned and the application-environment branch was unreachable. Compile-time defaults locked out runtime configuration, the reverse of what Ecto, Phoenix and Oban do. It blocked the case that surfaced the ticket, a full-cluster test wanting to inject per-run paths into a cluster that already shipped inline config.

A second defect sat in the same path. `path_to_descriptor/3` built its fallback with `Keyword.get/3`, whose default argument is evaluated eagerly, and wrapped its whole body in a blanket `rescue`. The fallback calls `Application.app_dir/2`, which raises when the application is not loaded, routine for the synthetic otp_apps in tests, scripts and livebooks. The raise happened before the keyword lookup, the rescue caught it, and the bare file name came back even when a path was explicitly set. That same rescue would have swallowed errors raised inside a user's `init/1`.

## What changed

The resolver merges instead of selecting: static config, then `Keyword.merge/2` of the application environment over it, then the module's `init/1` when it exports one. `Bedrock.Cluster` declares that callback and marks it optional. The descriptor default is computed lazily, and the rescue is narrowed to `ArgumentError` around the `app_dir/2` call alone, so everything else propagates.

The merge is shallow, matching Ecto: an app-env `coordinator:` list replaces the static one whole. Start-time options are not layered in; `child_spec/1` still honours an explicit `path_to_descriptor` option. Nothing is cached, so the env read and `init/1` run on every access, which is what makes runtime config effective and means `init/1` must be cheap. The changelog flags the behaviour reversal for clusters declaring both `otp_app:` and `config:`.

## How it works

```elixir
use Bedrock.Cluster,
  otp_app: :my_app,
  name: "production",
  config: [capabilities: [:coordination, :log], coordinator_ping_timeout_in_ms: 500]

def init(config),
  do: {:ok, Keyword.put(config, :path_to_descriptor, System.fetch_env!("BEDROCK_DESCRIPTOR"))}

# config/runtime.exs
config :my_app, MyApp.Cluster, capabilities: [:materializer]
```

`node_config/0` resolves to `capabilities: [:materializer]` (the env wins), `coordinator_ping_timeout_in_ms: 500` (untouched by the env, so the static value survives), and a descriptor path from the callback.

With no `otp_app` the merge is a no-op and behaviour matches `develop`. With no static config the env stands alone, as before. A callback returning anything but `{:ok, keyword}` raises at the call site.

## Verification

Six tests in the cluster test's precedence block define fresh cluster modules against an unloaded otp_app: key-by-key override, static config standing when the env is unset, a `put_env` after compilation taking effect, an injected descriptor path, the bare-file-name fallback, and `init/1` beating both lower layers. Three fail on `develop`. The supervisor test adds an identity `init/1` stub, since Mox defines optional callbacks on mocks. A cold audit returned PASS-WITH-NOTES; its notes produced the second commit, `46c81b15`. All four CI test jobs pass; the scheduled distributed durability job is skipped.

Related: bedrock-s9x and bedrock-uvk track the load-dependent `assert_receive` timeouts seen in one intermediate run, in untouched files.
