### PR TITLE
bedrock-tz1: add mutation-list transaction helper; dedupe create_transaction/2

### DIFF
--- a/test/bedrock/data_plane/materializer/olivine/atomic_operations_test.exs
+++ b/test/bedrock/data_plane/materializer/olivine/atomic_operations_test.exs
@@ -15,7 +15,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.AtomicOperationsTest do
   alias Bedrock.DataPlane.Materializer.Olivine.Index
   alias Bedrock.DataPlane.Materializer.Olivine.IndexManager
   alias Bedrock.DataPlane.Transaction
-  alias Bedrock.DataPlane.Version
+  alias Bedrock.Test.DataPlane.TransactionTestSupport
 
   describe "Olivine IndexManager atomic operations" do
     setup do
@@ -86,24 +86,10 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.AtomicOperationsTest do
   end
 
   defp create_atomic_transaction(mutations, version_int \\ 1) do
-    create_transaction(mutations, version_int)
+    TransactionTestSupport.new_log_transaction_from_mutations(mutations, version_int)
   end
 
   defp create_set_transaction(key, value, version_int) do
-    create_transaction([{:set, key, value}], version_int)
-  end
-
-  defp create_transaction(mutations, version_int) do
-    transaction_map = %{
-      mutations: mutations,
-      read_conflicts: {nil, []},
-      write_conflicts: []
-    }
-
-    encoded = Transaction.encode(transaction_map)
-    version = Version.from_integer(version_int)
-
-    {:ok, with_version} = Transaction.add_commit_version(encoded, version)
-    with_version
+    TransactionTestSupport.new_log_transaction_from_mutations([{:set, key, value}], version_int)
   end
 end

--- a/test/bedrock/data_plane/materializer/olivine/empty_block_squashing_test.exs
+++ b/test/bedrock/data_plane/materializer/olivine/empty_block_squashing_test.exs
@@ -4,8 +4,8 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.EmptyBlockSquashingTest do
   alias Bedrock.DataPlane.Materializer.Olivine.Database
   alias Bedrock.DataPlane.Materializer.Olivine.IndexManager
   alias Bedrock.DataPlane.Materializer.Olivine.TestHelpers
-  alias Bedrock.DataPlane.Transaction
   alias Bedrock.DataPlane.Version
+  alias Bedrock.Test.DataPlane.TransactionTestSupport
 
   defp setup_tmp_dir(context) do
     tmp_dir =
@@ -19,20 +19,6 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.EmptyBlockSquashingTest do
     end)
 
     {:ok, tmp_dir: tmp_dir}
-  end
-
-  defp create_transaction(mutations, version_int) do
-    transaction_map = %{
-      mutations: mutations,
-      read_conflicts: {nil, []},
-      write_conflicts: []
-    }
-
-    encoded = Transaction.encode(transaction_map)
-    version = Version.from_integer(version_int)
-
-    {:ok, with_version} = Transaction.add_commit_version(encoded, version)
-    with_version
   end
 
   defp data_size_in_bytes({data_db, _index_db}), do: data_db.file_offset
@@ -50,7 +36,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.EmptyBlockSquashingTest do
 
       # Version 1: Create initial data
       keys_v1 = [{:set, "initial_key", "initial_value"}]
-      transaction_v1 = create_transaction(keys_v1, 1_000_000)
+      transaction_v1 = TransactionTestSupport.new_log_transaction_from_mutations(keys_v1, 1_000_000)
 
       index_manager = IndexManager.new()
       {index_manager_v1, database_v1} = IndexManager.apply_transactions(index_manager, [transaction_v1], database)
@@ -68,7 +54,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.EmptyBlockSquashingTest do
         )
 
       # Version 2: Empty (no modifications)
-      transaction_v2 = create_transaction([], 2_000_000)
+      transaction_v2 = TransactionTestSupport.new_log_transaction_from_mutations([], 2_000_000)
       {index_manager_v2, database_v2} = IndexManager.apply_transactions(index_manager_v1, [transaction_v2], database_v1)
 
       [{_v2, {_index2, modified_pages_v2}} | _] = index_manager_v2.versions
@@ -83,7 +69,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.EmptyBlockSquashingTest do
         )
 
       # Version 3: Empty again (should squash with v2)
-      transaction_v3 = create_transaction([], 3_000_000)
+      transaction_v3 = TransactionTestSupport.new_log_transaction_from_mutations([], 3_000_000)
       {index_manager_v3, database_v3} = IndexManager.apply_transactions(index_manager_v2, [transaction_v3], database_v2)
 
       [{_v3, {_index3, modified_pages_v3}} | _] = index_manager_v3.versions
@@ -98,7 +84,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.EmptyBlockSquashingTest do
         )
 
       # Version 4: Empty again (should squash with v3)
-      transaction_v4 = create_transaction([], 4_000_000)
+      transaction_v4 = TransactionTestSupport.new_log_transaction_from_mutations([], 4_000_000)
       {index_manager_v4, database_v4} = IndexManager.apply_transactions(index_manager_v3, [transaction_v4], database_v3)
 
       [{_v4, {_index4, modified_pages_v4}} | _] = index_manager_v4.versions
@@ -143,7 +129,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.EmptyBlockSquashingTest do
 
       # Version 1: Create initial data
       keys_v1 = [{:set, "key1", "value1"}]
-      transaction_v1 = create_transaction(keys_v1, 1_000_000)
+      transaction_v1 = TransactionTestSupport.new_log_transaction_from_mutations(keys_v1, 1_000_000)
 
       index_manager = IndexManager.new()
       {index_manager_v1, database_v1} = IndexManager.apply_transactions(index_manager, [transaction_v1], database)
@@ -160,7 +146,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.EmptyBlockSquashingTest do
         )
 
       # Version 2: Empty
-      transaction_v2 = create_transaction([], 2_000_000)
+      transaction_v2 = TransactionTestSupport.new_log_transaction_from_mutations([], 2_000_000)
       {index_manager_v2, database_v2} = IndexManager.apply_transactions(index_manager_v1, [transaction_v2], database_v1)
 
       [{_v2, {_index2, modified_pages_v2}} | _] = index_manager_v2.versions
@@ -176,7 +162,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.EmptyBlockSquashingTest do
 
       # Version 3: Non-empty (should NOT squash)
       keys_v3 = [{:set, "key2", "value2"}]
-      transaction_v3 = create_transaction(keys_v3, 3_000_000)
+      transaction_v3 = TransactionTestSupport.new_log_transaction_from_mutations(keys_v3, 3_000_000)
       {index_manager_v3, database_v3} = IndexManager.apply_transactions(index_manager_v2, [transaction_v3], database_v2)
 
       [{_v3, {_index3, modified_pages_v3}} | _] = index_manager_v3.versions

--- a/test/bedrock/data_plane/materializer/olivine/incremental_loading_test.exs
+++ b/test/bedrock/data_plane/materializer/olivine/incremental_loading_test.exs
@@ -7,8 +7,8 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.IncrementalLoadingTest do
   alias Bedrock.DataPlane.Materializer.Olivine.IndexDatabase
   alias Bedrock.DataPlane.Materializer.Olivine.IndexManager
   alias Bedrock.DataPlane.Materializer.Olivine.TestHelpers
-  alias Bedrock.DataPlane.Transaction
   alias Bedrock.DataPlane.Version
+  alias Bedrock.Test.DataPlane.TransactionTestSupport
 
   defp setup_tmp_dir(context, base_name) do
     tmp_dir =
@@ -22,20 +22,6 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.IncrementalLoadingTest do
     end)
 
     {:ok, tmp_dir: tmp_dir}
-  end
-
-  defp create_transaction(mutations, version_int) do
-    transaction_map = %{
-      mutations: mutations,
-      read_conflicts: {nil, []},
-      write_conflicts: []
-    }
-
-    encoded = Transaction.encode(transaction_map)
-    version = Version.from_integer(version_int)
-
-    {:ok, with_version} = Transaction.add_commit_version(encoded, version)
-    with_version
   end
 
   defp data_size_in_bytes({data_db, _index_db}), do: data_db.file_offset
@@ -69,11 +55,14 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.IncrementalLoadingTest do
 
       # Use timestamps outside the 5-second window (5_000_000 microseconds) to trigger eviction
       # 1 second
-      transaction_v1 = create_transaction(keys_for_page_splits, 1_000_000)
+      transaction_v1 = TransactionTestSupport.new_log_transaction_from_mutations(keys_for_page_splits, 1_000_000)
       # 10 seconds - update existing keys to maintain tree ordering
-      transaction_v2 = create_transaction([{:set, "key_00050", "updated_value"}], 10_000_000)
+      transaction_v2 =
+        TransactionTestSupport.new_log_transaction_from_mutations([{:set, "key_00050", "updated_value"}], 10_000_000)
+
       # 20 seconds
-      transaction_v3 = create_transaction([{:set, "key_00100", "updated_value"}], 20_000_000)
+      transaction_v3 =
+        TransactionTestSupport.new_log_transaction_from_mutations([{:set, "key_00100", "updated_value"}], 20_000_000)
 
       # Apply transactions to build version history
       index_manager = IndexManager.new()
@@ -200,15 +189,15 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.IncrementalLoadingTest do
 
       # Version 1: Create a large set of keys that will create multiple pages (0,1,2,3,4,5)
       keys_v1 = for i <- 1..1000, do: {:set, "old_key_#{String.pad_leading("#{i}", 5, "0")}", "old_value_#{i}"}
-      transaction_v1 = create_transaction(keys_v1, 1_000_000)
+      transaction_v1 = TransactionTestSupport.new_log_transaction_from_mutations(keys_v1, 1_000_000)
 
       # Version 2: Modify some keys, creating new versions of some pages but leaving others unchanged
       keys_v2 = for i <- 1..200, do: {:set, "old_key_#{String.pad_leading("#{i}", 5, "0")}", "updated_value_#{i}"}
-      transaction_v2 = create_transaction(keys_v2, 2_000_000)
+      transaction_v2 = TransactionTestSupport.new_log_transaction_from_mutations(keys_v2, 2_000_000)
 
       # Version 3: Add entirely new keys that will create new pages and potentially modify page chain
       keys_v3 = for i <- 1..300, do: {:set, "new_key_#{String.pad_leading("#{i}", 5, "0")}", "new_value_#{i}"}
-      transaction_v3 = create_transaction(keys_v3, 3_000_000)
+      transaction_v3 = TransactionTestSupport.new_log_transaction_from_mutations(keys_v3, 3_000_000)
 
       # Apply transactions sequentially to build version history
       index_manager = IndexManager.new()
@@ -304,7 +293,9 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.IncrementalLoadingTest do
       {:ok, database} = Database.open(:missing_test, file_path)
 
       # Create some data
-      transaction = create_transaction([{:set, "test_key", "test_value"}], 1_000_000)
+      transaction =
+        TransactionTestSupport.new_log_transaction_from_mutations([{:set, "test_key", "test_value"}], 1_000_000)
+
       index_manager = IndexManager.new()
 
       {_final_index_manager, final_database} =

--- a/test/bedrock/data_plane/materializer/olivine/logic_test.exs
+++ b/test/bedrock/data_plane/materializer/olivine/logic_test.exs
@@ -8,12 +8,12 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.LogicTest do
   alias Bedrock.DataPlane.Materializer.Olivine.Logic
   alias Bedrock.DataPlane.Materializer.Olivine.ReadingTestHelpers
   alias Bedrock.DataPlane.Materializer.Olivine.State
-  alias Bedrock.DataPlane.Transaction
   alias Bedrock.DataPlane.Version
   alias Bedrock.KeySelector
   alias Bedrock.ObjectStorage
   alias Bedrock.ObjectStorage.LocalFilesystem
   alias Bedrock.ObjectStorage.Snapshot
+  alias Bedrock.Test.DataPlane.TransactionTestSupport
 
   setup do
     test_dir = Path.join(System.tmp_dir!(), "olivine_logic_test_#{:rand.uniform(100_000)}")
@@ -43,20 +43,6 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.LogicTest do
 
     {:ok, state} = result
     state
-  end
-
-  # Builds an encoded transaction with a commit version, matching how the
-  # pulling pipeline delivers transactions to apply_transactions/2.
-  defp create_transaction(mutations, version_int) do
-    transaction_map = %{
-      mutations: mutations,
-      read_conflicts: {nil, []},
-      write_conflicts: []
-    }
-
-    encoded = Transaction.encode(transaction_map)
-    {:ok, with_version} = Transaction.add_commit_version(encoded, Version.from_integer(version_int))
-    with_version
   end
 
   describe "startup/4" do
@@ -312,7 +298,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.LogicTest do
     test "applies a single transaction and makes its writes readable", %{test_dir: test_dir} do
       state = create_test_state(test_dir, :apply_single_test)
 
-      txn = create_transaction([{:set, "hello", "world"}], 1)
+      txn = TransactionTestSupport.new_log_transaction_from_mutations([{:set, "hello", "world"}], 1)
 
       assert {:ok, %State{} = updated_state, version} = Logic.apply_transactions(state, [txn])
       assert version == Version.from_integer(1)
@@ -327,9 +313,12 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.LogicTest do
       state = create_test_state(test_dir, :apply_batch_test)
 
       transactions = [
-        create_transaction([{:set, "key_a", "value_a"}], 1),
-        create_transaction([{:set, "key_b", "value_b"}], 2),
-        create_transaction([{:set, "key_c", "value_c"}, {:set, "key_a", "value_a2"}], 3)
+        TransactionTestSupport.new_log_transaction_from_mutations([{:set, "key_a", "value_a"}], 1),
+        TransactionTestSupport.new_log_transaction_from_mutations([{:set, "key_b", "value_b"}], 2),
+        TransactionTestSupport.new_log_transaction_from_mutations(
+          [{:set, "key_c", "value_c"}, {:set, "key_a", "value_a2"}],
+          3
+        )
       ]
 
       assert {:ok, %State{} = updated_state, version} = Logic.apply_transactions(state, transactions)
@@ -366,8 +355,8 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.LogicTest do
       # Both versions are less than window_lag_time_μs apart from the newest,
       # so nothing falls behind the window edge.
       txns = [
-        create_transaction([{:set, "a", "1"}], 1),
-        create_transaction([{:set, "b", "2"}], 2)
+        TransactionTestSupport.new_log_transaction_from_mutations([{:set, "a", "1"}], 1),
+        TransactionTestSupport.new_log_transaction_from_mutations([{:set, "b", "2"}], 2)
       ]
 
       {:ok, state, _version} = Logic.apply_transactions(state, txns)
@@ -384,8 +373,8 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.LogicTest do
       # window_lag_time_μs defaults to 5_000_000. With the newest version at
       # 12_000_000, the window edge is 7_000_000: version 6_000_000 is evicted,
       # version 12_000_000 stays in the window.
-      old_txn = create_transaction([{:set, "old_key", "old_value"}], 6_000_000)
-      new_txn = create_transaction([{:set, "new_key", "new_value"}], 12_000_000)
+      old_txn = TransactionTestSupport.new_log_transaction_from_mutations([{:set, "old_key", "old_value"}], 6_000_000)
+      new_txn = TransactionTestSupport.new_log_transaction_from_mutations([{:set, "new_key", "new_value"}], 12_000_000)
 
       {:ok, state, _} = Logic.apply_transactions(state, [old_txn])
       {:ok, state, _} = Logic.apply_transactions(state, [new_txn])
@@ -408,8 +397,8 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.LogicTest do
       # Eviction version 1 is smaller than window_lag_time_μs (5_000_000), so
       # computing the telemetry window edge underflows and must clamp to zero
       # rather than raising.
-      tiny_txn = create_transaction([{:set, "tiny", "value"}], 1)
-      newer_txn = create_transaction([{:set, "newer", "value"}], 10_000_000)
+      tiny_txn = TransactionTestSupport.new_log_transaction_from_mutations([{:set, "tiny", "value"}], 1)
+      newer_txn = TransactionTestSupport.new_log_transaction_from_mutations([{:set, "newer", "value"}], 10_000_000)
 
       {:ok, state, _} = Logic.apply_transactions(state, [tiny_txn])
       {:ok, state, _} = Logic.apply_transactions(state, [newer_txn])
@@ -426,8 +415,8 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.LogicTest do
       state = create_test_state(test_dir, :compaction_test)
 
       txns = [
-        create_transaction([{:set, "compact_a", "value_a"}], 1),
-        create_transaction([{:set, "compact_b", "value_b"}], 2)
+        TransactionTestSupport.new_log_transaction_from_mutations([{:set, "compact_a", "value_a"}], 1),
+        TransactionTestSupport.new_log_transaction_from_mutations([{:set, "compact_b", "value_b"}], 2)
       ]
 
       {:ok, state, _version} = Logic.apply_transactions(state, txns)

--- a/test/bedrock/data_plane/materializer/olivine/page_chain_loading_test.exs
+++ b/test/bedrock/data_plane/materializer/olivine/page_chain_loading_test.exs
@@ -4,8 +4,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.PageChainLoadingTest do
   alias Bedrock.DataPlane.Materializer.Olivine.Database
   alias Bedrock.DataPlane.Materializer.Olivine.Index
   alias Bedrock.DataPlane.Materializer.Olivine.IndexManager
-  alias Bedrock.DataPlane.Transaction
-  alias Bedrock.DataPlane.Version
+  alias Bedrock.Test.DataPlane.TransactionTestSupport
 
   defp setup_tmp_dir(context, base_name) do
     tmp_dir =
@@ -19,20 +18,6 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.PageChainLoadingTest do
     end)
 
     {:ok, tmp_dir: tmp_dir}
-  end
-
-  defp create_transaction(mutations, version_int) do
-    transaction_map = %{
-      mutations: mutations,
-      read_conflicts: {nil, []},
-      write_conflicts: []
-    }
-
-    encoded = Transaction.encode(transaction_map)
-    version = Version.from_integer(version_int)
-
-    {:ok, with_version} = Transaction.add_commit_version(encoded, version)
-    with_version
   end
 
   defp data_size_in_bytes({data_db, _index_db}), do: data_db.file_offset
@@ -81,7 +66,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.PageChainLoadingTest do
         end
 
       all_keys_v1 = keys_v1 ++ additional_keys
-      transaction_v1 = create_transaction(all_keys_v1, 1_000_000)
+      transaction_v1 = TransactionTestSupport.new_log_transaction_from_mutations(all_keys_v1, 1_000_000)
 
       # Apply version 1
       index_manager = IndexManager.new()
@@ -98,7 +83,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.PageChainLoadingTest do
         {:set, "fff", "new_value_6"}
       ]
 
-      transaction_v2 = create_transaction(keys_v2, 2_000_000)
+      transaction_v2 = TransactionTestSupport.new_log_transaction_from_mutations(keys_v2, 2_000_000)
 
       {index_manager_v2, _database_v2} =
         IndexManager.apply_transactions(index_manager_v1, [transaction_v2], database_v1)
@@ -177,7 +162,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.PageChainLoadingTest do
         {:set, "initial_key", "initial_value"}
       ]
 
-      transaction_v1 = create_transaction(keys_v1, 1_000_000)
+      transaction_v1 = TransactionTestSupport.new_log_transaction_from_mutations(keys_v1, 1_000_000)
 
       index_manager = IndexManager.new()
       {index_manager_v1, database_v1} = IndexManager.apply_transactions(index_manager, [transaction_v1], database)
@@ -201,7 +186,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.PageChainLoadingTest do
         {:set, "zzz_end_key", "end_value"}
       ]
 
-      transaction_v2 = create_transaction(keys_v2, 2_000_000)
+      transaction_v2 = TransactionTestSupport.new_log_transaction_from_mutations(keys_v2, 2_000_000)
 
       {index_manager_v2, database_v2} =
         IndexManager.apply_transactions(index_manager_v1, [transaction_v2], database_after_v1)
@@ -243,7 +228,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.PageChainLoadingTest do
 
       # Create a simple transaction
       keys = [{:set, "test_key", "test_value"}]
-      transaction = create_transaction(keys, 1_000_000)
+      transaction = TransactionTestSupport.new_log_transaction_from_mutations(keys, 1_000_000)
 
       index_manager = IndexManager.new()
       {index_manager, database} = IndexManager.apply_transactions(index_manager, [transaction], database)

--- a/test/bedrock/data_plane/materializer/olivine/page_chain_recovery_bug_test.exs
+++ b/test/bedrock/data_plane/materializer/olivine/page_chain_recovery_bug_test.exs
@@ -5,8 +5,8 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.PageChainRecoveryBugTest do
   alias Bedrock.DataPlane.Materializer.Olivine.Index
   alias Bedrock.DataPlane.Materializer.Olivine.Index.Page
   alias Bedrock.DataPlane.Materializer.Olivine.IndexManager
-  alias Bedrock.DataPlane.Transaction
   alias Bedrock.DataPlane.Version
+  alias Bedrock.Test.DataPlane.TransactionTestSupport
 
   defp setup_tmp_dir(context) do
     tmp_dir =
@@ -20,20 +20,6 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.PageChainRecoveryBugTest do
     end)
 
     {:ok, tmp_dir: tmp_dir}
-  end
-
-  defp create_transaction(mutations, version_int) do
-    transaction_map = %{
-      mutations: mutations,
-      read_conflicts: {nil, []},
-      write_conflicts: []
-    }
-
-    encoded = Transaction.encode(transaction_map)
-    version = Version.from_integer(version_int)
-
-    {:ok, with_version} = Transaction.add_commit_version(encoded, version)
-    with_version
   end
 
   defp data_size_in_bytes({data_db, _index_db}), do: data_db.file_offset
@@ -68,7 +54,9 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.PageChainRecoveryBugTest do
       transactions =
         keys
         |> Enum.with_index(1)
-        |> Enum.map(fn {key, version} -> create_transaction([{:set, key, key}], version) end)
+        |> Enum.map(fn {key, version} ->
+          TransactionTestSupport.new_log_transaction_from_mutations([{:set, key, key}], version)
+        end)
 
       {index_manager, database} =
         IndexManager.apply_transactions(IndexManager.new(), transactions, database)
@@ -480,7 +468,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.PageChainRecoveryBugTest do
           {:set, key, "value_#{i}"}
         end
 
-      transaction_v1 = create_transaction(mutations_v1, 1_000_000)
+      transaction_v1 = TransactionTestSupport.new_log_transaction_from_mutations(mutations_v1, 1_000_000)
 
       index_manager = IndexManager.new()
       {index_manager_v1, database_v1} = IndexManager.apply_transactions(index_manager, [transaction_v1], database)
@@ -500,7 +488,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.PageChainRecoveryBugTest do
         )
 
       # V2: Empty version (simulates the squashing scenario)
-      transaction_v2 = create_transaction([], 2_000_000)
+      transaction_v2 = TransactionTestSupport.new_log_transaction_from_mutations([], 2_000_000)
       {index_manager_v2, database_v2} = IndexManager.apply_transactions(index_manager_v1, [transaction_v2], database_v1)
 
       [{_v2, {_index_v2, modified_pages_v2}} | _] = index_manager_v2.versions
@@ -569,7 +557,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.PageChainRecoveryBugTest do
           {:set, key, "value_#{i}"}
         end
 
-      transaction_v1 = create_transaction(mutations_v1, 1_000_000)
+      transaction_v1 = TransactionTestSupport.new_log_transaction_from_mutations(mutations_v1, 1_000_000)
       index_manager = IndexManager.new()
       {index_manager_v1, database_v1} = IndexManager.apply_transactions(index_manager, [transaction_v1], database)
 
@@ -592,7 +580,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.PageChainRecoveryBugTest do
           {:set, key, "value_#{i}_updated"}
         end
 
-      transaction_v2 = create_transaction(mutations_v2, 2_000_000)
+      transaction_v2 = TransactionTestSupport.new_log_transaction_from_mutations(mutations_v2, 2_000_000)
       {index_manager_v2, database_v2} = IndexManager.apply_transactions(index_manager_v1, [transaction_v2], database_v1)
 
       [{_v2, {_index_v2, modified_pages_v2}} | _] = index_manager_v2.versions
@@ -607,7 +595,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.PageChainRecoveryBugTest do
         )
 
       # V3: Empty version
-      transaction_v3 = create_transaction([], 3_000_000)
+      transaction_v3 = TransactionTestSupport.new_log_transaction_from_mutations([], 3_000_000)
       {index_manager_v3, database_v3} = IndexManager.apply_transactions(index_manager_v2, [transaction_v3], database_v2)
 
       [{_v3, {_index_v3, modified_pages_v3}} | _] = index_manager_v3.versions

--- a/test/bedrock/data_plane/materializer/olivine/persistence_integration_test.exs
+++ b/test/bedrock/data_plane/materializer/olivine/persistence_integration_test.exs
@@ -5,24 +5,9 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.PersistenceIntegrationTest do
   alias Bedrock.DataPlane.Materializer.Olivine.Index.Page
   alias Bedrock.DataPlane.Materializer.Olivine.IndexManager
   alias Bedrock.DataPlane.Materializer.Olivine.Logic
-  alias Bedrock.DataPlane.Transaction
   alias Bedrock.DataPlane.Version
+  alias Bedrock.Test.DataPlane.TransactionTestSupport
   alias Bedrock.Test.Materializer.Olivine.PageTestHelpers
-
-  # Helper functions for cleaner test assertions
-  defp create_transaction(mutations, version_int) do
-    transaction_map = %{
-      mutations: mutations,
-      read_conflicts: {nil, []},
-      write_conflicts: []
-    }
-
-    encoded = Transaction.encode(transaction_map)
-    version = Version.from_integer(version_int)
-
-    {:ok, with_version} = Transaction.add_commit_version(encoded, version)
-    with_version
-  end
 
   defp setup_tmp_dir(context, base_name) do
     tmp_dir =
@@ -146,8 +131,10 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.PersistenceIntegrationTest do
       index_manager = IndexManager.new()
 
       # Create transactions with different timestamps to test eviction
-      old_transaction = create_transaction([{:set, "old_key", "old_value"}], 1)
-      recent_transaction = create_transaction([{:set, "recent_key", "recent_value"}], 1000)
+      old_transaction = TransactionTestSupport.new_log_transaction_from_mutations([{:set, "old_key", "old_value"}], 1)
+
+      recent_transaction =
+        TransactionTestSupport.new_log_transaction_from_mutations([{:set, "recent_key", "recent_value"}], 1000)
 
       # Apply transactions to build up data in the IndexManager and Database
       {index_manager_with_old, database_with_old} =
@@ -159,7 +146,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.PersistenceIntegrationTest do
       # Create many more transactions to fill the buffer tracking queue
       buffer_fill_transactions =
         for i <- 2..50 do
-          create_transaction([{:set, "key_#{i}", "value_#{i}"}], i)
+          TransactionTestSupport.new_log_transaction_from_mutations([{:set, "key_#{i}", "value_#{i}"}], i)
         end
 
       {final_index_manager, final_database} =

--- a/test/support/data_plane/transaction_test_support.ex
+++ b/test/support/data_plane/transaction_test_support.ex
@@ -57,6 +57,35 @@ defmodule Bedrock.Test.DataPlane.TransactionTestSupport do
   end
 
   @doc """
+  Creates a log-style transaction from an explicit, ordered list of mutations.
+
+  Unlike `new_log_transaction/3`, which builds mutations from a map (or list)
+  of key-value pairs and so cannot preserve mutation order or duplicate keys,
+  this accepts already-built `t:Transaction.mutation/0` tuples directly
+  (`{:set, key, value}`, `{:clear_range, start, end}`, `{:atomic, ...}`, etc).
+
+  ## Examples
+
+      iex> encoded = new_log_transaction_from_mutations([{:set, "key1", "value1"}], 42)
+      iex> Transaction.commit_version(encoded)
+      {:ok, <<42::64>>}
+  """
+  @spec new_log_transaction_from_mutations([Transaction.mutation()], Bedrock.version() | integer()) ::
+          Transaction.encoded()
+  def new_log_transaction_from_mutations(mutations, version) do
+    transaction = %{mutations: mutations, read_conflicts: {nil, []}, write_conflicts: []}
+    encoded = Transaction.encode(transaction)
+
+    version_binary =
+      if is_binary(version) and byte_size(version) == 8,
+        do: version,
+        else: Version.from_integer(version)
+
+    {:ok, with_version} = Transaction.add_commit_version(encoded, version_binary)
+    with_version
+  end
+
+  @doc """
   Extracts the commit version from a transaction created with new_log_transaction.
   """
   @spec extract_log_version(Transaction.encoded()) :: binary() | nil


### PR DESCRIPTION
Seven Olivine materializer test files each carried a private copy of the same six-line `create_transaction/2`, because the shared builder in `TransactionTestSupport` derives mutations from a key-value map and cannot express an ordered mutation list. A sibling helper now takes the mutation list directly, and all seven files call it.

Ticket: bedrock-tz1
Stacked on: #248 (bedrock-b28/fix-read-conflict-encoding)

## Why

The shared builder, `new_log_transaction/3`, accepts `%{key => value}` and derives the mutation tuples itself. Its list clause routes through `Map.new/1`, which loses mutation order and collapses repeated keys. Olivine tests need both: one applies `key_c` before `key_a` inside a single transaction, and another builds page chains from lists whose order drives the layout.

Those tests also pass raw mutation tuples such as `{:atomic, :add, key, operand}`, which are not pairs and cannot go through `Map.new/1` at all. So each new test file copied the helper again.

## What changed

`new_log_transaction_from_mutations/2` is added as a separate public function, not a new clause on its sibling. It encodes the same map the seven copies built, with empty conflict sets and no shard index, then stamps the commit version. Argument order matches the deleted helpers, so every call site became a mechanical rename, and the version may be an integer or an 8-byte binary.

The seven local definitions are deleted along with the aliases they solely used. `atomic_operations_test.exs` keeps its two thin wrappers, now delegating. `new_log_transaction/3` is untouched.

## How it works

`Transaction.encode/1` emits one section per non-empty field, so empty conflict sets and an absent shard index produce a binary holding exactly a mutations section plus the commit version, byte-for-byte what the deleted helpers produced. An empty mutation list still yields a zero-mutation section rather than no section at all, which the empty-version squashing tests rely on. Order and duplicates survive because the list is encoded as given.

## Verification

No `create_transaction/2` definitions remain under the Olivine test directory; similarly named helpers elsewhere are unrelated and untouched. Targeted run of the seven files: 65 tests, 0 failures. Full suite: 2892 tests, 0 failures, matching base. The PR is a draft with no checks reported.

Related: bedrock-aa5, shared Olivine index fixtures.
