### PR TITLE
bedrock-q67.44: don't evict routing when a lone storage server is merely slow

### DIFF
--- a/lib/bedrock/internal/transaction_builder/storage_racing.ex
+++ b/lib/bedrock/internal/transaction_builder/storage_racing.ex
@@ -83,13 +83,42 @@ defmodule Bedrock.Internal.TransactionBuilder.StorageRacing do
     fastest_server
     |> operation_fn.(state.read_version, state.fetch_timeout_in_ms)
     |> case do
-      {:ok, result} -> {state, {:ok, {result, key_range}}}
-      {:error, :not_found} -> {state, {:ok, {nil, key_range}}}
-      {:error, :version_too_old} -> {state, {:failure, %{version_too_old: [fastest_server]}}}
-      _ -> race_all_servers(state, key_range, :lists.delete(fastest_server, all_servers), operation_fn)
+      {:ok, result} ->
+        {state, {:ok, {result, key_range}}}
+
+      {:error, :not_found} ->
+        {state, {:ok, {nil, key_range}}}
+
+      {:error, :version_too_old} ->
+        {state, {:failure, %{version_too_old: [fastest_server]}}}
+
+      {:error, reason} ->
+        race_remaining_servers(state, key_range, all_servers, fastest_server, reason, operation_fn)
+
+      {:failure, reason, _server} ->
+        race_remaining_servers(state, key_range, all_servers, fastest_server, reason, operation_fn)
     end
   end
 
+  # A failure on the cached-fastest server falls back to the shard's other
+  # servers. When it was the only one - today's singleton refs always - the
+  # read fails with that server's own reason rather than collapsing into
+  # :no_servers_to_race: the shard is routed, the server just didn't answer,
+  # and only a routing-shaped verdict may evict the node's routing cache.
+  # FDB's locationCache is invalidated by wrong_shard_server and by
+  # all_alternatives_failed (thrown only when every endpoint is known-failed,
+  # LoadBalance.actor.cpp), never by a slow reply - slow is not stale.
+  defp race_remaining_servers(state, key_range, all_servers, fastest_server, reason, operation_fn) do
+    case :lists.delete(fastest_server, all_servers) do
+      [] -> {state, {:failure, %{reason => [fastest_server]}}}
+      remaining -> race_all_servers(state, key_range, remaining, operation_fn)
+    end
+  end
+
+  # An empty ref list is unroutable, and routing-shaped by construction. No
+  # index the builder writes can hold one (insert above is [_ | _]-guarded),
+  # so this is a fallthrough that keeps an empty set out of run_race/3, which
+  # would otherwise reduce to a reasonless %{}.
   defp race_all_servers(state, _key_range, [], _operation_fn), do: {state, {:failure, %{no_servers_to_race: []}}}
 
   defp race_all_servers(state, key_range, servers, operation_fn) do

--- a/test/bedrock/internal/transaction_builder/storage_racing_test.exs
+++ b/test/bedrock/internal/transaction_builder/storage_racing_test.exs
@@ -1,0 +1,91 @@
+defmodule Bedrock.Internal.TransactionBuilder.StorageRacingTest do
+  use ExUnit.Case, async: true
+
+  alias Bedrock.DataPlane.Version
+  alias Bedrock.Internal.TransactionBuilder.LayoutIndex
+  alias Bedrock.Internal.TransactionBuilder.State
+  alias Bedrock.Internal.TransactionBuilder.StorageRacing
+
+  defp state_for(storage_refs) do
+    %State{
+      layout_index: %LayoutIndex{
+        tree: :gb_trees.from_orddict([{<<0xFF, 0xFF>>, {"", storage_refs}}])
+      },
+      read_version: Version.from_integer(42),
+      fetch_timeout_in_ms: 50
+    }
+  end
+
+  describe "cached-fastest server failures" do
+    test "a slow singleton server fails as :timeout, not a routing-shaped verdict" do
+      server = self()
+      state = state_for([server])
+
+      {state, {:ok, {"value", _range}}} =
+        StorageRacing.race_storage_servers(state, "key", fn ^server, _version, _timeout -> {:ok, "value"} end)
+
+      assert %{{"", <<0xFF, 0xFF>>} => ^server} = state.fastest_storage_servers
+
+      # The second read of the transaction takes the cached-fastest path.
+      # A merely slow server must not degrade into :no_servers_to_race,
+      # which would evict the node's routing cache.
+      assert {_state, {:failure, %{timeout: [^server]}}} =
+               StorageRacing.race_storage_servers(state, "key", fn ^server, _version, _timeout ->
+                 {:failure, :timeout, server}
+               end)
+    end
+
+    test "a dead singleton server still fails as :unavailable" do
+      server = self()
+      state = %{state_for([server]) | fastest_storage_servers: %{{"", <<0xFF, 0xFF>>} => server}}
+
+      assert {_state, {:failure, %{unavailable: [^server]}}} =
+               StorageRacing.race_storage_servers(state, "key", fn ^server, _version, _timeout ->
+                 {:failure, :unavailable, server}
+               end)
+    end
+
+    test "a version_too_new reply on a singleton server fails as :version_too_new" do
+      server = self()
+      state = %{state_for([server]) | fastest_storage_servers: %{{"", <<0xFF, 0xFF>>} => server}}
+
+      assert {_state, {:failure, %{version_too_new: [^server]}}} =
+               StorageRacing.race_storage_servers(state, "key", fn ^server, _version, _timeout ->
+                 {:error, :version_too_new}
+               end)
+    end
+
+    test "a slow server still races the shard's other servers" do
+      slow = self()
+      other = spawn(fn -> :ok end)
+      state = %{state_for([slow, other]) | fastest_storage_servers: %{{"", <<0xFF, 0xFF>>} => slow}}
+
+      assert {state, {:ok, {"value", _range}}} =
+               StorageRacing.race_storage_servers(state, "key", fn
+                 ^slow, _version, _timeout -> {:failure, :timeout, slow}
+                 ^other, _version, _timeout -> {:ok, "value"}
+               end)
+
+      assert %{{"", <<0xFF, 0xFF>>} => ^other} = state.fastest_storage_servers
+    end
+
+    test "every other server failing reports their reasons, not :no_servers_to_race" do
+      slow = self()
+      other = spawn(fn -> :ok end)
+      state = %{state_for([slow, other]) | fastest_storage_servers: %{{"", <<0xFF, 0xFF>>} => slow}}
+
+      assert {_state, {:failure, %{unavailable: [^other]}}} =
+               StorageRacing.race_storage_servers(state, "key", fn
+                 ^slow, _version, _timeout -> {:failure, :timeout, slow}
+                 ^other, _version, _timeout -> {:failure, :unavailable, other}
+               end)
+    end
+  end
+
+  test "a shard with no servers is :no_servers_to_race" do
+    state = state_for([])
+
+    assert {_state, {:failure, %{no_servers_to_race: []}}} =
+             StorageRacing.race_storage_servers(state, "key", fn _server, _version, _timeout -> {:ok, "value"} end)
+  end
+end


### PR DESCRIPTION
A storage server that was merely slow could evict the whole node's routing cache. On the cached-fastest read path a failure fell back to racing the shard's *remaining* servers, and every shard carries one server ref today, so the remainder was empty and the read reported `no_servers_to_race`, a routing-shaped verdict. That path now reports the failed server's own reason when there is nobody else to race.

Ticket: bedrock-q67.44

## Why

The client retry loop treats several read failures as retryable, and of those only a definitively routing-shaped subset evicts the node's location cache before retrying: an unroutable key, a dead ref, a locked proxy, an empty server set. A timeout is deliberately excluded: slow is not stale, and evicting on slowness turns overload latency into cache thrash and refetch traffic. FoundationDB draws the same line.

The racing layer undercut that. The first read on a shard races its servers and caches the winner, so later reads in the same transaction call that pid directly. A failure there deleted that server from the ref list and raced what was left. The routing function wraps a shard's single materializer as a one-element list, so the remainder was always empty, which is the clause returning the routing-shaped verdict. One slow server therefore dropped the node's location cache on the second read of every transaction touching its shard.

## What changed

`try_fastest_server/5` loses its catch-all and matches the two declared failure shapes explicitly, both routing into a new helper that does the deletion: a non-empty remainder races as before, an empty one fails with the fastest server's own reason attributed to it.

On a singleton shard that path now yields `%{timeout: [pid]}` where it yielded `%{no_servers_to_race: []}`, and likewise for `:unavailable` and `:version_too_new`. Only the timeout case changes the eviction decision; a dead ref still evicts, for the honest reason. Non-retryable range-read reasons also stop being laundered into a retryable verdict, so a doomed read fails at once rather than burning the transaction deadline.

Left alone under the ticket's own gating: the auto-connect no-eviction window, and the arbitrary tie-break among mixed reasons.

## How it works

The reason travels with the failure instead of being inferred from an exhausted list:

```
cached fastest [s], read times out
  -> {:failure, :timeout, s}
  -> delete s from [s] -> []
  -> {:failure, %{timeout: [s]}}
```

The retry loop sees `:timeout`, keeps the cache, and the fresh builder races that shard from scratch. With two refs and the cached one slow, the other is raced and becomes the new cached fastest, unchanged from before.

`no_servers_to_race` now means only a genuinely empty ref list, which the builder's index writer cannot produce: its insert is guarded on a non-empty list.

## Verification

A new test module drives the racing entry point over a hand-built single-shard index with stub operation functions. Three of its six cases fail on `develop` with `{:failure, %{no_servers_to_race: []}}`: a slow singleton, a dead one that must still evict, and a version-too-new reply. The rest cover the two-ref fallback, the all-fail case, and an empty ref list. CI is green.

Follow-up: bedrock-q67.44 item (2), auto-connect no-eviction window.
Follow-up: bedrock-q67.21, client cache rework, mixed-reason tie-break.
Follow-up: bedrock-h8c, blanket-rescue narrowing.
