### PR TITLE
238: Validate read conflicts and verify complete resolver verdicts

### DIFF
--- a/lib/bedrock/data_plane/resolver/tree.ex
+++ b/lib/bedrock/data_plane/resolver/tree.ex
@@ -12,7 +12,9 @@ defmodule Bedrock.DataPlane.Resolver.Tree do
   Intervals are represented as tuples of a start and end key paired with a value.
   Operations are provided for both inserting new intervals into the tree and querying
   for existing intervals that overlap a given range. The tree is kept balanced
-  automatically to ensure operations perform optimally.
+  automatically to ensure operations perform optimally. Nodes are ordered by
+  the complete `{start, end}` interval and track the maximum endpoint in their
+  subtree so overlap searches can find intervals spanning a node's start key.
 
   Various utility functions are also provided, including converting the tree into
   a list of its intervals and filtering by a predicate.
@@ -39,7 +41,8 @@ defmodule Bedrock.DataPlane.Resolver.Tree do
           value: Bedrock.version(),
           left: t() | nil,
           right: t() | nil,
-          height: non_neg_integer()
+          height: non_neg_integer(),
+          max_end: Bedrock.key()
         }
   defstruct [
     :start,
@@ -47,7 +50,8 @@ defmodule Bedrock.DataPlane.Resolver.Tree do
     :value,
     :left,
     :right,
-    :height
+    :height,
+    :max_end
   ]
 
   @doc """
@@ -68,29 +72,17 @@ defmodule Bedrock.DataPlane.Resolver.Tree do
 
   def overlap?(nil, _), do: false
 
+  def overlap?(_tree, {start, end_}) when start >= end_, do: false
+
+  def overlap?(%Tree{max_end: max_end}, {start, _end}) when max_end <= start, do: false
+
   def overlap?(%Tree{start: tree_start, end: tree_end} = tree, {start, end_} = range) do
-    if start < tree_end and tree_start < end_ do
-      true
-    else
-      if start < tree.start do
-        overlap?(tree.left, range)
-      else
-        overlap?(tree.right, range)
-      end
-    end
+    (start < tree_end and tree_start < end_) or
+      overlap?(tree.left, range) or
+      (tree_start < end_ and overlap?(tree.right, range))
   end
 
-  def overlap?(%Tree{start: tree_start, end: tree_end} = tree, key) when is_binary(key) do
-    if key >= tree_start and key < tree_end do
-      true
-    else
-      if key < tree_start do
-        overlap?(tree.left, key)
-      else
-        overlap?(tree.right, key)
-      end
-    end
-  end
+  def overlap?(%Tree{} = tree, key) when is_binary(key), do: overlap?(tree, {key, key <> <<0>>})
 
   @doc """
   Inserts a new interval into the tree, balancing it if necessary, and returns
@@ -108,20 +100,20 @@ defmodule Bedrock.DataPlane.Resolver.Tree do
     - The updated interval tree containing the new interval.
   """
   @spec insert(nil | t(), Bedrock.key() | Bedrock.key_range(), Bedrock.version()) :: t()
-  def insert(nil, {start, end_}, value), do: %Tree{start: start, end: end_, value: value, height: 1}
+  def insert(nil, {start, end_}, value), do: %Tree{start: start, end: end_, value: value, height: 1, max_end: end_}
 
-  def insert(%Tree{} = tree, {start, _end} = range, value) do
+  def insert(%Tree{} = tree, {_start, _end} = range, value) do
     cond_result =
       cond do
         # If the range comes before the current tree
-        start < tree.start ->
+        range < {tree.start, tree.end} ->
           %{tree | left: insert(tree.left, range, value)}
 
         # If the range comes after the current tree
-        start > tree.start ->
+        range > {tree.start, tree.end} ->
           %{tree | right: insert(tree.right, range, value)}
 
-        # If the range overlaps or is the same, we can choose to overwrite or handle differently
+        # Only an identical interval replaces its associated value.
         true ->
           %{tree | value: value}
       end
@@ -172,14 +164,14 @@ defmodule Bedrock.DataPlane.Resolver.Tree do
 
   @spec insert_no_balance(nil | t(), Bedrock.key() | Bedrock.key_range(), Bedrock.version()) :: t()
   defp insert_no_balance(nil, {start, end_}, value),
-    do: %Tree{start: start, end: end_, value: value, left: nil, right: nil, height: 1}
+    do: %Tree{start: start, end: end_, value: value, left: nil, right: nil, height: 1, max_end: end_}
 
-  defp insert_no_balance(%Tree{} = tree, {start, _end} = range, value) do
+  defp insert_no_balance(%Tree{} = tree, {_start, _end} = range, value) do
     cond do
-      start < tree.start ->
+      range < {tree.start, tree.end} ->
         %{tree | left: insert_no_balance(tree.left, range, value)}
 
-      start > tree.start ->
+      range > {tree.start, tree.end} ->
         %{tree | right: insert_no_balance(tree.right, range, value)}
 
       true ->
@@ -197,8 +189,16 @@ defmodule Bedrock.DataPlane.Resolver.Tree do
   defp update_height(%Tree{left: left, right: right} = tree) do
     left_height = if left, do: left.height, else: 0
     right_height = if right, do: right.height, else: 0
-    %{tree | height: 1 + max(left_height, right_height)}
+
+    %{
+      tree
+      | height: 1 + max(left_height, right_height),
+        max_end: max(tree.end, max(subtree_max_end(left), subtree_max_end(right)))
+    }
   end
+
+  defp subtree_max_end(nil), do: <<>>
+  defp subtree_max_end(%Tree{max_end: max_end}), do: max_end
 
   @spec balance_factor(t()) :: integer()
   defp balance_factor(%Tree{left: left, right: right}) do

--- a/lib/bedrock/data_plane/transaction.ex
+++ b/lib/bedrock/data_plane/transaction.ex
@@ -137,6 +137,11 @@ defmodule Bedrock.DataPlane.Transaction do
   Automatically selects the most compact opcode variants based on data sizes
   and omits empty sections for optimal space efficiency.
 
+  Read conflicts use `read_conflicts: {read_version, ranges}`. A separate
+  `read_version` field does not supply that version. Nonempty flat lists raise
+  rather than silently dropping conflict checks; omitted, nil, and empty-list
+  read conflicts remain compatible no-read forms.
+
   ## Options
   - `:include_commit_version` - Include placeholder commit version section
   - `:include_transaction_id` - DEPRECATED: Use `:include_commit_version` instead
@@ -180,6 +185,10 @@ defmodule Bedrock.DataPlane.Transaction do
         section = encode_section(@read_conflicts_tag, payload)
         [section | sections]
     end
+  end
+
+  defp add_read_conflicts_section(_sections, %{read_conflicts: [_ | _]}) do
+    raise ArgumentError, "read_conflicts must be {read_version, ranges}, not a nonempty flat list"
   end
 
   defp add_read_conflicts_section(sections, _), do: sections

--- a/test/bedrock/data_plane/resolver/conflict_oracle_test.exs
+++ b/test/bedrock/data_plane/resolver/conflict_oracle_test.exs
@@ -1,0 +1,117 @@
+defmodule Bedrock.DataPlane.Resolver.ConflictOracleTest do
+  use ExUnit.Case, async: true
+  use ExUnitProperties
+
+  alias Bedrock.DataPlane.Resolver.ConflictResolution
+  alias Bedrock.DataPlane.Resolver.Conflicts
+  alias Bedrock.DataPlane.Transaction
+  alias Bedrock.DataPlane.Version
+
+  test "exact verdicts include conflicts, endpoint nonconflicts and discarded aborted writes" do
+    batches = [
+      [
+        tx(nil, [], [point("b")]),
+        tx(0, [point("b")], [point("x")]),
+        tx(0, [point("x")], [point("d")]),
+        tx(0, [{"a", "c"}], []),
+        tx(0, [{"a", "b"}], []),
+        tx(nil, [], [{"m", "p"}]),
+        tx(0, [point("n")], []),
+        tx(0, [point("p")], [])
+      ],
+      [
+        tx(10, [point("b"), point("n")], []),
+        tx(0, [point("b")], []),
+        tx(nil, [], [point("b")]),
+        tx(10, [point("b")], [])
+      ]
+    ]
+
+    assert check_history(batches) == [[1, 3, 6], [1, 3]]
+  end
+
+  test "same-start write ranges preserve all stale-read conflicts in either order" do
+    for writes <- [[{"a", "c"}, {"a", "b"}], [{"a", "b"}, {"a", "c"}]] do
+      assert check_history([[tx(nil, [], writes)], [tx(0, [point("b")], [])]]) == [[], [0]]
+    end
+  end
+
+  test "a spanning write interval in the left subtree still aborts a stale read" do
+    writes = [{"x", "y"}, {"a", "z"}, {"m", "n"}]
+    assert check_history([[tx(nil, [], writes)], [tx(0, [point("p")], [])]]) == [[], [0]]
+  end
+
+  property "complete multi-batch verdicts match independent versioned interval history" do
+    check all(
+            raw_batches <-
+              list_of(list_of(transaction_spec(), min_length: 1, max_length: 10), min_length: 2, max_length: 8),
+            max_runs: 100
+          ) do
+      batches =
+        raw_batches
+        |> Enum.with_index()
+        |> Enum.map(fn {specs, batch_index} ->
+          Enum.map(specs, fn {reads, writes, snapshot} ->
+            read_version = if reads == [], do: nil, else: 10 * rem(snapshot, batch_index + 1)
+            tx(read_version, reads, writes)
+          end)
+        end)
+
+      check_history(batches)
+    end
+  end
+
+  defp transaction_spec do
+    ranges = Enum.map(~w(a b c d), &point/1) ++ [{"a", "b"}, {"a", "c"}, {"b", "d"}, {"c", "d"}]
+    tuple({list_of(member_of(ranges), max_length: 3), list_of(member_of(ranges), max_length: 3), integer(0..20)})
+  end
+
+  defp tx(read_version, reads, writes), do: %{read_version: read_version, reads: reads, writes: writes}
+  defp point(key), do: {key, key <> <<0>>}
+
+  defp check_history(batches) do
+    {_, _, verdicts} =
+      batches
+      |> Enum.with_index(1)
+      |> Enum.reduce({Conflicts.new(), [], []}, fn {batch, n}, {actual, history, verdicts} ->
+        commit_version = n * 10
+        encoded = Enum.map(batch, &encode_checked/1)
+        {history, expected_aborts} = interpret_batch(history, batch, commit_version)
+        {actual, aborts} = ConflictResolution.resolve(actual, encoded, Version.from_integer(commit_version))
+        assert Enum.sort(aborts) == expected_aborts
+        {actual, history, verdicts ++ [expected_aborts]}
+      end)
+
+    verdicts
+  end
+
+  defp encode_checked(%{reads: reads, writes: writes, read_version: version}) do
+    read_version = if is_nil(version), do: nil, else: Version.from_integer(version)
+    encoded = Transaction.encode(%{read_conflicts: {read_version, reads}, write_conflicts: writes})
+    assert {:ok, {^read_version, ^reads}} = Transaction.read_conflicts(encoded)
+    assert {:ok, {{^read_version, ^reads}, ^writes}} = Transaction.read_write_conflicts(encoded)
+    encoded
+  end
+
+  # Plain successful-write history and mathematical half-open intersection.
+  # No production conflict, tree, encoding or resolution helpers calculate verdicts.
+  defp interpret_batch(history, transactions, commit_version) do
+    transactions
+    |> Enum.with_index()
+    |> Enum.reduce({history, []}, fn {transaction, index}, {history, aborted} ->
+      conflict? =
+        Enum.any?(transaction.reads, fn {read_start, read_end} ->
+          Enum.any?(history, fn {write_version, writes} ->
+            write_version > transaction.read_version and
+              Enum.any?(writes, fn {write_start, write_end} ->
+                read_start < write_end and write_start < read_end
+              end)
+          end)
+        end)
+
+      if conflict?,
+        do: {history, aborted ++ [index]},
+        else: {history ++ [{commit_version, transaction.writes}], aborted}
+    end)
+  end
+end

--- a/test/bedrock/data_plane/resolver/conflict_resolution_test.exs
+++ b/test/bedrock/data_plane/resolver/conflict_resolution_test.exs
@@ -1,6 +1,5 @@
 defmodule Bedrock.DataPlane.Resolver.ConflictResolutionTest do
   use ExUnit.Case, async: true
-  use ExUnitProperties
 
   import Bedrock.DataPlane.Resolver.ConflictResolution,
     only: [
@@ -10,41 +9,6 @@ defmodule Bedrock.DataPlane.Resolver.ConflictResolutionTest do
 
   alias Bedrock.DataPlane.Resolver.Conflicts
   alias Bedrock.DataPlane.Transaction
-
-  # Generate a random alphanumeric string of length 1-5 characters for use as database keys
-  def key_generator do
-    string(:alphanumeric, min_length: 1, max_length: 5)
-  end
-
-  # Generate a range where start <= end. Returns a single key if both values are equal,
-  # otherwise returns a properly ordered {start_key, end_key} tuple
-  def range_generator do
-    StreamData.bind(key_generator(), fn v1 ->
-      StreamData.map(key_generator(), fn
-        v2 when v1 > v2 -> {v2, v1}
-        v2 when v1 == v2 -> v1
-        v2 -> {v1, v2}
-      end)
-    end)
-  end
-
-  # Generate keys (99% probability) or ranges (1% probability) to simulate
-  # realistic database access patterns with occasional range operations
-  def key_or_range_generator do
-    one_of([range_generator() | 1..99 |> Enum.map(fn _ -> key_generator() end) |> Enum.to_list()])
-  end
-
-  # Generate realistic read/write patterns for transactions:
-  # - Reads: 1-10 keys/ranges (simulating queries)
-  # - Writes: 1-5 keys/ranges (simulating updates)
-  def reads_and_writes_generator do
-    gen all(
-          reads <- list_of(key_or_range_generator(), min_length: 1, max_length: 10),
-          writes <- list_of(key_or_range_generator(), min_length: 1, max_length: 5)
-        ) do
-      {reads, writes}
-    end
-  end
 
   describe "version merging optimization" do
     test "add_conflicts merges when version matches top version" do
@@ -117,12 +81,14 @@ defmodule Bedrock.DataPlane.Resolver.ConflictResolutionTest do
       # Create a transaction with read version and read conflicts
       transaction_map = %{
         mutations: [{:set, "key1", "value"}],
-        read_conflicts: [{"key1", "key2"}],
-        write_conflicts: [{"key1", "key2"}],
-        read_version: Bedrock.DataPlane.Version.from_integer(50)
+        read_conflicts: {Bedrock.DataPlane.Version.from_integer(50), [{"key1", "key2"}]},
+        write_conflicts: [{"key1", "key2"}]
       }
 
       transaction = Transaction.encode(transaction_map)
+
+      assert Transaction.read_conflicts(transaction) ==
+               {:ok, {Bedrock.DataPlane.Version.from_integer(50), [{"key1", "key2"}]}}
 
       # Should successfully resolve (no prior conflicts)
       write_version = Bedrock.DataPlane.Version.from_integer(100)
@@ -131,102 +97,6 @@ defmodule Bedrock.DataPlane.Resolver.ConflictResolutionTest do
       assert failed_indexes == []
       # New conflict should be added for the write
       assert new_conflicts != conflicts
-    end
-  end
-
-  property "commit/2 commits transactions without conflicts and aborts those with conflicts" do
-    check all(
-            reads_and_writes <-
-              list_of(reads_and_writes_generator(), min_length: 10, max_length: 40),
-            write_version <- integer(1_000_000..100_000_000)
-          ) do
-      initial_conflicts = Conflicts.new()
-
-      # Generate binary transactions with read and write conflicts. The write_version is
-      # used to generate the read version for each transaction. The read
-      # version is used to detect conflicts between reads and writes, and must
-      # be some number that is lower than the index of the transaction.
-      transactions =
-        reads_and_writes
-        |> Enum.with_index()
-        |> Enum.map(fn {{reads, writes}, index} ->
-          read_version = rem(write_version, index + 1) - 1
-          read_version_binary = if read_version >= 0, do: Bedrock.DataPlane.Version.from_integer(read_version)
-
-          # Convert read keys/ranges to conflicts
-          read_conflicts =
-            Enum.map(reads, fn
-              key when is_binary(key) -> {key, key <> "\0"}
-              {start_key, end_key} -> {start_key, end_key}
-            end)
-
-          # Convert write keys/ranges to conflicts
-          write_conflicts =
-            Enum.map(writes, fn
-              key when is_binary(key) -> {key, key <> "\0"}
-              {start_key, end_key} -> {start_key, end_key}
-            end)
-
-          # Create transaction map
-          transaction_map = %{
-            mutations:
-              Enum.map(writes, fn
-                key when is_binary(key) -> {:set, key, "value"}
-                # Use start key for ranges
-                {start_key, _end_key} -> {:set, start_key, "value"}
-              end),
-            read_conflicts: read_conflicts,
-            write_conflicts: write_conflicts,
-            read_version: read_version_binary
-          }
-
-          # Encode to binary
-          Transaction.encode(transaction_map)
-        end)
-
-      # Pattern match the resolve result to extract failed transaction indexes
-      assert {_final_conflicts, failed_indexes} = resolve(initial_conflicts, transactions, write_version)
-
-      # They can't *all* fail...
-      assert length(failed_indexes) < length(transactions)
-
-      # Ensure that the failed indexes are the ones that have conflicts.
-      Enum.each(failed_indexes, fn index ->
-        transactions_up_to_failure = Enum.take(transactions, index)
-
-        # Resolve transactions up to the failure point to build the conflict structure
-        assert {conflicts, failed_indexes} = resolve(initial_conflicts, transactions_up_to_failure, write_version)
-
-        # The first transaction has an empty conflicts structure and should never conflict
-        # with anything.
-        assert index != 0
-
-        # The transactions up to the failed index should not include the one
-        # that has failed (since we're not supposed to have processed it yet.)
-        refute index in failed_indexes
-
-        # Pull out the transaction that failed.
-        failed_transaction = Enum.at(transactions, index)
-
-        # The failed transaction should have read-write conflicts
-        case Transaction.read_write_conflicts(failed_transaction) do
-          {:ok, {read_info, _writes}} ->
-            # Only check read-write conflicts
-            case read_info do
-              {read_version, reads} ->
-                assert :abort == Conflicts.check_conflicts(conflicts, reads, read_version)
-
-              _ ->
-                :ok
-            end
-
-          _ ->
-            assert false, "Failed to extract conflicts from transaction"
-        end
-
-        # The failed transaction should abort when attempted against the conflict structure
-        assert :abort = try_to_resolve_transaction(conflicts, failed_transaction, index)
-      end)
     end
   end
 end

--- a/test/bedrock/data_plane/resolver/tree_extent_test.exs
+++ b/test/bedrock/data_plane/resolver/tree_extent_test.exs
@@ -1,0 +1,80 @@
+defmodule Bedrock.DataPlane.Resolver.TreeExtentTest do
+  use ExUnit.Case, async: true
+  use ExUnitProperties
+
+  alias Bedrock.DataPlane.Resolver.Tree
+
+  test "same-start extents retain their values in either insertion order" do
+    for ranges <- [[{{"a", "b"}, 1}, {{"a", "c"}, 2}], [{{"a", "c"}, 2}, {{"a", "b"}, 1}]],
+        padding <- [[], [{{"m", "n"}, 3}, {{"x", "y"}, 4}]] do
+      tree = Tree.insert_bulk(nil, ranges ++ padding)
+      assert Tree.overlap?(tree, "b")
+      assert {"a", "b", 1} in Tree.to_list(tree)
+      assert {"a", "c", 2} in Tree.to_list(tree)
+      refute tree |> Tree.filter_by_value(&(&1 == 1)) |> Tree.overlap?("b")
+      assert tree |> Tree.filter_by_value(&(&1 == 2)) |> Tree.overlap?("b")
+    end
+  end
+
+  test "search finds an interval spanning the query from the left subtree" do
+    tree = Tree.insert_bulk(nil, [{{"m", "n"}, 1}, {{"a", "z"}, 2}, {{"x", "y"}, 3}])
+    assert Tree.overlap?(tree, "p")
+    assert Tree.overlap?(tree, {"p", "q"})
+    refute Tree.overlap?(tree, "z")
+  end
+
+  test "empty interval queries never overlap and exact duplicate intervals replace values" do
+    tree = nil |> Tree.insert({"a", "z"}, 1) |> Tree.insert({"a", "z"}, 2)
+    assert Tree.to_list(tree) == [{"a", "z", 2}]
+    refute Tree.overlap?(tree, {"m", "m"})
+    refute Tree.overlap?(tree, {"z", "a"})
+  end
+
+  property "insertions and filtering match a plain interval list including subtree metadata" do
+    keys = ~w(a b c d e f g h)
+    ranges = for first <- keys, last <- keys, first < last, do: {first, last}
+
+    check all(
+            entries <- list_of(tuple({member_of(ranges), integer(0..20)}), min_length: 1, max_length: 30),
+            threshold <- integer(0..20),
+            max_runs: 60
+          ) do
+      expected = Map.new(entries)
+      regular = Enum.reduce(entries, nil, fn {range, value}, tree -> Tree.insert(tree, range, value) end)
+      bulk = Tree.insert_bulk(nil, entries)
+
+      for tree <- [regular, bulk] do
+        assert_tree(tree, expected, keys, ranges)
+        filtered = Tree.filter_by_value(tree, &(&1 > threshold))
+        assert_tree(filtered, Map.reject(expected, fn {_, value} -> value <= threshold end), keys, ranges)
+      end
+    end
+  end
+
+  defp assert_tree(tree, expected, keys, queries) do
+    expected_entries = expected |> Enum.map(fn {{first, last}, value} -> {first, last, value} end) |> Enum.sort()
+    assert Tree.to_list(tree) == expected_entries
+    assert_metadata(tree)
+
+    for key <- keys do
+      assert Tree.overlap?(tree, key) == Enum.any?(expected, fn {{first, last}, _} -> first <= key and key < last end)
+    end
+
+    for {first, last} = query <- queries do
+      assert Tree.overlap?(tree, query) ==
+               Enum.any?(expected, fn {{start, stop}, _} -> first < stop and start < last end)
+    end
+  end
+
+  defp assert_metadata(nil), do: {0, <<>>}
+
+  defp assert_metadata(tree) do
+    {left_height, left_max} = assert_metadata(tree.left)
+    {right_height, right_max} = assert_metadata(tree.right)
+    height = 1 + max(left_height, right_height)
+    max_end = max(tree.end, max(left_max, right_max))
+    assert tree.height == height
+    assert tree.max_end == max_end
+    {height, max_end}
+  end
+end

--- a/test/bedrock/data_plane/transaction_read_conflict_shape_test.exs
+++ b/test/bedrock/data_plane/transaction_read_conflict_shape_test.exs
@@ -1,0 +1,38 @@
+defmodule Bedrock.DataPlane.TransactionReadConflictShapeTest do
+  use ExUnit.Case, async: true
+
+  alias Bedrock.DataPlane.Transaction
+  alias Bedrock.DataPlane.Version
+
+  test "rejects nonempty flat read conflicts instead of dropping them" do
+    for extra <- [%{}, %{read_version: Version.from_integer(50)}] do
+      assert_raise ArgumentError, ~r/read_conflicts.*read_version/, fn ->
+        extra |> Map.put(:read_conflicts, [{"a", "b"}]) |> Transaction.encode()
+      end
+    end
+  end
+
+  test "canonical tuple round-trips read ranges and binary version" do
+    reads = [{"a", "b"}, {"c", "c\0"}]
+    version = Version.from_integer(50)
+    encoded = Transaction.encode(%{read_conflicts: {version, reads}})
+    assert {:ok, {^version, ^reads}} = Transaction.read_conflicts(encoded)
+    assert {:ok, {{^version, ^reads}, []}} = Transaction.read_write_conflicts(encoded)
+  end
+
+  test "compatible empty forms remain no-read transactions" do
+    for input <- [%{}, %{read_conflicts: nil}, %{read_conflicts: []}, %{read_conflicts: {nil, []}}] do
+      assert {:ok, {nil, []}} = input |> Transaction.encode() |> Transaction.read_conflicts()
+    end
+  end
+
+  test "nil read version is valid only when there are no read conflicts" do
+    assert_raise ArgumentError, ~r/read_version is nil/, fn ->
+      Transaction.encode(%{read_conflicts: {nil, [{"a", "b"}]}})
+    end
+
+    assert_raise ArgumentError, ~r/read_version is non-nil/, fn ->
+      Transaction.encode(%{read_conflicts: {Version.zero(), []}})
+    end
+  end
+end


### PR DESCRIPTION
The resolver's conflict property built its transactions in a shape the transaction encoder silently drops: a flat list of read ranges with a separate `read_version` key. The abort list was therefore always empty, and every read-abort assertion sat inside a loop that never ran. An independent history oracle replaces the property, the encoder now rejects the flat shape, and two real missed-conflict defects the oracle exposed in the resolver's interval tree are fixed.

Ticket: bedrock-b28
Closes #238
Stacked on: #245 (bedrock-oep/empty-range)

## Why

`Transaction.encode/1` recognises only `read_conflicts: {read_version, ranges}`; anything else falls through a catch-all and no section is written. Such transactions decode as having no reads, so the resolver commits them without checking. The property asserted only that aborts were fewer than transactions, then iterated that empty list, so its body was dead code.

The oracle then found two holes in the AVL interval tree behind range writes. Nodes were keyed by start alone, so writing `[a,c)` after `[a,b)` kept the shorter extent and a later stale read of `b` saw no overlap. Search followed only the binary-search path for the query's start, so `[a,z)` sitting left of a root `[m,n)` was invisible to a stale read of `p`. Both silently commit a read that should abort.

## What changed

- `Transaction.encode/1` raises on a nonempty flat read-conflict list. Omitted, `nil`, `[]` and `{nil, []}` still encode to no section, and the only production caller already builds the tuple, so the commit path is unaffected.
- Tree nodes order by the whole `{start, end}` pair, so only an identical interval replaces a stored value.
- Each node carries `max_end`, the largest endpoint in its subtree, maintained in the height update that every insert, rebalance and filter already passes through.
- Overlap becomes an augmented search: prune on `max_end`, test the node, always descend left, descend right only while a match can still follow.
- The old property and its generators are deleted.

## How it works

The oracle replays batches, batch `n` committing at version `n * 10`, keeping its own list of `{commit_version, writes}` for transactions that committed. A transaction conflicts if any read intersects a write recorded strictly newer than its read version, by half-open arithmetic alone; no production conflict, tree or encoding code participates. The same batch is encoded and handed to `resolve/3`, and the two abort lists must match exactly, so a missed conflict and a spurious abort both fail. Aborted writes enter neither history, keeping the two aligned across batches.

## Verification

Three deterministic histories pin exact per-batch abort lists, including both tree defects, and a property runs multi-batch histories over a dense keyspace of shared starts and exclusive endpoints. Every encode is asserted to round-trip before resolution runs, so a regression of the original bug fails first. Evidence: the same-start miss at seed 500675 (`/tmp/issue238-oracle-baseline.log`), red tree regressions (`/tmp/issue238-tree-red.log`), and a mutant whose `resolve/3` always succeeds failing both new tests (`/tmp/issue238-sensitivity.log`). Local run clean at 2908 tests, audit approved (`/tmp/bedrock-issue-team-20260905/238-final-review.md`), branch is a draft with no CI checks.

This supersedes #248, which addresses the same ticket against `develop`: both add the same encoder raise, and #248 rewrites the property deleted here, so only one should land. #248 uses the production conflict checker as its own oracle, which cannot detect either tree defect.
