### PR TITLE
bedrock-jb4: make Olivine n_keys and key_ranges track the live index

### DIFF
--- a/lib/bedrock/data_plane/materializer/olivine/index.ex
+++ b/lib/bedrock/data_plane/materializer/olivine/index.ex
@@ -71,8 +71,6 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Index do
   @type t :: %__MODULE__{
           tree: :gb_trees.tree(),
           page_map: map(),
-          min_key: Bedrock.key(),
-          max_key: Bedrock.key(),
           max_keys_per_page: pos_integer(),
           target_keys_per_page: pos_integer()
         }
@@ -80,8 +78,6 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Index do
   defstruct [
     :tree,
     :page_map,
-    :min_key,
-    :max_key,
     max_keys_per_page: @default_max_keys_per_page,
     target_keys_per_page: div(@default_max_keys_per_page * 9, 10)
   ]
@@ -104,8 +100,6 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Index do
     %__MODULE__{
       tree: initial_tree,
       page_map: initial_page_map,
-      min_key: <<0xFF, 0xFF>>,
-      max_key: <<>>,
       max_keys_per_page: max_keys,
       target_keys_per_page: target_keys
     }
@@ -119,6 +113,30 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Index do
     case Page.locator_for_key(page, key) do
       {:ok, locator} -> {:ok, page, locator}
       {:error, :not_found} -> {:error, :not_found}
+    end
+  end
+
+  @doc """
+  The smallest and largest keys the index currently holds, computed from the
+  pages rather than cached: nothing on the mutation path is cheap enough to
+  maintain a running minimum, and a cached bound that mutations do not update
+  is a stale bound. Callers are info/telemetry paths, not the hot path.
+
+  An index with no keys reports the inverted sentinel `{<<0xFF, 0xFF>>, <<>>}`
+  — an empty range, distinguishable from any real one.
+  """
+  @spec key_bounds(t()) :: {Bedrock.key(), Bedrock.key()}
+  def key_bounds(%__MODULE__{page_map: page_map}) do
+    page_map
+    |> Enum.flat_map(fn {_page_id, {page, _next_id}} ->
+      case {Page.left_key(page), Page.right_key(page)} do
+        {nil, nil} -> []
+        {left_key, right_key} -> [left_key, right_key]
+      end
+    end)
+    |> case do
+      [] -> {<<0xFF, 0xFF>>, <<>>}
+      keys -> Enum.min_max(keys)
     end
   end
 
@@ -408,8 +426,6 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Index do
         page_map
       end
 
-    {min_key, max_key} = calculate_key_bounds(tree, initial_page_map)
-
     total_key_count =
       initial_page_map
       |> Enum.map(fn {_, {page, _next_id}} -> Page.key_count(page) end)
@@ -418,8 +434,6 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Index do
     index = %__MODULE__{
       tree: tree,
       page_map: initial_page_map,
-      min_key: min_key,
-      max_key: max_key,
       max_keys_per_page: max_keys_per_page,
       target_keys_per_page: target_keys_per_page
     }
@@ -787,35 +801,6 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Index do
       :none ->
         # Reached end without finding target page
         nil
-    end
-  end
-
-  # Helper function to calculate min/max keys efficiently
-  defp calculate_key_bounds(tree, page_map) do
-    if :gb_trees.is_empty(tree) do
-      {<<0xFF, 0xFF>>, <<>>}
-    else
-      # Get max from tree structure (O(log n) operation)
-      {max_tree_key, _max_id} = :gb_trees.largest(tree)
-
-      # For min_key, we need to find the actual smallest first_key across all pages
-      # This is a one-time calculation during load
-      min_key = find_minimum_first_key(page_map)
-
-      {min_key, max_tree_key}
-    end
-  end
-
-  # Find the minimum first_key across all pages (only used during load)
-  defp find_minimum_first_key(page_map) when map_size(page_map) == 0, do: <<0xFF, 0xFF>>
-
-  defp find_minimum_first_key(page_map) do
-    page_map
-    |> Enum.map(fn {_page_id, {page, _next_id}} -> Page.left_key(page) end)
-    |> Enum.reject(&is_nil/1)
-    |> case do
-      [] -> <<0xFF, 0xFF>>
-      keys -> Enum.min(keys)
     end
   end
 end

--- a/lib/bedrock/data_plane/materializer/olivine/index.ex
+++ b/lib/bedrock/data_plane/materializer/olivine/index.ex
@@ -117,6 +117,13 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Index do
   end
 
   @doc """
+  The number of keys the index currently holds, counted from the page headers.
+  """
+  @spec key_count(t()) :: non_neg_integer()
+  def key_count(%__MODULE__{page_map: page_map}),
+    do: Enum.reduce(page_map, 0, fn {_page_id, {page, _next_id}}, total -> total + Page.key_count(page) end)
+
+  @doc """
   The smallest and largest keys the index currently holds, computed from the
   pages rather than cached: nothing on the mutation path is cheap enough to
   maintain a running minimum, and a cached bound that mutations do not update
@@ -129,6 +136,8 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Index do
   def key_bounds(%__MODULE__{page_map: page_map}) do
     page_map
     |> Enum.flat_map(fn {_page_id, {page, _next_id}} ->
+      # A page holds no keys or holds at least one, so the bounds are both
+      # nil or neither is: a half-nil pair has no shape here.
       case {Page.left_key(page), Page.right_key(page)} do
         {nil, nil} -> []
         {left_key, right_key} -> [left_key, right_key]
@@ -426,11 +435,6 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Index do
         page_map
       end
 
-    total_key_count =
-      initial_page_map
-      |> Enum.map(fn {_, {page, _next_id}} -> Page.key_count(page) end)
-      |> Enum.sum()
-
     index = %__MODULE__{
       tree: tree,
       page_map: initial_page_map,
@@ -438,7 +442,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Index do
       target_keys_per_page: target_keys_per_page
     }
 
-    {:ok, index, max_id, free_ids, total_key_count}
+    {:ok, index, max_id, free_ids, key_count(index)}
   end
 
   defp calculate_free_ids(0, _all_existing_page_ids), do: []

--- a/lib/bedrock/data_plane/materializer/olivine/index_manager.ex
+++ b/lib/bedrock/data_plane/materializer/olivine/index_manager.ex
@@ -496,9 +496,12 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.IndexManager do
   Disk is untouched, and never needs to be: eviction is clamped to the
   known-committed version, and a recovery version is always at or above the
   known-committed version at the moment of the crash, so everything durable
-  survives every rollback. (Statistics such as `n_keys` are left as-is; the
-  data-file offset is not rewound, so orphaned bytes linger until the next
-  compaction.)
+  survives every rollback. (The data-file offset is not rewound, so orphaned
+  bytes linger until the next compaction.)
+
+  `n_keys` rewinds with the index: the resumed stream re-delivers the
+  discarded suffix, and a count carried across the rollback would tally
+  those transactions twice.
   """
   @spec rollback_to(t(), Bedrock.version()) :: t()
   def rollback_to(%{current_version: current} = index_manager, version) when current <= version, do: index_manager
@@ -507,11 +510,18 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.IndexManager do
     # Newest-first: drop entries above the target. The base (durable)
     # entry is always at or below any legitimate rollback target, so the
     # list can never empty — a crash here means corrupted state.
-    [{new_current, _} | _] = versions = Enum.drop_while(index_manager.versions, fn {v, _} -> v > version end)
+    [{new_current, {new_index, _}} | _] =
+      versions = Enum.drop_while(index_manager.versions, fn {v, _} -> v > version end)
 
     output_queue = :queue.filter(fn {v, _, _, _} -> v <= version end, index_manager.output_queue)
 
-    %{index_manager | versions: versions, current_version: new_current, output_queue: output_queue}
+    %{
+      index_manager
+      | versions: versions,
+        current_version: new_current,
+        output_queue: output_queue,
+        n_keys: Index.key_count(new_index)
+    }
   end
 
   defp split_versions([{version, _data} = entry | rest], target, kept_versions) when version >= target,

--- a/lib/bedrock/data_plane/materializer/olivine/index_manager.ex
+++ b/lib/bedrock/data_plane/materializer/olivine/index_manager.ex
@@ -196,8 +196,8 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.IndexManager do
 
     {new_index, new_database, new_id_allocator, modified_pages} = IndexUpdate.finish(update)
 
-    %{keys_added: keys_added, keys_removed: keys_removed, keys_changed: keys_changed} = update
-    new_n_keys = index_manager.n_keys + keys_added - keys_removed
+    %{key_count_delta: key_count_delta} = update
+    new_n_keys = index_manager.n_keys + key_count_delta
 
     {updated_data_db, _} = new_database
     this_version_ended_at_offset = updated_data_db.file_offset
@@ -211,7 +211,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.IndexManager do
         index_manager.output_queue
       )
 
-    Telemetry.trace_index_update_complete(keys_added, keys_removed, keys_changed, new_n_keys)
+    Telemetry.trace_index_update_complete(key_count_delta, new_n_keys)
 
     {%{
        index_manager
@@ -257,7 +257,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.IndexManager do
   end
 
   @spec get_key_ranges(t()) :: [{Bedrock.key(), Bedrock.key()}]
-  defp get_key_ranges(%{versions: [{_, {current_index, _}} | _]}), do: [{current_index.min_key, current_index.max_key}]
+  defp get_key_ranges(%{versions: [{_, {current_index, _}} | _]}), do: [Index.key_bounds(current_index)]
   defp get_key_ranges(%{versions: []}), do: []
 
   @doc """

--- a/lib/bedrock/data_plane/materializer/olivine/index_update.ex
+++ b/lib/bedrock/data_plane/materializer/olivine/index_update.ex
@@ -43,10 +43,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.IndexUpdate do
           id_allocator: IdAllocator.t(),
           modified_page_ids: MapSet.t(Page.id()),
           pending_operations: %{Page.id() => %{Bedrock.key() => {:set, Bedrock.version()} | :clear}},
-          keys_added: non_neg_integer(),
-          keys_removed: non_neg_integer(),
-          keys_changed: non_neg_integer(),
-          track_statistics: boolean()
+          key_count_delta: integer()
         }
 
   defstruct [
@@ -56,15 +53,11 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.IndexUpdate do
     :id_allocator,
     :modified_page_ids,
     :pending_operations,
-    keys_added: 0,
-    keys_removed: 0,
-    keys_changed: 0,
-    track_statistics: false
+    key_count_delta: 0
   ]
 
   @doc """
   Creates an IndexUpdate for mutation tracking from an Index, version, and id allocator.
-  Statistics tracking is disabled by default for maximum performance.
   """
   @spec new(Index.t(), Bedrock.version(), IdAllocator.t(), Database.t()) :: t()
   def new(%Index{} = index, version, id_allocator, database) do
@@ -75,25 +68,21 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.IndexUpdate do
       id_allocator: id_allocator,
       modified_page_ids: MapSet.new(),
       pending_operations: %{},
-      keys_added: 0,
-      keys_removed: 0,
-      keys_changed: 0,
-      # Default to false for maximum performance
-      track_statistics: false
+      key_count_delta: 0
     }
   end
 
   @doc """
-  Finishes the IndexUpdate, returning the final Index, Database, IdAllocator, and key change counts.
+  Finishes the IndexUpdate, returning the final Index, Database, IdAllocator, and modified pages.
+
+  The net change in live keys is read from the `key_count_delta` field, which
+  is only complete once `process_pending_operations/1` has run.
   """
   @spec finish(t()) :: {Index.t(), Database.t(), IdAllocator.t(), %{Page.id() => {Page.t(), Page.id()}}}
   def finish(%__MODULE__{
         index: index,
         id_allocator: id_allocator,
         database: database,
-        keys_added: _keys_added,
-        keys_removed: _keys_removed,
-        keys_changed: _keys_changed,
         modified_page_ids: modified_page_ids
       }) do
     modified_pages = Map.new(modified_page_ids, &{&1, Index.get_page_with_next_id!(index, &1)})
@@ -177,11 +166,12 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.IndexUpdate do
         page = Index.get_page!(index_update.index, single_page_id)
         keys_to_clear = extract_keys_in_range(page, start_key, end_key)
 
+        # The cleared keys become pending clears on a page that survives, so
+        # the key count they cost is picked up when that page is processed.
         %{
           index_update
           | pending_operations:
-              add_clear_operations_for_keys(index_update.pending_operations, single_page_id, keys_to_clear),
-            keys_removed: index_update.keys_removed + length(keys_to_clear)
+              add_clear_operations_for_keys(index_update.pending_operations, single_page_id, keys_to_clear)
         }
 
       [first_page_id | remaining_page_ids] ->
@@ -211,39 +201,32 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.IndexUpdate do
           |> Enum.map(&Page.key_count/1)
           |> Enum.sum()
 
-        {page_0_keys_to_clear, final_operations} =
+        final_operations =
           if 0 in middle_page_ids do
             page_0 = Index.get_page!(index_update.index, 0)
             page_0_keys = extract_keys_in_range(page_0, start_key, end_key)
 
-            operations =
-              index_update.pending_operations
-              |> Map.drop(middle_page_ids_excluding_page_zero)
-              |> add_clear_operations_for_keys(first_page_id, first_keys_to_clear)
-              |> add_clear_operations_for_keys(last_page_id, last_keys_to_clear)
-              |> add_clear_operations_for_keys(0, page_0_keys)
-
-            {page_0_keys, operations}
+            index_update.pending_operations
+            |> Map.drop(middle_page_ids_excluding_page_zero)
+            |> add_clear_operations_for_keys(first_page_id, first_keys_to_clear)
+            |> add_clear_operations_for_keys(last_page_id, last_keys_to_clear)
+            |> add_clear_operations_for_keys(0, page_0_keys)
           else
-            operations =
-              index_update.pending_operations
-              |> Map.drop(middle_page_ids_excluding_page_zero)
-              |> add_clear_operations_for_keys(first_page_id, first_keys_to_clear)
-              |> add_clear_operations_for_keys(last_page_id, last_keys_to_clear)
-
-            {[], operations}
+            index_update.pending_operations
+            |> Map.drop(middle_page_ids_excluding_page_zero)
+            |> add_clear_operations_for_keys(first_page_id, first_keys_to_clear)
+            |> add_clear_operations_for_keys(last_page_id, last_keys_to_clear)
           end
 
-        total_keys_removed =
-          length(first_keys_to_clear) + length(last_keys_to_clear) +
-            middle_keys_count + length(page_0_keys_to_clear)
-
+        # Only the wholesale-deleted middle pages are accounted for here: the
+        # boundary (and page 0) keys become pending clears on pages that
+        # survive, and are counted when those pages are processed.
         %{
           index_update
           | index: Index.delete_pages(index_update.index, middle_page_ids_excluding_page_zero),
             id_allocator: IdAllocator.recycle_ids(index_update.id_allocator, middle_page_ids_excluding_page_zero),
             pending_operations: final_operations,
-            keys_removed: index_update.keys_removed + total_keys_removed
+            key_count_delta: index_update.key_count_delta - middle_keys_count
         }
     end
   end
@@ -265,12 +248,10 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.IndexUpdate do
           Map.put(index_update.pending_operations, insertion_page, %{key => set_operation})
       end
 
-    # Atomics are always treated as changes (even if the key didn't exist before)
     %{
       index_update
       | pending_operations: updated_pending_operations,
-        database: database,
-        keys_changed: index_update.keys_changed + 1
+        database: database
     }
   end
 
@@ -353,24 +334,18 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.IndexUpdate do
   defp apply_mutations_to_page(%__MODULE__{} = index_update, page_id, page_mutations) do
     page = Index.get_page!(index_update.index, page_id)
 
-    # Only calculate statistics if tracking is enabled
-    updated_index_update =
-      if index_update.track_statistics do
-        stats = calculate_mutation_stats(page, page_mutations)
-
-        %{
-          index_update
-          | keys_added: index_update.keys_added + stats.added,
-            keys_changed: index_update.keys_changed + stats.changed,
-            keys_removed: index_update.keys_removed + stats.removed
-        }
-      else
-        index_update
-      end
-
     # Get segments without building final binary yet
     {segments, key_count, rightmost_key} =
       Page.apply_operations_as_segments(page, page_mutations)
+
+    # The merge already knows how many keys the page ends up holding, so the
+    # index-wide key count follows from the before/after page counts — exactly,
+    # and without a second pass over the keys. Splits preserve the total, so a
+    # page that splits still contributes only its own delta.
+    updated_index_update = %{
+      index_update
+      | key_count_delta: index_update.key_count_delta + key_count - Page.key_count(page)
+    }
 
     cond do
       key_count == 0 ->
@@ -470,54 +445,6 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.IndexUpdate do
     end
   rescue
     _ -> <<>>
-  end
-
-  # Calculate mutation statistics using a more efficient approach
-  # Instead of building a MapSet, scan the page directly for each key
-  defp calculate_mutation_stats(page, page_mutations) do
-    # For small mutation batches, checking keys individually is faster than building a MapSet
-    if map_size(page_mutations) <= 10 do
-      calculate_mutation_stats_direct(page, page_mutations)
-    else
-      # For larger batches, MapSet is worth the overhead
-      calculate_mutation_stats_with_mapset(page, page_mutations)
-    end
-  end
-
-  defp calculate_mutation_stats_direct(page, page_mutations) do
-    Enum.reduce(page_mutations, %{added: 0, changed: 0, removed: 0}, fn {key, op}, stats ->
-      key_exists = page_contains_key?(page, key)
-
-      case {op, key_exists} do
-        {{:set, _}, true} -> %{stats | changed: stats.changed + 1}
-        {{:set, _}, false} -> %{stats | added: stats.added + 1}
-        {:clear, true} -> %{stats | removed: stats.removed + 1}
-        {:clear, false} -> stats
-      end
-    end)
-  end
-
-  defp calculate_mutation_stats_with_mapset(page, page_mutations) do
-    existing_keys = page |> Page.keys() |> MapSet.new()
-
-    Enum.reduce(page_mutations, %{added: 0, changed: 0, removed: 0}, fn {key, op}, stats ->
-      key_exists = MapSet.member?(existing_keys, key)
-
-      case {op, key_exists} do
-        {{:set, _}, true} -> %{stats | changed: stats.changed + 1}
-        {{:set, _}, false} -> %{stats | added: stats.added + 1}
-        {:clear, true} -> %{stats | removed: stats.removed + 1}
-        {:clear, false} -> stats
-      end
-    end)
-  end
-
-  # Fast binary scan to check if a key exists in a page
-  defp page_contains_key?(page, target_key) do
-    case Page.locator_for_key(page, target_key) do
-      {:ok, _locator} -> true
-      {:error, :not_found} -> false
-    end
   end
 
   # Check if page boundaries (first_key/last_key) changed

--- a/lib/bedrock/data_plane/materializer/olivine/server.ex
+++ b/lib/bedrock/data_plane/materializer/olivine/server.ex
@@ -8,7 +8,6 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Server do
   alias Bedrock.DataPlane.Materializer
   alias Bedrock.DataPlane.Materializer.Olivine.DataDatabase
   alias Bedrock.DataPlane.Materializer.Olivine.Index
-  alias Bedrock.DataPlane.Materializer.Olivine.Index.Page
   alias Bedrock.DataPlane.Materializer.Olivine.IndexDatabase
   alias Bedrock.DataPlane.Materializer.Olivine.IndexManager
   alias Bedrock.DataPlane.Materializer.Olivine.IntakeQueue
@@ -473,7 +472,6 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Server do
 
     # Build index structures from in-memory compacted pages
     new_tree = Index.Tree.from_page_map(compacted_pages)
-    compacted_key_count = Enum.sum(Enum.map(compacted_pages, fn {_, {page, _}} -> Page.key_count(page) end))
 
     # Get max_keys_per_page from the durable version's index
     {^durable_version, {durable_index, _modified}} =
@@ -485,6 +483,8 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Server do
       max_keys_per_page: durable_index.max_keys_per_page,
       target_keys_per_page: durable_index.target_keys_per_page
     }
+
+    compacted_key_count = Index.key_count(new_index)
 
     new_index_manager = %IndexManager{
       versions: [{durable_version, {new_index, %{}}}],

--- a/lib/bedrock/data_plane/materializer/olivine/server.ex
+++ b/lib/bedrock/data_plane/materializer/olivine/server.ex
@@ -473,7 +473,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Server do
 
     # Build index structures from in-memory compacted pages
     new_tree = Index.Tree.from_page_map(compacted_pages)
-    {min_key, max_key} = calculate_key_bounds_from_pages(compacted_pages)
+    compacted_key_count = Enum.sum(Enum.map(compacted_pages, fn {_, {page, _}} -> Page.key_count(page) end))
 
     # Get max_keys_per_page from the durable version's index
     {^durable_version, {durable_index, _modified}} =
@@ -482,8 +482,6 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Server do
     new_index = %Index{
       tree: new_tree,
       page_map: compacted_pages,
-      min_key: min_key,
-      max_key: max_key,
       max_keys_per_page: durable_index.max_keys_per_page,
       target_keys_per_page: durable_index.target_keys_per_page
     }
@@ -496,7 +494,10 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Server do
       output_queue: :queue.new(),
       last_version_ended_at_offset: 0,
       window_lag_time_μs: 5_000_000,
-      n_keys: IndexManager.info(t.index_manager, :n_keys)
+      # The cutover rewinds to the durable snapshot and the stream re-delivers
+      # everything ingested since, so the count must rewind with it: carrying
+      # the live count forward would double every replayed transaction.
+      n_keys: compacted_key_count
     }
 
     # Reset state for replay
@@ -510,15 +511,13 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Server do
     }
 
     # Emit completion telemetry
-    values_compacted = Enum.sum(Enum.map(compacted_pages, fn {_, {page, _}} -> Page.key_count(page) end))
-
     OlivineTelemetry.trace_compaction_complete(durable_version,
       duration_μs: duration,
       data_size_before: data_size_before,
       data_size_after: new_data_offset,
       index_size_before: index_size_before,
       index_size_after: index_offset,
-      values_compacted: values_compacted
+      values_compacted: compacted_key_count
     )
 
     # Optionally upload snapshot to ObjectStorage (async, fire-and-forget)
@@ -702,29 +701,4 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Server do
   end
 
   defp schedule_waiter_expiration(_previous_manager, _updated_manager, _wait_ms), do: :ok
-
-  # Calculate min/max key bounds from page_map
-  defp calculate_key_bounds_from_pages(page_map) when map_size(page_map) == 0, do: {<<0xFF, 0xFF>>, <<>>}
-
-  defp calculate_key_bounds_from_pages(page_map) do
-    min_key =
-      page_map
-      |> Enum.map(fn {_id, {page, _next}} -> Page.left_key(page) end)
-      |> Enum.reject(&is_nil/1)
-      |> case do
-        [] -> <<0xFF, 0xFF>>
-        keys -> Enum.min(keys)
-      end
-
-    max_key =
-      page_map
-      |> Enum.map(fn {_id, {page, _next}} -> Page.right_key(page) end)
-      |> Enum.reject(&is_nil/1)
-      |> case do
-        [] -> <<>>
-        keys -> Enum.max(keys)
-      end
-
-    {min_key, max_key}
-  end
 end

--- a/lib/bedrock/data_plane/materializer/olivine/telemetry.ex
+++ b/lib/bedrock/data_plane/materializer/olivine/telemetry.ex
@@ -10,17 +10,12 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Telemetry do
     Telemetry.trace_read_operation_complete(operation, key, opts)
   end
 
-  @spec trace_index_update_complete(non_neg_integer(), non_neg_integer(), non_neg_integer(), non_neg_integer()) :: :ok
-  def trace_index_update_complete(keys_added, keys_removed, keys_changed, total_keys) do
-    total_keys_affected = keys_added + keys_removed + keys_changed
-
+  @spec trace_index_update_complete(integer(), non_neg_integer()) :: :ok
+  def trace_index_update_complete(key_count_delta, total_keys) do
     Telemetry.emit_materializer_operation(
       :index_update_complete,
       %{
-        keys_added: keys_added,
-        keys_removed: keys_removed,
-        keys_changed: keys_changed,
-        total_keys_affected: total_keys_affected,
+        key_count_delta: key_count_delta,
         total_keys: total_keys
       },
       %{}

--- a/test/bedrock/data_plane/materializer/olivine/compaction_cutover_test.exs
+++ b/test/bedrock/data_plane/materializer/olivine/compaction_cutover_test.exs
@@ -109,6 +109,15 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.CompactionCutoverTest do
     Transaction.encode(%{mutations: [{:set, "key", value}], commit_version: version})
   end
 
+  # One new key per version, so a version applied twice is visible in the count.
+  defp distinct_slice(version, key) do
+    Transaction.encode(%{mutations: [{:set, key, "v"}], commit_version: version})
+  end
+
+  defp await_key(pid, version, key) do
+    assert {:ok, "v"} = GenServer.call(pid, {:get, key, version, [wait_ms: 15_000]}, 20_000)
+  end
+
   # Generous waits: under full-suite parallelism the stream round-trips
   # (discovery, pull, apply, read wake-up) share cores with everything else.
   defp await_value(pid, version, expected) do
@@ -175,6 +184,43 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.CompactionCutoverTest do
     resumed_from = Version.increment(durable_version)
     assert_receive {:pulled, ^resumed_from}, 15_000
     assert_pulls_monotonic(resumed_from)
+  end
+
+  # The rewind is the whole point of the cutover, so the key count has to
+  # rewind with it: the replayed suffix adds its keys a second time, and a
+  # count carried over from the live index would count them twice.
+  test "the key count rewinds with the index and is rebuilt by the replay",
+       %{tmp_dir: tmp_dir} do
+    {:ok, shard_server} = ReplayShardServer.start_link(self())
+    {:ok, log_stub} = StubLog.start_link(shard_server)
+
+    pid = start_worker(tmp_dir)
+    unlock_with_stream(pid, log_stub)
+
+    v1000 = Version.from_integer(1_000)
+    v2000 = Version.from_integer(2_000)
+    v3000 = Version.from_integer(3_000)
+
+    :ok = ReplayShardServer.append(shard_server, v1000, distinct_slice(v1000, "k1"))
+    await_key(pid, v1000, "k1")
+
+    state = :sys.get_state(pid)
+    {:ok, task} = Logic.start_compaction(state)
+    assert_receive {:compaction_ready, _, _, _, _, _, _, _, _, _, _, _} = cutover_msg, 10_000
+    Task.await(task)
+
+    :ok = ReplayShardServer.append(shard_server, v2000, distinct_slice(v2000, "k2"))
+    :ok = ReplayShardServer.append(shard_server, v3000, distinct_slice(v3000, "k3"))
+    await_key(pid, v3000, "k3")
+
+    assert {:ok, %{n_keys: 3}} = GenServer.call(pid, {:info, [:n_keys]})
+
+    send(pid, cutover_msg)
+
+    # After the replay all three keys are back — and counted exactly once.
+    await_key(pid, v3000, "k3")
+    assert {:ok, %{n_keys: 3}} = GenServer.call(pid, {:info, [:n_keys]})
+    assert {:ok, %{key_ranges: [{"k1", "k3"}]}} = GenServer.call(pid, {:info, [:key_ranges]})
   end
 
   test "a superseded puller's queued ingest is acknowledged and discarded",

--- a/test/bedrock/data_plane/materializer/olivine/index_manager_test.exs
+++ b/test/bedrock/data_plane/materializer/olivine/index_manager_test.exs
@@ -92,6 +92,25 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.IndexManagerTest do
       assert rolled.current_version == v1
     end
 
+    # The resumed stream re-delivers the discarded suffix, so a count that
+    # did not rewind with the index would tally those transactions twice.
+    test "the key count rewinds with the index" do
+      db = create_test_database()
+      im = IndexManager.new()
+
+      v1 = Version.from_integer(1_000)
+      v2 = Version.from_integer(2_000)
+
+      {im, db} = IndexManager.apply_transactions(im, [test_transaction([{:set, "a", "1"}], v1)], db)
+      {im, _db} = IndexManager.apply_transactions(im, [test_transaction([{:set, "b", "2"}, {:set, "c", "3"}], v2)], db)
+      assert IndexManager.info(im, :n_keys) == 3
+
+      rolled = IndexManager.rollback_to(im, v1)
+
+      assert IndexManager.info(rolled, :n_keys) == 1
+      assert IndexManager.info(rolled, :key_ranges) == [{"a", "a"}]
+    end
+
     test "a rollback at or above the current version is a no-op" do
       db = create_test_database()
       im = IndexManager.new()

--- a/test/bedrock/data_plane/materializer/olivine/index_manager_test.exs
+++ b/test/bedrock/data_plane/materializer/olivine/index_manager_test.exs
@@ -159,31 +159,119 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.IndexManagerTest do
     end
 
     test "info/2 returns key_ranges with real data after transactions" do
-      # Create a database and apply transactions to get real min/max keys
       database = create_test_database()
 
       try do
-        # Create transaction with keys spanning from "apple" to "zebra"
-        mutations = [
-          {:set, <<"apple">>, <<"value1">>},
-          {:set, <<"zebra">>, <<"value2">>}
-        ]
-
-        transaction = test_transaction(mutations, Version.from_integer(1000))
-
-        # Apply transaction and check key ranges
         index_manager = IndexManager.new()
-        {updated_manager, _database} = IndexManager.apply_transaction(index_manager, transaction, database)
 
-        key_ranges = IndexManager.info(updated_manager, :key_ranges)
-        assert [{min_key, max_key}] = key_ranges
+        {index_manager, database} =
+          IndexManager.apply_transaction(
+            index_manager,
+            test_transaction([{:set, "apple", "v1"}, {:set, "zebra", "v2"}], Version.from_integer(1000)),
+            database
+          )
 
-        # Note: Currently the Index doesn't update min/max keys during mutations
-        # This returns the initial empty values. This could be improved in the future.
-        # Initial empty min_key
-        assert min_key == <<0xFF, 0xFF>>
-        # Initial empty max_key
-        assert max_key == <<>>
+        assert [{"apple", "zebra"}] = IndexManager.info(index_manager, :key_ranges)
+
+        # The bounds follow the data: a key outside them widens the range...
+        {index_manager, database} =
+          IndexManager.apply_transaction(
+            index_manager,
+            test_transaction([{:set, "aardvark", "v3"}], Version.from_integer(2000)),
+            database
+          )
+
+        assert [{"aardvark", "zebra"}] = IndexManager.info(index_manager, :key_ranges)
+
+        # ...and clearing the extremes narrows it back.
+        {index_manager, database} =
+          IndexManager.apply_transaction(
+            index_manager,
+            test_transaction([{:clear, "aardvark"}, {:clear, "zebra"}], Version.from_integer(3000)),
+            database
+          )
+
+        assert [{"apple", "apple"}] = IndexManager.info(index_manager, :key_ranges)
+
+        # An index emptied of its keys reports the empty-range sentinel again
+        {index_manager, _database} =
+          IndexManager.apply_transaction(
+            index_manager,
+            test_transaction([{:clear, "apple"}], Version.from_integer(4000)),
+            database
+          )
+
+        assert [{<<0xFF, 0xFF>>, <<>>}] = IndexManager.info(index_manager, :key_ranges)
+      after
+        Database.close(database)
+      end
+    end
+
+    test "info/2 tracks n_keys across sets, clears and range clears" do
+      database = create_test_database()
+
+      try do
+        index_manager = IndexManager.new()
+        assert IndexManager.info(index_manager, :n_keys) == 0
+
+        {index_manager, database} =
+          IndexManager.apply_transaction(
+            index_manager,
+            test_transaction([{:set, "a", "1"}, {:set, "b", "2"}, {:set, "c", "3"}], Version.from_integer(1000)),
+            database
+          )
+
+        assert IndexManager.info(index_manager, :n_keys) == 3
+
+        # Overwriting an existing key is not a new key; clearing a key that
+        # was never there is not a removal.
+        {index_manager, database} =
+          IndexManager.apply_transaction(
+            index_manager,
+            test_transaction([{:set, "a", "1-again"}, {:clear, "zzz"}], Version.from_integer(2000)),
+            database
+          )
+
+        assert IndexManager.info(index_manager, :n_keys) == 3
+
+        {index_manager, database} =
+          IndexManager.apply_transaction(
+            index_manager,
+            test_transaction([{:clear, "b"}], Version.from_integer(3000)),
+            database
+          )
+
+        assert IndexManager.info(index_manager, :n_keys) == 2
+
+        # A range clear over everything that is left lands on zero — never
+        # below it, which is what double-counted removals used to produce.
+        {index_manager, _database} =
+          IndexManager.apply_transaction(
+            index_manager,
+            test_transaction([{:clear_range, "", "zz"}], Version.from_integer(4000)),
+            database
+          )
+
+        assert IndexManager.info(index_manager, :n_keys) == 0
+      after
+        Database.close(database)
+      end
+    end
+
+    test "n_keys counts keys, not pages, once a transaction splits a page" do
+      database = create_test_database()
+
+      try do
+        mutations = for i <- 1..600, do: {:set, "key#{String.pad_leading(to_string(i), 4, "0")}", "v"}
+
+        {index_manager, _database} =
+          IndexManager.apply_transaction(
+            IndexManager.new(),
+            test_transaction(mutations, Version.from_integer(1000)),
+            database
+          )
+
+        assert IndexManager.info(index_manager, :n_keys) == 600
       after
         Database.close(database)
       end

--- a/test/bedrock/data_plane/materializer/olivine/index_test.exs
+++ b/test/bedrock/data_plane/materializer/olivine/index_test.exs
@@ -25,9 +25,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.IndexTest do
 
     %Index{
       tree: tree,
-      page_map: page_map,
-      min_key: <<>>,
-      max_key: <<0xFF, 0xFF>>
+      page_map: page_map
     }
   end
 

--- a/test/bedrock/data_plane/materializer/olivine/index_update_test.exs
+++ b/test/bedrock/data_plane/materializer/olivine/index_update_test.exs
@@ -2,7 +2,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.IndexUpdateTest do
   @moduledoc """
   Behavioral tests for IndexUpdate mutation processing: pending-operation
   merging, multi-page range clears, page 0 protection, chain-following edge
-  cases, empty-page handling, statistics tracking, and atomic mutations.
+  cases, empty-page handling, key-count accounting, and atomic mutations.
   """
   use ExUnit.Case, async: true
 
@@ -62,13 +62,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.IndexUpdateTest do
 
   defp new_update(index, allocator, database, opts \\ []) do
     version = Keyword.get(opts, :version, Version.from_bytes(<<1::64>>))
-    update = IndexUpdate.new(index, version, allocator, database)
-
-    if Keyword.get(opts, :track_statistics, false) do
-      %{update | track_statistics: true}
-    else
-      update
-    end
+    IndexUpdate.new(index, version, allocator, database)
   end
 
   defp run_mutations(index, allocator, database, mutations, opts \\ []) do
@@ -148,8 +142,8 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.IndexUpdateTest do
       {_page, next_id} = Index.get_page_with_next_id!(final_index, 1)
       assert next_id == 3
 
-      # keys_removed counts first-page (b, c), middle-page (d, e, f) and last-page (g, h) keys
-      assert update.keys_removed == 7
+      # The delta covers first-page (b, c), middle-page (d, e, f) and last-page (g, h) keys
+      assert update.key_count_delta == -7
     end
 
     test "clear_range followed by sets of in-range keys in the same batch keeps only the re-set keys", %{
@@ -207,7 +201,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.IndexUpdateTest do
       assert all_keys(final_index) == ["f"]
 
       # a, b from page 0 + c, d from the middle page + e from the last page
-      assert update.keys_removed == 5
+      assert update.key_count_delta == -5
     end
   end
 
@@ -225,7 +219,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.IndexUpdateTest do
       {final_index, _db, final_allocator, _modified} = IndexUpdate.finish(update)
 
       assert all_keys(final_index) == ["a", "b", "d", "e"]
-      assert update.keys_removed == 0
+      assert update.key_count_delta == 0
       assert final_allocator.free_ids == []
       assert final_index.page_map |> Map.keys() |> Enum.sort() == [0, 1, 2]
     end
@@ -242,7 +236,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.IndexUpdateTest do
       {final_index, _db, final_allocator, _modified} = IndexUpdate.finish(update)
 
       assert all_keys(final_index) == ["a", "b"]
-      assert update.keys_removed == 2
+      assert update.key_count_delta == -2
 
       # Page 2 became empty, was deleted, and its id recycled
       refute Map.has_key?(final_index.page_map, 2)
@@ -261,7 +255,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.IndexUpdateTest do
       {final_index, _db, final_allocator, _modified} = IndexUpdate.finish(update)
 
       assert all_keys(final_index) == []
-      assert update.keys_removed == 6
+      assert update.key_count_delta == -6
 
       # All non-zero pages are gone and recycled; page 0 survives
       assert Map.keys(final_index.page_map) == [0]
@@ -297,70 +291,78 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.IndexUpdateTest do
     end
   end
 
-  describe "statistics tracking" do
-    test "small mutation batch (direct path) counts added, changed, and removed keys", %{database: database} do
+  describe "key-count accounting" do
+    test "only sets that introduce a key raise the count", %{database: database} do
       {index, allocator} = build_index([{0, ["k1", "k2", "k3"]}])
 
       update =
-        run_mutations(
-          index,
-          allocator,
-          database,
-          [
-            # set on existing key -> changed
-            {:set, "k1", "new-value"},
-            # set on new key -> added
-            {:set, "k9", "fresh"},
-            # clear on existing key -> removed
-            {:clear, "k2"},
-            # clear on missing key -> no count
-            {:clear, "missing"}
-          ],
-          track_statistics: true
-        )
+        run_mutations(index, allocator, database, [
+          # set on an existing key -> no change
+          {:set, "k1", "new-value"},
+          # sets on new keys -> two more keys
+          {:set, "k8", "fresh"},
+          {:set, "k9", "fresh"}
+        ])
 
-      assert update.keys_added == 1
-      assert update.keys_changed == 1
-      assert update.keys_removed == 1
+      assert update.key_count_delta == 2
+
+      {final_index, _db, _allocator, _modified} = IndexUpdate.finish(update)
+      assert all_keys(final_index) == ["k1", "k2", "k3", "k8", "k9"]
+    end
+
+    test "a clear of a key that was never there costs nothing", %{database: database} do
+      {index, allocator} = build_index([{0, ["k1", "k2", "k3"]}])
+
+      update =
+        run_mutations(index, allocator, database, [
+          {:clear, "k1"},
+          {:clear, "k2"},
+          {:clear, "zzz-missing"}
+        ])
+
+      assert update.key_count_delta == -2
+
+      {final_index, _db, _allocator, _modified} = IndexUpdate.finish(update)
+      assert all_keys(final_index) == ["k3"]
+    end
+
+    test "sets and clears in the same batch net out", %{database: database} do
+      {index, allocator} = build_index([{0, ["k1", "k2", "k3"]}])
+
+      update =
+        run_mutations(index, allocator, database, [
+          {:set, "k9", "fresh"},
+          {:clear, "k2"}
+        ])
+
+      assert update.key_count_delta == 0
 
       {final_index, _db, _allocator, _modified} = IndexUpdate.finish(update)
       assert all_keys(final_index) == ["k1", "k3", "k9"]
     end
 
-    test "large mutation batch (MapSet path) counts added, changed, and removed keys", %{database: database} do
-      existing = for i <- 1..8, do: "k#{i}"
+    # A split turns one page into several; the keys move, they do not multiply,
+    # so the delta must still be the number of keys the batch introduced.
+    test "a batch that splits a page counts the added keys once", %{database: database} do
+      existing = for i <- 1..200, do: "k#{String.pad_leading(to_string(i), 4, "0")}"
       {index, allocator} = build_index([{0, existing}])
 
-      # 4 sets on existing keys -> changed
-      # 4 sets on new keys -> added
-      # 3 clears on existing keys -> removed
-      # 1 clear on a missing key -> no count
-      mutations =
-        Enum.map(1..4, fn i -> {:set, "k#{i}", "updated-#{i}"} end) ++
-          Enum.map(1..4, fn i -> {:set, "n#{i}", "new-#{i}"} end) ++
-          Enum.map(5..7, fn i -> {:clear, "k#{i}"} end) ++
-          [{:clear, "zzz-missing"}]
+      new_keys = for i <- 1..100, do: "n#{String.pad_leading(to_string(i), 4, "0")}"
+      update = run_mutations(index, allocator, database, Enum.map(new_keys, &{:set, &1, "v"}))
 
-      assert length(mutations) == 12
-
-      update = run_mutations(index, allocator, database, mutations, track_statistics: true)
-
-      assert update.keys_added == 4
-      assert update.keys_changed == 4
-      assert update.keys_removed == 3
+      assert update.key_count_delta == 100
 
       {final_index, _db, _allocator, _modified} = IndexUpdate.finish(update)
-      assert all_keys(final_index) == Enum.sort(["k1", "k2", "k3", "k4", "k8", "n1", "n2", "n3", "n4"])
+      assert map_size(final_index.page_map) > 1
+      assert length(all_keys(final_index)) == 300
     end
 
-    test "statistics are not accumulated when tracking is disabled", %{database: database} do
-      {index, allocator} = build_index([{0, ["k1", "k2"]}])
+    test "emptying a non-zero page counts every key it held", %{database: database} do
+      {index, allocator} = build_index([{1, ["a", "b"]}])
 
-      update = run_mutations(index, allocator, database, [{:set, "k1", "v"}, {:clear, "k2"}])
+      update = run_mutations(index, allocator, database, [{:clear, "a"}, {:clear, "b"}])
 
-      assert update.keys_added == 0
-      assert update.keys_changed == 0
-      assert update.keys_removed == 0
+      assert update.key_count_delta == -2
     end
   end
 
@@ -370,8 +372,8 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.IndexUpdateTest do
 
       update = run_mutations(index, allocator, database, [{:atomic, :add, "counter", <<5>>}])
 
-      # Atomics are always counted as changes, even for previously-missing keys
-      assert update.keys_changed == 1
+      # An atomic on a missing key materializes it, so the count grows
+      assert update.key_count_delta == 1
 
       {final_index, final_db, _allocator, _modified} = IndexUpdate.finish(update)
 

--- a/test/bedrock/data_plane/materializer/olivine/index_update_test.exs
+++ b/test/bedrock/data_plane/materializer/olivine/index_update_test.exs
@@ -331,14 +331,15 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.IndexUpdateTest do
 
       update =
         run_mutations(index, allocator, database, [
+          {:set, "k8", "fresh"},
           {:set, "k9", "fresh"},
           {:clear, "k2"}
         ])
 
-      assert update.key_count_delta == 0
+      assert update.key_count_delta == 1
 
       {final_index, _db, _allocator, _modified} = IndexUpdate.finish(update)
-      assert all_keys(final_index) == ["k1", "k3", "k9"]
+      assert all_keys(final_index) == ["k1", "k3", "k8", "k9"]
     end
 
     # A split turns one page into several; the keys move, they do not multiply,


### PR DESCRIPTION
Olivine's `IndexManager` advertises two facts about the shard it holds, a live key count and the range those keys span, and it maintained neither. The count could only fall, and went negative on the first range clear; the range was the empty sentinel no matter how much data the index held. Both are now derived from the pages themselves.

Ticket: bedrock-jb4
Closes bedrock-jb4.

## Why

The index update carried four statistics fields behind a `track_statistics` flag that `new/4` set to false "for maximum performance" and nothing ever set to true, so the increments never ran. The decrements did: both range-clear branches subtracted their cleared-key counts outside the flag. Two sets followed by a range clear over both left `n_keys` at -2, in a field typed `non_neg_integer()`.

That count is not decorative: recovery seeds it from the durable index, idle spin-down reports it, and the guard that drops out-of-bounds keys exists to protect it.

The range failed differently. `Index` cached its minimum and maximum key at load time and the mutation path never touched them, so a fresh index kept the inverted sentinel forever. A test pinned that, with a note saying it could be improved later.

Making the count live exposed a third problem. Two paths rewind the in-memory index and let the resumed stream re-deliver the discarded suffix: the compaction cutover and `rollback_to/2`. Both carried the live count across the rewind, which is harmless at a stuck zero and a double-count the moment it is not.

## What changed

The four statistics fields collapse to one signed `key_count_delta`; the flag, the per-key existence scans, and the atomic-mutation counter bump are gone. `Index` gains `key_count/1` and `key_bounds/1`, both page-map scans, and loses its cached bound fields plus the duplicate bounds helper in the cutover. Telemetry now measures `key_count_delta` and `total_keys` instead of four structurally-zero values.

Not changed: `size_in_bytes` and `utilization` stay stubbed, being unimplemented facts rather than broken accounting.

## How it works

The segment merge already returns the page's post-mutation key count, so the delta is that count minus the page header's count, computed once before the empty, oversized, and normal branches. A split adds nothing extra: the same total is redistributed across the new pages.

Range clears are the one adjustment made outside the merge, and only for middle pages deleted wholesale. Boundary and page-0 keys become pending clears on surviving pages, counted when those pages merge. Counting them at both points would double them.

```
2 sets, then a range clear over both
before:  0 -> 0 -> -2
after:   0 -> 2 ->  0
```

Rewinds now follow one rule: when the head index is replaced by an older snapshot, re-derive the count from that snapshot. The replay then climbs back exactly once.

## Verification

New tests cover sets, overwrites, clears of absent keys, range clears to zero, a 600-key transaction that splits pages, and bounds widening and narrowing back to the sentinel. Two rewind tests fail with only their one-line fix reverted, yielding 3 and 5 instead of 1 and 3. CI is green on OTP 27.3, 28.3, 29.0 plus the S3 MinIO job.

Follow-up: bedrock-5yg, pages mutated without being marked modified.
