### PR TITLE
bedrock-q67.36: arm the empty-transaction heartbeat at the recover_from reply

### DIFF
--- a/lib/bedrock/data_plane/commit_proxy/server.ex
+++ b/lib/bedrock/data_plane/commit_proxy/server.ex
@@ -152,18 +152,25 @@ defmodule Bedrock.DataPlane.CommitProxy.Server do
           State.t()
         ) ::
           {:reply, term(), State.t()} | {:noreply, State.t(), timeout() | {:continue, term()}}
-  def handle_call(
-        {:recover_from, lock_token, sequencer, resolver_layout, routing_snapshot},
-        _from,
-        %{mode: :locked} = t
-      ) do
+  # Unlock (FDB's proxy becoming usable once recovery reaches
+  # RECOVERY_TRANSACTION, which is where commitProxyServerCore arms
+  # commitBatcher). Replying arms the cadence: the empty-transaction
+  # heartbeat must run from unlock onward, not from the first client
+  # request, or a freshly recovered but idle cluster stops advancing
+  # versions until someone commits.
+  def handle_call({:recover_from, lock_token, sequencer, resolver_layout, routing_snapshot}, from, %{mode: :locked} = t) do
     if lock_token == t.lock_token do
       routing_data = RoutingData.from_snapshot(routing_snapshot)
 
-      reply(
-        %{t | mode: :running, sequencer: sequencer, resolver_layout: resolver_layout, routing_data: routing_data},
-        :ok
-      )
+      GenServer.reply(from, :ok)
+
+      noreply_resuming_cadence(%{
+        t
+        | mode: :running,
+          sequencer: sequencer,
+          resolver_layout: resolver_layout,
+          routing_data: routing_data
+      })
     else
       reply(t, {:error, :unauthorized})
     end

--- a/test/bedrock/data_plane/commit_proxy/recovery_heartbeat_test.exs
+++ b/test/bedrock/data_plane/commit_proxy/recovery_heartbeat_test.exs
@@ -1,0 +1,141 @@
+defmodule Bedrock.DataPlane.CommitProxy.RecoveryHeartbeatTest do
+  @moduledoc """
+  A proxy that has just been unlocked by `recover_from/5` must beat on its
+  own, before any client arrives. FDB arms the batcher the moment the proxy
+  becomes usable (`commitBatcherActor = commitBatcher(...)` in
+  CommitProxyServer.actor.cpp, whose loop unconditionally `out.send`s the
+  batch when MAX_COMMIT_BATCH_INTERVAL elapses - empty or not), so versions
+  advance smoothly from recovery onward.
+
+  Uses a real Sequencer.Server and Resolver.Server with only the log faked,
+  the established seam in this directory: the heartbeat is observable as the
+  push the empty transaction makes to the logs.
+  """
+  use ExUnit.Case, async: false
+
+  alias Bedrock.DataPlane.CommitProxy.ResolverLayout
+  alias Bedrock.DataPlane.CommitProxy.Server, as: CommitProxyServer
+  alias Bedrock.DataPlane.Resolver.Server, as: ResolverServer
+  alias Bedrock.DataPlane.Sequencer.Server, as: SequencerServer
+  alias Bedrock.DataPlane.Version
+
+  @heartbeat_ms 100
+
+  defmodule TestCluster do
+    @moduledoc false
+    def otp_name(component) when is_atom(component), do: :"recovery_heartbeat_test_#{component}"
+  end
+
+  # Fake log that accepts every push and tells the test about it, so the
+  # heartbeat is observable from outside the proxy.
+  defmodule ReportingLog do
+    @moduledoc false
+    use GenServer
+
+    def start_link(test_pid), do: GenServer.start_link(__MODULE__, test_pid)
+
+    def init(test_pid), do: {:ok, test_pid}
+
+    def handle_call({:push, transaction, last_commit_version, _kcv}, _from, test_pid) do
+      send(test_pid, {:log_push, transaction, last_commit_version})
+      {:reply, :ok, test_pid}
+    end
+  end
+
+  setup do
+    director = self()
+    epoch = 1
+    lock_token = :crypto.strong_rand_bytes(32)
+
+    sequencer =
+      start_supervised!(
+        {SequencerServer,
+         [
+           cluster: TestCluster,
+           otp_name: :recovery_heartbeat_test_sequencer,
+           director: director,
+           epoch: epoch,
+           last_committed_version: Version.zero()
+         ]}
+      )
+
+    resolver =
+      start_supervised!(
+        {ResolverServer,
+         [
+           lock_token: lock_token,
+           key_range: {"", <<0xFF, 0xFF>>},
+           epoch: epoch,
+           last_version: Version.zero(),
+           director: director,
+           cluster: TestCluster,
+           commit_proxy_count: 1
+         ]}
+      )
+
+    log = start_supervised!({ReportingLog, self()})
+
+    resolver_layout = ResolverLayout.from_layout(%{resolvers: [{"", resolver}]})
+
+    routing_snapshot = %{
+      shard_layout: %{<<0xFF, 0xFF>> => {0, <<>>}},
+      log_map: %{0 => "log_1"},
+      log_services: %{"log_1" => log},
+      materializers: %{0 => %{"wkr_sys" => "n1@host"}},
+      replication_factor: 1
+    }
+
+    proxy =
+      start_supervised!(
+        CommitProxyServer.child_spec(
+          cluster: TestCluster,
+          director: director,
+          epoch: epoch,
+          instance: 0,
+          max_latency_in_ms: 1,
+          max_per_batch: 10,
+          empty_transaction_timeout_ms: @heartbeat_ms,
+          lock_token: lock_token,
+          sequencer: sequencer,
+          resolver_layout: resolver_layout
+        )
+      )
+
+    %{
+      proxy: proxy,
+      lock_token: lock_token,
+      sequencer: sequencer,
+      resolver_layout: resolver_layout,
+      routing_snapshot: routing_snapshot
+    }
+  end
+
+  test "an unlocked proxy beats without any client traffic", ctx do
+    %{
+      proxy: proxy,
+      lock_token: lock_token,
+      sequencer: sequencer,
+      resolver_layout: resolver_layout,
+      routing_snapshot: routing_snapshot
+    } = ctx
+
+    :ok = GenServer.call(proxy, {:recover_from, lock_token, sequencer, resolver_layout, routing_snapshot})
+
+    # No commit, no fetch, nothing: the reply to recover_from is the only
+    # thing that has happened to this proxy.
+    assert_receive {:log_push, _transaction, _last_commit_version}, @heartbeat_ms * 5
+  end
+
+  test "a proxy that never got unlocked stays quiet", %{proxy: _proxy} do
+    refute_receive {:log_push, _transaction, _last_commit_version}, @heartbeat_ms * 3
+  end
+
+  test "a refused unlock leaves the proxy locked and quiet", ctx do
+    %{proxy: proxy, sequencer: sequencer, resolver_layout: resolver_layout, routing_snapshot: routing_snapshot} = ctx
+
+    assert {:error, :unauthorized} =
+             GenServer.call(proxy, {:recover_from, "wrong_token", sequencer, resolver_layout, routing_snapshot})
+
+    refute_receive {:log_push, _transaction, _last_commit_version}, @heartbeat_ms * 3
+  end
+end

--- a/test/bedrock/data_plane/commit_proxy/recovery_heartbeat_test.exs
+++ b/test/bedrock/data_plane/commit_proxy/recovery_heartbeat_test.exs
@@ -7,14 +7,16 @@ defmodule Bedrock.DataPlane.CommitProxy.RecoveryHeartbeatTest do
   batch when MAX_COMMIT_BATCH_INTERVAL elapses - empty or not), so versions
   advance smoothly from recovery onward.
 
-  Uses a real Sequencer.Server and Resolver.Server with only the log faked,
-  the established seam in this directory: the heartbeat is observable as the
-  push the empty transaction makes to the logs.
+  Pinned twice: once on the handler's return, the way the sibling cadence
+  tests do it, and once end to end on a live proxy - a real Sequencer.Server
+  and Resolver.Server with only the log faked, so the heartbeat is observable
+  as the push the empty transaction makes to the logs.
   """
   use ExUnit.Case, async: false
 
   alias Bedrock.DataPlane.CommitProxy.ResolverLayout
   alias Bedrock.DataPlane.CommitProxy.Server, as: CommitProxyServer
+  alias Bedrock.DataPlane.CommitProxy.State
   alias Bedrock.DataPlane.Resolver.Server, as: ResolverServer
   alias Bedrock.DataPlane.Sequencer.Server, as: SequencerServer
   alias Bedrock.DataPlane.Version
@@ -42,100 +44,116 @@ defmodule Bedrock.DataPlane.CommitProxy.RecoveryHeartbeatTest do
     end
   end
 
-  setup do
-    director = self()
-    epoch = 1
-    lock_token = :crypto.strong_rand_bytes(32)
+  test "the unlock reply arms the heartbeat timeout" do
+    t = %State{mode: :locked, lock_token: "tok", empty_transaction_timeout_ms: 1_234}
+    snapshot = %{shard_layout: %{}, log_map: %{}, log_services: %{}, replication_factor: 1}
 
-    sequencer =
-      start_supervised!(
-        {SequencerServer,
-         [
-           cluster: TestCluster,
-           otp_name: :recovery_heartbeat_test_sequencer,
-           director: director,
-           epoch: epoch,
-           last_committed_version: Version.zero()
-         ]}
-      )
+    assert {:noreply, %State{mode: :running}, 1_234} =
+             CommitProxyServer.handle_call(
+               {:recover_from, "tok", :sequencer, :resolver_layout, snapshot},
+               {self(), make_ref()},
+               t
+             )
 
-    resolver =
-      start_supervised!(
-        {ResolverServer,
-         [
-           lock_token: lock_token,
-           key_range: {"", <<0xFF, 0xFF>>},
-           epoch: epoch,
-           last_version: Version.zero(),
-           director: director,
-           cluster: TestCluster,
-           commit_proxy_count: 1
-         ]}
-      )
+    assert_received {_ref, :ok}
+  end
 
-    log = start_supervised!({ReportingLog, self()})
+  describe "a live proxy" do
+    setup do
+      director = self()
+      epoch = 1
+      lock_token = :crypto.strong_rand_bytes(32)
 
-    resolver_layout = ResolverLayout.from_layout(%{resolvers: [{"", resolver}]})
-
-    routing_snapshot = %{
-      shard_layout: %{<<0xFF, 0xFF>> => {0, <<>>}},
-      log_map: %{0 => "log_1"},
-      log_services: %{"log_1" => log},
-      materializers: %{0 => %{"wkr_sys" => "n1@host"}},
-      replication_factor: 1
-    }
-
-    proxy =
-      start_supervised!(
-        CommitProxyServer.child_spec(
-          cluster: TestCluster,
-          director: director,
-          epoch: epoch,
-          instance: 0,
-          max_latency_in_ms: 1,
-          max_per_batch: 10,
-          empty_transaction_timeout_ms: @heartbeat_ms,
-          lock_token: lock_token,
-          sequencer: sequencer,
-          resolver_layout: resolver_layout
+      sequencer =
+        start_supervised!(
+          {SequencerServer,
+           [
+             cluster: TestCluster,
+             otp_name: :recovery_heartbeat_test_sequencer,
+             director: director,
+             epoch: epoch,
+             last_committed_version: Version.zero()
+           ]}
         )
-      )
 
-    %{
-      proxy: proxy,
-      lock_token: lock_token,
-      sequencer: sequencer,
-      resolver_layout: resolver_layout,
-      routing_snapshot: routing_snapshot
-    }
-  end
+      resolver =
+        start_supervised!(
+          {ResolverServer,
+           [
+             lock_token: lock_token,
+             key_range: {"", <<0xFF, 0xFF>>},
+             epoch: epoch,
+             last_version: Version.zero(),
+             director: director,
+             cluster: TestCluster,
+             commit_proxy_count: 1
+           ]}
+        )
 
-  test "an unlocked proxy beats without any client traffic", ctx do
-    %{
-      proxy: proxy,
-      lock_token: lock_token,
-      sequencer: sequencer,
-      resolver_layout: resolver_layout,
-      routing_snapshot: routing_snapshot
-    } = ctx
+      log = start_supervised!({ReportingLog, self()})
 
-    :ok = GenServer.call(proxy, {:recover_from, lock_token, sequencer, resolver_layout, routing_snapshot})
+      resolver_layout = ResolverLayout.from_layout(%{resolvers: [{"", resolver}]})
 
-    # No commit, no fetch, nothing: the reply to recover_from is the only
-    # thing that has happened to this proxy.
-    assert_receive {:log_push, _transaction, _last_commit_version}, @heartbeat_ms * 5
-  end
+      routing_snapshot = %{
+        shard_layout: %{<<0xFF, 0xFF>> => {0, <<>>}},
+        log_map: %{0 => "log_1"},
+        log_services: %{"log_1" => log},
+        materializers: %{0 => %{"wkr_sys" => "n1@host"}},
+        replication_factor: 1
+      }
 
-  test "a proxy that never got unlocked stays quiet", %{proxy: _proxy} do
-    refute_receive {:log_push, _transaction, _last_commit_version}, @heartbeat_ms * 3
-  end
+      proxy =
+        start_supervised!(
+          CommitProxyServer.child_spec(
+            cluster: TestCluster,
+            director: director,
+            epoch: epoch,
+            instance: 0,
+            max_latency_in_ms: 1,
+            max_per_batch: 10,
+            empty_transaction_timeout_ms: @heartbeat_ms,
+            lock_token: lock_token,
+            sequencer: sequencer,
+            resolver_layout: resolver_layout
+          )
+        )
 
-  test "a refused unlock leaves the proxy locked and quiet", ctx do
-    %{proxy: proxy, sequencer: sequencer, resolver_layout: resolver_layout, routing_snapshot: routing_snapshot} = ctx
+      %{
+        proxy: proxy,
+        lock_token: lock_token,
+        sequencer: sequencer,
+        resolver_layout: resolver_layout,
+        routing_snapshot: routing_snapshot
+      }
+    end
 
-    assert {:error, :unauthorized} =
-             GenServer.call(proxy, {:recover_from, "wrong_token", sequencer, resolver_layout, routing_snapshot})
+    test "beats without any client traffic once unlocked", ctx do
+      %{
+        proxy: proxy,
+        lock_token: lock_token,
+        sequencer: sequencer,
+        resolver_layout: resolver_layout,
+        routing_snapshot: routing_snapshot
+      } = ctx
 
-    refute_receive {:log_push, _transaction, _last_commit_version}, @heartbeat_ms * 3
+      :ok = GenServer.call(proxy, {:recover_from, lock_token, sequencer, resolver_layout, routing_snapshot})
+
+      # No commit, no fetch, nothing: the reply to recover_from is the only
+      # thing that has happened to this proxy.
+      assert_receive {:log_push, _transaction, _last_commit_version}, @heartbeat_ms * 5
+    end
+
+    test "that never got unlocked stays quiet", %{proxy: _proxy} do
+      refute_receive {:log_push, _transaction, _last_commit_version}, @heartbeat_ms * 3
+    end
+
+    test "whose unlock was refused stays locked and quiet", ctx do
+      %{proxy: proxy, sequencer: sequencer, resolver_layout: resolver_layout, routing_snapshot: routing_snapshot} = ctx
+
+      assert {:error, :unauthorized} =
+               GenServer.call(proxy, {:recover_from, "wrong_token", sequencer, resolver_layout, routing_snapshot})
+
+      refute_receive {:log_push, _transaction, _last_commit_version}, @heartbeat_ms * 3
+    end
   end
 end


### PR DESCRIPTION
A commit proxy's empty-transaction heartbeat is driven by the GenServer timeout, and the reply that unlocks the proxy at the end of recovery returned without one. A freshly recovered but idle cluster had no heartbeat until some client request happened to re-arm the timer. The unlock clause now replies out of band and returns through the cadence-resuming helper, arming the heartbeat the moment the proxy becomes usable.

Ticket: bedrock-q67.36

## Why

The proxy owns no timer process. Everything periodic it does, heartbeat and batch flush alike, rides on the third element of the tuple a callback returns. That timeout is one-shot and any arriving message cancels it, so the cadence survives only if every callback re-arms it on the way out. Hence the routing-fetch and worker-rejoin handlers reply with `GenServer.reply/2` and return a noreply carrying a timeout.

The unlock clause returned `{:reply, :ok, t}` instead, flipping the mode to running with no timeout attached:

```
init                     {:ok, t, 100}      armed, proxy locked
:timeout while locked    {:noreply, t, 100} re-armed, repeats
recover_from arrives     arrival cancels the pending timer
  {:reply, :ok, t}                          nothing re-arms it
t + 500ms                silence: no empty transaction, no log push
```

The heartbeat clause could then never fire, because nothing scheduled it. Only a commit, a metadata apply, or a routing fetch would restore the cadence, and all three need a client or worker to show up. A recovered cluster with nobody talking to it stopped advancing versions, the condition the heartbeat exists to prevent. FoundationDB arms its batcher at the same lifecycle point, in `commitProxyServerCore` once recovery reaches `RECOVERY_TRANSACTION`, and that loop sends the batch whenever the interval elapses, empty or not.

## What changed

The unlock clause now binds `from`, replies with `GenServer.reply/2`, and hands the running state to `noreply_resuming_cadence/1`. That helper re-arms `empty_transaction_timeout_ms` when no batch is open and a zero timeout otherwise; a just-unlocked proxy always takes the first, since only a commit opens a batch and locked commits are refused before touching it. No caller sees a different value, and the spec already admitted a noreply return.

The refused-unlock branch still replies without a timeout, deliberately: the locked timer only existed to survive until unlock, which now arms its own.

## How it works

One interval after unlock the timeout fires into the running-with-no-batch clause, which takes a commit version for an empty transaction, finalizes it through the resolver and the log push, then re-arms. A proxy is no longer inert after unlock, so one wired to a sequencer that does not answer exits with `{:sequencer_unavailable, :timeout_empty_transaction}` within a heartbeat interval rather than waiting for first traffic. That is the heartbeat's intended fail-fast behaviour, applied earlier.

## Verification

A new test pins the fix twice. A direct handler call asserts a noreply carrying the state's own timeout, with the reply already delivered; on develop it gets a reply tuple. A live proxy with a real sequencer and resolver and a reporting fake log is unlocked and then left alone; it must push to the log within 500ms, where develop's mailbox stays empty. Two controls, never unlocked and refused unlock, assert silence. All four CI jobs pass; the scheduled durability job is skipped.

Follow-up: bedrock-q67.47, two running-mode replies leave the cadence unarmed.
Follow-up: bedrock-q67.34 / PR #261, stalled recovery leaves proxies heartbeating.
