### PR TITLE
bedrock-sfu: normalize unrecognised exit reasons in Calls.call/3

### DIFF
--- a/lib/bedrock/internal/gen_server/calls.ex
+++ b/lib/bedrock/internal/gen_server/calls.ex
@@ -32,6 +32,12 @@ defmodule Bedrock.Internal.GenServer.Calls do
     :exit, {:normal, _} -> {:error, :unavailable}
     :exit, {:shutdown, _} -> {:error, :unavailable}
     :exit, {{:shutdown, _}, _} -> {:error, :unavailable}
+    # Any other exit reason means the callee died mid-call (e.g. a posix
+    # error like :enospc/:eacces, or a raised exception) rather than the
+    # caller doing something wrong — report unavailability, not the reason.
+    # :calling_self is excluded: it means the caller passed itself as the
+    # server, a caller-side bug that should still surface as a raise.
+    :exit, {reason, _} when reason != :calling_self -> {:error, :unavailable}
   end
 
   @spec call!(GenServer.server(), message :: term(), timeout()) :: term()

--- a/test/bedrock/internal/gen_server/calls_test.exs
+++ b/test/bedrock/internal/gen_server/calls_test.exs
@@ -1,0 +1,48 @@
+defmodule Bedrock.Internal.GenServer.CallsTest do
+  use ExUnit.Case, async: true
+
+  alias Bedrock.Internal.GenServer.Calls
+
+  # A GenServer that dies mid-call with whatever reason the test asks for,
+  # simulating a callee that crashes on a resource fault (e.g. the Shale
+  # SegmentRecycler exiting with :enospc/:eacces instead of :shutdown).
+  defmodule CrashingServer do
+    @moduledoc false
+    use GenServer
+
+    def init(:ok), do: {:ok, :ok}
+
+    def handle_call({:die, reason}, _from, state), do: {:stop, reason, state}
+  end
+
+  setup do
+    # Unlinked on purpose: a linked start would deliver the crash to this
+    # test process as its own EXIT signal, which is not what Calls.call/3
+    # is meant to shield callers from.
+    {:ok, pid} = GenServer.start(CrashingServer, :ok)
+    %{pid: pid}
+  end
+
+  describe "call/3 against a callee that dies mid-call" do
+    test "a posix exit reason is normalized to :unavailable", %{pid: pid} do
+      assert Calls.call(pid, {:die, :eacces}, 1000) == {:error, :unavailable}
+    end
+
+    test "a different posix exit reason is normalized to :unavailable", %{pid: pid} do
+      assert Calls.call(pid, {:die, :enospc}, 1000) == {:error, :unavailable}
+    end
+
+    test "{:shutdown, term} is normalized to :unavailable", %{pid: pid} do
+      assert Calls.call(pid, {:die, {:shutdown, :disk_full}}, 1000) == {:error, :unavailable}
+    end
+
+    test "an exception-shaped crash reason is normalized to :unavailable", %{pid: pid} do
+      reason = {%RuntimeError{message: "boom"}, [{__MODULE__, :handle_call, 3, []}]}
+      assert Calls.call(pid, {:die, reason}, 1000) == {:error, :unavailable}
+    end
+
+    test "an arbitrary exit reason is normalized to :unavailable", %{pid: pid} do
+      assert Calls.call(pid, {:die, :some_arbitrary_reason}, 1000) == {:error, :unavailable}
+    end
+  end
+end


### PR DESCRIPTION
`Calls.call/3` translated a fixed allowlist of GenServer exit reasons into `{:error, :unavailable}` or `{:error, :timeout}` and let every other reason escape as a raise, so a callee that died of a posix fault such as `:enospc` killed its caller instead of reporting that it was gone. A trailing catch-all clause now classifies any remaining exit reason as unavailable.

Ticket: bedrock-sfu

## Why

Every module built on the internal GenServer API funnels its calls through this wrapper, so it is the single place where "the process I was talking to is gone" becomes a value the caller can match on. The catch block covered `:noproc`, `:nodedown`, `:timeout`, `:normal`, and both shutdown shapes; anything else fell through and was re-raised.

That became reachable with bedrock-m7j (#216). The Shale segment recycler now stops with the real allocation failure instead of masking it as `:shutdown`, and the log links to it without trapping exits, so a full disk takes the log down with `:enospc` and its callers see that exit. The commit proxy and the director's recovery phases survived by accident, wrapping their calls in `Task.async_stream`, which converts exits into results. `Shale.Recovery.pull_transactions/4` does not, so it crashed the recovering log and its `{:source_log_unavailable, log_ref}` branch, written for exactly this case, never ran.

## What changed

One clause at the end of the catch block:

```elixir
:exit, {reason, _} when reason != :calling_self -> {:error, :unavailable}
```

`call!/3` and the caller-side `rescue` are untouched, and the spec already listed both return values. Returning `{:error, {:unavailable, reason}}` is deferred until the non-exhaustive `case` expressions on these results are audited; the dying process still logs the real reason either way.

## How it works

Clause order carries the meaning. The new clause is last, so the named reasons still match first and a slow-but-alive callee keeps reporting `{:error, :timeout}`. Only reasons that would previously have been re-raised reach the catch-all, and they all mean the same thing to a caller: the process is gone.

That collapse is the point. A caller cannot do anything different for `:enospc` than for `:noproc`; both mean retry elsewhere or give up, and the branch that decides is already written against `:unavailable`. Recovery's pull path is the case in hand, where a source log dying of a full disk now takes its `{:source_log_unavailable, log_ref}` branch instead of crashing the caller.

`:calling_self` is excluded deliberately. OTP produces it before any message is sent, when a caller passes its own pid as the server, so it marks a bug in the caller rather than a dead callee and should stay loud.

## Verification

A new test module starts an unlinked server that stops mid-call and asserts unavailability for `:eacces`, `:enospc`, `{:shutdown, :disk_full}`, an exception-shaped reason, and an arbitrary term; four of the five raise against pre-fix `develop`. Full suite 2897 tests, 0 failures, with format, credo, and dialyzer clean. CI is green on OTP 27, 28, and 29 plus the S3 MinIO run (https://github.com/bedrock-kv/bedrock/actions/runs/34003486250). No follow-ups filed.

