### PR TITLE
bedrock-q67.19: make Olivine's clear_range end key exclusive

### DIFF
--- a/lib/bedrock/data_plane/materializer/olivine/index_update.ex
+++ b/lib/bedrock/data_plane/materializer/olivine/index_update.ex
@@ -181,19 +181,8 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.IndexUpdate do
         first_page = Index.get_page!(index_update.index, first_page_id)
         last_page = Index.get_page!(index_update.index, last_page_id)
 
-        first_keys_to_clear =
-          extract_keys_in_range(
-            first_page,
-            max(start_key, Page.left_key(first_page) || <<>>),
-            min(end_key, Page.right_key(first_page) || @max_key)
-          )
-
-        last_keys_to_clear =
-          extract_keys_in_range(
-            last_page,
-            max(start_key, Page.left_key(last_page) || <<>>),
-            min(end_key, Page.right_key(last_page) || @max_key)
-          )
+        first_keys_to_clear = extract_keys_in_range(first_page, start_key, end_key)
+        last_keys_to_clear = extract_keys_in_range(last_page, start_key, end_key)
 
         middle_keys_count =
           middle_page_ids_excluding_page_zero
@@ -292,7 +281,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.IndexUpdate do
   end
 
   defp page_entirely_after_range?(page_first_key, end_key) do
-    page_first_key != nil and page_first_key > end_key
+    page_first_key != nil and page_first_key >= end_key
   end
 
   defp continue_to_next_page(page_map, next_id, start_key, end_key, collected_page_ids) do
@@ -314,11 +303,12 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.IndexUpdate do
     end
   end
 
+  # `end_key` is exclusive, as it is everywhere else a key range is named.
   @spec extract_keys_in_range(Page.t(), Bedrock.key(), Bedrock.key()) :: [Bedrock.key()]
   defp extract_keys_in_range(page, start_key, end_key) do
     page
     |> Page.key_locators()
-    |> Enum.filter(fn {key, _version} -> key >= start_key and key <= end_key end)
+    |> Enum.filter(fn {key, _version} -> key >= start_key and key < end_key end)
     |> Enum.map(fn {key, _version} -> key end)
   end
 

--- a/test/bedrock/data_plane/materializer/olivine/index_manager_test.exs
+++ b/test/bedrock/data_plane/materializer/olivine/index_manager_test.exs
@@ -627,7 +627,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.IndexManagerTest do
       ]
 
       clear_transaction = test_transaction(clear_mutations, Version.from_integer(1100))
-      {vm_after_clear, _database} = IndexManager.apply_transaction(vm_with_data, clear_transaction, database)
+      {vm_after_clear, database} = IndexManager.apply_transaction(vm_with_data, clear_transaction, database)
 
       # Keys outside the range should still be accessible
       assert {:ok, _page} = IndexManager.page_for_key(vm_after_clear, <<"key_01">>, Version.from_integer(1100))
@@ -641,9 +641,10 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.IndexManagerTest do
       assert {:ok, page} = IndexManager.page_for_key(vm_after_clear, <<"key_10">>, Version.from_integer(1100))
       assert {:error, :not_found} = Page.locator_for_key(page, <<"key_10">>)
 
-      # key_15 is the exclusive end of the range and survives
+      # key_15 is the exclusive end of the range and keeps its value
       assert {:ok, page} = IndexManager.page_for_key(vm_after_clear, <<"key_15">>, Version.from_integer(1100))
-      assert {:ok, _locator} = Page.locator_for_key(page, <<"key_15">>)
+      assert {:ok, locator} = Page.locator_for_key(page, <<"key_15">>)
+      assert {:ok, <<"value_15">>} = Database.load_value(database, locator)
 
       Database.close(database)
     end

--- a/test/bedrock/data_plane/materializer/olivine/index_manager_test.exs
+++ b/test/bedrock/data_plane/materializer/olivine/index_manager_test.exs
@@ -641,8 +641,9 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.IndexManagerTest do
       assert {:ok, page} = IndexManager.page_for_key(vm_after_clear, <<"key_10">>, Version.from_integer(1100))
       assert {:error, :not_found} = Page.locator_for_key(page, <<"key_10">>)
 
+      # key_15 is the exclusive end of the range and survives
       assert {:ok, page} = IndexManager.page_for_key(vm_after_clear, <<"key_15">>, Version.from_integer(1100))
-      assert {:error, :not_found} = Page.locator_for_key(page, <<"key_15">>)
+      assert {:ok, _locator} = Page.locator_for_key(page, <<"key_15">>)
 
       Database.close(database)
     end

--- a/test/bedrock/data_plane/materializer/olivine/index_update_test.exs
+++ b/test/bedrock/data_plane/materializer/olivine/index_update_test.exs
@@ -135,15 +135,16 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.IndexUpdateTest do
 
       # Boundary pages keep only their out-of-range keys
       assert final_index |> Index.get_page!(1) |> Page.keys() == ["a"]
-      assert final_index |> Index.get_page!(3) |> Page.keys() == ["i"]
-      assert all_keys(final_index) == ["a", "i"]
+      assert final_index |> Index.get_page!(3) |> Page.keys() == ["h", "i"]
+      assert all_keys(final_index) == ["a", "h", "i"]
 
       # Chain is repaired: page 1 now points past the deleted page to page 3
       {_page, next_id} = Index.get_page_with_next_id!(final_index, 1)
       assert next_id == 3
 
-      # The delta covers first-page (b, c), middle-page (d, e, f) and last-page (g, h) keys
-      assert update.key_count_delta == -7
+      # The delta covers first-page (b, c), middle-page (d, e, f) and last-page
+      # (g) keys; "h" is the exclusive end and survives
+      assert update.key_count_delta == -6
     end
 
     test "clear_range followed by sets of in-range keys in the same batch keeps only the re-set keys", %{
@@ -167,6 +168,51 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.IndexUpdateTest do
       assert all_keys(final_index) == ["b", "d"]
       assert {:ok, _page, locator} = Index.locator_for_key(final_index, "b")
       assert {:ok, "rewritten-b"} = Database.load_value(final_db, locator)
+    end
+  end
+
+  describe "clear_range end key is exclusive" do
+    test "the key at the range end survives a single-page clear", %{database: database} do
+      {index, allocator} = build_index([{0, ["a", "b", "c"]}])
+
+      update = run_mutations(index, allocator, database, [{:clear_range, "a", "c"}])
+      {final_index, _db, _allocator, _modified} = IndexUpdate.finish(update)
+
+      assert all_keys(final_index) == ["c"]
+      assert update.key_count_delta == -2
+    end
+
+    test "the key at the range end survives when it opens a later page", %{database: database} do
+      # "c" is the right key of the first page and lies strictly inside the
+      # range; "g" is the left key of the last page and sits exactly on the
+      # exclusive end.
+      {index, allocator} =
+        build_index([
+          {1, ["a", "b", "c"]},
+          {2, ["d", "e", "f"]},
+          {3, ["g", "h", "i"]}
+        ])
+
+      update = run_mutations(index, allocator, database, [{:clear_range, "c", "g"}])
+      {final_index, _db, final_allocator, _modified} = IndexUpdate.finish(update)
+
+      assert all_keys(final_index) == ["a", "b", "g", "h", "i"]
+      assert update.key_count_delta == -4
+
+      # Page 2 is emptied and recycled; page 3 is untouched
+      refute Map.has_key?(final_index.page_map, 2)
+      assert 2 in final_allocator.free_ids
+      assert final_index |> Index.get_page!(3) |> Page.keys() == ["g", "h", "i"]
+    end
+
+    test "an empty range clears nothing", %{database: database} do
+      {index, allocator} = build_index([{0, ["a", "b", "c"]}])
+
+      update = run_mutations(index, allocator, database, [{:clear_range, "b", "b"}])
+      {final_index, _db, _allocator, _modified} = IndexUpdate.finish(update)
+
+      assert all_keys(final_index) == ["a", "b", "c"]
+      assert update.key_count_delta == 0
     end
   end
 
@@ -194,14 +240,14 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.IndexUpdateTest do
       refute 0 in final_allocator.free_ids
       assert final_index |> Index.get_page!(0) |> Page.key_count() == 0
 
-      # The middle page is deleted and recycled; the last page keeps "f"
+      # Page 1 is emptied and recycled; page 2 keeps the exclusive end "e"
       refute Map.has_key?(final_index.page_map, 1)
       assert 1 in final_allocator.free_ids
-      assert final_index |> Index.get_page!(2) |> Page.keys() == ["f"]
-      assert all_keys(final_index) == ["f"]
+      assert final_index |> Index.get_page!(2) |> Page.keys() == ["e", "f"]
+      assert all_keys(final_index) == ["e", "f"]
 
-      # a, b from page 0 + c, d from the middle page + e from the last page
-      assert update.key_count_delta == -5
+      # a, b from page 0 + c, d from page 1
+      assert update.key_count_delta == -4
     end
   end
 

--- a/test/bedrock/data_plane/materializer/olivine/range_clear_ordering_property_test.exs
+++ b/test/bedrock/data_plane/materializer/olivine/range_clear_ordering_property_test.exs
@@ -287,9 +287,9 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.RangeClearOrderingPropertyTest 
 
     remaining_keys =
       Enum.reduce(clear_ranges, sorted_initial_keys, fn {start_key, end_key}, current_keys ->
-        # Remove all keys in this range
+        # Remove all keys in this half-open range
         Enum.reject(current_keys, fn key ->
-          key >= start_key and key <= end_key
+          key >= start_key and key < end_key
         end)
       end)
 


### PR DESCRIPTION
Olivine's materializer applied a `clear_range` mutation as the closed interval `[start, end]`, deleting the key on the end. Every other component treats that tuple as half-open. The write path now filters with `key < end_key` and drops the per-page clamping that would otherwise spare boundary keys.

Ticket: bedrock-q67.19
Stacked on: #253 (bedrock-jb4/index-manager-stats-accounting)

## Why

A key range in Bedrock is `[start, end)`. The transaction builder names the argument `end_ex`, shard routing clamps a cross-shard clear to the shard's exclusive upper bound, and Olivine's read path stops at `key < end_key`.

The write path was the exception. `extract_keys_in_range/3` filtered `key <= end_key`, so clearing `[a, c)` on a page holding a, b, c cleared all three. That durably deletes a key the transaction never took a write conflict on, so a concurrent writer of c commits against a resolver seeing no overlap and loses its write. Issue #236 reproduced this at 8f962e09.

Flipping the comparison alone would not have sufficed. The multi-page branch handed each boundary page the range clamped to that page's own bounds. Under an inclusive filter that clamp is inert; under an exclusive one it lowers the end to the page's right key, which then survives despite lying inside the range. The property oracle repeated the same mistake.

## What changed

- `extract_keys_in_range/3` filters `key >= start_key and key < end_key`.
- Both boundary pages receive the original range; the `max`/`min` clamps are gone.
- `page_entirely_after_range?/2` stops at `page_first_key >= end_key`, an inert edit: such a page is always the last collected and yields nothing.
- The property oracle uses the half-open predicate; three boundary tests added, four expectations re-derived.

No guard for empty or reversed ranges: the client path drops them and one arriving anyway clears nothing.

## How it works

A clear walks the page chain from the start key's page, collecting until a page lies entirely after the range. Boundary pages contribute pending clears; middle pages are deleted wholesale and recycled, which stays exact because a middle page's successor was collected only for having a left key below the end, above that middle page's right key.

```
pages [a b c] [d e f] [g h i], clear_range("c", "g")

before:  a b _ | _ _ _ | _ h i     "g" deleted, delta -5
after:   a b _ | _ _ _ | g h i     page 2 recycled, delta -4
```

## Verification

Three new tests were red on the base: the end key surviving a single-page clear, surviving when it opens a later page (this one fails on either half of the fix alone), and an empty range clearing nothing. The manager-level test asserts the end key still loads its value (e5771706). Local: 2901 tests, 158 properties, 17 doctests, one unrelated `LogTest` timeout that passes in isolation; format, Credo, Dialyzer clean. No checks on this draft branch.

PR #247 is a duplicate fix for this ticket on the #242 stack, closing issue #236. Exactly one of the two should merge; the other should be closed, not merged on top. #247 also covers a site that does not exist here: #242 adds `clear_pending_keys_in_range/3`, whose staged-overlay filter is inclusive. If #262 lands first and #242 rebases onto it, that predicate needs the same fix.

Follow-up: bedrock-9mo, remove the unreachable page-0 middle branch (PR #274).
