### PR TITLE
bedrock-0s9: reject :resolution as a node capability with a clear error

### DIFF
--- a/lib/bedrock/cluster.ex
+++ b/lib/bedrock/cluster.ex
@@ -20,7 +20,14 @@ defmodule Bedrock.Cluster do
   @type transaction :: Transaction.encoded()
   @type materializer :: Materializer.ref()
   @type log :: Log.ref()
-  @type capability :: :coordination | :log | :materializer | :resolution
+  @typedoc """
+  A capability a node may advertise in its `:capabilities` configuration.
+
+  Resolvers are not in this set: the coordinator places them on coordination
+  nodes (see `Bedrock.ControlPlane.Coordinator.State.convert_to_capability_map/1`),
+  a node never advertises `:resolution` itself.
+  """
+  @type capability :: :coordination | :log | :materializer
 
   @callback node_capabilities() :: [Bedrock.Cluster.capability()]
   @callback coordinator!() :: Coordinator.ref()

--- a/lib/bedrock/control_plane/coordinator/state.ex
+++ b/lib/bedrock/control_plane/coordinator/state.ex
@@ -164,8 +164,11 @@ defmodule Bedrock.ControlPlane.Coordinator.State do
     def update_node_capabilities(t, node, capabilities),
       do: %{t | node_capabilities: Map.put(t.node_capabilities, node, capabilities)}
 
+    # The result carries `:resolution` in addition to `Cluster.capability()`:
+    # resolvers are placed on coordination nodes here, never advertised by a
+    # node, so `:resolution` never appears in the input map's capabilities.
     @spec convert_to_capability_map(%{node() => [Cluster.capability()]}) :: %{
-            Cluster.capability() => [node()]
+            (Cluster.capability() | :resolution) => [node()]
           }
     def convert_to_capability_map(node_capabilities) do
       capability_map =

--- a/lib/bedrock/control_plane/director.ex
+++ b/lib/bedrock/control_plane/director.ex
@@ -132,7 +132,7 @@ defmodule Bedrock.ControlPlane.Director do
   """
   @spec notify_capabilities_updated(
           director :: ref(),
-          node_capabilities :: %{Bedrock.Cluster.capability() => [node()]}
+          node_capabilities :: %{(Bedrock.Cluster.capability() | :resolution) => [node()]}
         ) :: :ok
   def notify_capabilities_updated(director, node_capabilities),
     do: cast(director, {:capabilities_updated, node_capabilities})

--- a/lib/bedrock/control_plane/director/recovery.ex
+++ b/lib/bedrock/control_plane/director/recovery.ex
@@ -42,7 +42,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery do
   @type recovery_context :: %{
           cluster_config: Config.t(),
           prior_core_state: CoreState.t() | nil,
-          node_capabilities: %{Bedrock.Cluster.capability() => [node()]},
+          node_capabilities: %{(Bedrock.Cluster.capability() | :resolution) => [node()]},
           lock_token: binary(),
           available_services: %{Worker.id() => {atom(), {atom(), node()}}},
           coordinator: pid()

--- a/lib/bedrock/control_plane/director/recovery/recovery_phase.ex
+++ b/lib/bedrock/control_plane/director/recovery/recovery_phase.ex
@@ -12,7 +12,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery.RecoveryPhase do
   @type context :: %{
           cluster_config: Config.t(),
           prior_core_state: Config.CoreState.t() | nil,
-          node_capabilities: %{Bedrock.Cluster.capability() => [node()]},
+          node_capabilities: %{(Bedrock.Cluster.capability() | :resolution) => [node()]},
           lock_token: binary(),
           available_services: %{String.t() => {atom(), {atom(), node()}}},
           coordinator: pid()

--- a/lib/bedrock/control_plane/director/server.ex
+++ b/lib/bedrock/control_plane/director/server.ex
@@ -37,7 +37,7 @@ defmodule Bedrock.ControlPlane.Director.Server do
             epoch: Bedrock.epoch(),
             coordinator: Coordinator.ref(),
             services: %{String.t() => {atom(), {atom(), node()}}} | nil,
-            node_capabilities: %{Bedrock.Cluster.capability() => [node()]} | nil
+            node_capabilities: %{(Bedrock.Cluster.capability() | :resolution) => [node()]} | nil
           ]
         ) :: Supervisor.child_spec()
   def child_spec(opts) do

--- a/lib/bedrock/control_plane/director/state.ex
+++ b/lib/bedrock/control_plane/director/state.ex
@@ -25,7 +25,7 @@ defmodule Bedrock.ControlPlane.Director.State do
           transaction_system_layout: TransactionSystemLayout.t() | nil,
           prior_core_state: CoreState.t() | nil,
           coordinator: pid(),
-          node_capabilities: %{Cluster.capability() => [node()]},
+          node_capabilities: %{(Cluster.capability() | :resolution) => [node()]},
           timers: timer_registry() | nil,
           services: %{Worker.id() => {atom(), {atom(), node()}}},
           lock_token: binary(),

--- a/lib/bedrock/control_plane/distributor/recruitment.ex
+++ b/lib/bedrock/control_plane/distributor/recruitment.ex
@@ -33,7 +33,7 @@ defmodule Bedrock.ControlPlane.Distributor.Recruitment do
   @type context :: %{
           required(:cluster) => module(),
           required(:epoch) => Bedrock.epoch(),
-          required(:node_capabilities) => %{Bedrock.Cluster.capability() => [node()]},
+          required(:node_capabilities) => %{(Bedrock.Cluster.capability() | :resolution) => [node()]},
           required(:logs) => %{Log.id() => [Bedrock.range_tag()]},
           required(:log_refs) => %{Log.id() => Log.ref()},
           optional(:worker_params) => %{String.t() => term()},

--- a/lib/bedrock/internal/cluster_supervisor.ex
+++ b/lib/bedrock/internal/cluster_supervisor.ex
@@ -252,6 +252,13 @@ defmodule Bedrock.Internal.ClusterSupervisor do
   defp module_for_capability(:materializer), do: Foreman
   defp module_for_capability(:log), do: Foreman
 
+  defp module_for_capability(:resolution),
+    do:
+      raise(
+        "Invalid capability :resolution — resolvers are placed by the coordinator on " <>
+          "coordination nodes, a node never advertises them. Remove :resolution from :capabilities."
+      )
+
   defp module_for_capability(capability), do: raise("Unknown capability: #{inspect(capability)}")
 
   defp start_tracing(module) do

--- a/test/bedrock/internal/cluster_supervisor_test.exs
+++ b/test/bedrock/internal/cluster_supervisor_test.exs
@@ -76,6 +76,27 @@ defmodule Bedrock.Internal.ClusterSupervisorTest do
       # This would need integration testing to fully verify
       assert [:coordination, :log, :materializer] == capabilities
     end
+
+    # bedrock-0s9: resolvers are placed by the coordinator on coordination
+    # nodes (Coordinator.State.convert_to_capability_map/1) — a node never
+    # advertises :resolution itself. Before the fix, :resolution fell through
+    # the same catch-all as a genuine typo like :storage above, raising
+    # "Unknown capability: :resolution" with no hint that :resolution is
+    # special (documented, but never node-advertised) rather than unknown.
+    test "raises a specific, actionable error for :resolution instead of the generic catch-all" do
+      capabilities = [:coordination, :log, :resolution]
+
+      expect(Bedrock.MockCluster, :otp_name, fn :sup -> :test_sup end)
+      expect(Bedrock.MockCluster, :otp_name, fn :link -> :test_link end)
+
+      assert_raise RuntimeError, ~r/resolvers are placed by the coordinator/, fn ->
+        ClusterSupervisor.init(
+          {:test_node, Bedrock.MockCluster, nil,
+           [capabilities: capabilities, coordinator: [path: "/tmp"], worker: [path: "/tmp"], durability_mode: :relaxed],
+           "bedrock.cluster", %Descriptor{cluster_name: "test", coordinator_nodes: [:test_node]}}
+        )
+      end
+    end
   end
 
   describe "child_spec/1" do


### PR DESCRIPTION
`Bedrock.Cluster.capability/0` listed `:resolution` as something a node could put in its `:capabilities` config, but the cluster supervisor had no clause turning it into a child, so a node configured exactly as the type invited crashed at boot with a generic "unknown capability" error. The type now names only the three capabilities a node can advertise, and `:resolution` gets an explicit rejection that says why.

Ticket: bedrock-0s9
Stacked on: #246 (bedrock-31d/app-env-overrides-use-config)

## Why

Two shapes shared one type. A node advertises a list of capabilities; the coordinator inverts the collected lists into a map from capability to nodes. Only that second shape holds `:resolution`, and it is derived rather than declared: `convert_to_capability_map/1` maps `:resolution` onto whichever nodes advertised `:coordination`, because resolvers are placed on coordination nodes rather than announced by machines, as in FoundationDB.

So `capabilities: [:coordination, :materializer, :log, :resolution]` type-checked and then raised inside `children_for_capabilities/3`, before `Supervisor.init/2` ran, looking identical to a typo like `:storage`. The bedrock-5tq.4 guide audit hit it by documenting that exact four-element list.

## What changed

- `capability/0` drops `:resolution`, with a typedoc pointing at where resolvers are placed instead.
- `module_for_capability/1` gains a `:resolution` clause raising "resolvers are placed by the coordinator on coordination nodes ... Remove :resolution from :capabilities". The generic catch-all is untouched.
- Six specs carrying the derived map widen to `Cluster.capability() | :resolution`: the director notification, its child spec and state, the recovery and phase contexts, and distributor recruitment.

`:resolution` was deliberately not made a silent no-op: accepting a role a node cannot fulfil would let an operator believe resolver placement had been influenced.

## How it works

```
nodes advertise:  n1 => [:coordination, :log], n2 => [:materializer]
coordinator derives: %{coordination: [:n1], log: [:n1],
                       materializer: [:n2], resolution: [:n1]}
```

Nothing on the node side emits the `:resolution` key, and nothing reading the derived map sees it absent. Dialyzer forced the widening: under the narrower type, the literal `Map.put(capability_map, :resolution, ...)` made the old return spec unsatisfiable.

## Verification

A new test initialises the supervisor with `[:coordination, :log, :resolution]` and asserts a `RuntimeError` matching the new wording; on the base branch it fails with the old catch-all message, so it is not vacuous. The neighbouring `:storage` test still pins the generic path. Reported gates: 2898 tests, 0 failures, credo strict and dialyzer clean. A cold audit returned PASS-WITH-NOTES; the six spec changes address its one note. No checks reported on the branch (draft, stacked on #246).

Related: bedrock-5tq.4, the guide audit that filed this bug.
