### PR TITLE
bedrock-mi1: resolve KeySelectors with FoundationDB anchor arithmetic

### DIFF
--- a/lib/bedrock/data_plane/materializer/olivine/index_manager.ex
+++ b/lib/bedrock/data_plane/materializer/olivine/index_manager.ex
@@ -115,7 +115,6 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.IndexManager do
 
   @spec page_for_key(t(), KeySelector.t(), Bedrock.version()) ::
           {:ok, resolved_key :: binary(), Page.t()}
-          | {:partial, keys_available :: non_neg_integer()}
           | {:error, :not_found | :version_too_new | :version_too_old}
   def page_for_key(index_manager, %KeySelector{} = _key_selector, version) when index_manager.current_version < version,
     do: {:error, :version_too_new}

--- a/lib/bedrock/data_plane/materializer/olivine/index_manager.ex
+++ b/lib/bedrock/data_plane/materializer/olivine/index_manager.ex
@@ -277,34 +277,26 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.IndexManager do
 
   @spec resolve_key_selector_in_index(Index.t(), KeySelector.t()) ::
           {:ok, resolved_key :: binary(), Page.t()}
-          | {:partial, keys_available :: non_neg_integer()}
           | {:error, :not_found}
-  defp resolve_key_selector_in_index(
-         index,
-         %KeySelector{key: ref_key, or_equal: or_equal, offset: offset} = key_selector
-       ) do
+  defp resolve_key_selector_in_index(index, %KeySelector{key: ref_key, or_equal: or_equal, offset: offset}) do
     page = Index.page_for_key(index, ref_key)
 
     case resolve_key_selector_in_page(page, ref_key, or_equal, offset) do
       {:ok, resolved_key, page} ->
         {:ok, resolved_key, page}
 
-      {:partial, keys_available} ->
-        handle_cross_page_continuation(index, page, key_selector, keys_available)
+      {:partial, residual} ->
+        handle_cross_page_continuation(index, page, residual)
     end
   end
 
-  defp handle_cross_page_continuation(index, page, key_selector, keys_available) do
-    if keys_available == 0 and key_selector.offset < 0 do
-      {:error, :not_found}
-    else
-      case calculate_cross_page_continuation(index, page, key_selector, keys_available) do
-        {:ok, continuation_selector} ->
-          resolve_key_selector_in_index(index, continuation_selector)
+  defp handle_cross_page_continuation(index, page, residual) do
+    case calculate_cross_page_continuation(index, page, residual) do
+      {:ok, continuation_selector} ->
+        resolve_key_selector_in_index(index, continuation_selector)
 
-        {:error, reason} ->
-          {:error, reason}
-      end
+      {:error, reason} ->
+        {:error, reason}
     end
   end
 
@@ -325,7 +317,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.IndexManager do
 
   @spec resolve_key_selector_in_page(Page.t(), binary(), boolean(), integer()) ::
           {:ok, resolved_key :: binary(), Page.t()}
-          | {:partial, keys_available :: non_neg_integer()}
+          | {:partial, residual :: integer()}
           | {:error, :not_found}
   defp resolve_key_selector_in_page(page, ref_key, or_equal, offset) do
     <<_id::unsigned-big-32, key_count::unsigned-big-16, _offset::unsigned-big-32, _reserved::unsigned-big-48,
@@ -333,58 +325,45 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.IndexManager do
 
     case Page.search_entries_with_position(entries, key_count, ref_key) do
       {:found, pos} ->
-        target_pos = calculate_target_position_found(pos, or_equal, offset)
-        resolve_at_position_optimized(entries, target_pos, key_count, page)
+        resolve_at_position_optimized(entries, anchor_position(pos, or_equal) + offset, key_count, page)
 
       {:not_found, insertion_pos} ->
-        target_pos = calculate_target_position_not_found(insertion_pos, or_equal, offset)
-        resolve_at_position_optimized(entries, target_pos, key_count, page)
+        # ref_key is absent, so "last key <= ref_key" and "last key < ref_key"
+        # are the same position and or_equal makes no difference.
+        resolve_at_position_optimized(entries, insertion_pos - 1 + offset, key_count, page)
     end
   end
 
-  defp calculate_target_position_found(pos, or_equal, offset) do
-    if or_equal do
-      pos + offset
-    else
-      pos + 1 + offset
-    end
-  end
-
-  defp calculate_target_position_not_found(insertion_pos, or_equal, offset) do
-    if offset >= 0 do
-      insertion_pos + offset
-    else
-      if or_equal do
-        insertion_pos - 1 + offset
-      else
-        insertion_pos - 1 + offset
-      end
-    end
-  end
+  # FoundationDB's KeySelectorRef anchors on the last key less than ref_key —
+  # or less than or equal to it, when or_equal is set — and then moves offset
+  # keys from there.
+  defp anchor_position(pos, true), do: pos
+  defp anchor_position(pos, false), do: pos - 1
 
   defp resolve_at_position_optimized(entries, pos, key_count, page) when pos >= 0 and pos < key_count do
-    case Page.decode_entry_at_position(entries, pos, key_count) do
-      {:ok, {key, _version}} -> {:ok, key, page}
-      :out_of_bounds -> {:partial, key_count}
-    end
+    {:ok, {key, _version}} = Page.decode_entry_at_position(entries, pos, key_count)
+    {:ok, key, page}
   end
 
-  defp resolve_at_position_optimized(_entries, pos, _key_count, _page) when pos < 0, do: {:partial, 0}
-  defp resolve_at_position_optimized(_entries, _pos, key_count, _page), do: {:partial, key_count}
+  # A target outside the page carries a residual: how many keys past the page's
+  # last key (>= 0) or before its first key (< 0) the target lies. The
+  # neighbouring page continues from there.
+  defp resolve_at_position_optimized(_entries, pos, _key_count, _page) when pos < 0, do: {:partial, pos}
+  defp resolve_at_position_optimized(_entries, pos, key_count, _page), do: {:partial, pos - key_count}
 
-  @spec calculate_cross_page_continuation(Index.t(), Page.t(), KeySelector.t(), non_neg_integer()) ::
+  @spec calculate_cross_page_continuation(Index.t(), Page.t(), integer()) ::
           {:ok, KeySelector.t()} | {:error, :not_found}
-  defp calculate_cross_page_continuation(index, current_page, key_selector, keys_available) do
-    if key_selector.offset >= 0 do
-      calculate_forward_page_continuation(index, current_page, key_selector, keys_available)
+  defp calculate_cross_page_continuation(index, current_page, residual) do
+    if residual >= 0 do
+      calculate_forward_page_continuation(index, current_page, residual)
     else
-      calculate_backward_page_continuation(index, current_page, key_selector, keys_available)
+      calculate_backward_page_continuation(index, current_page, residual)
     end
   end
 
-  @spec calculate_forward_page_continuation(Index.t(), Page.t(), KeySelector.t(), non_neg_integer()) ::
+  @spec calculate_forward_page_continuation(Index.t(), Page.t(), non_neg_integer()) ::
           {:ok, KeySelector.t()} | {:error, :not_found}
-  defp calculate_forward_page_continuation(index, current_page, key_selector, keys_available) do
+  defp calculate_forward_page_continuation(index, current_page, residual) do
     {_page, next_id} = Index.get_page_with_next_id!(index, Page.id(current_page))
 
     case next_id do
@@ -393,23 +372,19 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.IndexManager do
 
       next_page_id ->
         next_page = Index.get_page!(index, next_page_id)
-        remaining_offset = key_selector.offset - keys_available
 
         case Page.left_key(next_page) do
+          # Only page 0 survives becoming empty, and page 0 is never a next page.
           nil ->
-            continuation_selector = %KeySelector{
-              key: "",
-              or_equal: true,
-              offset: remaining_offset
-            }
-
-            {:ok, continuation_selector}
+            {:error, :not_found}
 
           first_key_of_next_page ->
+            # The next page's first key is the residual's origin: anchoring on
+            # it with or_equal leaves the residual as the offset from there.
             continuation_selector = %KeySelector{
               key: first_key_of_next_page,
               or_equal: true,
-              offset: remaining_offset
+              offset: residual
             }
 
             {:ok, continuation_selector}
@@ -417,9 +392,9 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.IndexManager do
     end
   end
 
-  @spec calculate_backward_page_continuation(Index.t(), Page.t(), KeySelector.t(), non_neg_integer()) ::
+  @spec calculate_backward_page_continuation(Index.t(), Page.t(), neg_integer()) ::
           {:ok, KeySelector.t()} | {:error, :not_found}
-  defp calculate_backward_page_continuation(index, current_page, key_selector, keys_available) do
+  defp calculate_backward_page_continuation(index, current_page, residual) do
     case find_previous_page(index, Page.id(current_page)) do
       {:ok, previous_page} ->
         case Page.right_key(previous_page) do
@@ -427,12 +402,12 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.IndexManager do
             {:error, :not_found}
 
           last_key_of_prev_page ->
-            remaining_offset = key_selector.offset + keys_available
-
+            # A residual of -1 is the previous page's last key itself, so the
+            # offset from that anchor is one step shorter than the residual.
             continuation_selector = %KeySelector{
               key: last_key_of_prev_page,
               or_equal: true,
-              offset: remaining_offset
+              offset: residual + 1
             }
 
             {:ok, continuation_selector}
@@ -444,6 +419,10 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.IndexManager do
   end
 
   @spec find_previous_page(Index.t(), Page.id()) :: {:ok, Page.t()} | {:error, :not_found}
+  # Page 0 is always the leftmost page, and 0 doubles as the end-of-chain
+  # sentinel — searching for a page pointing at it would find the last page.
+  defp find_previous_page(_index, 0), do: {:error, :not_found}
+
   defp find_previous_page(%Index{page_map: page_map}, target_page_id) do
     page_map
     |> Enum.find_value(fn {_page_id, {page, next_id}} ->

--- a/lib/bedrock/key_selector.ex
+++ b/lib/bedrock/key_selector.ex
@@ -27,7 +27,7 @@ defmodule Bedrock.KeySelector do
           offset: integer()
         }
 
-  defstruct key: <<>>, or_equal: true, offset: 0
+  defstruct key: <<>>, or_equal: false, offset: 0
 
   @doc """
   Creates a KeySelector that resolves to the lexicographically smallest key

--- a/lib/bedrock/key_selector.ex
+++ b/lib/bedrock/key_selector.ex
@@ -5,13 +5,20 @@ defmodule Bedrock.KeySelector do
   KeySelectors leverage the lexicographically ordered nature of keys to find keys based on their
   positional relationships to other keys, without needing to know exact key values.
 
+  The encoding matches FoundationDB's `KeySelectorRef`: `key` anchors the selector at the last
+  key less than it — or less than *or equal to* it, when `or_equal` is set — and `offset` then
+  moves that many keys forward (or backward, when negative). Anchoring on `or_equal` rather than
+  on "the first key at or after `key`" is what makes the four constructors expressible with a
+  single additive offset, so `add/2` and `subtract/2` compose regardless of whether `key` is
+  present in the database.
+
   ## Examples
 
       iex> KeySelector.first_greater_or_equal("user:")
-      %KeySelector{key: "user:", or_equal: true, offset: 0}
-      
+      %KeySelector{key: "user:", or_equal: false, offset: 1}
+
       iex> KeySelector.first_greater_than("data") |> KeySelector.add(5)
-      %KeySelector{key: "data", or_equal: false, offset: 6}
+      %KeySelector{key: "data", or_equal: true, offset: 6}
   """
 
   @type t :: %__MODULE__{
@@ -27,7 +34,7 @@ defmodule Bedrock.KeySelector do
   greater than or equal to the given key.
   """
   @spec first_greater_or_equal(binary()) :: t()
-  def first_greater_or_equal(key) when is_binary(key), do: %__MODULE__{key: key, or_equal: true, offset: 0}
+  def first_greater_or_equal(key) when is_binary(key), do: %__MODULE__{key: key, or_equal: false, offset: 1}
 
   @doc """
   Creates a KeySelector that resolves to the lexicographically smallest key
@@ -41,7 +48,7 @@ defmodule Bedrock.KeySelector do
   less than or equal to the given key.
   """
   @spec last_less_or_equal(binary()) :: t()
-  def last_less_or_equal(key) when is_binary(key), do: %__MODULE__{key: key, or_equal: true, offset: -1}
+  def last_less_or_equal(key) when is_binary(key), do: %__MODULE__{key: key, or_equal: true, offset: 0}
 
   @doc """
   Creates a KeySelector that resolves to the lexicographically largest key
@@ -57,10 +64,10 @@ defmodule Bedrock.KeySelector do
   ## Examples
 
       iex> KeySelector.first_greater_or_equal("a") |> KeySelector.add(3)
-      %KeySelector{key: "a", or_equal: true, offset: 3}
-      
+      %KeySelector{key: "a", or_equal: false, offset: 4}
+
       iex> KeySelector.first_greater_than("z") |> KeySelector.add(-2)
-      %KeySelector{key: "z", or_equal: false, offset: -1}
+      %KeySelector{key: "z", or_equal: true, offset: -1}
   """
   @spec add(t(), integer()) :: t()
   def add(%__MODULE__{} = selector, offset) when is_integer(offset), do: %{selector | offset: selector.offset + offset}
@@ -72,7 +79,7 @@ defmodule Bedrock.KeySelector do
   ## Examples
 
       iex> KeySelector.first_greater_or_equal("m") |> KeySelector.subtract(2)
-      %KeySelector{key: "m", or_equal: true, offset: -2}
+      %KeySelector{key: "m", or_equal: false, offset: -1}
   """
   @spec subtract(t(), integer()) :: t()
   def subtract(%__MODULE__{} = selector, offset) when is_integer(offset), do: add(selector, -offset)
@@ -113,7 +120,7 @@ defmodule Bedrock.KeySelector do
       "first_greater_than(\"data\") + 3"
   """
   @spec to_string(t()) :: String.t()
-  def to_string(%__MODULE__{key: key, or_equal: true, offset: 0}) do
+  def to_string(%__MODULE__{key: key, or_equal: false, offset: 1}) do
     ~s{first_greater_or_equal(#{inspect(key)})}
   end
 
@@ -121,7 +128,7 @@ defmodule Bedrock.KeySelector do
     ~s{first_greater_than(#{inspect(key)})}
   end
 
-  def to_string(%__MODULE__{key: key, or_equal: true, offset: -1}) do
+  def to_string(%__MODULE__{key: key, or_equal: true, offset: 0}) do
     ~s{last_less_or_equal(#{inspect(key)})}
   end
 
@@ -130,14 +137,22 @@ defmodule Bedrock.KeySelector do
   end
 
   def to_string(%__MODULE__{key: key, or_equal: or_equal, offset: offset}) do
-    # Always use first_greater_or_equal as canonical base and adjust offset
-    canonical_offset = if or_equal, do: offset, else: offset - 1
+    # Name the selector after the constructor sharing its anchor: the sign of
+    # the offset picks the direction, or_equal picks whether key itself counts.
+    {base_name, base_offset} =
+      case {or_equal, offset > 0} do
+        {false, true} -> {"first_greater_or_equal", offset - 1}
+        {true, true} -> {"first_greater_than", offset - 1}
+        {true, false} -> {"last_less_or_equal", offset}
+        {false, false} -> {"last_less_than", offset}
+      end
 
-    base_str = ~s{first_greater_or_equal(#{inspect(key)})}
+    base_str = ~s{#{base_name}(#{inspect(key)})}
 
+    # base_offset can't be zero here: those four selectors match above.
     cond do
-      canonical_offset > 0 -> "#{base_str} + #{canonical_offset}"
-      canonical_offset < 0 -> "#{base_str} - #{abs(canonical_offset)}"
+      base_offset > 0 -> "#{base_str} + #{base_offset}"
+      base_offset < 0 -> "#{base_str} - #{abs(base_offset)}"
     end
   end
 end

--- a/test/bedrock/data_plane/materializer/olivine/index_manager_test.exs
+++ b/test/bedrock/data_plane/materializer/olivine/index_manager_test.exs
@@ -5,10 +5,13 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.IndexManagerTest do
 
   alias Bedrock.DataPlane.Materializer.Olivine.Database
   alias Bedrock.DataPlane.Materializer.Olivine.IdAllocator
+  alias Bedrock.DataPlane.Materializer.Olivine.Index
   alias Bedrock.DataPlane.Materializer.Olivine.Index.Page
+  alias Bedrock.DataPlane.Materializer.Olivine.Index.Tree
   alias Bedrock.DataPlane.Materializer.Olivine.IndexManager
   alias Bedrock.DataPlane.Transaction
   alias Bedrock.DataPlane.Version
+  alias Bedrock.KeySelector
   alias Bedrock.Test.Materializer.Olivine.IndexManagerTestHelpers
   alias Bedrock.Test.Materializer.Olivine.PageTestHelpers
 
@@ -834,8 +837,6 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.IndexManagerTest do
   end
 
   describe "KeySelector resolution algorithms" do
-    alias Bedrock.KeySelector
-
     setup do
       # Create index manager with test data
       manager = IndexManager.new()
@@ -971,6 +972,85 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.IndexManagerTest do
       # key5 - 2 should be "key10", key5 + 2 should be "range:b"
       assert {:ok, {"key10", "range:b"}, pages} = result
       assert is_list(pages)
+    end
+  end
+
+  describe "KeySelector resolution follows FoundationDB semantics" do
+    # "b", "d" and "f" are absent, so the present-key and absent-key paths
+    # through the anchor arithmetic resolve differently.
+    setup do
+      {:ok, manager: index_manager_from_pages([{0, ~w(a c e g), 0}])}
+    end
+
+    test "the four constructors resolve against a key that is present", %{manager: manager} do
+      assert resolve(manager, KeySelector.first_greater_or_equal("c")) == "c"
+      assert resolve(manager, KeySelector.first_greater_than("c")) == "e"
+      assert resolve(manager, KeySelector.last_less_or_equal("c")) == "c"
+      assert resolve(manager, KeySelector.last_less_than("c")) == "a"
+    end
+
+    test "the four constructors resolve against a key that is absent", %{manager: manager} do
+      assert resolve(manager, KeySelector.first_greater_or_equal("d")) == "e"
+      assert resolve(manager, KeySelector.first_greater_than("d")) == "e"
+      assert resolve(manager, KeySelector.last_less_or_equal("d")) == "c"
+      assert resolve(manager, KeySelector.last_less_than("d")) == "c"
+    end
+
+    test "offsets step from the anchor in both directions", %{manager: manager} do
+      assert resolve(manager, KeySelector.add(KeySelector.first_greater_or_equal("c"), 1)) == "e"
+      assert resolve(manager, KeySelector.add(KeySelector.first_greater_or_equal("c"), -1)) == "a"
+      assert resolve(manager, KeySelector.add(KeySelector.first_greater_or_equal("d"), 1)) == "g"
+      assert resolve(manager, KeySelector.add(KeySelector.first_greater_or_equal("d"), -1)) == "c"
+      assert resolve(manager, KeySelector.add(KeySelector.first_greater_than("c"), 1)) == "g"
+      assert resolve(manager, KeySelector.add(KeySelector.last_less_or_equal("d"), -1)) == "a"
+    end
+
+    test "a target beyond either end of the index does not resolve", %{manager: manager} do
+      assert resolve(manager, KeySelector.add(KeySelector.first_greater_or_equal("a"), -1)) == {:error, :not_found}
+      assert resolve(manager, KeySelector.last_less_than("a")) == {:error, :not_found}
+      assert resolve(manager, KeySelector.first_greater_than("g")) == {:error, :not_found}
+    end
+  end
+
+  describe "KeySelector resolution across pages" do
+    setup do
+      {:ok, manager: index_manager_from_pages([{0, ~w(a b), 1}, {1, ~w(c d), 2}, {2, ~w(e f), 0}])}
+    end
+
+    test "a forward target continues into the following pages", %{manager: manager} do
+      assert resolve(manager, KeySelector.add(KeySelector.first_greater_or_equal("b"), 1)) == "c"
+      assert resolve(manager, KeySelector.first_greater_than("d")) == "e"
+      assert resolve(manager, KeySelector.add(KeySelector.first_greater_or_equal("a"), 5)) == "f"
+    end
+
+    test "a backward target continues into the preceding pages", %{manager: manager} do
+      assert resolve(manager, KeySelector.add(KeySelector.last_less_or_equal("c"), -1)) == "b"
+      assert resolve(manager, KeySelector.last_less_than("e")) == "d"
+      assert resolve(manager, KeySelector.add(KeySelector.first_greater_or_equal("f"), -5)) == "a"
+    end
+
+    test "a target beyond either end of the page chain does not resolve", %{manager: manager} do
+      assert resolve(manager, KeySelector.add(KeySelector.first_greater_or_equal("a"), -1)) == {:error, :not_found}
+      assert resolve(manager, KeySelector.add(KeySelector.first_greater_or_equal("f"), 1)) == {:error, :not_found}
+    end
+  end
+
+  defp index_manager_from_pages(page_specs) do
+    version = Version.from_integer(1)
+
+    page_map =
+      Map.new(page_specs, fn {page_id, keys, next_id} ->
+        {page_id, {Page.new(page_id, Enum.map(keys, &{&1, version})), next_id}}
+      end)
+
+    index = %Index{tree: Tree.from_page_map(page_map), page_map: page_map}
+    %IndexManager{versions: [{version, {index, %{}}}], current_version: version}
+  end
+
+  defp resolve(manager, key_selector) do
+    case IndexManager.page_for_key(manager, key_selector, Version.from_integer(1)) do
+      {:ok, resolved_key, _page} -> resolved_key
+      {:error, reason} -> {:error, reason}
     end
   end
 end

--- a/test/bedrock/data_plane/materializer/olivine/key_selector_test.exs
+++ b/test/bedrock/data_plane/materializer/olivine/key_selector_test.exs
@@ -214,14 +214,14 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.KeySelectorTest do
       extreme_selector = "key1" |> KeySelector.first_greater_or_equal() |> KeySelector.add(999_999)
 
       # Should handle gracefully without crashing
-      assert %KeySelector{offset: 999_999} = extreme_selector
+      assert %KeySelector{offset: 1_000_000} = extreme_selector
       assert {:error, :not_found} = ReadingTestHelpers.get(state, extreme_selector, test_version(), [])
     end
 
     test "empty key KeySelector", %{state: state} do
       empty_key_selector = KeySelector.first_greater_or_equal("")
 
-      assert %KeySelector{key: "", or_equal: true, offset: 0} = empty_key_selector
+      assert %KeySelector{key: "", or_equal: false, offset: 1} = empty_key_selector
       # Should handle empty keys appropriately - should find the first key
       assert {:ok, {resolved_key, _value}} =
                ReadingTestHelpers.get(state, empty_key_selector, test_version(), [])

--- a/test/bedrock/key_selector_test.exs
+++ b/test/bedrock/key_selector_test.exs
@@ -7,7 +7,7 @@ defmodule Bedrock.KeySelectorTest do
     test "first_greater_or_equal/1 creates correct KeySelector" do
       selector = KeySelector.first_greater_or_equal("user:")
 
-      assert %KeySelector{key: "user:", or_equal: true, offset: 0} = selector
+      assert %KeySelector{key: "user:", or_equal: false, offset: 1} = selector
     end
 
     test "first_greater_than/1 creates correct KeySelector" do
@@ -19,7 +19,7 @@ defmodule Bedrock.KeySelectorTest do
     test "last_less_or_equal/1 creates correct KeySelector" do
       selector = KeySelector.last_less_or_equal("items")
 
-      assert %KeySelector{key: "items", or_equal: true, offset: -1} = selector
+      assert %KeySelector{key: "items", or_equal: true, offset: 0} = selector
     end
 
     test "last_less_than/1 creates correct KeySelector" do
@@ -52,7 +52,7 @@ defmodule Bedrock.KeySelectorTest do
       selector = KeySelector.first_greater_or_equal("base")
 
       result = KeySelector.add(selector, 5)
-      assert %KeySelector{key: "base", or_equal: true, offset: 5} = result
+      assert %KeySelector{key: "base", or_equal: false, offset: 6} = result
     end
 
     test "add/2 with negative number decreases offset" do
@@ -70,14 +70,14 @@ defmodule Bedrock.KeySelectorTest do
         |> KeySelector.add(2)
         |> KeySelector.add(-1)
 
-      assert %KeySelector{key: "base", or_equal: true, offset: 4} = selector
+      assert %KeySelector{key: "base", or_equal: false, offset: 5} = selector
     end
 
     test "subtract/2 decreases offset" do
       selector = KeySelector.first_greater_or_equal("base")
 
       result = KeySelector.subtract(selector, 3)
-      assert %KeySelector{key: "base", or_equal: true, offset: -3} = result
+      assert %KeySelector{key: "base", or_equal: false, offset: -2} = result
     end
 
     test "subtract/2 with negative number increases offset" do
@@ -102,30 +102,30 @@ defmodule Bedrock.KeySelectorTest do
 
   describe "offset predicates" do
     test "zero_offset?/1 correctly identifies zero offsets" do
-      assert "a" |> KeySelector.first_greater_or_equal() |> KeySelector.zero_offset?()
+      assert "a" |> KeySelector.last_less_or_equal() |> KeySelector.zero_offset?()
       assert "z" |> KeySelector.last_less_than() |> KeySelector.zero_offset?()
 
       refute "b" |> KeySelector.first_greater_than() |> KeySelector.zero_offset?()
-      refute "y" |> KeySelector.last_less_or_equal() |> KeySelector.zero_offset?()
+      refute "y" |> KeySelector.first_greater_or_equal() |> KeySelector.zero_offset?()
       refute "c" |> KeySelector.first_greater_or_equal() |> KeySelector.add(1) |> KeySelector.zero_offset?()
     end
 
     test "positive_offset?/1 correctly identifies positive offsets" do
       assert "a" |> KeySelector.first_greater_than() |> KeySelector.positive_offset?()
-      assert "b" |> KeySelector.first_greater_or_equal() |> KeySelector.add(1) |> KeySelector.positive_offset?()
+      assert "b" |> KeySelector.first_greater_or_equal() |> KeySelector.positive_offset?()
       assert "c" |> KeySelector.last_less_than() |> KeySelector.add(5) |> KeySelector.positive_offset?()
 
-      refute "d" |> KeySelector.first_greater_or_equal() |> KeySelector.positive_offset?()
+      refute "d" |> KeySelector.last_less_or_equal() |> KeySelector.positive_offset?()
       refute "e" |> KeySelector.last_less_than() |> KeySelector.positive_offset?()
       refute "f" |> KeySelector.first_greater_or_equal() |> KeySelector.add(-1) |> KeySelector.positive_offset?()
     end
 
     test "negative_offset?/1 correctly identifies negative offsets" do
-      assert "a" |> KeySelector.last_less_or_equal() |> KeySelector.negative_offset?()
-      assert "b" |> KeySelector.first_greater_or_equal() |> KeySelector.add(-1) |> KeySelector.negative_offset?()
+      assert "a" |> KeySelector.last_less_or_equal() |> KeySelector.add(-1) |> KeySelector.negative_offset?()
+      assert "b" |> KeySelector.first_greater_or_equal() |> KeySelector.add(-2) |> KeySelector.negative_offset?()
       assert "c" |> KeySelector.first_greater_than() |> KeySelector.subtract(5) |> KeySelector.negative_offset?()
 
-      refute "d" |> KeySelector.first_greater_or_equal() |> KeySelector.negative_offset?()
+      refute "d" |> KeySelector.last_less_or_equal() |> KeySelector.negative_offset?()
       refute "e" |> KeySelector.first_greater_than() |> KeySelector.negative_offset?()
       refute "f" |> KeySelector.last_less_than() |> KeySelector.negative_offset?()
     end
@@ -151,7 +151,7 @@ defmodule Bedrock.KeySelectorTest do
       assert KeySelector.to_string(selector) == ~s{first_greater_or_equal("base") + 3}
 
       selector = "data" |> KeySelector.first_greater_than() |> KeySelector.add(5)
-      assert KeySelector.to_string(selector) == ~s{first_greater_or_equal("data") + 6}
+      assert KeySelector.to_string(selector) == ~s{first_greater_than("data") + 5}
 
       selector = "end" |> KeySelector.last_less_than() |> KeySelector.add(2)
       assert KeySelector.to_string(selector) == ~s{first_greater_or_equal("end") + 1}
@@ -159,22 +159,23 @@ defmodule Bedrock.KeySelectorTest do
 
     test "to_string/1 for selectors with negative offsets" do
       selector = "base" |> KeySelector.first_greater_or_equal() |> KeySelector.add(-2)
-      assert KeySelector.to_string(selector) == ~s{first_greater_or_equal("base") - 2}
+      assert KeySelector.to_string(selector) == ~s{last_less_than("base") - 1}
 
       selector = "data" |> KeySelector.first_greater_than() |> KeySelector.add(-3)
-      assert KeySelector.to_string(selector) == ~s{first_greater_or_equal("data") - 2}
+      assert KeySelector.to_string(selector) == ~s{last_less_or_equal("data") - 2}
 
       selector = "end" |> KeySelector.last_less_than() |> KeySelector.add(-1)
-      assert KeySelector.to_string(selector) == ~s{first_greater_or_equal("end") - 2}
+      assert KeySelector.to_string(selector) == ~s{last_less_than("end") - 1}
     end
 
     test "to_string/1 handles complex offsets correctly" do
-      # last_less_or_equal is internally first_greater_or_equal with offset -1
+      # last_less_or_equal is the anchor itself, so a forward offset names the
+      # selector after first_greater_than and a backward one keeps the anchor
       selector = "test" |> KeySelector.last_less_or_equal() |> KeySelector.add(3)
-      assert KeySelector.to_string(selector) == ~s{first_greater_or_equal("test") + 2}
+      assert KeySelector.to_string(selector) == ~s{first_greater_than("test") + 2}
 
       selector = "test" |> KeySelector.last_less_or_equal() |> KeySelector.subtract(2)
-      assert KeySelector.to_string(selector) == ~s{first_greater_or_equal("test") - 3}
+      assert KeySelector.to_string(selector) == ~s{last_less_or_equal("test") - 2}
     end
 
     test "String.Chars protocol implementation" do
@@ -182,7 +183,7 @@ defmodule Bedrock.KeySelectorTest do
       assert to_string(selector) == ~s{first_greater_or_equal("test")}
 
       selector = "data" |> KeySelector.first_greater_than() |> KeySelector.add(2)
-      assert to_string(selector) == ~s{first_greater_or_equal("data") + 3}
+      assert to_string(selector) == ~s{first_greater_than("data") + 2}
     end
   end
 
@@ -195,14 +196,14 @@ defmodule Bedrock.KeySelectorTest do
         |> KeySelector.subtract(3)
         |> KeySelector.add(-2)
 
-      assert %KeySelector{key: "start", or_equal: true, offset: 5} = selector
+      assert %KeySelector{key: "start", or_equal: false, offset: 6} = selector
       assert KeySelector.to_string(selector) == ~s{first_greater_or_equal("start") + 5}
     end
 
     test "edge case with empty key" do
       selector = KeySelector.first_greater_or_equal("")
 
-      assert %KeySelector{key: "", or_equal: true, offset: 0} = selector
+      assert %KeySelector{key: "", or_equal: false, offset: 1} = selector
       assert KeySelector.to_string(selector) == ~s{first_greater_or_equal("")}
     end
 
@@ -218,15 +219,15 @@ defmodule Bedrock.KeySelectorTest do
     test "large offset values" do
       selector = "base" |> KeySelector.first_greater_or_equal() |> KeySelector.add(1000)
 
-      assert %KeySelector{key: "base", or_equal: true, offset: 1000} = selector
+      assert %KeySelector{key: "base", or_equal: false, offset: 1001} = selector
       assert KeySelector.to_string(selector) == ~s{first_greater_or_equal("base") + 1000}
     end
 
     test "very negative offset values" do
       selector = "base" |> KeySelector.first_greater_or_equal() |> KeySelector.add(-500)
 
-      assert %KeySelector{key: "base", or_equal: true, offset: -500} = selector
-      assert KeySelector.to_string(selector) == ~s{first_greater_or_equal("base") - 500}
+      assert %KeySelector{key: "base", or_equal: false, offset: -499} = selector
+      assert KeySelector.to_string(selector) == ~s{last_less_than("base") - 499}
     end
   end
 
@@ -256,14 +257,14 @@ defmodule Bedrock.KeySelectorTest do
   end
 
   describe "equivalence and comparison scenarios" do
-    test "different construction methods can produce equivalent KeySelectors" do
-      # These should be functionally equivalent
-      selector1 = KeySelector.first_greater_than("key")
-      selector2 = "key" |> KeySelector.first_greater_or_equal() |> KeySelector.add(1)
+    test "stepping one key past a backward selector gives its forward twin" do
+      # The anchor a selector resolves from is what or_equal picks, so each
+      # backward constructor is one step behind its forward counterpart.
+      assert "key" |> KeySelector.last_less_or_equal() |> KeySelector.add(1) ==
+               KeySelector.first_greater_than("key")
 
-      # They have different internal representations but same logical meaning
-      assert %KeySelector{key: key, offset: offset, or_equal: or_equal} = selector1
-      assert %KeySelector{key: ^key, offset: ^offset, or_equal: ^or_equal} = selector2
+      assert "key" |> KeySelector.last_less_than() |> KeySelector.add(1) ==
+               KeySelector.first_greater_or_equal("key")
     end
 
     test "offset manipulation creates predictable patterns" do


### PR DESCRIPTION
`Bedrock.KeySelector`'s four constructors and Olivine's resolver disagreed about what `{or_equal, offset}` means, so three of the four resolved to the wrong key, and every backward resolution that crossed a page boundary returned `:not_found`. The constructors are re-encoded to FoundationDB's `KeySelectorRef` scheme, and the resolver rewritten as anchor-plus-offset with a signed residual carried between pages.

Ticket: bedrock-mi1

## Why

A key selector names a key by position: anchor near a reference key, then step some number of keys. On `develop` the anchor was "the first key at or after `key`" whenever `or_equal` was set. But `first_greater_or_equal` and `first_greater_than` both set `or_equal: true` and differ by one in `offset`, so that anchor would need to sit at two positions at once, depending on whether the reference key exists. No resolver satisfies both.

FoundationDB puts the existence-dependence in the anchor instead: the last key less than `key`, or less than or equal to it when `or_equal` is set. All four constructors then become one additive offset from a single anchor, so `add/2` composes.

In production, `Bedrock.HighContentionAllocator` finds its highest counter with `last_less_than/1` on the range end. That resolved past the range, the prefix guard rejected the key, and the allocator restarted from window zero on every call.

Cross-page continuation was separately broken: it derived the next offset from the original selector, and a backward overshoot always reported zero keys available, which an early-out turned into `:not_found`. That path had never run.

## What changed

`first_greater_or_equal/1` is now `{or_equal: false, offset: 1}` and `last_less_or_equal/1` is `{true, 0}`; the other two already matched FDB. `to_string/1` names a selector after the constructor sharing its anchor. The resolver drops its two position helpers, `{:partial, _}` carries a signed residual, and `find_previous_page/2` gains a page-0 clause, since id 0 is both the leftmost page and the end-of-chain sentinel and the scan otherwise returned the last page. The ticket's `LayoutIndex` dead-code observation was already resolved in 1b9921b8.

## How it works

A search returns a hit position or an insertion position. On a hit the anchor is that position when `or_equal`, one before it otherwise; on a miss both readings collapse to `insertion_pos - 1`. The target is anchor plus offset.

Page `["a", "c", "e", "g"]`, against present `"c"` and absent `"d"`:

| selector | before | after |
| --- | --- | --- |
| `first_greater_or_equal("c")` | `"c"` | `"c"` |
| `first_greater_than("c")` | `"e"` | `"e"` |
| `last_less_or_equal("c")` | `"a"` | `"c"` |
| `last_less_than("c")` | `"e"` | `"a"` |
| `first_greater_or_equal("d")` | `"e"` | `"e"` |
| `first_greater_than("d")` | `"g"` | `"e"` |
| `last_less_or_equal("d")` | `"a"` | `"c"` |
| `last_less_than("d")` | `"e"` | `"c"` |

Off the page, the residual counts keys past the last or before the first, and its sign picks the direction. Forward, the next page's first key becomes the anchor and the residual the offset; backward, the previous page's last key with the residual plus one. Each hop shrinks the residual, so the recursion terminates.

## Verification

New tests resolve all four constructors against present and absent keys, step offsets both ways, and walk page boundaries in both directions. With `lib/` reverted, six of the seven fail. A cold audit's differential model over 10,200 cases found zero mismatches here and 1,991 on `develop`; its notes were applied in 4604f99a. CI is green on all four test jobs.
