### PR TITLE
bedrock-q67.25: cluster config authority — desired_commit_proxies moves to the \xFF/system/config keyspace

### DIFF
--- a/lib/bedrock/control_plane/config/recovery_attempt.ex
+++ b/lib/bedrock/control_plane/config/recovery_attempt.ex
@@ -57,6 +57,7 @@ defmodule Bedrock.ControlPlane.Config.RecoveryAttempt do
     shard_materializers: %{},
     seeded_layout?: false,
     prior_materializer_refs: nil,
+    committed_parameters: %{},
     lock_failed_service_ids: MapSet.new()
   ]
 
@@ -84,6 +85,7 @@ defmodule Bedrock.ControlPlane.Config.RecoveryAttempt do
           shard_materializers: %{Bedrock.range_tag() => %{Worker.id() => node_name :: String.t()}},
           seeded_layout?: boolean(),
           prior_materializer_refs: %{Bedrock.range_tag() => %{Worker.id() => String.t()}} | nil,
+          committed_parameters: %{binary() => pos_integer()},
           lock_failed_service_ids: MapSet.t(Worker.id()),
           shard_layout: shard_layout() | nil
         }
@@ -125,6 +127,7 @@ defmodule Bedrock.ControlPlane.Config.RecoveryAttempt do
       shard_materializers: %{},
       seeded_layout?: false,
       prior_materializer_refs: nil,
+      committed_parameters: %{},
       lock_failed_service_ids: MapSet.new()
     }
   end

--- a/lib/bedrock/control_plane/director/recovery/commit_proxy_startup_phase.ex
+++ b/lib/bedrock/control_plane/director/recovery/commit_proxy_startup_phase.ex
@@ -13,6 +13,11 @@ defmodule Bedrock.ControlPlane.Director.Recovery.CommitProxyStartupPhase do
   proxies across different machines. Each proxy is configured with epoch and director
   information for recovery coordination.
 
+  How many proxies to start is the committed `\\xff/system/config/desired_commit_proxies`,
+  read from the keyspace by the materializer bootstrap phase; the coordinator's
+  configuration answers only for a cluster whose family does not carry the
+  parameter yet.
+
   Stalls if no coordination-capable nodes are available since at least one proxy
   must be operational for transaction processing. Proxies remain locked until
   Transaction System Layout phase transitions them to operational mode.
@@ -24,6 +29,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery.CommitProxyStartupPhase do
   alias Bedrock.Cluster
   alias Bedrock.ControlPlane.Director.Recovery.Shared
   alias Bedrock.DataPlane.CommitProxy
+  alias Bedrock.SystemKeys
 
   @impl true
   def execute(recovery_attempt, context) do
@@ -36,7 +42,8 @@ defmodule Bedrock.ControlPlane.Director.Recovery.CommitProxyStartupPhase do
 
     available_commit_proxy_nodes = Map.get(context.node_capabilities, :coordination, [])
 
-    context.cluster_config.parameters.desired_commit_proxies
+    recovery_attempt
+    |> desired_commit_proxies(context)
     |> define_commit_proxies(
       recovery_attempt.cluster,
       recovery_attempt.epoch,
@@ -54,6 +61,27 @@ defmodule Bedrock.ControlPlane.Director.Recovery.CommitProxyStartupPhase do
         updated_recovery_attempt = %{recovery_attempt | proxies: commit_proxies}
         {updated_recovery_attempt, Bedrock.ControlPlane.Director.Recovery.ResolverStartupPhase}
     end
+  end
+
+  # The keyspace is the authority. FDB recruits commit proxies from
+  # `configuration.getDesiredCommitProxies()` — a field of the
+  # DatabaseConfiguration the cluster controller built by reading
+  # `\xff/conf/` out of the txnStateStore (ClusterRecovery.actor.cpp:1191,
+  # DatabaseConfiguration.cpp:606-609), and `\xff/conf/commit_proxies` is
+  # changed by an ordinary transaction, not by touching the coordinators.
+  # The materializer bootstrap phase performed the equivalent read.
+  #
+  # The coordinator's value is the BOOTSTRAP ANCHOR: it answers only for
+  # a cluster whose committed family does not carry the parameter yet (a
+  # fresh cluster, or one that predates the family), and the persistence
+  # phase then seeds the family with it. Preferring it once the family
+  # carries a value would make every configuration change last exactly
+  # until the next recovery.
+  @spec desired_commit_proxies(RecoveryAttempt.t(), map()) :: pos_integer()
+  defp desired_commit_proxies(recovery_attempt, context) do
+    Map.get_lazy(recovery_attempt.committed_parameters, SystemKeys.desired_commit_proxies(), fn ->
+      context.cluster_config.parameters.desired_commit_proxies
+    end)
   end
 
   @spec define_commit_proxies(

--- a/lib/bedrock/control_plane/director/recovery/commit_proxy_startup_phase.ex
+++ b/lib/bedrock/control_plane/director/recovery/commit_proxy_startup_phase.ex
@@ -67,9 +67,11 @@ defmodule Bedrock.ControlPlane.Director.Recovery.CommitProxyStartupPhase do
   # `configuration.getDesiredCommitProxies()` — a field of the
   # DatabaseConfiguration the cluster controller built by reading
   # `\xff/conf/` out of the txnStateStore (ClusterRecovery.actor.cpp:1191,
-  # DatabaseConfiguration.cpp:606-609), and `\xff/conf/commit_proxies` is
-  # changed by an ordinary transaction, not by touching the coordinators.
-  # The materializer bootstrap phase performed the equivalent read.
+  # DatabaseConfiguration.cpp:607-610), and `\xff/conf/commit_proxies` is
+  # changed by an ordinary transaction, not by touching the coordinators
+  # (Bedrock has no operator-facing writer for the range yet,
+  # bedrock-q67.51). The materializer bootstrap phase performed the
+  # equivalent read.
   #
   # The coordinator's value is the BOOTSTRAP ANCHOR: it answers only for
   # a cluster whose committed family does not carry the parameter yet (a

--- a/lib/bedrock/control_plane/director/recovery/materializer_bootstrap_phase.ex
+++ b/lib/bedrock/control_plane/director/recovery/materializer_bootstrap_phase.ex
@@ -21,6 +21,8 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhase do
   3. Unlock it with its replica set of pull sources to start pulling
   4. Wait for it to catch up (60s timeout)
   5. Query the shard layout from `\\xff/system/shard_keys/*`
+  6. Query the committed cluster configuration from `\\xff/system/config/*`
+     (FDB's `\\xff/conf/` read at recovery, `ClusterRecovery.actor.cpp:1191`)
 
   Stalls if the named members are unavailable, if catchup times out, or if
   the recovered layout reads empty. Records written before the core state
@@ -256,6 +258,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhase do
          {:ok, shard_layout} <- get_shard_layout(materializer_pid, recovery_version, context),
          :ok <- reject_empty_layout(shard_layout),
          {:ok, prior_refs} <- read_prior_refs(materializer_pid, recovery_version, context),
+         {:ok, committed_parameters} <- read_committed_parameters(materializer_pid, recovery_version, context),
          {:ok, shard_materializers, created_services} <-
            ensure_materializers_for_shards(
              shard_layout,
@@ -281,6 +284,11 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhase do
         # the diff base for materializer writes.
         |> Map.put(:seeded_layout?, false)
         |> Map.put(:prior_materializer_refs, prior_refs)
+        # The committed cluster configuration, read at the same version
+        # from the same materializer as the other two families. Later
+        # phases size the transaction system from it; the coordinator's
+        # copy is only the anchor for what the family does not carry.
+        |> Map.put(:committed_parameters, committed_parameters)
         |> Map.put(:resolvers, resolver_descriptors_for_layout(shard_layout))
         |> Map.update!(:transaction_services, &Map.merge(&1, created_services))
 
@@ -552,6 +560,33 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhase do
 
     case Reader.read_family(range_read_fn, prefix, :prior_refs_query_failed) do
       {:ok, entries} -> decode_prior_refs(entries)
+      {:error, _reason} = error -> error
+    end
+  end
+
+  # Read the durable config/ family at the recovery version: the cluster
+  # configuration the later phases size the transaction system from. FDB
+  # does exactly this and nowhere else — the cluster controller builds
+  # its DatabaseConfiguration from a read of the \xff/conf/ range out of
+  # the txnStateStore (ClusterRecovery.actor.cpp:1191-1193), never from
+  # the coordinators, whose coordinated state carries only the anchor.
+  # Same materializer, same version as the other two families, so the
+  # three cannot be read torn.
+  defp read_committed_parameters(materializer_pid, read_version, context) do
+    read_fn = Map.get(context, :read_committed_parameters_fn, &default_read_committed_parameters/2)
+    read_fn.(materializer_pid, read_version)
+  end
+
+  defp default_read_committed_parameters(materializer_pid, read_version) do
+    prefix = Bedrock.SystemKeys.config_prefix()
+    {_range_start, range_end} = Bedrock.KeyRange.from_prefix(prefix)
+
+    range_read_fn = fn start_key ->
+      Materializer.get_range(materializer_pid, start_key, range_end, read_version, limit: 1000)
+    end
+
+    case Reader.read_family(range_read_fn, prefix, :config_query_failed) do
+      {:ok, entries} -> Reader.decode_config_parameters(entries)
       {:error, _reason} = error -> error
     end
   end

--- a/lib/bedrock/control_plane/director/recovery/materializer_bootstrap_phase.ex
+++ b/lib/bedrock/control_plane/director/recovery/materializer_bootstrap_phase.ex
@@ -287,7 +287,11 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhase do
         # The committed cluster configuration, read at the same version
         # from the same materializer as the other two families. Later
         # phases size the transaction system from it; the coordinator's
-        # copy is only the anchor for what the family does not carry.
+        # copy is only the anchor for what the family does not carry. A
+        # STALLED attempt is stashed into the coordinator's config (as
+        # shard_layout already is), so the read transits coordinator
+        # state — as scratch, never as authority: the next attempt
+        # re-reads before any phase consumes it.
         |> Map.put(:committed_parameters, committed_parameters)
         |> Map.put(:resolvers, resolver_descriptors_for_layout(shard_layout))
         |> Map.update!(:transaction_services, &Map.merge(&1, created_services))

--- a/lib/bedrock/control_plane/director/recovery/persistence_phase.ex
+++ b/lib/bedrock/control_plane/director/recovery/persistence_phase.ex
@@ -38,7 +38,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery.PersistencePhase do
 
     transaction_system_layout = recovery_attempt.transaction_system_layout
 
-    system_transaction = build_system_transaction(recovery_attempt)
+    system_transaction = build_system_transaction(recovery_attempt, context.cluster_config)
 
     case submit_system_transaction(system_transaction, recovery_attempt.proxies, recovery_attempt.epoch, context) do
       {:ok, _version, _sequence} ->
@@ -179,6 +179,12 @@ defmodule Bedrock.ControlPlane.Director.Recovery.PersistencePhase do
     }
   end
 
+  # The cold-boot record. `desired_commit_proxies` is now the BOOTSTRAP
+  # ANCHOR only: it seeds `\xff/system/config/desired_commit_proxies` on a
+  # cluster that has none, and a cluster that has one ignores it (FDB's
+  # coordinated state carries the connection string, not the
+  # configuration). The rest are still authoritative here, and move to the
+  # keyspace as their readers move with them.
   defp build_parameters(config) do
     params = config.parameters
 
@@ -211,10 +217,10 @@ defmodule Bedrock.ControlPlane.Director.Recovery.PersistencePhase do
     end)
   end
 
-  @spec build_system_transaction(RecoveryAttempt.t()) :: Transaction.encoded()
-  defp build_system_transaction(recovery_attempt) do
+  @spec build_system_transaction(RecoveryAttempt.t(), map()) :: Transaction.encoded()
+  defp build_system_transaction(recovery_attempt, cluster_config) do
     tx = Tx.new()
-    tx = build_readable_keys(tx, recovery_attempt)
+    tx = build_readable_keys(tx, recovery_attempt, cluster_config)
 
     Tx.commit(tx, nil)
   end
@@ -223,12 +229,15 @@ defmodule Bedrock.ControlPlane.Director.Recovery.PersistencePhase do
   # RoutingData and the next recovery's materializer bootstrap, and
   # materializers/ refs feed the client-facing routing projection (FDB's
   # serverList analogue - runtime hints, never recovery input) and worker
-  # rejoin validation. Nothing else is written (config and policy travel
-  # via the object-storage cluster bootstrap, which the coordinator
-  # actually reads; services are rebuilt each recovery from foreman
-  # discovery). Families return to the keyspace when their readers do
-  # (bedrock-q67.9, q67.25) - and only then. FDB does keep a keyspace
-  # copy of its log set (`\xff/logs`, SystemData.cpp:1171, written by the
+  # rejoin validation, and config/ carries the cluster configuration the
+  # commit-proxy startup phase sizes itself from (seeded once, then the
+  # keyspace's to change). Nothing else is written (the remaining
+  # parameters and the policies still travel via the object-storage
+  # cluster bootstrap, which the coordinator actually reads; services are
+  # rebuilt each recovery from foreman discovery). Families return to the
+  # keyspace when their readers do (bedrock-q67.9) - and only then. FDB
+  # does keep a keyspace copy of its log set (`\xff/logs`,
+  # SystemData.cpp:1171, written by the
   # recovery transaction at ClusterRecovery.actor.cpp:1728), so the
   # deleted layout/logs family was its analogue - but FDB's copy has
   # three readers we have no equivalent of: recovery's stale-master
@@ -238,13 +247,46 @@ defmodule Bedrock.ControlPlane.Director.Recovery.PersistencePhase do
   # and the tag mapping it held survives in the cluster bootstrap the
   # coordinator actually loads. The family comes back when one of those
   # readers does (bedrock-q67.21.10).
-  @spec build_readable_keys(Tx.t(), RecoveryAttempt.t()) :: Tx.t()
-  defp build_readable_keys(tx, recovery_attempt) do
+  @spec build_readable_keys(Tx.t(), RecoveryAttempt.t(), map()) :: Tx.t()
+  defp build_readable_keys(tx, recovery_attempt, cluster_config) do
     # The mapping families are durable, distributor-era state: recovery
     # reads and heals, never blanket-clears (bedrock-q67.21.2).
     tx
     |> build_shard_keys(recovery_attempt)
     |> build_materializer_keys(recovery_attempt)
+    |> build_config_keys(recovery_attempt, cluster_config)
+  end
+
+  # Seeds `config/<name>` for a parameter the committed family does not
+  # carry — a fresh cluster, or one that predates the family — and writes
+  # nothing otherwise.
+  #
+  # The keyspace copy is the authority, so this must not be a rewrite:
+  # `\xff/conf/` is changed by an ordinary transaction (FDB's
+  # `changeConfig`, ManagementAPI.actor.cpp), and recovery's own commit
+  # only READS it (ClusterRecovery.actor.cpp:1191). Re-stamping the
+  # coordinator's bootstrap anchor over the committed value each epoch
+  # would make every configuration change last exactly until the next
+  # recovery. The coordinator keeps the anchor and nothing more: it
+  # answers the seed, and the family answers everything after it.
+  #
+  # Only `desired_commit_proxies` moves here for now — the parameter with
+  # a live keyspace-side reader (the commit-proxy startup phase). The
+  # rest of the parameters and the policies follow their own readers, one
+  # at a time; writing them ahead of a reader would be inventory.
+  @spec build_config_keys(Tx.t(), RecoveryAttempt.t(), map()) :: Tx.t()
+  defp build_config_keys(tx, recovery_attempt, cluster_config) do
+    name = SystemKeys.desired_commit_proxies()
+
+    if Map.has_key?(recovery_attempt.committed_parameters, name) do
+      tx
+    else
+      Tx.set(
+        tx,
+        SystemKeys.config_key(name),
+        Values.encode_config_integer(cluster_config.parameters.desired_commit_proxies)
+      )
+    end
   end
 
   # Creates materializer_key(tag, worker_id) -> node entries as a DIFF

--- a/lib/bedrock/control_plane/director/recovery/persistence_phase.ex
+++ b/lib/bedrock/control_plane/director/recovery/persistence_phase.ex
@@ -184,7 +184,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery.PersistencePhase do
   # cluster that has none, and a cluster that has one ignores it (FDB's
   # coordinated state carries the connection string, not the
   # configuration). The rest are still authoritative here, and move to the
-  # keyspace as their readers move with them.
+  # keyspace as their readers move with them (bedrock-q67.50).
   defp build_parameters(config) do
     params = config.parameters
 
@@ -263,8 +263,8 @@ defmodule Bedrock.ControlPlane.Director.Recovery.PersistencePhase do
   #
   # The keyspace copy is the authority, so this must not be a rewrite:
   # `\xff/conf/` is changed by an ordinary transaction (FDB's
-  # `changeConfig`, ManagementAPI.actor.cpp), and recovery's own commit
-  # only READS it (ClusterRecovery.actor.cpp:1191). Re-stamping the
+  # `changeConfig`, GenericManagementAPI.actor.h:256), and recovery's own
+  # commit only READS it (ClusterRecovery.actor.cpp:1191). Re-stamping the
   # coordinator's bootstrap anchor over the committed value each epoch
   # would make every configuration change last exactly until the next
   # recovery. The coordinator keeps the anchor and nothing more: it
@@ -273,7 +273,9 @@ defmodule Bedrock.ControlPlane.Director.Recovery.PersistencePhase do
   # Only `desired_commit_proxies` moves here for now — the parameter with
   # a live keyspace-side reader (the commit-proxy startup phase). The
   # rest of the parameters and the policies follow their own readers, one
-  # at a time; writing them ahead of a reader would be inventory.
+  # at a time (bedrock-q67.50); writing them ahead of a reader would be
+  # inventory. Bedrock has no operator-facing writer for the family yet
+  # (bedrock-q67.51), so a seeded parameter is fixed until one lands.
   @spec build_config_keys(Tx.t(), RecoveryAttempt.t(), map()) :: Tx.t()
   defp build_config_keys(tx, recovery_attempt, cluster_config) do
     name = SystemKeys.desired_commit_proxies()

--- a/lib/bedrock/system_keys.ex
+++ b/lib/bedrock/system_keys.ex
@@ -16,8 +16,9 @@ defmodule Bedrock.SystemKeys do
   mutating distributor transaction, so ownership is enforced by the
   commit pipeline itself. `config/<name>` carries the cluster's
   configuration (FDB's `\\xff/conf/`, `SystemData.cpp:1005`): recovery
-  READS it to size the transaction system, and an ordinary transaction
-  is what changes it. A system key without a
+  READS it to size the transaction system, and recovery seeds it exactly
+  once - only `desired_commit_proxies` lives here so far, the rest
+  following their own readers (bedrock-q67.50). A system key without a
   reader is inventory, not communication - unread MACHINERY is deleted,
   while durable observability keys stay by decision, named as such;
   families return here when their readers do.
@@ -43,8 +44,10 @@ defmodule Bedrock.SystemKeys do
   reading this range out of the txnStateStore during recovery
   (`ClusterRecovery.actor.cpp:1191-1193`), never from the coordinators,
   and configuration changes are ordinary transactions over the range
-  (`ManagementAPI.actor.cpp` `changeConfig`). Recovery only seeds a
-  parameter the family does not carry yet.
+  (`changeConfig`, `GenericManagementAPI.actor.h:256`). Recovery only
+  seeds a parameter the family does not carry yet; Bedrock has no
+  operator-facing writer for the range yet (bedrock-q67.51), so a seeded
+  parameter is currently fixed until one lands.
   """
   @spec config_key(name :: binary()) :: Bedrock.key()
   def config_key(name) when is_binary(name), do: "#{@system_prefix}/config/#{name}"
@@ -55,7 +58,7 @@ defmodule Bedrock.SystemKeys do
 
   @doc """
   The parameter naming the desired number of commit proxies (FDB's
-  `\\xff/conf/commit_proxies`, `DatabaseConfiguration.cpp:606-609`).
+  `\\xff/conf/commit_proxies`, `DatabaseConfiguration.cpp:607-610`).
 
   The name is the family's vocabulary, shared by recovery's seed writer
   and the commit-proxy startup phase that reads it, so neither can spell

--- a/lib/bedrock/system_keys.ex
+++ b/lib/bedrock/system_keys.ex
@@ -14,11 +14,13 @@ defmodule Bedrock.SystemKeys do
   write}` is the distributor's write fence (FDB's MoveKeys lock,
   bedrock-q67.21): opaque UIDs read-checked-written inside every
   mutating distributor transaction, so ownership is enforced by the
-  commit pipeline itself. A system key without a
+  commit pipeline itself. `config/<name>` carries the cluster's
+  configuration (FDB's `\\xff/conf/`, `SystemData.cpp:1005`): recovery
+  READS it to size the transaction system, and an ordinary transaction
+  is what changes it. A system key without a
   reader is inventory, not communication - unread MACHINERY is deleted,
   while durable observability keys stay by decision, named as such;
-  families return here when their readers do (config authority with
-  bedrock-q67.25).
+  families return here when their readers do.
   """
 
   alias Bedrock.Service.Worker
@@ -32,6 +34,35 @@ defmodule Bedrock.SystemKeys do
   @doc "Distributor write-fence write UID: `distributor_lock/write` (FDB's moveKeysLockWriteKey)"
   @spec distributor_lock_write() :: Bedrock.key()
   def distributor_lock_write, do: "#{@system_prefix}/distributor_lock/write"
+
+  @doc """
+  Cluster configuration parameter: `config/<name>` -> the parameter's value.
+
+  FDB's `configKeys` (`\\xff/conf/`, `SystemData.cpp:1005`), and the same
+  authority: the cluster controller builds its `DatabaseConfiguration` by
+  reading this range out of the txnStateStore during recovery
+  (`ClusterRecovery.actor.cpp:1191-1193`), never from the coordinators,
+  and configuration changes are ordinary transactions over the range
+  (`ManagementAPI.actor.cpp` `changeConfig`). Recovery only seeds a
+  parameter the family does not carry yet.
+  """
+  @spec config_key(name :: binary()) :: Bedrock.key()
+  def config_key(name) when is_binary(name), do: "#{@system_prefix}/config/#{name}"
+
+  @doc "Prefix covering every cluster configuration parameter"
+  @spec config_prefix() :: Bedrock.key()
+  def config_prefix, do: "#{@system_prefix}/config/"
+
+  @doc """
+  The parameter naming the desired number of commit proxies (FDB's
+  `\\xff/conf/commit_proxies`, `DatabaseConfiguration.cpp:606-609`).
+
+  The name is the family's vocabulary, shared by recovery's seed writer
+  and the commit-proxy startup phase that reads it, so neither can spell
+  it alone.
+  """
+  @spec desired_commit_proxies() :: binary()
+  def desired_commit_proxies, do: "desired_commit_proxies"
 
   @doc "Shard boundary entry: `shard_keys/<end_key>` -> `{tag, start_key}` (ceiling search)"
   @spec shard_key(Bedrock.key()) :: Bedrock.key()
@@ -89,11 +120,13 @@ defmodule Bedrock.SystemKeys do
           {:shard_key, Bedrock.key()}
           | {:materializer_key, Bedrock.range_tag(), Worker.id()}
           | {:distributor_lock, :owner | :write}
+          | {:config, name :: binary()}
           | :unknown
           | :error
   def parse_key(<<@system_prefix, "/distributor_lock/owner">>), do: {:distributor_lock, :owner}
   def parse_key(<<@system_prefix, "/distributor_lock/write">>), do: {:distributor_lock, :write}
   def parse_key(<<@system_prefix, "/shard_keys/", rest::binary>>), do: {:shard_key, rest}
+  def parse_key(<<@system_prefix, "/config/", rest::binary>>) when rest != "", do: {:config, rest}
 
   def parse_key(<<@system_prefix, "/materializers/", rest::binary>>) do
     case String.split(rest, "/", parts: 2) do

--- a/lib/bedrock/system_keys/reader.ex
+++ b/lib/bedrock/system_keys/reader.ex
@@ -82,6 +82,38 @@ defmodule Bedrock.SystemKeys.Reader do
   defp decode_member_entry(_not_a_member_key, _value), do: :error
 
   @doc """
+  Decodes `config/<name>` entries into `%{name => value}`, with the
+  parameter name as the binary it is in the key - decoding durable bytes
+  never creates atoms, so consumers look parameters up by the names
+  `Bedrock.SystemKeys` publishes.
+
+  A foreign key, or a parameter whose value does not decode, fails the
+  whole read. Skipping it would report the parameter as ABSENT, and
+  absent means "seed me from the coordinator's bootstrap anchor" - so a
+  single corrupt value would silently revert a configured cluster to its
+  cold-boot defaults and then rewrite them as committed.
+  """
+  @spec decode_config_parameters([{Bedrock.key(), binary()}]) ::
+          {:ok, %{binary() => pos_integer()}} | {:error, {:invalid_config_entry, Bedrock.key()}}
+  def decode_config_parameters(entries) do
+    Enum.reduce_while(entries, {:ok, %{}}, fn {key, value}, {:ok, acc} ->
+      case decode_config_entry(SystemKeys.parse_key(key), value) do
+        {:ok, name, decoded} -> {:cont, {:ok, Map.put(acc, name, decoded)}}
+        :error -> {:halt, {:error, {:invalid_config_entry, key}}}
+      end
+    end)
+  end
+
+  defp decode_config_entry({:config, name}, value) do
+    case Values.decode_config_integer(value) do
+      {:ok, decoded} -> {:ok, name, decoded}
+      _ -> :error
+    end
+  end
+
+  defp decode_config_entry(_not_a_config_key, _value), do: :error
+
+  @doc """
   Decodes `shard_keys/<end_key>` entries into the boundary map
   `%{end_key => {tag, start_key}}`, consuming the carried start key
   verbatim — the same meaning `RoutingData.apply_mutation` gives the

--- a/lib/bedrock/system_keys/reader.ex
+++ b/lib/bedrock/system_keys/reader.ex
@@ -92,6 +92,13 @@ defmodule Bedrock.SystemKeys.Reader do
   absent means "seed me from the coordinator's bootstrap anchor" - so a
   single corrupt value would silently revert a configured cluster to its
   cold-boot defaults and then rewrite them as committed.
+
+  This is stricter than FDB, which discards `setInternal`'s return value
+  in `DatabaseConfiguration::fromKeyValues` and so simply skips a
+  `\\xff/conf/` key it does not recognize. With one member and one codec
+  the strict direction is the safe one; when the family goes
+  heterogeneous or version-skewed, an unreadable NAME must be tolerated
+  where an unreadable VALUE still must not (bedrock-q67.50).
   """
   @spec decode_config_parameters([{Bedrock.key(), binary()}]) ::
           {:ok, %{binary() => pos_integer()}} | {:error, {:invalid_config_entry, Bedrock.key()}}

--- a/lib/bedrock/system_keys/values.ex
+++ b/lib/bedrock/system_keys/values.ex
@@ -8,10 +8,11 @@ defmodule Bedrock.SystemKeys.Values do
   bytes must never create atoms.
 
   The surface is exactly the written families - `shard_keys/` entries
-  (the routing boundary map) and `materializers/` membership (the node as
+  (the routing boundary map), `materializers/` membership (the node as
   a string; consumers derive the callable `{otp_name, node}` ref from it
   and the worker id in the key, so the no-atoms rule holds through
-  decode). Families return here when their readers do.
+  decode), and `config/` parameters. Families return here when their
+  readers do.
   """
 
   alias Bedrock.Encoding.Tuple, as: TupleEncoding
@@ -43,6 +44,27 @@ defmodule Bedrock.SystemKeys.Values do
   @spec encode_materializer_node(String.t()) :: binary()
   def encode_materializer_node(node) when is_binary(node), do: TupleEncoding.pack(node)
 
+  @doc """
+  Encodes a `config/<name>` value: a positive integer.
+
+  Every member of the family is a count or a duration today, so the
+  family has one codec and `decode_for/2` needs no per-name dispatch.
+  FDB stores its `\\xff/conf/` values as decimal text and parses them per
+  key (`DatabaseConfiguration::setInternal`); we keep the repo's tuple
+  encoding, which is self-describing enough that a wrongly-typed value
+  fails the decode instead of silently reading as zero.
+  """
+  @spec encode_config_integer(pos_integer()) :: binary()
+  def encode_config_integer(value) when is_integer(value) and value > 0, do: TupleEncoding.pack(value)
+
+  def encode_config_integer(other) do
+    raise ArgumentError, "config parameter value must be a positive integer: #{inspect(other)}"
+  end
+
+  @doc "Decodes a `config/<name>` value to `{:ok, integer}`."
+  @spec decode_config_integer(binary()) :: {:ok, pos_integer()} | decode_error()
+  def decode_config_integer(binary), do: safe_unpack(binary, &(is_integer(&1) and &1 > 0))
+
   @doc "Decodes a shard key entry to `{:ok, {tag, start_key}}`."
   @spec decode_shard_key_entry(binary()) :: {:ok, {Bedrock.range_tag(), Bedrock.key()}} | decode_error()
   def decode_shard_key_entry(binary),
@@ -60,6 +82,7 @@ defmodule Bedrock.SystemKeys.Values do
   def decode_for({:distributor_lock, _which}, value), do: decode_lock_uid(value)
   def decode_for({:shard_key, _end_key}, value), do: decode_shard_key_entry(value)
   def decode_for({:materializer_key, _tag, _worker_id}, value), do: decode_materializer_node(value)
+  def decode_for({:config, _name}, value), do: decode_config_integer(value)
   def decode_for(_unknown, _value), do: {:error, :unknown_family}
 
   defp safe_unpack(binary, valid?) when is_binary(binary) do

--- a/lib/bedrock/system_keys/values.ex
+++ b/lib/bedrock/system_keys/values.ex
@@ -48,7 +48,8 @@ defmodule Bedrock.SystemKeys.Values do
   Encodes a `config/<name>` value: a positive integer.
 
   Every member of the family is a count or a duration today, so the
-  family has one codec and `decode_for/2` needs no per-name dispatch.
+  family has one codec and `decode_for/2` needs no per-name dispatch; a
+  boolean or string parameter needs one (bedrock-q67.50).
   FDB stores its `\\xff/conf/` values as decimal text and parses them per
   key (`DatabaseConfiguration::setInternal`); we keep the repo's tuple
   encoding, which is self-describing enough that a wrongly-typed value

--- a/test/bedrock/control_plane/director/recovery/commit_proxy_startup_phase_test.exs
+++ b/test/bedrock/control_plane/director/recovery/commit_proxy_startup_phase_test.exs
@@ -5,6 +5,7 @@ defmodule Bedrock.ControlPlane.Director.Recovery.CommitProxyStartupPhaseTest do
 
   alias Bedrock.ControlPlane.Director.Recovery.CommitProxyStartupPhase
   alias Bedrock.DataPlane.CommitProxy.Server
+  alias Bedrock.SystemKeys
 
   # Mock cluster module for testing
   defmodule TestCluster do
@@ -51,6 +52,22 @@ defmodule Bedrock.ControlPlane.Director.Recovery.CommitProxyStartupPhaseTest do
                CommitProxyStartupPhase.execute(recovery_attempt, context)
 
       assert is_pid(pid1) and is_pid(pid2)
+    end
+
+    test "the committed keyspace parameter governs the proxy count, not the coordinator's anchor" do
+      # \xff/system/config/desired_commit_proxies says three; the
+      # coordinator's bootstrap anchor still says one. An operator changed
+      # the configuration with an ordinary transaction, and nothing wrote
+      # it back to the coordinator — the keyspace is the authority
+      # (FDB: configuration.getDesiredCommitProxies(), built from the
+      # \xff/conf/ range, ClusterRecovery.actor.cpp:1191).
+      recovery_attempt =
+        Map.put(base_recovery_attempt(), :committed_parameters, %{SystemKeys.desired_commit_proxies() => 3})
+
+      context = base_context(1, [node()], successful_start_fn())
+
+      assert {%{proxies: [_, _, _]}, _next_phase} =
+               CommitProxyStartupPhase.execute(recovery_attempt, context)
     end
 
     test "stalls when no coordination capable nodes available" do

--- a/test/bedrock/control_plane/director/recovery/materializer_bootstrap_phase_test.exs
+++ b/test/bedrock/control_plane/director/recovery/materializer_bootstrap_phase_test.exs
@@ -662,6 +662,54 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhaseTest 
       end)
     end
 
+    test "the committed config family rides the attempt to the phases that size the system" do
+      # Read at the same version, from the same materializer, as the other
+      # two durable families — FDB builds its DatabaseConfiguration from
+      # exactly this read (ClusterRecovery.actor.cpp:1191), never from the
+      # coordinators.
+      recovery_version = Version.from_integer(500)
+      sys_pid = spawn(fn -> Process.sleep(:infinity) end)
+      named_pid = spawn(fn -> Process.sleep(:infinity) end)
+      stray_pid = spawn(fn -> Process.sleep(:infinity) end)
+
+      context =
+        existing_context(recovery_version, %{
+          read_committed_parameters_fn: fn _pid, version ->
+            assert version == recovery_version
+            {:ok, %{Bedrock.SystemKeys.desired_commit_proxies() => 4}}
+          end
+        })
+
+      recovery_attempt = two_claimants_attempt(recovery_version, named_pid, stray_pid, sys_pid)
+
+      ExUnit.CaptureLog.capture_log(fn ->
+        assert {updated_attempt, CommitProxyStartupPhase} =
+                 MaterializerBootstrapPhase.execute(recovery_attempt, context)
+
+        assert updated_attempt.committed_parameters == %{Bedrock.SystemKeys.desired_commit_proxies() => 4}
+      end)
+    end
+
+    test "a failed config read stalls the attempt — never a silent fall back to the anchor" do
+      # Reading the family as empty would mean "not configured", and the
+      # persistence phase would then seed the coordinator's anchor over a
+      # cluster that has a committed configuration it could not read.
+      recovery_version = Version.from_integer(500)
+      sys_pid = spawn(fn -> Process.sleep(:infinity) end)
+      named_pid = spawn(fn -> Process.sleep(:infinity) end)
+      stray_pid = spawn(fn -> Process.sleep(:infinity) end)
+
+      context =
+        existing_context(recovery_version, %{
+          read_committed_parameters_fn: fn _pid, _version -> {:error, {:config_query_failed, :timeout}} end
+        })
+
+      recovery_attempt = two_claimants_attempt(recovery_version, named_pid, stray_pid, sys_pid)
+
+      assert {_attempt, {:stalled, {:config_query_failed, :timeout}}} =
+               MaterializerBootstrapPhase.execute(recovery_attempt, context)
+    end
+
     test "a failed family read stalls the attempt — never a silently unnamed layout" do
       recovery_version = Version.from_integer(500)
       sys_pid = spawn(fn -> Process.sleep(:infinity) end)

--- a/test/bedrock/control_plane/director/recovery/persistence_phase_test.exs
+++ b/test/bedrock/control_plane/director/recovery/persistence_phase_test.exs
@@ -113,6 +113,36 @@ defmodule Bedrock.ControlPlane.Director.Recovery.PersistencePhaseTest do
       node_string = Atom.to_string(node())
       assert decoded[{:materializer_key, 0, "wkr_sys"}] == node_string
       assert decoded[{:materializer_key, 1, "wkr_user"}] == node_string
+
+      # The seeded configuration parameter, decoding to the anchor value
+      # the commit-proxy startup phase will read back next epoch.
+      assert decoded[{:config, SystemKeys.desired_commit_proxies()}] == 1
+    end
+
+    test "seeds the config family from the coordinator's anchor when the committed family has none" do
+      # A fresh cluster (or one that predates the family): the keyspace
+      # carries no desired_commit_proxies, so recovery writes the anchor
+      # once. recovery_context/0's anchor is 1.
+      mutations = captured_system_mutations(base_recovery_attempt())
+      key = SystemKeys.config_key(SystemKeys.desired_commit_proxies())
+
+      assert {:set, ^key, value} = Enum.find(mutations, &match?({:set, ^key, _}, &1))
+      assert Values.decode_config_integer(value) == {:ok, 1}
+    end
+
+    test "leaves a committed config parameter exactly as committed" do
+      # FDB's recovery reads \xff/conf and never rewrites it; a re-stamp
+      # from the coordinator's anchor would revert every configuration
+      # change at the next epoch.
+      recovery_attempt =
+        Map.put(base_recovery_attempt(), :committed_parameters, %{SystemKeys.desired_commit_proxies() => 7})
+
+      mutations = captured_system_mutations(recovery_attempt)
+
+      refute Enum.any?(mutations, fn
+               {:set, key, _} -> String.starts_with?(key, SystemKeys.config_prefix())
+               _ -> false
+             end)
     end
 
     test "materializer family is skipped entirely when shard_materializers is absent" do

--- a/test/bedrock/system_keys/reader_test.exs
+++ b/test/bedrock/system_keys/reader_test.exs
@@ -1,0 +1,48 @@
+defmodule Bedrock.SystemKeys.ReaderTest do
+  use ExUnit.Case, async: true
+
+  alias Bedrock.SystemKeys
+  alias Bedrock.SystemKeys.Reader
+  alias Bedrock.SystemKeys.Values
+
+  describe "decode_config_parameters/1" do
+    test "decodes entries into a map keyed by the parameter name in the key" do
+      # Names stay binaries: decoding durable bytes never creates atoms,
+      # so consumers look up the names SystemKeys publishes.
+      entries = [
+        {SystemKeys.config_key(SystemKeys.desired_commit_proxies()), Values.encode_config_integer(3)},
+        {SystemKeys.config_key("some_future_parameter"), Values.encode_config_integer(9)}
+      ]
+
+      assert {:ok, %{"desired_commit_proxies" => 3, "some_future_parameter" => 9}} =
+               Reader.decode_config_parameters(entries)
+    end
+
+    test "an empty family decodes as no parameters, not as an error" do
+      # This is the fresh-cluster read, and it is what tells the
+      # persistence phase to seed.
+      assert {:ok, %{}} = Reader.decode_config_parameters([])
+    end
+
+    test "an undecodable value fails the WHOLE read" do
+      # Skipping it would report the parameter as absent, and absent means
+      # "seed from the coordinator's anchor" — a corrupt value would
+      # silently revert a configured cluster and re-commit the default.
+      key = SystemKeys.config_key(SystemKeys.desired_commit_proxies())
+
+      entries = [
+        {key, Values.encode_materializer_node("not_a_count")},
+        {SystemKeys.config_key("other"), Values.encode_config_integer(2)}
+      ]
+
+      assert {:error, {:invalid_config_entry, ^key}} = Reader.decode_config_parameters(entries)
+    end
+
+    test "a foreign key fails the read rather than being ignored" do
+      key = SystemKeys.shard_key("m")
+      entries = [{key, Values.encode_config_integer(3)}]
+
+      assert {:error, {:invalid_config_entry, ^key}} = Reader.decode_config_parameters(entries)
+    end
+  end
+end

--- a/test/bedrock/system_keys/values_test.exs
+++ b/test/bedrock/system_keys/values_test.exs
@@ -40,6 +40,23 @@ defmodule Bedrock.SystemKeys.ValuesTest do
     end
   end
 
+  describe "config parameters" do
+    test "round-trip" do
+      assert {:ok, 3} = Values.decode_config_integer(Values.encode_config_integer(3))
+    end
+
+    test "encoder rejects a value that is not a positive integer" do
+      assert_raise ArgumentError, fn -> Values.encode_config_integer(0) end
+      assert_raise ArgumentError, fn -> Values.encode_config_integer("3") end
+    end
+
+    test "decoder never raises on garbage or wrong shapes" do
+      assert {:error, :invalid_encoding} = Values.decode_config_integer(<<0xEE, 0xEE>>)
+      assert {:error, :invalid_type} = Values.decode_config_integer(Values.encode_materializer_node("3"))
+      assert {:error, :invalid_encoding} = Values.decode_config_integer(:not_binary)
+    end
+  end
+
   describe "decode_for/2 - the writer/reader contract" do
     test "dispatches by parsed key family" do
       shard_value = Values.encode_shard_key_entry(3, "a")
@@ -49,6 +66,12 @@ defmodule Bedrock.SystemKeys.ValuesTest do
 
       assert {:ok, "node@host"} =
                Values.decode_for(SystemKeys.parse_key(SystemKeys.materializer_key(7, "wkr_abc")), ref_value)
+
+      assert {:ok, 5} =
+               Values.decode_for(
+                 SystemKeys.parse_key(SystemKeys.config_key(SystemKeys.desired_commit_proxies())),
+                 Values.encode_config_integer(5)
+               )
     end
 
     test "unknown families decode as errors, never raise" do

--- a/test/bedrock/system_keys_test.exs
+++ b/test/bedrock/system_keys_test.exs
@@ -52,7 +52,10 @@ defmodule Bedrock.SystemKeysTest do
         shard_key: {SystemKeys.shard_keys_prefix(), [SystemKeys.shard_key(<<>>), SystemKeys.shard_key(<<0xFF, 0xFF>>)]},
         materializer_key:
           {SystemKeys.materializers_prefix(),
-           [SystemKeys.materializer_key(0, "wkr_a"), SystemKeys.materializer_key(4200, "wkr_b")]}
+           [SystemKeys.materializer_key(0, "wkr_a"), SystemKeys.materializer_key(4200, "wkr_b")]},
+        config:
+          {SystemKeys.config_prefix(),
+           [SystemKeys.config_key(SystemKeys.desired_commit_proxies()), SystemKeys.config_key("z")]}
       }
 
       # Plausible future siblings that share leading bytes with a family.
@@ -83,6 +86,20 @@ defmodule Bedrock.SystemKeysTest do
       assert SystemKeys.parse_key(<<0xFF, "/system/future/feature">>) == :unknown
       assert SystemKeys.parse_key("user/key") == :error
       assert SystemKeys.parse_key(:not_a_key) == :error
+    end
+  end
+
+  describe "cluster configuration keys" do
+    test "config_key/1 round-trips through parse_key/1, carrying the parameter name" do
+      assert SystemKeys.config_key(SystemKeys.desired_commit_proxies()) ==
+               "\xff/system/config/desired_commit_proxies"
+
+      assert SystemKeys.parse_key(SystemKeys.config_key("desired_commit_proxies")) ==
+               {:config, "desired_commit_proxies"}
+    end
+
+    test "the bare prefix names no parameter" do
+      assert SystemKeys.parse_key(SystemKeys.config_prefix()) == :unknown
     end
   end
 

--- a/test/support/control_plane/recovery_test_support.ex
+++ b/test/support/control_plane/recovery_test_support.ex
@@ -50,6 +50,9 @@ defmodule Bedrock.Test.ControlPlane.RecoveryTestSupport do
       # Deterministic default for the bootstrap's durable-family read;
       # tests exercising the read path override it.
       read_prior_refs_fn: fn _materializer_pid, _read_version -> {:ok, %{}} end,
+      # Likewise for the committed config family: absent by default, so
+      # the coordinator's anchor answers unless a test commits one.
+      read_committed_parameters_fn: fn _materializer_pid, _read_version -> {:ok, %{}} end,
       cluster_config: %{
         coordinators: [],
         parameters: %{


### PR DESCRIPTION
Bedrock kept every cluster parameter in the object-storage bootstrap record, loaded by the coordinator at cold boot and handed to each recovery phase, so changing the commit proxy count meant editing that record and waiting for a recovery. FoundationDB does the opposite, keeping configuration in `\xff/conf/` and having recovery read it out of the keyspace rather than off the coordinators. One parameter, `desired_commit_proxies`, now moves into a new `\xff/system/config/<name>` family together with the reader that consumes it.

Ticket: bedrock-q67.25
Stacked on: #251 (bedrock-0s9/drop-resolution-capability)

## Why

The ticket was reframed on 2026-08-20. It originally described a write-only shadow copy of the configuration that nothing read back; bedrock-q67.31 deleted that copy and its codecs, leaving coordinator raft cleanly the sole authority. What survived is the rule: a system key with no reader is inventory, so a family returns to the keyspace only when its reader lands with it.

`desired_commit_proxies` is the parameter that has such a reader today: the commit-proxy startup phase runs after the materializer bootstrap, where the system shard becomes readable at the recovery version. `desired_logs`, by contrast, is consumed by two phases that run before that, so it cannot move until its consumers do.

## What changed

The materializer bootstrap phase reads the `config/` family from the same materializer, at the same recovery version, as the shard boundaries and materializer refs, and carries the decoded map on the recovery attempt. The commit-proxy startup phase sizes the fleet from that map, falling back to the coordinator's value only when the family lacks the parameter. The persistence phase seeds the key once and never rewrites it. Values are tuple-packed positive integers under one codec.

Deliberately unchanged: the remaining parameters and both policies stay in the bootstrap record (bedrock-q67.50), and there is no operator-facing path to commit a `\xff/system/config/` mutation (bedrock-q67.51), so a seeded parameter is fixed until that writer lands.

## How it works

```
recovery 1 (fresh):  family empty; proxies = coordinator anchor (1)
                     persistence sets config/desired_commit_proxies = 1

a system-mode commit sets that key to 3

recovery 2:          family read at the recovery version -> 3
                     proxies = 3 (coordinator still says 1, ignored)
                     persistence writes nothing under config/
```

Seeding without rewriting is what makes the keyspace copy authoritative rather than a mirror: re-stamping the anchor each epoch would make every configuration change last only until the next recovery.

Because absence means "seed from the anchor", the decoder is strict: a foreign key, or a value that does not decode, fails the entire read and stalls the attempt. Reading it as empty would let recovery overwrite a committed configuration the node merely could not parse. FDB is laxer, skipping an unrecognized `\xff/conf/` key; bedrock-q67.50 revisits that once the family is heterogeneous.

## Verification

The reproduction is a startup-phase test where the committed family says three and the coordinator's anchor says one: the base starts one proxy, the head three. Bootstrap tests assert the read happens at the recovery version and that a failed read stalls rather than falling back; persistence tests cover both directions of the seed rule; new tests cover the decoder's strictness, the codec, and key parsing. The author reports suite, format, credo, and dialyzer clean; the branch is a draft with no CI checks.

Follow-up: bedrock-q67.50, remaining parameters and policies.
Follow-up: bedrock-q67.51, operator-facing config writer.
