### PR TITLE
236: Respect exclusive range-clear endpoints

### DIFF
--- a/lib/bedrock/data_plane/materializer/olivine/index_update.ex
+++ b/lib/bedrock/data_plane/materializer/olivine/index_update.ex
@@ -168,6 +168,9 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.IndexUpdate do
     %{index_update | pending_operations: updated_pending_operations}
   end
 
+  defp apply_mutation({:clear_range, start_key, end_key}, _target_version, index_update) when start_key >= end_key,
+    do: index_update
+
   defp apply_mutation({:clear_range, start_key, end_key}, _target_version, index_update) do
     # Range discovery sees the base pages; staged inserts may extend beyond
     # their old bounds and must be cleared before handling those pages.
@@ -198,19 +201,8 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.IndexUpdate do
         first_page = Index.get_page!(index_update.index, first_page_id)
         last_page = Index.get_page!(index_update.index, last_page_id)
 
-        first_keys_to_clear =
-          extract_keys_in_range(
-            first_page,
-            max(start_key, Page.left_key(first_page) || <<>>),
-            min(end_key, Page.right_key(first_page) || @max_key)
-          )
-
-        last_keys_to_clear =
-          extract_keys_in_range(
-            last_page,
-            max(start_key, Page.left_key(last_page) || <<>>),
-            min(end_key, Page.right_key(last_page) || @max_key)
-          )
+        first_keys_to_clear = extract_keys_in_range(first_page, start_key, end_key)
+        last_keys_to_clear = extract_keys_in_range(last_page, start_key, end_key)
 
         middle_keys_count =
           middle_page_ids_excluding_page_zero
@@ -285,7 +277,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.IndexUpdate do
     Map.new(pending_operations, fn {page_id, operations} ->
       {page_id,
        Map.new(operations, fn {key, operation} ->
-         {key, if(key >= start_key and key <= end_key, do: :clear, else: operation)}
+         {key, if(key >= start_key and key < end_key, do: :clear, else: operation)}
        end)}
     end)
   end
@@ -327,7 +319,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.IndexUpdate do
   end
 
   defp page_entirely_after_range?(page_first_key, end_key) do
-    page_first_key != nil and page_first_key > end_key
+    page_first_key != nil and page_first_key >= end_key
   end
 
   defp continue_to_next_page(page_map, next_id, start_key, end_key, collected_page_ids) do
@@ -353,7 +345,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.IndexUpdate do
   defp extract_keys_in_range(page, start_key, end_key) do
     page
     |> Page.key_locators()
-    |> Enum.filter(fn {key, _version} -> key >= start_key and key <= end_key end)
+    |> Enum.filter(fn {key, _version} -> key >= start_key and key < end_key end)
     |> Enum.map(fn {key, _version} -> key end)
   end
 

--- a/test/bedrock/data_plane/materializer/olivine/exclusive_clear_test.exs
+++ b/test/bedrock/data_plane/materializer/olivine/exclusive_clear_test.exs
@@ -1,0 +1,159 @@
+defmodule Bedrock.DataPlane.Materializer.Olivine.ExclusiveClearTest do
+  use ExUnit.Case, async: true
+
+  alias Bedrock.DataPlane.Materializer.Olivine.Database
+  alias Bedrock.DataPlane.Materializer.Olivine.Index
+  alias Bedrock.DataPlane.Materializer.Olivine.Index.Page
+  alias Bedrock.DataPlane.Materializer.Olivine.IndexManager
+  alias Bedrock.DataPlane.ShardRouter
+  alias Bedrock.DataPlane.Transaction
+  alias Bedrock.DataPlane.Version
+  alias Bedrock.Internal.TransactionBuilder.Tx
+
+  @moduletag :tmp_dir
+
+  for {name, keys, first, last} <- [
+        {:single_page, ["a", "b", "c"], "a", "b"},
+        {:empty, ["a", "b", "c"], "b", "b"},
+        {:reversed, ["a", "b", "c"], "c", "a"},
+        {:binary_prefix, [<<0>>, <<0, 0>>, <<0, 255>>, <<1>>], <<0>>, <<0, 255>>}
+      ],
+      pending <- [false, true] do
+    test "#{name}: exclusive endpoint with pending=#{pending}", %{tmp_dir: dir} do
+      keys = unquote(keys)
+      first = unquote(first)
+      last = unquote(last)
+
+      pending = unquote(pending)
+      path = Path.join(dir, "db-#{pending}")
+      db = open_db(path)
+      sets = Enum.map(keys, &{:set, &1, "value"})
+      {manager, db} = apply_mutations(IndexManager.new(), db, if(pending, do: [], else: sets))
+      db = persist(manager, db)
+      mutations = if(pending, do: sets, else: [])
+      {manager, db} = apply_mutations(manager, db, mutations ++ [{:clear_range, first, last}])
+      expected = Enum.reject(keys, &(&1 >= first and &1 < last))
+      assert_keys(manager, db, expected)
+      db = persist(manager, db)
+      Database.close(db)
+      db = open_db(path)
+      {:ok, recovered} = IndexManager.recover_from_database(db)
+      assert recovered.current_version == manager.current_version
+      assert_keys(recovered, db, expected)
+      Database.close(db)
+    end
+  end
+
+  test "exclusive ends at page edges retain endpoint and clear earlier page right edges", %{tmp_dir: dir} do
+    keys = for n <- 1..800, do: key(n)
+
+    ranges = [
+      {key(100), key(200)},
+      {key(100), key(201)},
+      {key(100), key(400)},
+      {key(100), key(401)},
+      {key(200), key(700)},
+      {key(201), key(201)},
+      {key(1), key(800)}
+    ]
+
+    for {{first, last}, n} <- Enum.with_index(ranges) do
+      path = Path.join(dir, "pages-#{n}")
+      db = open_db(path)
+      {manager, db} = apply_mutations(IndexManager.new(), db, Enum.map(keys, &{:set, &1, "value"}))
+      [{_, {index, _}} | _] = manager.versions
+      assert map_size(index.page_map) > 2
+      assert {page_zero, next_id} = Map.fetch!(index.page_map, 0)
+      assert Page.right_key(page_zero) == key(200)
+      assert Page.left_key(Index.get_page!(index, next_id)) == key(201)
+      db = persist(manager, db)
+      {manager, db} = apply_mutations(manager, db, [{:set, last, "value"}, {:clear_range, first, last}])
+      expected = Enum.reject(keys, &(&1 >= first and &1 < last))
+      assert_keys(manager, db, expected)
+      db = persist(manager, db)
+      Database.close(db)
+      db = open_db(path)
+      {:ok, recovered} = IndexManager.recover_from_database(db)
+      assert recovered.current_version == manager.current_version
+      assert_keys(recovered, db, expected)
+      Database.close(db)
+    end
+  end
+
+  test "affected keys match the builder write conflict and shard boundary", %{tmp_dir: dir} do
+    keys = ["a", "l", "m", "z"]
+    tx = Tx.new() |> Tx.clear_range("a", "m") |> Tx.commit(nil)
+    assert {:ok, %{write_conflicts: [{"a", "m"}]}} = Transaction.decode(tx)
+    shards = :gb_trees.from_orddict([{"m", {0, ""}}, {<<255, 255>>, {1, "m"}}])
+    assert [{0, "", "m"}] = ShardRouter.lookup_shards_with_ranges(shards, "a", "m")
+    assert 1 = ShardRouter.lookup_shard(shards, "m")
+    db = open_db(Path.join(dir, "conflicts"))
+    {manager, db} = apply_mutations(IndexManager.new(), db, Enum.map(keys, &{:set, &1, "value"}))
+    {:ok, tx} = Transaction.add_commit_version(tx, Version.from_integer(2))
+    {manager, db} = IndexManager.apply_transaction(manager, tx, db)
+    assert_keys(manager, db, ["m", "z"])
+    Database.close(db)
+  end
+
+  defp key(n), do: "k" <> String.pad_leading(Integer.to_string(n), 4, "0")
+
+  defp open_db(path) do
+    File.mkdir_p!(path)
+    {:ok, db} = Database.open(__MODULE__, Path.join(path, "db"))
+
+    on_exit(fn ->
+      try do
+        Database.close(db)
+      catch
+        _, _ -> :ok
+      end
+    end)
+
+    db
+  end
+
+  defp apply_mutations(manager, db, mutations) do
+    version = Version.from_integer(Version.to_integer(manager.current_version) + 1)
+    IndexManager.apply_transaction(manager, Transaction.encode(%{commit_version: version, mutations: mutations}), db)
+  end
+
+  defp persist(manager, db) do
+    [{_, {_, pages}} | _] = manager.versions
+
+    {:ok, db, _} =
+      Database.advance_durable_version(
+        db,
+        manager.current_version,
+        Database.durable_version(db),
+        manager.last_version_ended_at_offset,
+        [pages]
+      )
+
+    db
+  end
+
+  defp assert_keys(manager, db, expected) do
+    [{_, {index, _}} | _] = manager.versions
+    {actual, visited} = chain_keys(index.page_map, 0, MapSet.new())
+    assert MapSet.size(visited) == map_size(index.page_map)
+    assert actual == expected
+
+    for key <- expected do
+      assert {:ok, _, locator} = Index.locator_for_key(index, key)
+      assert {:ok, "value"} = Database.load_value(db, locator)
+    end
+  end
+
+  defp chain_keys(pages, id, visited) do
+    refute MapSet.member?(visited, id)
+    {page, next} = Map.fetch!(pages, id)
+    visited = MapSet.put(visited, id)
+
+    if next == 0 do
+      {Page.keys(page), visited}
+    else
+      {remaining, visited} = chain_keys(pages, next, visited)
+      {Page.keys(page) ++ remaining, visited}
+    end
+  end
+end

--- a/test/bedrock/data_plane/materializer/olivine/index_manager_test.exs
+++ b/test/bedrock/data_plane/materializer/olivine/index_manager_test.exs
@@ -535,7 +535,9 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.IndexManagerTest do
       assert {:error, :not_found} = Page.locator_for_key(page, <<"key_10">>)
 
       assert {:ok, page} = IndexManager.page_for_key(vm_after_clear, <<"key_15">>, Version.from_integer(1100))
-      assert {:error, :not_found} = Page.locator_for_key(page, <<"key_15">>)
+      # The exclusive endpoint is outside the clear and its write-conflict range.
+      assert {:ok, locator} = Page.locator_for_key(page, <<"key_15">>)
+      assert {:ok, "value_15"} = Database.load_value(database, locator)
 
       Database.close(database)
     end

--- a/test/bedrock/data_plane/materializer/olivine/index_update_test.exs
+++ b/test/bedrock/data_plane/materializer/olivine/index_update_test.exs
@@ -141,15 +141,15 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.IndexUpdateTest do
 
       # Boundary pages keep only their out-of-range keys
       assert final_index |> Index.get_page!(1) |> Page.keys() == ["a"]
-      assert final_index |> Index.get_page!(3) |> Page.keys() == ["i"]
-      assert all_keys(final_index) == ["a", "i"]
+      assert final_index |> Index.get_page!(3) |> Page.keys() == ["h", "i"]
+      assert all_keys(final_index) == ["a", "h", "i"]
 
       # Chain is repaired: page 1 now points past the deleted page to page 3
       {_page, next_id} = Index.get_page_with_next_id!(final_index, 1)
       assert next_id == 3
 
-      # keys_removed counts first-page (b, c), middle-page (d, e, f) and last-page (g, h) keys
-      assert update.keys_removed == 7
+      # keys_removed counts first-page (b, c), middle-page (d, e, f) and last-page (g) keys
+      assert update.keys_removed == 6
     end
 
     test "clear_range followed by sets of in-range keys in the same batch keeps only the re-set keys", %{
@@ -200,14 +200,14 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.IndexUpdateTest do
       refute 0 in final_allocator.free_ids
       assert final_index |> Index.get_page!(0) |> Page.key_count() == 0
 
-      # The middle page is deleted and recycled; the last page keeps "f"
+      # The middle page is deleted and recycled; the last page keeps endpoint "e" and "f"
       refute Map.has_key?(final_index.page_map, 1)
       assert 1 in final_allocator.free_ids
-      assert final_index |> Index.get_page!(2) |> Page.keys() == ["f"]
-      assert all_keys(final_index) == ["f"]
+      assert final_index |> Index.get_page!(2) |> Page.keys() == ["e", "f"]
+      assert all_keys(final_index) == ["e", "f"]
 
-      # a, b from page 0 + c, d from the middle page + e from the last page
-      assert update.keys_removed == 5
+      # a, b from page 0 + c, d from the middle page; endpoint e survives
+      assert update.keys_removed == 4
     end
   end
 

--- a/test/bedrock/data_plane/materializer/olivine/range_clear_ordering_property_test.exs
+++ b/test/bedrock/data_plane/materializer/olivine/range_clear_ordering_property_test.exs
@@ -289,7 +289,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.RangeClearOrderingPropertyTest 
       Enum.reduce(clear_ranges, sorted_initial_keys, fn {start_key, end_key}, current_keys ->
         # Remove all keys in this range
         Enum.reject(current_keys, fn key ->
-          key >= start_key and key <= end_key
+          key >= start_key and key < end_key
         end)
       end)
 


### PR DESCRIPTION
Olivine's index applied `{:clear_range, start, end}` with an inclusive end, deleting a key sitting exactly at `end`. Everywhere else a range clear is the half-open interval `[start, end)`. The comparisons defining the range are now half-open, the boundary-page clamps that would have masked that change are gone, and an empty range is a no-op.

Ticket: bedrock-q67.19
Closes #236
Stacked on: #242 (`bedrock-8cx/mutation-order`)

## Why

`Tx.clear_range/4` drops the range when the start is not below the end and records the write conflict as `{start, end}`, and the shard router places the key `end` itself in the following shard.

The materializer disagreed in three places: the per-page entry filter, the pending-operation overlay #242 added for keys staged earlier in the same batch, and the chain-traversal stop test, which collected a page beginning exactly at `end`. Clearing `[a, m)` over `a`, `l`, `m`, `z` also removed `m`, a key with no conflict claim on it and, in a multi-shard layout, one the mutation never reached. The ordering property test hid this by asserting the same predicate.

A one-character fix would not have sufficed. For a multi-page range the old code clamped the per-page filter bounds to that page's own extent. Under `<=` that clamp is inert; under `<` it degrades `key < end` into `key < right_key` whenever the range runs past the page, sparing the page's rightmost key.

## What changed

The page filter and the pending overlay now select `start <= key < end`, the traversal stop test fires at `page_first_key >= end`, the first- and last-page filters take the original bounds with the clamps deleted, and a new guarded clause returns the update untouched for an empty range. Because `IndexManager.apply_transaction/3` derives `n_keys` from added minus removed, a clear whose endpoint exists now reports one fewer removal.

## How it works

Traversal starts at the page containing `start`, skips pages ending before it, and halts at the first page starting at or past `end`. Middle pages are still deleted wholesale, which is safe because every key on them lies inside the interval; page 0 stays exempt. Only the first and last collected pages straddle a bound, and the original bounds filter those correctly.

```
[a b c] [d e f] [g h i], clear_range("b", "h")
was: a, i   now: a, h, i
```

## Verification

The new test covers eight generated cases (single page, empty, reversed, binary prefixes, each with the keys persisted beforehand and again staged alongside the clear), seven boundary ranges over an 800-key fixture, and a builder round trip tying survivors to the encoded write conflict and shard routing. Each case walks the page chain, loads every surviving value, and repeats its assertions after a cold reopen. The focused suite and corrected oracle failed 9 of 10 tests beforehand (`/tmp/issue236-red.log`); plan and result were reviewed at `/tmp/bedrock-issue-team-20260905/236-plan.md` and `236-final-review.md`. Full non-S3 suite green: 2900 tests, 158 properties, 17 doctests. No CI on a branch targeting a feature branch.

PR #262 fixes the same ticket on the #253 stack, and exactly one of the two should merge. This branch additionally fixes the pending-overlay site, which exists only on the #242 stack. The stacks also disagree on the accounting field: #253 replaced `keys_removed` with `key_count_delta`, so whichever lands second needs its expectations rebased onto the other's name.
