### PR TITLE
237: Rebuild bootstrap coverage after materializer retirement

### DIFF
--- a/guides/quick-reads/recovery/materializer-bootstrap.md
+++ b/guides/quick-reads/recovery/materializer-bootstrap.md
@@ -1,54 +1,53 @@
 # Materializer Bootstrap
 
-**Get the shard layout back, by asking the materializer that already holds it.**
+**Read the committed shard layout from a verified cache or rebuild that view from durable history.**
 
-Recovery needs to know the cluster's shard boundaries before it can place
-resolvers or route anything. Those boundaries live in the committed keyspace
-under `\xff/system/shard_keys/`, which means recovery has to bring one
-materializer — the one serving the system shard, tag 0 — back online and read
-them out of it.
-
-This phase is deliberately *not* a recruitment phase. Materializers hold
-irreplaceable committed state, so the goal is to reuse the survivors, not to
-replace them.
+The shard boundaries live in `\xff/system/shard_keys/*`, served by tag 0.
+The materializer serving that view is disposable: recovered logs and
+object-storage chunks hold the history. Recovery must make the view readable
+at its chosen recovery version before placing resolvers or routing writes.
 
 ## Fresh Cluster
 
-With no prior logs there is nothing to recover, so the phase invents the
-starting layout: two shards, the system shard (tag 0) covering `0xFF` to the
-end of the keyspace, and the user shard (tag 1) covering everything below
-`0xFF`.
+A bootstrap record with no prior logs means there is no committed history.
+Recovery creates a system materializer and seeds two shards: tag 0 for system
+keys and tag 1 for user keys. Only this fresh path invents a layout.
 
 ## Existing Cluster
 
-1. **Resolve the system materializer by name** from the prior
-   [`CoreState`](../transaction-system-layout.md). It is looked up, never
-   invented — recovery does not guess which worker was serving tag 0.
-2. **Lock it** for this recovery.
-3. **Unlock it** with its replica set of pull sources, so it starts pulling
-   from the logs.
-4. **Wait for catchup** — up to 60 seconds, polling — until it has applied
-   through the recovery version.
-5. **Read the shard layout** from `\xff/system/shard_keys/*`.
+1. Prefer a locked tag-0 cache named by CoreState. Unlock it at the recovery
+   version and let it resume its own stream cursor.
+2. Wait until it can serve that version, then read the shard layout and
+   materializer membership at the same version. Reuse the cache only if the
+   committed family still names its worker and node.
+3. If no named cache is available or the named cache was displaced, recruit a
+   fresh tag-0 worker. Legacy records without cache hints use this path too.
+   The worker starts from a committed snapshot or zero and streams old chunks
+   followed by the recovered WAL suffix through its ShardServer.
+4. Wait for catchup and read the existing layout and membership. An empty
+   layout or failed read stalls recovery; it never becomes a fresh layout.
+5. Carry any new worker into the recovery system transaction so its read
+   coverage is published only after the historical reads succeed.
 
-The `\xff/system/materializers/` family is read alongside it: a family-named
-worker that this epoch locked, whose own shard assignment agrees, is
-re-adopted for its shard. Only a shard with no survivor gets a fresh
-materializer, which rebuilds from its object-storage chunks.
+The distributor owns committed read coverage between recoveries and may
+retire a CoreState-named cache. CoreState's log identities remain durable
+recovery input; its materializer names are only a cache preference. No atomic
+write across the keyspace and bootstrap object is required to keep those
+preferences usable. An arbitrary worker claiming tag 0 is not substituted
+for a missing named cache: reconstruction starts a worker with known replay
+provenance instead.
 
-## Stalls
+## Failures
 
-The phase stalls — and recovery retries — if the named members are
-unavailable, if catchup times out, or if the recovered layout reads empty. An
-empty read is treated as a failure rather than as "this cluster has no
-shards", because the difference matters: see
-[The System Keyspace](../system-keyspace.md).
+Missing capacity, failed worker startup, unavailable history, catchup timeout,
+and failed or empty layout reads stall with their cause. A newly created
+worker that fails before publication is removed. Potentially published workers
+are reconciled against committed membership, so a lost persistence reply is
+never treated as permission to destroy them.
 
 ## Next Phase
 
-Recovery proceeds to [commit proxy startup](proxy-startup.md) with the system
-materializer's pid and the shard layout in hand.
-
----
+Recovery proceeds to [commit proxy startup](proxy-startup.md) with the recovered
+shard layout and system read coverage.
 
 **Implementation**: `lib/bedrock/control_plane/director/recovery/materializer_bootstrap_phase.ex`

--- a/lib/bedrock/control_plane/config/core_state.ex
+++ b/lib/bedrock/control_plane/config/core_state.ex
@@ -1,47 +1,17 @@
 defmodule Bedrock.ControlPlane.Config.CoreState do
   @moduledoc """
-  The durable record a recovery recovers FROM — FDB's `DBCoreState`,
-  held during recovery as `cstate.prevDBState`.
+  The durable bootstrap record consumed by recovery.
 
-  This is the other half of a divide FDB keeps in two structures and
-  Bedrock, until now, kept in one type:
+  Log identities name the previous epoch's durable sources; recovery must
+  establish their recoverable history before starting a new epoch. Transient
+  addresses and process wiring belong in TransactionSystemLayout instead.
 
-    * `CoreState` — DURABLE. Persisted (for us, in the object-storage
-      cluster bootstrap the coordinator loads at cold start), it names
-      what the next recovery must find in order to recover at all.
-      FDB's `DBCoreState` (`DBCoreState.h:132`): the tLog sets, old
-      generations, `recoveryCount`.
-    * `TransactionSystemLayout` — TRANSIENT. Rebuilt every recovery and
-      broadcast so workers can reach each other; it carries pids, which
-      are meaningless the moment the epoch ends. FDB's `ServerDBInfo`,
-      whose own comment reads: "This structure contains transient
-      information which is broadcast to all workers for a database,
-      permitting them to communicate with each other."
-
-  The rule the split makes structural: what must SURVIVE goes here;
-  what must be REACHED goes in the layout. That is why the layout may
-  never carry anything `O(workers)` (see its moduledoc) while this
-  record may — a thing you must recover is worth persisting, a thing
-  you must merely contact is not worth broadcasting.
-
-  ## Why only `logs`
-
-  Recovery consumes exactly one fact from its prior state: which logs
-  the last epoch ran, so it can lock them and copy from them. The
-  durable bootstrap record also carries the epoch, the cluster id and
-  the coordinator set — all read by the coordinator directly, none
-  consumed as recovery's prior state — so projecting them here would
-  add fields with no reader.
-
-  Log LOCATIONS are likewise absent: the bootstrap schema HAS an
-  `otp_ref` per log, but the writer always sets it to nil
-  (`persistence_phase.ex`), because recovery discovers live services
-  through foreman registration rather than trusting a durable address.
-  The record says WHICH logs, never where they were last seen.
-
-  Materializer membership joins this record in bedrock-q67.21.12, for
-  the one shard recovery cannot do without: the system shard, whose
-  keyspace holds the metadata every later phase reads.
+  System materializer names are cached locations for reading bootstrap metadata,
+  not durable-history ownership. The distributor can change their committed
+  membership between recoveries. Recovery verifies a named cache against the
+  membership it reads, or reconstructs tag 0 from recovered logs and chunks when
+  the cache is missing or displaced. Losing every materializer costs replay
+  work; it does not lose the committed shard layout.
   """
 
   alias Bedrock.ControlPlane.Config.LogDescriptor
@@ -74,9 +44,8 @@ defmodule Bedrock.ControlPlane.Config.CoreState do
     %{logs: logs, system_materializers: members_from(bootstrap)}
   end
 
-  # A record written before this field existed names no members. That is
-  # not a crash and not a fresh cluster — it is an upgrade, and recovery
-  # says so rather than guessing where the metadata lives.
+  # Legacy records have no cache hints. Their log history still determines
+  # whether to seed a fresh cluster or reconstruct an existing one.
   defp members_from(bootstrap) do
     bootstrap
     |> Map.get(:system_materializers)
@@ -107,13 +76,10 @@ defmodule Bedrock.ControlPlane.Config.CoreState do
     do: %{logs: Map.get(layout, :logs) || %{}, system_materializers: system_materializers}
 
   @doc """
-  The system shard's materializer members — the record that says WHERE
-  the cluster's metadata lives.
+  Preferred cached locations for the system shard.
 
-  Recovery cannot read the shard layout or the materializers family
-  until it knows which workers hold tag 0, because both live IN tag 0.
-  FDB has the same indirection: its coordinated state names the tlogs
-  that hold the txnStateStore, and recovery peeks them to rebuild it.
+  These may lag committed coverage changes. Recovery can rebuild the metadata
+  view from the independently durable log/chunk history when none is usable.
   """
   @spec system_materializers(t() | nil) :: %{Worker.id() => String.t()}
   def system_materializers(nil), do: %{}

--- a/lib/bedrock/control_plane/director/recovery/materializer_bootstrap_phase.ex
+++ b/lib/bedrock/control_plane/director/recovery/materializer_bootstrap_phase.ex
@@ -1,35 +1,21 @@
 defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhase do
   @moduledoc """
-  Bootstraps the metadata shard materializer for recovery.
+  Makes the system shard readable at the recovery version.
 
-  The metadata materializer holds the authoritative shard layout - the mapping from
-  key ranges to shard tags. This phase ensures the materializer is available and
-  queries it for the current shard layout.
+  Fresh clusters seed the default system/user shard layout. Existing clusters
+  read their committed layout from tag 0 after replaying through the recovery
+  version; they never substitute a default layout for missing history.
 
-  ## Fresh Cluster
+  CoreState's materializer names are preferred cache locations. A locked named
+  worker is reused only if the recovered membership still names it on its node.
+  Missing or displaced caches, and legacy records without names, are rebuilt
+  by a newly recruited worker from the recovered logs and epoch-spanning chunks.
+  Arbitrary tag-0 claimants are never adopted as bootstrap authority.
 
-  For a fresh cluster (no old logs), creates a default shard layout with two shards:
-  - System shard (tag 0): Keys from 0xFF to end-of-keyspace (system metadata)
-  - User shard (tag 1): Keys from empty string to 0xFF (user data)
-
-  ## Existing Cluster
-
-  For an existing cluster:
-  1. Resolve the system materializer BY NAME from the prior core state —
-     it is looked up, never invented (bedrock-q67.21.12)
-  2. Lock it for recovery
-  3. Unlock it with its replica set of pull sources to start pulling
-  4. Wait for it to catch up (60s timeout)
-  5. Query the shard layout from `\\xff/system/shard_keys/*`
-
-  Stalls if the named members are unavailable, if catchup times out, or if
-  the recovered layout reads empty. Records written before the core state
-  carried system materializers take a one-time migration: recovery adopts
-  the sole locked worker claiming tag 0, and refuses to choose when
-  several do (bedrock-q67.21.21).
-
-  Transitions to CommitProxyStartupPhase with the materializer pid and
-  shard layout.
+  Reconstruction waits for catchup and reads both layout and membership at one
+  version before publishing coverage. Failed creation, replay or reads stall;
+  an empty existing-cluster layout is an error. Unpublished created workers
+  are cleaned up on failure. Transitions to CommitProxyStartupPhase on success.
   """
 
   use Bedrock.ControlPlane.Director.Recovery.RecoveryPhase
@@ -170,16 +156,46 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhase do
   # assignment from creation — it is never recovered by inverting a
   # services map) plus the service record ({id, descriptor}) that must
   # travel into transaction_services so the layout references the creation.
-  defp create_and_start_materializer(shard_tag, recovery_attempt, context) do
+  defp create_and_start_materializer(
+         shard_tag,
+         recovery_attempt,
+         context,
+         recovery_version \\ Bedrock.DataPlane.Version.zero()
+       ) do
     with {:ok, node} <- find_materializer_capable_node(context),
          {:ok, {worker_id, worker_ref, node}} <-
-           create_materializer_worker(node, shard_tag, recovery_attempt, context),
-         {:ok, pid} <-
-           lock_new_materializer({:materializer, {worker_ref, node}, shard_tag}, recovery_attempt.epoch, context),
-         :ok <- start_materializer_pulling(pid, shard_tag, recovery_attempt, context) do
-      descriptor = %{kind: :materializer, last_seen: {worker_ref, node}, status: {:up, pid}}
-      {:ok, {worker_id, node, pid}, {worker_id, descriptor}}
+           create_materializer_worker(node, shard_tag, recovery_attempt, context) do
+      case lock_and_start_materializer(
+             {:materializer, {worker_ref, node}, shard_tag},
+             shard_tag,
+             recovery_version,
+             recovery_attempt,
+             context
+           ) do
+        {:ok, pid} ->
+          descriptor = %{kind: :materializer, last_seen: {worker_ref, node}, status: {:up, pid}}
+          {:ok, {worker_id, node, pid}, {worker_id, descriptor}}
+
+        {:error, _} = error ->
+          remove_created_materializer(worker_id, node, recovery_attempt, context)
+          error
+      end
     end
+  end
+
+  defp lock_and_start_materializer(service, shard_tag, recovery_version, recovery_attempt, context) do
+    with {:ok, pid} <- lock_materializer(service, recovery_attempt.epoch, context),
+         :ok <- unlock_and_start_pulling(pid, shard_tag, recovery_version, recovery_attempt, context) do
+      {:ok, pid}
+    end
+  end
+
+  # Only a worker created by this phase and not yet offered to persistence
+  # may be removed here. Existing or potentially published members retire
+  # through committed membership reconciliation, never this cleanup path.
+  defp remove_created_materializer(worker_id, node, recovery_attempt, context) do
+    remove_fn = Map.get(context, :remove_worker_fn, &Foreman.remove_worker/3)
+    remove_fn.({recovery_attempt.cluster.otp_name(:foreman), node}, worker_id, timeout: 5_000)
   end
 
   # Create worker via Foreman for a specific shard. The shard assignment
@@ -199,25 +215,6 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhase do
     end
   end
 
-  # Lock a newly created materializer
-  defp lock_new_materializer(service, epoch, context) do
-    lock_fn = Map.get(context, :lock_materializer_fn, &default_lock_materializer/2)
-    lock_fn.(service, epoch)
-  end
-
-  # Start materializer pulling from its replica set of logs
-  defp start_materializer_pulling(pid, shard_tag, recovery_attempt, context) do
-    # For fresh cluster, start from version zero
-    durable_version = Bedrock.DataPlane.Version.zero()
-    unlock_fn = Map.get(context, :unlock_materializer_fn, &default_unlock_materializer/3)
-
-    case unlock_fn.(pid, durable_version, pull_sources_for_shard(shard_tag, recovery_attempt)) do
-      :ok -> :ok
-      {:error, reason} -> {:error, {:unlock_failed, reason}}
-      {:failure, reason, _ref} -> {:error, {:unlock_failed, reason}}
-    end
-  end
-
   defp handle_existing_cluster(recovery_attempt, context) do
     # Read at the newest version determined during log recovery planning;
     # this is also the cluster's rollback point, and therefore the version
@@ -227,38 +224,15 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhase do
     # would discard real state.)
     {_available_after, recovery_version} = recovery_attempt.version_vector
 
-    # Materializers were locked during the locking phase; their recovery
-    # info carries their shard assignments. Reuse them — they hold the
-    # durable state, including the shard layout this phase exists to read.
+    # Locked caches can save replay work. Their coverage is independent of
+    # the durable log/chunk history, which can reconstruct a missing cache.
     existing_by_shard = existing_materializers_by_shard(recovery_attempt)
 
-    with {:ok, {system_worker_id, materializer_service}} <-
-           resolve_system_materializer(recovery_attempt, context),
-         {:ok, materializer_pid} <- lock_materializer(materializer_service, recovery_attempt.epoch, context),
-         # Unlock with logs so it streams the replayed WAL from the demux
-         :ok <-
-           unlock_and_start_pulling(
-             materializer_pid,
-             RecoveryAttempt.system_shard_id(),
-             recovery_version,
-             recovery_attempt,
-             context
-           ),
-         # It must be able to SERVE the layout query: wait on the applied
-         # position, which the stream advances (durability trails by design)
-         :ok <-
-           wait_for_materializer_catchup(
-             materializer_pid,
-             {RecoveryAttempt.system_shard_id(), recovery_attempt.attempt},
-             recovery_version,
-             context
-           ),
-         {:ok, shard_layout} <- get_shard_layout(materializer_pid, recovery_version, context),
-         :ok <- reject_empty_layout(shard_layout),
-         {:ok, prior_refs} <- read_prior_refs(materializer_pid, recovery_version, context),
+    with {:ok, {system_worker_id, _node, materializer_pid}, shard_layout, prior_refs, bootstrap_services} <-
+           recover_system_shard(recovery_attempt, recovery_version, context),
          {:ok, shard_materializers, created_services} <-
-           ensure_materializers_for_shards(
-             shard_layout,
+           shard_layout
+           |> ensure_materializers_for_shards(
              prefer_family_named(existing_by_shard, prior_refs, recovery_attempt),
              %{
                RecoveryAttempt.system_shard_id() => {system_worker_id, node(materializer_pid), materializer_pid}
@@ -266,12 +240,11 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhase do
              recovery_version,
              recovery_attempt,
              context
-           ) do
-      # Every creation must reach transaction_services: the layout and the
-      # materializers keyspace are built from it, and workers self-retire
-      # when the committed state doesn't name them. The system shard needs
-      # no synthetic entry — it is never created here, only looked up, so
-      # it is already in transaction_services from the locking phase.
+           )
+           |> cleanup_bootstrap_on_failure(bootstrap_services, recovery_attempt, context) do
+      # A reconstructed bootstrap worker must reach transaction_services
+      # and the persistence transaction, just like a fresh-cluster creation.
+      # Its new membership is published only after historical reads succeed.
       updated_attempt =
         recovery_attempt
         |> Map.put(:shard_layout, shard_layout)
@@ -282,7 +255,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhase do
         |> Map.put(:seeded_layout?, false)
         |> Map.put(:prior_materializer_refs, prior_refs)
         |> Map.put(:resolvers, resolver_descriptors_for_layout(shard_layout))
-        |> Map.update!(:transaction_services, &Map.merge(&1, created_services))
+        |> Map.update!(:transaction_services, &(&1 |> Map.merge(bootstrap_services) |> Map.merge(created_services)))
 
       {updated_attempt, CommitProxyStartupPhase}
     else
@@ -290,6 +263,16 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhase do
         {recovery_attempt, {:stalled, reason}}
     end
   end
+
+  defp cleanup_bootstrap_on_failure({:error, _} = error, bootstrap_services, recovery_attempt, context) do
+    for {worker_id, %{last_seen: {_ref, node}}} <- bootstrap_services do
+      remove_created_materializer(worker_id, node, recovery_attempt, context)
+    end
+
+    error
+  end
+
+  defp cleanup_bootstrap_on_failure(result, _bootstrap_services, _recovery_attempt, _context), do: result
 
   # An empty shard_keys family decodes as a SUCCESSFUL read of no shards
   # (Reader.shard_layout_from_entries([]) returns {:ok, %{}}), and nothing
@@ -352,88 +335,68 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhase do
     end)
   end
 
-  # The system shard is LOOKED UP by name. Discovery exists only as
-  # the one-time migration for records that predate the field, and it
-  # refuses to choose when the answer is ambiguous.
-  #
-  # The prior core state names its members, because both durable
-  # families — the shard layout and materializer membership — are served
-  # from tag 0, and recovery cannot read either until it knows who holds
-  # it. FDB has the same indirection and the same discipline: it builds
-  # its log system from exactly the servers the coordinated state names
-  # (TagPartitionedLogSystem.actor.cpp:2549-2585) and waits for a quorum
-  # of THOSE, never substituting another server and never fabricating
-  # one.
-  #
-  # So an unavailable named member is a STALL, not a fallback. Recovery
-  # manufacturing the store its own metadata lives in would come up
-  # "successfully" on an empty layout and orphan the cluster's data;
-  # stalling is retried by the director, and an operator can see why.
-  defp resolve_system_materializer(recovery_attempt, context) do
+  # Materializer names are cache hints, not durability authority. Only the
+  # recovered log/chunk stream owns the history needed to rebuild tag 0.
+  # A warm named cache saves replay work, but its recovered membership must
+  # still authorize it before recovery republishes that assignment.
+  defp recover_system_shard(recovery_attempt, recovery_version, context) do
     named = CoreState.system_materializers(context.prior_core_state)
 
     case Enum.min(available_named_members(named, recovery_attempt), fn -> nil end) do
       {worker_id, service} ->
-        {:ok, {worker_id, service}}
+        with {:ok, pid} <-
+               lock_and_start_materializer(
+                 service,
+                 RecoveryAttempt.system_shard_id(),
+                 recovery_version,
+                 recovery_attempt,
+                 context
+               ),
+             {:ok, layout, refs} <- read_system_metadata(pid, recovery_version, recovery_attempt, context) do
+          if get_in(refs, [RecoveryAttempt.system_shard_id(), worker_id]) == Atom.to_string(node(pid)) do
+            {:ok, {worker_id, node(pid), pid}, layout, refs, %{}}
+          else
+            rebuild_system_shard(recovery_attempt, recovery_version, context)
+          end
+        end
 
-      # A record that names NONE predates this field. That is not a lost
-      # cause: the locking phase has already locked every advertised
-      # materializer, and each one reports its own shard_id, so tag 0 can
-      # be READ from evidence rather than invented. Recovery adopts it,
-      # the persistence phase records it, and the next recovery resolves
-      # by name — the migration is one-time and self-healing.
-      nil when named == %{} ->
-        discover_system_materializer(recovery_attempt)
-
-      # A record that DOES name members is authoritative, and substituting
-      # a different worker is the fabrication FDB refuses: it locks
-      # exactly the servers its coordinated state names
-      # (TagPartitionedLogSystem.actor.cpp:2549-2585) and waits for a
-      # quorum of THOSE. So this stalls even with a healthy stranger
-      # available, and the reason carries the nodes to go looking on.
       nil ->
-        {:error, {:system_materializers_unavailable, named}}
+        # No pointer, unavailable named caches, and ambiguous legacy
+        # claimants all take the same controlled reconstruction. A random
+        # tag-0 claimant's reported position is not evidence of completeness.
+        rebuild_system_shard(recovery_attempt, recovery_version, context)
     end
   end
 
-  # The legacy path only, and it adopts exactly one UNAMBIGUOUS survivor.
-  #
-  # Recovery reads which locked worker claims the system shard; it never
-  # creates one. But it also refuses to CHOOSE. This path runs only on
-  # records written before the field existed — precisely the clusters
-  # whose recovery could invent a replacement when a tag-0 node missed
-  # the 2s roll call, so empty strays claiming shard 0 are the expected
-  # population here, not an exotic case. Picking among them by lowest
-  # RANDOM worker id would be a coin toss, and the winner is then written
-  # to the durable record and resolved by name forever: one wrong flip is
-  # permanent.
-  #
-  # So ambiguity stalls, naming the candidates. An operator can see the
-  # choice and make it; recovery cannot make it silently.
-  defp discover_system_materializer(recovery_attempt) do
-    case tag_zero_claimants(recovery_attempt) do
-      [{worker_id, service}] ->
-        Logger.info("Bootstrap record names no system materializers; adopting sole locked survivor #{worker_id}")
+  defp rebuild_system_shard(recovery_attempt, recovery_version, context) do
+    shard_tag = RecoveryAttempt.system_shard_id()
 
-        {:ok, {worker_id, service}}
+    with {:ok, {worker_id, node, pid} = assignment, service} <-
+           create_and_start_materializer(shard_tag, recovery_attempt, context, recovery_version) do
+      case read_system_metadata(pid, recovery_version, recovery_attempt, context) do
+        {:ok, layout, refs} ->
+          {:ok, assignment, layout, refs, Map.new([service])}
 
-      [] ->
-        {:error, :no_system_materializer_found}
-
-      several ->
-        {:error, {:ambiguous_system_materializer, Enum.map(several, fn {worker_id, _} -> worker_id end)}}
+        {:error, _} = error ->
+          remove_created_materializer(worker_id, node, recovery_attempt, context)
+          error
+      end
     end
   end
 
-  # Every locked worker that reports itself serving the system shard,
-  # ordered so the stall reason is stable across attempts.
-  defp tag_zero_claimants(recovery_attempt) do
-    system_shard = RecoveryAttempt.system_shard_id()
-
-    for {worker_id, info} <- Enum.sort(recovery_attempt.materializer_recovery_info_by_id),
-        Map.get(info, :shard_id) == system_shard,
-        %{status: {:up, ref}} <- [Map.get(recovery_attempt.transaction_services, worker_id)],
-        do: {worker_id, {:materializer, ref}}
+  defp read_system_metadata(pid, recovery_version, recovery_attempt, context) do
+    with :ok <-
+           wait_for_materializer_catchup(
+             pid,
+             {RecoveryAttempt.system_shard_id(), recovery_attempt.attempt},
+             recovery_version,
+             context
+           ),
+         {:ok, shard_layout} <- get_shard_layout(pid, recovery_version, context),
+         :ok <- reject_empty_layout(shard_layout),
+         {:ok, prior_refs} <- read_prior_refs(pid, recovery_version, context) do
+      {:ok, shard_layout, prior_refs}
+    end
   end
 
   # A named member counts only if this epoch actually locked it and it

--- a/lib/bedrock/control_plane/director/recovery/persistence_phase.ex
+++ b/lib/bedrock/control_plane/director/recovery/persistence_phase.ex
@@ -144,19 +144,10 @@ defmodule Bedrock.ControlPlane.Director.Recovery.PersistencePhase do
     })
   end
 
-  # Where the metadata lives, recorded out of band. Both durable families
-  # — the shard layout and materializer membership — are served from tag
-  # 0, so the next recovery cannot read either until it knows which
-  # workers hold it. FDB records the same indirection: its coordinated
-  # state names the tlogs that hold the txnStateStore.
-  # The full committed member SET, not just the one member this recovery
-  # adopted. FDB names a set here too and waits for a replication-policy
-  # quorum over it (TagPartitionedLogSystem.actor.cpp:2549-2585 locks
-  # every named tlog; getDurableVersion at :2070-2082 decides on a
-  # quorum of THOSE) — it never substitutes a server, but it also never
-  # depends on one specific server. Recording only the adopted member
-  # would mean losing that single node stalls recovery forever, with a
-  # healthy committed replica sitting right there.
+  # Cache hints for the next recovery, including already committed members
+  # and this recovery's newly published assignment. Distributor changes can
+  # make these stale; the log/chunk record remains the bootstrap authority,
+  # so publication does not require an atomic cross-store membership update.
   defp build_system_materializer_entries(recovery_attempt) do
     system_shard = RecoveryAttempt.system_shard_id()
     adopted = Map.get(recovery_attempt.shard_materializers, system_shard, %{})

--- a/test/bedrock/control_plane/director/recovery/bootstrap_membership_test.exs
+++ b/test/bedrock/control_plane/director/recovery/bootstrap_membership_test.exs
@@ -1,0 +1,404 @@
+defmodule Bedrock.ControlPlane.Director.Recovery.BootstrapMembershipTest do
+  use ExUnit.Case, async: true
+
+  import Bedrock.Test.ControlPlane.RecoveryTestSupport
+
+  alias Bedrock.ControlPlane.Config.CoreState
+  alias Bedrock.ControlPlane.Director.Recovery.CommitProxyStartupPhase
+  alias Bedrock.ControlPlane.Director.Recovery.LogReplayPhase
+  alias Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhase
+  alias Bedrock.ControlPlane.Director.Recovery.PersistencePhase
+  alias Bedrock.ControlPlane.Distributor.Lock
+  alias Bedrock.ControlPlane.Distributor.Server, as: Distributor
+  alias Bedrock.ControlPlane.Distributor.State, as: DistributorState
+  alias Bedrock.DataPlane.Demux.ShardServer
+  alias Bedrock.DataPlane.Materializer
+  alias Bedrock.DataPlane.Materializer.Olivine.Logic
+  alias Bedrock.DataPlane.Materializer.Olivine.Server, as: Olivine
+  alias Bedrock.DataPlane.Transaction
+  alias Bedrock.DataPlane.Version
+  alias Bedrock.ObjectStorage
+  alias Bedrock.ObjectStorage.LocalFilesystem
+  alias Bedrock.SystemKeys
+  alias Bedrock.SystemKeys.ClusterBootstrap
+  alias Bedrock.SystemKeys.Values
+
+  def otp_name_for_worker(id), do: :"bootstrap_membership_#{id}"
+  def otp_name(:foreman), do: :bootstrap_membership_foreman
+  def node_config, do: [object_storage: Process.get({__MODULE__, :backend})]
+
+  defmodule StaleBootstrapToken do
+    @moduledoc false
+    def get_with_version(opts, key) do
+      with {:ok, data, _token} <- LocalFilesystem.get_with_version(opts, key) do
+        {:ok, data, "sha256:stale-token"}
+      end
+    end
+
+    defdelegate put_if_version_matches(opts, key, token, data, write_opts), to: LocalFilesystem
+  end
+
+  defmodule LogDiscovery do
+    @moduledoc false
+    use GenServer
+
+    def start_link(shard), do: GenServer.start_link(__MODULE__, shard)
+    @impl true
+    def init(shard), do: {:ok, shard}
+    @impl true
+    def handle_call({:get_shard_server, 0}, _from, shard), do: {:reply, {:ok, shard}, shard}
+  end
+
+  for {previous_member, publication} <- [
+        {:displaced, :before_system_commit},
+        {:snapshot, :before_system_commit},
+        {:legacy, :before_system_commit},
+        {:dead, :before_add},
+        {:dead, :after_add},
+        {:dead, :before_system_commit},
+        {:dead, :failed_bootstrap_cas},
+        {:dead, :after_bootstrap}
+      ] do
+    @tag :tmp_dir
+    test "#{previous_member} cache with crash #{publication} preserves authoritative bootstrap history", %{
+      tmp_dir: path
+    } do
+      backend = ObjectStorage.backend(LocalFilesystem, root: Path.join(path, "objects"))
+      {:ok, shard} = ShardServer.start_link(shard_id: 0, cluster: __MODULE__, object_storage: backend)
+      {:ok, log} = start_supervised({LogDiscovery, shard})
+      on_exit(fn -> if Process.alive?(shard), do: GenServer.stop(shard) end)
+      w1 = "old_#{System.unique_integer([:positive])}"
+      w2 = "replacement_#{System.unique_integer([:positive])}"
+      node_string = Atom.to_string(node())
+      layout = %{"m" => {7, ""}, <<0xFF>> => {9, "m"}, Bedrock.end_of_keyspace() => {0, <<0xFF>>}}
+      v100 = Version.from_integer(100)
+      v200 = Version.from_integer(200)
+      v300 = Version.from_integer(300)
+
+      seed =
+        Enum.map(layout, fn {end_key, {tag, start_key}} ->
+          {:set, SystemKeys.shard_key(end_key), Values.encode_shard_key_entry(tag, start_key)}
+        end) ++ [{:set, SystemKeys.materializer_key(0, w1), Values.encode_materializer_node(node_string)}]
+
+      push(shard, 100, seed)
+      ShardServer.flush(shard, v100)
+      assert_receive {:durable, ^shard, 0, ^v100}, 5_000
+
+      old = start_materializer(path, w1)
+      unlock(old, 1, log, v100)
+      assert {:ok, _} = Materializer.get(old, SystemKeys.materializer_key(0, w1), v100, wait_ms: 5_000)
+      checkpoint = Path.join(path, "checkpoint")
+
+      if unquote(previous_member) == :snapshot do
+        :sys.replace_state(old, fn state ->
+          state = %{
+            state
+            | index_manager: %{state.index_manager | window_lag_time_μs: 0},
+              known_committed_version: v100
+          }
+
+          {:ok, state} = Logic.advance_window(state)
+          state
+        end)
+
+        File.mkdir_p!(checkpoint)
+        for name <- ["data", "idx"], do: File.cp!(Path.join([path, w1, name]), Path.join(checkpoint, name))
+      end
+
+      replacement = start_materializer(path, w2)
+      unlock(replacement, 1, log, v100)
+
+      {lock, _} = Lock.take(nil, nil)
+      counter = :counters.new(1, [])
+      :counters.put(counter, 1, 100)
+
+      deps = %{
+        epoch: 1,
+        proxies: [:proxy],
+        next_read_version_fn: fn -> {:ok, Version.from_integer(:counters.get(counter, 1))} end,
+        get_fn: fn _key, _version -> {:ok, lock.my_owner} end,
+        commit_fn: fn _proxy, 1, encoded, _opts ->
+          :counters.add(counter, 1, 100)
+          version = :counters.get(counter, 1)
+          push(shard, version, Transaction.mutations!(encoded))
+          {:ok, Version.from_integer(version), 0}
+        end
+      }
+
+      state = %DistributorState{
+        cluster: __MODULE__,
+        epoch: 1,
+        director: self(),
+        director_monitor: make_ref(),
+        lock: lock,
+        deps: deps,
+        placeholder: self(),
+        snapshot: %{shard_layout: layout, materializer_refs: %{0 => %{w1 => node_string}}}
+      }
+
+      assert {:noreply, state} =
+               Distributor.handle_info({:recruitment_complete, 0, {:ok, replacement, node(), w2}}, state)
+
+      assert state.snapshot.materializer_refs[0] |> Map.keys() |> Enum.sort() == Enum.sort([w1, w2])
+      assert {:ok, _} = Materializer.get(replacement, SystemKeys.materializer_key(0, w2), v200, wait_ms: 5_000)
+
+      if unquote(previous_member) == :dead, do: stop_supervised!(w1)
+      monitor = make_ref()
+      state = %{state | assignment_monitors: Map.put(state.assignment_monitors, monitor, {0, w1})}
+      assert {:noreply, retired} = Distributor.handle_info({:DOWN, monitor, :process, old, :killed}, state)
+      assert retired.snapshot.materializer_refs[0] == %{w2 => node_string}
+
+      assert {:error, :not_found} =
+               Materializer.get(replacement, SystemKeys.materializer_key(0, w1), v300, wait_ms: 5_000)
+
+      # Recovery creates a new log's ShardServer: no inherited durable
+      # watermark or buffer. Only the retained WAL suffix is replayed;
+      # rebuilding the layout requires independently reading the old chunk.
+      {:ok, new_shard} = ShardServer.start_link(shard_id: 0, cluster: __MODULE__, object_storage: backend)
+      on_exit(fn -> if Process.alive?(new_shard), do: GenServer.stop(new_shard) end)
+      assert ShardServer.durable_version(new_shard) == nil
+
+      for {version, encoded} <- Enum.reverse(:sys.get_state(shard).buffer) do
+        ShardServer.push(new_shard, version, encoded, v300)
+      end
+
+      {:ok, new_log} = start_supervised(Supervisor.child_spec({LogDiscovery, new_shard}, id: :new_log))
+
+      # Epoch 2 still names w1 out of band, despite the committed family
+      # having replaced it. An arbitrary tag-0 claim is not recovery authority.
+      assert {:ok, ^replacement, info} = Materializer.lock_for_recovery(replacement, 2)
+
+      attempt =
+        recovery_attempt(%{
+          cluster: __MODULE__,
+          epoch: 2,
+          logs: %{"log" => []},
+          version_vector: {v100, v300},
+          materializer_recovery_info_by_id: %{w2 => info},
+          transaction_services: %{
+            w2 => %{kind: :materializer, status: {:up, replacement}},
+            "log" => %{kind: :log, status: {:up, new_log}}
+          }
+        })
+
+      attempt =
+        if unquote(previous_member) in [:displaced, :legacy] do
+          {:ok, ^old, old_info} = Materializer.lock_for_recovery(old, 2)
+
+          %{
+            attempt
+            | materializer_recovery_info_by_id: Map.put(attempt.materializer_recovery_info_by_id, w1, old_info),
+              transaction_services:
+                Map.put(attempt.transaction_services, w1, %{kind: :materializer, status: {:up, old}})
+          }
+        else
+          attempt
+        end
+
+      context =
+        %{
+          prior_core_state: %{
+            logs: %{"prior-log" => []},
+            system_materializers: if(unquote(previous_member) == :legacy, do: %{}, else: %{w1 => node_string})
+          },
+          node_capabilities: %{materializer: [node()]},
+          create_worker_fn: fn _foreman, id, :materializer, opts ->
+            assert opts[:params] == %{"shard_id" => 0}
+
+            if unquote(previous_member) == :snapshot do
+              File.mkdir_p!(Path.join(path, id))
+              for name <- ["data", "idx"], do: File.cp!(Path.join(checkpoint, name), Path.join([path, id, name]))
+            end
+
+            pid = start_materializer(path, id)
+
+            if unquote(previous_member) == :snapshot do
+              assert {:ok, %{current_version: ^v100}} = Materializer.info(pid, [:current_version])
+            end
+
+            {:ok, otp_name_for_worker(id)}
+          end,
+          catchup_poll_interval_ms: 5,
+          catchup_timeout_ms: 5_000
+        }
+        |> recovery_context()
+        |> Map.delete(:read_prior_refs_fn)
+
+      assert {recovered, CommitProxyStartupPhase} = MaterializerBootstrapPhase.execute(attempt, context)
+      assert recovered.shard_layout == layout
+      refute recovered.seeded_layout?
+      assert recovered.prior_materializer_refs[0] == %{w2 => node_string}
+      [{reconstructed_id, ^node_string}] = Map.to_list(recovered.shard_materializers[0])
+      refute reconstructed_id in [w1, w2]
+      assert %{status: {:up, reconstructed}} = recovered.transaction_services[reconstructed_id]
+      assert {:ok, _} = Materializer.get(reconstructed, SystemKeys.shard_key(Bedrock.end_of_keyspace()), v300)
+
+      verify_publication_crash(unquote(publication), backend, context, recovered, %{
+        old_log: log,
+        old_shard: shard,
+        new_log: new_log,
+        new_shard: new_shard,
+        w1: w1,
+        w2: w2,
+        reconstructed_id: reconstructed_id,
+        reconstructed: reconstructed,
+        layout: layout
+      })
+    end
+  end
+
+  defp verify_publication_crash(boundary, {_, opts} = backend, context, recovered, fixture) do
+    original = %{
+      cluster_id: "membership-test",
+      epoch: 1,
+      logs: [%{id: "prior-log", otp_ref: nil, shard_tags: []}],
+      system_materializers: [%{id: fixture.w1, node: Atom.to_string(node())}],
+      coordinators: [%{node: Atom.to_string(node())}],
+      parameters: context.cluster_config.parameters,
+      policies: context.cluster_config.policies
+    }
+
+    assert :ok = ObjectStorage.put(backend, "bootstrap", ClusterBootstrap.to_binary(original))
+
+    Process.put(
+      {__MODULE__, :backend},
+      if(boundary == :failed_bootstrap_cas, do: {StaleBootstrapToken, opts}, else: backend)
+    )
+
+    attempt = %{recovered | proxies: [self()], transaction_system_layout: %{logs: %{"epoch2-log" => []}}}
+    v400 = Version.from_integer(400)
+
+    commit_context =
+      Map.put(context, :commit_transaction_fn, fn _, 2, encoded ->
+        # The recovery transaction is not yet a published epoch: its push
+        # carries the previous KCV, not a fictitious commit confirmation.
+        txn = Transaction.encode(%{mutations: Enum.to_list(Transaction.mutations!(encoded)), commit_version: v400})
+        ShardServer.push(fixture.new_shard, v400, txn, Version.from_integer(300))
+        {:ok, v400, 0}
+      end)
+
+    publish_at_boundary(boundary, attempt, commit_context, fixture, v400)
+
+    assert {:ok, binary} = ObjectStorage.get(backend, "bootstrap")
+    assert {:ok, bootstrap} = ClusterBootstrap.read(binary)
+    core = CoreState.from_bootstrap(bootstrap)
+    expected_log = if boundary == :after_bootstrap, do: "epoch2-log", else: "prior-log"
+    assert Map.keys(core.logs) == [expected_log]
+
+    rv = recovery_version_at_boundary(boundary)
+
+    # Crash all read caches. The next attempt must recover from exactly the
+    # LOG identities still named by the actual bootstrap object; a committed
+    # membership write before failed CAS does not change that identity.
+    for id <- [fixture.w1, fixture.w2, fixture.reconstructed_id], do: stop_supervised(id)
+    {:ok, replayed_shard} = ShardServer.start_link(shard_id: 0, cluster: __MODULE__, object_storage: backend)
+    on_exit(fn -> if Process.alive?(replayed_shard), do: GenServer.stop(replayed_shard) end)
+    assert ShardServer.durable_version(replayed_shard) == nil
+    {:ok, replayed_log} = start_supervised(Supervisor.child_spec({LogDiscovery, replayed_shard}, id: :replayed_log))
+    source_logs = %{"prior-log" => fixture.old_log, "epoch2-log" => fixture.new_log}
+
+    next_attempt =
+      recovery_attempt(%{
+        cluster: __MODULE__,
+        epoch: 3,
+        logs: %{"epoch3-log" => []},
+        old_log_ids_to_copy: Map.keys(core.logs),
+        version_vector: {Version.from_integer(100), rv},
+        service_pids: Map.put(source_logs, "epoch3-log", replayed_log),
+        transaction_services: %{"epoch3-log" => %{kind: :log, status: {:up, replayed_log}}}
+      })
+
+    replay_context =
+      Map.put(context, :copy_log_data_fn, fn "epoch3-log", sources, after_version, through_version, _services ->
+        assert sources == [Map.fetch!(source_logs, expected_log)]
+        {:ok, source_shard} = GenServer.call(hd(sources), {:get_shard_server, 0})
+
+        for {version, encoded} <- Enum.reverse(:sys.get_state(source_shard).buffer),
+            version > after_version and version <= through_version do
+          ShardServer.push(replayed_shard, version, encoded, through_version)
+        end
+
+        {:ok, replayed_log}
+      end)
+
+    assert {next_attempt, Bedrock.ControlPlane.Director.Recovery.SequencerStartupPhase} =
+             LogReplayPhase.execute(next_attempt, replay_context)
+
+    next_context = Map.put(context, :prior_core_state, core)
+    assert {next, CommitProxyStartupPhase} = MaterializerBootstrapPhase.execute(next_attempt, next_context)
+    assert next.shard_layout == fixture.layout
+    refute next.seeded_layout?
+
+    expected_members = members_at_boundary(boundary, fixture)
+
+    assert next.prior_materializer_refs[0] == expected_members
+    [{new_id, _}] = Map.to_list(next.shard_materializers[0])
+    refute new_id in [fixture.w1, fixture.w2, fixture.reconstructed_id]
+  end
+
+  defp publish_at_boundary(boundary, attempt, commit_context, fixture, v400) do
+    case boundary do
+      :failed_bootstrap_cas ->
+        assert {_, {:stalled, {:recovery_system_failed, :bootstrap_version_mismatch}}} =
+                 PersistencePhase.execute(attempt, commit_context)
+
+        assert Process.alive?(fixture.reconstructed)
+
+        assert {:ok, _} =
+                 Materializer.get(fixture.reconstructed, SystemKeys.materializer_key(0, fixture.reconstructed_id), v400,
+                   wait_ms: 5_000
+                 )
+
+      :after_bootstrap ->
+        assert {_, :completed} = PersistencePhase.execute(attempt, commit_context)
+
+      _before_publication ->
+        :ok
+    end
+  end
+
+  defp recovery_version_at_boundary(boundary) do
+    version =
+      case boundary do
+        :before_add -> 100
+        :after_add -> 200
+        :after_bootstrap -> 400
+        _ -> 300
+      end
+
+    Version.from_integer(version)
+  end
+
+  defp members_at_boundary(boundary, fixture) do
+    case boundary do
+      :before_add -> %{fixture.w1 => Atom.to_string(node())}
+      :after_add -> %{fixture.w1 => Atom.to_string(node()), fixture.w2 => Atom.to_string(node())}
+      :after_bootstrap -> %{fixture.w2 => Atom.to_string(node()), fixture.reconstructed_id => Atom.to_string(node())}
+      _ -> %{fixture.w2 => Atom.to_string(node())}
+    end
+  end
+
+  defp start_materializer(path, id) do
+    name = otp_name_for_worker(id)
+
+    {:ok, pid} =
+      start_supervised(%{
+        id: id,
+        start: {GenServer, :start_link, [Olivine, {name, self(), id, Path.join(path, id), [shard_id: 0]}, [name: name]]}
+      })
+
+    assert_receive {:"$gen_cast", {:worker_health, ^id, {:ok, ^pid}}}, 5_000
+    pid
+  end
+
+  defp unlock(pid, epoch, log, rv) do
+    {:ok, ^pid, _} = Materializer.lock_for_recovery(pid, epoch)
+    :ok = Materializer.unlock_after_recovery(pid, rv, [{"log", log}])
+  end
+
+  defp push(shard, version, mutations) do
+    version = Version.from_integer(version)
+    encoded = Transaction.encode(%{mutations: Enum.to_list(mutations), commit_version: version})
+    ShardServer.push(shard, version, encoded, version)
+  end
+end

--- a/test/bedrock/control_plane/director/recovery/materializer_bootstrap_phase_test.exs
+++ b/test/bedrock/control_plane/director/recovery/materializer_bootstrap_phase_test.exs
@@ -9,6 +9,15 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhaseTest 
   alias Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhase
   alias Bedrock.DataPlane.Version
 
+  defp with_named_membership(context) do
+    members =
+      context.prior_core_state
+      |> Map.get(:system_materializers, %{})
+      |> Map.new(fn {id, _node} -> {id, Atom.to_string(node())} end)
+
+    Map.put(context, :read_prior_refs_fn, fn _pid, _version -> {:ok, %{0 => members}} end)
+  end
+
   describe "execute/2" do
     test "for fresh cluster, creates default shard layout and materializers" do
       system_materializer_pid = spawn(fn -> Process.sleep(:infinity) end)
@@ -32,6 +41,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhaseTest 
           }
         ]
         |> create_test_context()
+        |> with_named_membership()
         |> Map.put(:create_worker_fn, fn _foreman_ref, _worker_id, :materializer, _opts ->
           {:ok, :new_materializer_ref}
         end)
@@ -118,6 +128,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhaseTest 
           }
         ]
         |> create_test_context()
+        |> with_named_membership()
         |> Map.put(:create_worker_fn, fn _foreman_ref, _worker_id, :materializer, _opts ->
           {:ok, :new_materializer_ref}
         end)
@@ -155,10 +166,8 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhaseTest 
     end
 
     test "a FRESH cluster stalls when no materializer capable nodes exist" do
-      # Creation is legitimate here and nowhere else: a fresh cluster has
-      # no prior data, so seeding the system shard invents nothing. (An
-      # EXISTING cluster stalls on :no_system_materializers instead — it
-      # must never manufacture the store its metadata lives in.)
+      # Fresh recovery requires capacity to seed a new layout. Existing
+      # recovery also needs capacity when its cached read coverage is lost.
       recovery_attempt = Map.put(recovery_attempt(), :shard_layout, nil)
 
       context =
@@ -171,6 +180,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhaseTest 
           }
         ]
         |> create_test_context()
+        |> with_named_membership()
         |> Map.put(:available_services, %{})
 
       capture_log(fn ->
@@ -212,6 +222,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhaseTest 
           }
         ]
         |> create_test_context()
+        |> with_named_membership()
         |> Map.put(:available_services, %{})
         |> Map.put(:lock_materializer_fn, fn {:materializer, ref}, _epoch -> {:ok, ref} end)
         |> Map.put(:unlock_materializer_fn, fn pid, version, _tsl ->
@@ -277,6 +288,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhaseTest 
           }
         ]
         |> create_test_context()
+        |> with_named_membership()
         |> Map.put(:available_services, %{})
         |> Map.put(:lock_materializer_fn, fn {:materializer, ref}, _epoch -> {:ok, ref} end)
         |> Map.put(:unlock_materializer_fn, fn _pid, _version, _tsl -> :ok end)
@@ -297,40 +309,16 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhaseTest 
       end)
     end
 
-    test "an existing cluster does NOT create a system materializer, even with capacity to spare" do
-      # Available capacity is not a licence to invent. Recovery
-      # manufacturing the store its own metadata lives in would come up
-      # "successfully" on an empty shard layout and orphan the cluster's
-      # data. FDB is unambiguous here: it locks exactly the servers its
-      # coordinated state names and waits for a quorum of THOSE
-      # (TagPartitionedLogSystem.actor.cpp:2549-2585), never substituting
-      # another and never fabricating one.
-      recovery_attempt =
-        recovery_attempt()
-        |> Map.put(:shard_layout, nil)
-        |> Map.put(:logs, %{"log_1" => [0, 1]})
-        |> Map.put(:durable_version, Version.from_integer(100))
-
+    test "an existing cluster reports reconstruction capacity failure" do
       context =
-        [
-          prior_core_state: %{
-            logs: %{"log_1" => [0, 1]},
-            system_materializers: %{"mat_sys" => "node@host"}
-          },
-          node_capabilities: %{
-            log: [Node.self()],
-            materializer: [Node.self()]
-          }
-        ]
-        |> create_test_context()
-        # The named member is not among the services this epoch locked.
-        |> Map.put(:available_services, %{})
-        |> Map.put(:create_worker_fn, fn _f, _i, :materializer, _o ->
-          flunk("recovery invented a system materializer instead of stalling")
-        end)
+        recovery_context(%{
+          prior_core_state: %{logs: %{"old_log" => []}, system_materializers: %{"gone" => "dead@host"}},
+          node_capabilities: %{materializer: [node()]},
+          create_worker_fn: fn _foreman, _id, :materializer, _opts -> {:error, :foreman_unavailable} end
+        })
 
-      assert {_attempt, {:stalled, {:system_materializers_unavailable, %{"mat_sys" => "node@host"}}}} =
-               MaterializerBootstrapPhase.execute(recovery_attempt, context)
+      assert {_, {:stalled, {:failed_to_create_materializer, :foreman_unavailable, 0}}} =
+               MaterializerBootstrapPhase.execute(recovery_attempt(), context)
     end
 
     test "stalls on catchup timeout" do
@@ -360,6 +348,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhaseTest 
           }
         ]
         |> create_test_context()
+        |> with_named_membership()
         |> Map.put(:available_services, %{})
         |> Map.put(:lock_materializer_fn, fn _service, _epoch -> {:ok, materializer_pid} end)
         |> Map.put(:unlock_materializer_fn, fn _pid, _version, _tsl -> :ok end)
@@ -406,6 +395,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhaseTest 
           }
         ]
         |> create_test_context()
+        |> with_named_membership()
         |> Map.put(:available_services, %{})
         |> Map.put(:lock_materializer_fn, fn _service, _epoch -> {:ok, materializer_pid} end)
         |> Map.put(:unlock_materializer_fn, fn _pid, _version, _tsl ->
@@ -418,8 +408,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhaseTest 
     end
 
     test "a FRESH cluster stalls on worker creation failure" do
-      # Seeding tag 0 is the one creation recovery still performs, so it
-      # is the only place a creation failure can stall it.
+      # Fresh-cluster creation reports its existing stage-specific error.
       recovery_attempt = Map.put(recovery_attempt(), :shard_layout, nil)
 
       context =
@@ -431,6 +420,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhaseTest 
           }
         ]
         |> create_test_context()
+        |> with_named_membership()
         |> Map.put(:available_services, %{})
         |> Map.put(:create_worker_fn, fn _foreman_ref, _worker_id, :materializer, _opts ->
           {:error, :foreman_unavailable}
@@ -480,6 +470,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhaseTest 
           }
         ]
         |> create_test_context()
+        |> with_named_membership()
         |> Map.put(:available_services, %{})
         |> Map.put(:lock_materializer_fn, fn {:materializer, ref}, _epoch -> {:ok, ref} end)
         |> Map.put(:unlock_materializer_fn, fn pid, _version, pull_sources ->
@@ -542,6 +533,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhaseTest 
           }
         ]
         |> create_test_context()
+        |> with_named_membership()
         |> Map.put(:available_services, %{})
         |> Map.put(:lock_materializer_fn, fn {:materializer, ref}, _epoch -> {:ok, ref} end)
         |> Map.put(:unlock_materializer_fn, fn _pid, _version, _sources -> :ok end)
@@ -584,7 +576,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhaseTest 
       context =
         existing_context(recovery_version, %{
           read_prior_refs_fn: fn _pid, _version ->
-            {:ok, %{1 => %{"mat_named" => Atom.to_string(node())}}}
+            {:ok, %{0 => %{"mat_sys" => Atom.to_string(node())}, 1 => %{"mat_named" => Atom.to_string(node())}}}
           end
         })
 
@@ -595,7 +587,12 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhaseTest 
                  MaterializerBootstrapPhase.execute(recovery_attempt, context)
 
         assert %{"mat_named" => _node} = updated_attempt.shard_materializers[1]
-        assert updated_attempt.prior_materializer_refs == %{1 => %{"mat_named" => Atom.to_string(node())}}
+
+        assert updated_attempt.prior_materializer_refs == %{
+                 0 => %{"mat_sys" => Atom.to_string(node())},
+                 1 => %{"mat_named" => Atom.to_string(node())}
+               }
+
         refute updated_attempt.seeded_layout?
       end)
     end
@@ -635,7 +632,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhaseTest 
       context =
         existing_context(recovery_version, %{
           read_prior_refs_fn: fn _pid, _version ->
-            {:ok, %{1 => %{"mat_gone" => Atom.to_string(node())}}}
+            {:ok, %{0 => %{"mat_sys" => Atom.to_string(node())}, 1 => %{"mat_gone" => Atom.to_string(node())}}}
           end
         })
 
@@ -691,6 +688,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhaseTest 
           node_capabilities: %{log: [Node.self()], materializer: [Node.self()]}
         ]
         |> create_test_context()
+        |> with_named_membership()
         |> Map.put(:create_worker_fn, fn _foreman_ref, _worker_id, :materializer, _opts ->
           {:ok, :new_materializer_ref}
         end)
@@ -851,124 +849,170 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhaseTest 
     end
   end
 
-  describe "the system shard is looked up; discovery is the legacy migration only" do
-    test "an existing cluster whose core state names no system materializer, and has none to adopt, STALLS" do
-      # Recovery must never manufacture the store its own metadata lives
-      # in. FDB refuses the same way: it builds its log system from
-      # exactly the servers the coordinated state names
-      # (TagPartitionedLogSystem.actor.cpp:2549-2585) and waits for a
-      # quorum of THOSE rather than substituting others.
-      recovery_attempt = recovery_attempt()
+  describe "failed unpublished reconstruction is cleaned up" do
+    for stage <- [:lock, :unlock, :catchup, :timeout, :layout, :empty_layout, :membership] do
+      test "#{stage} failure removes only this phase's newly created worker" do
+        parent = self()
+        rv = Version.from_integer(500)
 
-      context =
-        recovery_context()
-        |> Map.put(:prior_core_state, %{logs: %{"log_1" => [0]}, system_materializers: %{}})
-        |> Map.put(:create_worker_fn, fn _f, _i, _k, _o ->
-          flunk("recovery invented a system materializer instead of stalling")
-        end)
+        context =
+          recovery_context(%{
+            prior_core_state: %{logs: %{"prior" => []}, system_materializers: %{"gone" => "dead@host"}},
+            node_capabilities: %{materializer: [node()]},
+            create_worker_fn: fn _foreman, id, :materializer, _opts ->
+              send(parent, {:created, id})
+              {:ok, :created_ref}
+            end,
+            lock_materializer_fn: fn _, _ -> {:ok, parent} end,
+            unlock_materializer_fn: fn _, ^rv, _ -> :ok end,
+            materializer_info_fn: fn _, [:current_version] -> {:ok, %{current_version: rv}} end,
+            get_shard_layout_fn: fn _, ^rv -> {:ok, %{Bedrock.end_of_keyspace() => {0, <<0xFF>>}}} end,
+            read_prior_refs_fn: fn _, ^rv -> {:ok, %{}} end,
+            remove_worker_fn: fn _foreman, id, _opts ->
+              send(parent, {:removed, id})
+              :ok
+            end,
+            catchup_timeout_ms: 1,
+            catchup_poll_interval_ms: 1
+          })
 
-      assert {_attempt, {:stalled, :no_system_materializer_found}} =
-               MaterializerBootstrapPhase.execute(recovery_attempt, context)
+        {key, function, expected} =
+          case unquote(stage) do
+            :lock ->
+              {:lock_materializer_fn, fn _, _ -> {:error, :lock_failed} end, :lock_failed}
+
+            :unlock ->
+              {:unlock_materializer_fn, fn _, _, _ -> {:error, :unlock_failed} end, {:unlock_failed, :unlock_failed}}
+
+            :catchup ->
+              {:materializer_info_fn, fn _, _ -> {:error, :unavailable} end, {:catchup_info_failed, :unavailable}}
+
+            :timeout ->
+              {:materializer_info_fn, fn _, _ -> {:ok, %{current_version: Version.zero()}} end, :catchup_timeout}
+
+            :layout ->
+              {:get_shard_layout_fn, fn _, _ -> {:error, :layout_unavailable} end, :layout_unavailable}
+
+            :empty_layout ->
+              {:get_shard_layout_fn, fn _, _ -> {:ok, %{}} end, :recovered_shard_layout_is_empty}
+
+            :membership ->
+              {:read_prior_refs_fn, fn _, _ -> {:error, :membership_unavailable} end, :membership_unavailable}
+          end
+
+        attempt = recovery_attempt(%{version_vector: {Version.zero(), rv}})
+        assert {_, {:stalled, ^expected}} = MaterializerBootstrapPhase.execute(attempt, Map.put(context, key, function))
+        assert_receive {:created, id}
+        assert_receive {:removed, ^id}
+        refute_receive {:removed, "gone"}
+      end
     end
+  end
 
-    test "a legacy record naming NO members adopts a locked tag-0 survivor instead of stalling forever" do
-      # The upgrade path. A bootstrap written before system_materializers
-      # existed names nobody, and treating that as unrecoverable bricks
-      # every cluster created before the field: recovery stalls, the
-      # director retries the stall, and every client read hangs.
-      #
-      # The information is not actually lost. The locking phase has
-      # already locked every advertised materializer and each reports its
-      # own shard_id, so tag 0 can be READ from evidence rather than
-      # invented. Recovery then records what it adopted, and the next
-      # recovery takes the named path — a one-time, self-healing
-      # migration.
-      system_pid = spawn(fn -> Process.sleep(:infinity) end)
-      recovery_version = Version.from_integer(500)
+  for warm? <- [false, true], stage <- [:lock, :unlock] do
+    test "data #{stage} failure cleans only new bootstrap cache (warm=#{warm?})" do
+      parent = self()
+      rv = Version.from_integer(500)
+      data = spawn(fn -> Process.sleep(:infinity) end)
+      on_exit(fn -> Process.exit(data, :kill) end)
+      warm? = unquote(warm?)
+      stage = unquote(stage)
+      services = %{"data" => %{kind: :materializer, status: {:up, data}}}
+      info = %{"data" => %{shard_id: 1}}
+      services = if warm?, do: Map.put(services, "warm", %{kind: :materializer, status: {:up, parent}}), else: services
+      info = if warm?, do: Map.put(info, "warm", %{shard_id: 0}), else: info
 
-      recovery_attempt =
-        recovery_attempt()
-        |> Map.put(:shard_layout, nil)
-        |> Map.put(:logs, %{"log_1" => [0]})
-        |> Map.put(:version_vector, {Version.from_integer(0), recovery_version})
-        |> Map.put(:materializer_recovery_info_by_id, %{
-          "mat_legacy" => %{kind: :materializer, shard_id: 0, durable_version: recovery_version}
+      attempt =
+        recovery_attempt(%{
+          version_vector: {Version.zero(), rv},
+          transaction_services: services,
+          materializer_recovery_info_by_id: info
         })
-        |> Map.put(:transaction_services, %{"mat_legacy" => %{kind: :materializer, status: {:up, system_pid}}})
 
       context =
-        recovery_context()
-        # The legacy shape: the field is simply absent from the record.
-        |> Map.put(:prior_core_state, %{logs: %{"log_1" => [0]}})
-        |> Map.put(:lock_materializer_fn, fn {:materializer, ref}, _epoch -> {:ok, ref} end)
-        |> Map.put(:unlock_materializer_fn, fn _pid, _v, _s -> :ok end)
-        |> Map.put(:materializer_info_fn, fn _pid, [:current_version] ->
-          {:ok, %{current_version: recovery_version}}
-        end)
-        |> Map.put(:get_shard_layout_fn, fn _pid, _v ->
-          {:ok, %{Bedrock.end_of_keyspace() => {0, <<0xFF>>}}}
-        end)
-        |> Map.put(:create_worker_fn, fn _f, _i, _k, _o ->
-          flunk("the migration invented a materializer instead of adopting the survivor")
-        end)
-
-      capture_log(fn ->
-        assert {updated_attempt, CommitProxyStartupPhase} =
-                 MaterializerBootstrapPhase.execute(recovery_attempt, context)
-
-        # Recorded, so the persistence phase writes the field and the NEXT
-        # recovery resolves by name. That is what makes it one-time.
-        assert %{"mat_legacy" => _node} =
-                 updated_attempt.shard_materializers[RecoveryAttempt.system_shard_id()]
-      end)
-    end
-
-    test "a named system materializer that is not available STALLS rather than falling back" do
-      recovery_attempt = recovery_attempt()
-
-      context =
-        recovery_context()
-        |> Map.put(:prior_core_state, %{
-          logs: %{"log_1" => [0]},
-          system_materializers: %{"wkr_gone" => "dead@host"}
+        recovery_context(%{
+          prior_core_state: %{logs: %{"prior" => []}, system_materializers: %{"warm" => Atom.to_string(node())}},
+          node_capabilities: %{materializer: [node()]},
+          create_worker_fn: fn _, id, :materializer, _ ->
+            send(parent, {:created, id})
+            {:ok, :created_ref}
+          end,
+          lock_materializer_fn: fn
+            {:materializer, ^data}, _ -> if stage == :lock, do: {:error, :data_lock_failed}, else: {:ok, data}
+            _, _ -> {:ok, parent}
+          end,
+          unlock_materializer_fn: fn pid, ^rv, _ -> if pid == data, do: {:error, :data_unlock_failed}, else: :ok end,
+          materializer_info_fn: fn _, _ -> {:ok, %{current_version: rv}} end,
+          get_shard_layout_fn: fn _, ^rv ->
+            {:ok, %{<<0xFF>> => {1, ""}, Bedrock.end_of_keyspace() => {0, <<0xFF>>}}}
+          end,
+          read_prior_refs_fn: fn _, ^rv ->
+            {:ok, %{0 => %{"warm" => Atom.to_string(node())}, 1 => %{"data" => Atom.to_string(node())}}}
+          end,
+          remove_worker_fn: fn _, id, _ ->
+            send(parent, {:removed, id})
+            :ok
+          end
         })
-        |> Map.put(:create_worker_fn, fn _f, _i, _k, _o ->
-          flunk("recovery invented a replacement for an unavailable named member")
-        end)
 
-      # The reason carries the members and the nodes they were last seen
-      # on: this one is retryable, and that is where to go looking.
-      assert {_attempt, {:stalled, {:system_materializers_unavailable, %{"wkr_gone" => "dead@host"}}}} =
-               MaterializerBootstrapPhase.execute(recovery_attempt, context)
+      expected = if stage == :lock, do: :data_lock_failed, else: {:unlock_failed, :data_unlock_failed}
+      assert {^attempt, {:stalled, {1, ^expected}}} = MaterializerBootstrapPhase.execute(attempt, context)
+
+      if warm? do
+        refute_receive {:created, _}
+      else
+        assert_receive {:created, id}
+        assert_receive {:removed, ^id}
+      end
+
+      refute_receive {:removed, _}
     end
+  end
 
-    test "legacy discovery STALLS when more than one worker claims tag 0" do
-      # The migration runs only on pre-q67.21.12 records — precisely the
-      # clusters whose recovery could invent a replacement when a tag-0
-      # node missed the 2s roll call. So empty strays claiming shard 0
-      # are exactly the population here, and picking by lowest RANDOM
-      # worker id would be a coin toss whose result is then written to
-      # the durable record and resolved by name forever.
-      #
-      # Ambiguity is not a decision recovery gets to make silently.
+  describe "bootstrap cache hints do not replace durable history" do
+    test "legacy ambiguity cannot turn an arbitrary claimant into bootstrap authority" do
       a = spawn(fn -> Process.sleep(:infinity) end)
       b = spawn(fn -> Process.sleep(:infinity) end)
 
-      recovery_attempt =
-        recovery_attempt()
-        |> Map.put(:materializer_recovery_info_by_id, %{
-          "mat_a" => %{kind: :materializer, shard_id: 0, durable_version: Version.from_integer(500)},
-          "mat_b" => %{kind: :materializer, shard_id: 0, durable_version: Version.from_integer(500)}
-        })
-        |> Map.put(:transaction_services, %{
-          "mat_a" => %{kind: :materializer, status: {:up, a}},
-          "mat_b" => %{kind: :materializer, status: {:up, b}}
+      on_exit(fn ->
+        Process.exit(a, :kill)
+        Process.exit(b, :kill)
+      end)
+
+      attempt =
+        recovery_attempt(%{
+          materializer_recovery_info_by_id: %{"a" => %{shard_id: 0}, "b" => %{shard_id: 0}},
+          transaction_services: %{
+            "a" => %{kind: :materializer, status: {:up, a}},
+            "b" => %{kind: :materializer, status: {:up, b}}
+          }
         })
 
-      context = Map.put(recovery_context(), :prior_core_state, %{logs: %{"log_1" => [0]}})
+      context =
+        recovery_context(%{
+          prior_core_state: %{logs: %{"old_log" => []}},
+          node_capabilities: %{},
+          lock_materializer_fn: fn _, _ -> flunk("selected an untrusted claimant") end
+        })
 
-      assert {_attempt, {:stalled, {:ambiguous_system_materializer, ["mat_a", "mat_b"]}}} =
-               MaterializerBootstrapPhase.execute(recovery_attempt, context)
+      assert {_, {:stalled, :no_materializer_capable_nodes}} = MaterializerBootstrapPhase.execute(attempt, context)
+    end
+
+    test "a newer epoch on a named worker cannot be bypassed by reconstruction" do
+      attempt =
+        recovery_attempt(%{
+          materializer_recovery_info_by_id: %{"named" => %{shard_id: 0}},
+          transaction_services: %{"named" => %{kind: :materializer, status: {:up, self()}}}
+        })
+
+      context =
+        recovery_context(%{
+          prior_core_state: %{logs: %{"old_log" => []}, system_materializers: %{"named" => Atom.to_string(node())}},
+          lock_materializer_fn: fn _, _ -> {:error, :newer_epoch_exists} end,
+          create_worker_fn: fn _, _, _, _ -> flunk("bypassed the epoch fence") end
+        })
+
+      assert {_, {:stalled, :newer_epoch_exists}} = MaterializerBootstrapPhase.execute(attempt, context)
     end
 
     test "a recovered shard layout that reads EMPTY stalls instead of completing" do
@@ -1012,32 +1056,6 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhaseTest 
         assert {_attempt, {:stalled, :recovered_shard_layout_is_empty}} =
                  MaterializerBootstrapPhase.execute(recovery_attempt, context)
       end)
-    end
-
-    test "a NAMED-but-unavailable record never falls back to a healthy stranger" do
-      # The invariant the legacy migration must not weaken. Discovery is
-      # for a record that names NOBODY; a record that names someone is
-      # authoritative, and substituting a different worker is exactly the
-      # fabrication FDB refuses. Here a perfectly healthy tag-0
-      # materializer is locked and available — and recovery must still
-      # stall, because the record does not name it.
-      stranger_pid = spawn(fn -> Process.sleep(:infinity) end)
-
-      recovery_attempt =
-        recovery_attempt()
-        |> Map.put(:materializer_recovery_info_by_id, %{
-          "mat_stranger" => %{kind: :materializer, shard_id: 0, durable_version: Version.from_integer(500)}
-        })
-        |> Map.put(:transaction_services, %{"mat_stranger" => %{kind: :materializer, status: {:up, stranger_pid}}})
-
-      context =
-        Map.put(recovery_context(), :prior_core_state, %{
-          logs: %{"log_1" => [0]},
-          system_materializers: %{"wkr_gone" => "dead@host"}
-        })
-
-      assert {_attempt, {:stalled, {:system_materializers_unavailable, %{"wkr_gone" => "dead@host"}}}} =
-               MaterializerBootstrapPhase.execute(recovery_attempt, context)
     end
   end
 end


### PR DESCRIPTION
Recovery reads the shard layout from tag 0, finding a tag-0 materializer by the names it wrote into the object-storage bootstrap record. The distributor also manages tag-0 membership between recoveries, so it can retire the exact worker that record names, and recovery then stalled with a healthy replacement serving the shard. Those names are now a cache preference; a missing or stale cache is rebuilt from durable history.

Ticket: bedrock-q67.21.20
Closes #237

## Why

The shard boundaries and the materializer membership both live in tag 0, so recovery cannot read either until a tag-0 materializer is running. On the base it took the names from the bootstrap record, kept only workers this epoch had locked, and stalled if none survived. That rule came from FoundationDB, whose recorded server set changes only during recovery; Bedrock's changes constantly, and the distributor never touches the bootstrap record.

The resulting failure is all healthy behaviour: recovery records `w1`; the distributor recruits `w2`, then `w1` dies and is retired, leaving the committed family naming only `w2`. The next recovery looks for `w1`, does not find it, and cannot consult the keyspace to learn about `w2`, because reading that keyspace is what it was trying to bootstrap. A survivor withdrawn from the family hit the mirror bug: it was adopted and republished, resurrecting a dropped assignment.

## What changed

Authority moves from the recorded names to the durable stream behind them. A tag-0 materializer is only a read cache: `ShardServer` writes shard-keyed, epoch-spanning chunks that are never deleted, and log replay copies the recovered WAL suffix.

Operator-visible: three stall reasons are deleted, `{:system_materializers_unavailable, named}`, `:no_system_materializer_found`, and `{:ambiguous_system_materializer, ids}`. Those conditions reconstruct instead of stalling, and a stall now names the stage that failed. The distributor keeps tag-0 coverage, and no cross-store write ordering is assumed.

## How it works

A named worker is still preferred, since a warm cache saves replay. Recovery locks and unlocks it at the recovery version, reads the layout and membership at that version, and keeps it only if the membership it just read still names that worker on that worker's node. Otherwise a fresh tag-0 worker is recruited. Its new-epoch `ShardServer` has no durable watermark, so its pull serves retained chunks first and the replayed suffix after, reaching the committed layout rather than an empty one.

```
record names {w1}; committed family names {w2}
lock w1 -> gone  =>  recruit w3
w3 pulls chunk@100, then replayed 200, 300
read membership at 300 -> {w2}; publish {w2, w3}
```

Only a worker this phase created and has not yet offered to persistence is removed on failure; once the recovery transaction commits, a failed bootstrap write leaves it running for membership reconciliation. A lock failure on a named worker, such as a newer-epoch fence, still stalls rather than reconstructing around it.

## Verification

A new integration test reproduces that divergence against real chunk history, real Olivine materializers and the production distributor handlers, then runs bootstrap across four cache states (dead, displaced, snapshot-seeded, legacy nameless) and five publication crash boundaries. On the base the dead cases stalled and the displaced cases re-adopted the withdrawn worker. Unit tests cover cleanup of an unpublished worker at each failing stage. CI on `cc09b0dc` is green on OTP 27.3, 28.3 and 29.0 plus the MinIO S3 job.
