### PR TITLE
239: Check real transaction histories across persistence and recovery

### DIFF
--- a/guides/distributed-durability-tests.md
+++ b/guides/distributed-durability-tests.md
@@ -32,3 +32,84 @@ By default, `:distributed` tests are excluded unless explicitly enabled.
 The CI workflow runs distributed durability tests in a dedicated job on
 scheduled/manual runs with MinIO setup. This keeps default PR pipelines fast
 while preserving regular distributed durability coverage.
+
+## Transaction histories against the real core
+
+The transaction-history harness starts real coordinators, sequencers, commit
+proxies, resolvers, logs, and materializers. It submits transactions through the
+public Repo API and checks their observations and final state against an
+independent in-memory interpreter. It does not use Bedrock's mutation or conflict
+helpers to calculate expected results.
+
+Run all history scenarios without MinIO:
+
+```bash
+MIX_ENV=test elixir --sname bedrock_history -S mix run --no-start scripts/transaction_history.exs
+```
+
+The runner includes the oracle unit tests, local transaction histories, snapshot
+publication crashes, and three-node peer scenarios. A named Erlang node and local
+peer-process/distribution access are required. These tests remain tagged
+`:distributed` and excluded from the ordinary test run. The existing MinIO CI job
+does not automatically run this standalone command.
+
+Workloads cover batched atomic increments, ordered mutations, half-open clears,
+read-your-writes over an otherwise empty range, conditional reservations based on
+absence, and transfers based on point reads. Barriers make conflicting reads and
+shared proxy batches observable. Each attempt records its invocation, completion,
+operations, partial reads, callback completion, and outcome. Retries have distinct
+IDs; a timeout after a possibly committed callback is recorded as an unknown outcome
+rather than proof of an abort.
+The bounded checker searches legal serial orders, preserves real-time order for
+known completed attempts, and permits each unknown attempt to commit at most once
+or not at all. The final state must match exactly. It rejects oversized or invalid
+histories rather than silently accepting them.
+
+Fault schedules exercise:
+
+- Log loss before append and after the real WAL sync, before the reply. The log
+  and coordinator are crashed together; recovery must advance the epoch and
+  preserve acknowledged transactions.
+- Materializer loss immediately before and after snapshot publication to real
+  filesystem object storage. The fixture establishes a durable version below the
+  applied tail, checks the published snapshot against that exact prefix, starts
+  a replacement with empty local storage, and checks tail replay exactly once.
+- Three actual BEAM nodes with distinct component roles. One schedule severs and
+  verifies all distribution edges across the log-node cut; another stops and
+  restarts that node with its WAL preserved. Both recover through a coordinator
+  restart and check current-epoch shard coverage before checking the history.
+
+These are bounded, repeatable fault schedules, not a deterministic BEAM simulator
+or a quorum-availability test. The fixtures use replication factor one and retain
+log disks. Coordinator restart is deliberate: autonomous director-only recovery
+currently reuses an epoch and can stall after log loss, tracked in
+[issue #259](https://github.com/bedrock-kv/bedrock/issues/259). To retain that failing
+schedule for investigation, run the command above with
+`BEDROCK_HISTORY_SINGLE_LOG_REPRO=1`; it is expected to fail until that issue is
+resolved. Snapshot replacement waits for the foreman's automatic restart health
+before eviction; the separate immediate-eviction race is tracked as `bedrock-gu0.5`.
+
+## History artifacts and replay
+
+Every scenario writes a binary Erlang term, including on assertion failure.
+Local and snapshot scenarios also write a readable `.term.txt` companion. The output prints their paths. Set
+`BEDROCK_HISTORY_ARTIFACT_DIR` to retain them in a chosen directory. Artifacts
+include source revision, seeds, attempt histories, fault/epoch evidence, and final
+state when reached. An unfinished attempt remains visible as `:in_flight` with
+its partial observations, so an early failure does not erase its evidence.
+
+Set `BEDROCK_HISTORY_SEED` to repeat ExUnit ordering (default `239`). Mixed mutation
+workloads use explicit seeds `239`, `240`, and `241`. Replaying repeats workload
+choices and controlled boundaries; operating-system process timing can differ.
+Read a trusted local artifact from IEx with:
+
+```elixir
+history = path |> File.read!() |> :erlang.binary_to_term()
+IO.inspect(history, pretty: true, limit: :infinity)
+```
+
+The four tests tagged `:counterexample` reproduce the original atomic batching,
+clear endpoint, pending range visibility, and absence-conflict failures on the
+pre-fix core. Snapshot tests separately reject a snapshot containing the applied
+suffix beyond its advertised durable version. Keep these failures as concrete
+checks that the harness detects corruption rather than merely cluster liveness.

--- a/scripts/transaction_history.exs
+++ b/scripts/transaction_history.exs
@@ -1,0 +1,11 @@
+if !Node.alive?() do
+  raise "Run with MIX_ENV=test elixir --sname bedrock_history -S mix run --no-start scripts/transaction_history.exs"
+end
+
+{:ok, _} = Application.ensure_all_started(:bedrock)
+seed = String.to_integer(System.get_env("BEDROCK_HISTORY_SEED", "239"))
+ExUnit.start(seed: seed, max_cases: 1)
+
+for suite <- ~w(history_oracle transaction_history snapshot_history peer_history) do
+  Code.require_file("test/bedrock/distributed/#{suite}_test.exs")
+end

--- a/test/bedrock/distributed/history_oracle_test.exs
+++ b/test/bedrock/distributed/history_oracle_test.exs
@@ -1,0 +1,118 @@
+defmodule Bedrock.Distributed.HistoryOracleTest do
+  use ExUnit.Case, async: true
+
+  alias Bedrock.Test.History.Driver
+  alias Bedrock.Test.History.Gates
+  alias Bedrock.Test.History.Oracle
+
+  defp tx(id, start, stop, status, ops, reads \\ []),
+    do: %{id: id, invoke: start, complete: stop, status: status, ops: ops, reads: reads}
+
+  test "overlapping transactions may serialize in a different completion order" do
+    history = [tx(1, 0, 3, :committed, [{:put, "k", "one"}]), tx(2, 1, 2, :committed, [{:put, "k", "two"}])]
+    assert {:ok, _} = Oracle.check(%{}, history, %{"k" => "two"})
+    assert {:ok, _} = Oracle.check(%{}, history, %{"k" => "one"})
+  end
+
+  test "real-time precedence forbids reordering nonoverlapping commits" do
+    history = [tx(1, 0, 1, :committed, [{:put, "k", "one"}]), tx(2, 2, 3, :committed, [{:put, "k", "two"}])]
+    assert {:error, :no_serialization} = Oracle.check(%{}, history, %{"k" => "one"})
+    assert {:ok, [1, 2]} = Oracle.check(%{}, history, %{"k" => "two"})
+  end
+
+  test "acknowledged commits cannot disappear or execute twice" do
+    history = [tx(1, 0, 1, :committed, [{:add, "k", 1}])]
+    assert {:error, :no_serialization} = Oracle.check(%{}, history, %{})
+    assert {:error, :no_serialization} = Oracle.check(%{}, history, %{"k" => <<2::64-little>>})
+  end
+
+  test "unknown attempts may apply or omit while acknowledged retries remain mandatory" do
+    history = [tx(1, 0, 1, :unknown, [{:add, "k", 1}]), tx(2, 2, 3, :committed, [{:add, "k", 1}])]
+    assert {:ok, _} = Oracle.check(%{}, history, %{"k" => <<1::64-little>>})
+    assert {:ok, _} = Oracle.check(%{}, history, %{"k" => <<2::64-little>>})
+    assert {:error, :no_serialization} = Oracle.check(%{}, history, %{})
+  end
+
+  test "an included unknown attempt must obey its observed reads" do
+    history = [tx(1, 0, 1, :unknown, [{:get, "k"}, {:put, "x", "yes"}], [{:get, "k", "missing"}])]
+    assert {:error, :no_serialization} = Oracle.check(%{}, history, %{"x" => "yes"})
+    assert {:ok, []} = Oracle.check(%{}, history, %{})
+  end
+
+  test "aborted transactions never contribute writes" do
+    assert {:error, :no_serialization} = Oracle.check(%{}, [tx(1, 0, 1, :aborted, [{:put, "k", "v"}])], %{"k" => "v"})
+  end
+
+  test "two overlapping reservations cannot both observe the same absence" do
+    range = {"r/", "r0"}
+
+    history =
+      for {id, key} <- [{1, "r/a"}, {2, "r/b"}],
+          do: tx(id, 0, 2, :committed, [{:reserve, range, key}], [{:reserve, true}])
+
+    assert {:error, :no_serialization} = Oracle.check(%{}, history, %{"r/a" => "reserved", "r/b" => "reserved"})
+  end
+
+  test "interpreter respects ordered sets, half-open clears, arithmetic and transfers" do
+    ops = [
+      {:put, "a", "old"},
+      {:put, "b", "endpoint"},
+      {:clear_range, "a", "b"},
+      {:put, "a", "new"},
+      {:get, "a"},
+      {:range, "a", "c"},
+      {:add, "alice", 10},
+      {:transfer, "alice", "bob", 3}
+    ]
+
+    {map, reads} = Oracle.evaluate(%{}, ops)
+    assert map == %{"a" => "new", "b" => "endpoint", "alice" => <<7::64-little>>, "bob" => <<3::64-little>>}
+
+    assert reads == [
+             {:get, "a", "new"},
+             {:range, [{"a", "new"}, {"b", "endpoint"}]},
+             {:transfer, <<10::64-little>>, nil, true}
+           ]
+  end
+
+  test "a timed-out attempt may commit after a later acknowledged operation" do
+    history = [tx(1, 0, 1, :unknown, [{:put, "k", "late"}]), tx(2, 2, 3, :committed, [{:put, "k", "ack"}])]
+    assert {:ok, [2, 1]} = Oracle.check(%{}, history, %{"k" => "late"})
+  end
+
+  test "transfer observations retain balances even if later writes hide the bad read" do
+    initial = %{"a" => <<10::64-little>>, "b" => <<0::64-little>>}
+    bad = tx(1, 0, 1, :committed, [{:transfer, "a", "b", 1}], [{:transfer, <<99::64-little>>, <<0::64-little>>, true}])
+    overwrite = tx(2, 2, 3, :committed, [{:put, "a", <<0::64-little>>}, {:put, "b", <<0::64-little>>}])
+
+    assert {:error, :no_serialization} =
+             Oracle.check(initial, [bad, overwrite], %{"a" => <<0::64-little>>, "b" => <<0::64-little>>})
+  end
+
+  test "driver distinguishes acknowledgments from rollback returns and ambiguous failures" do
+    observations = [{:get, "k", nil}]
+    assert Driver.classify_return(observations, observations) == :committed
+    assert Driver.classify_return({:error, :key_out_of_range}, observations) == :aborted
+    assert Driver.classify_return(:unexpected, observations) == :unknown
+
+    assert Driver.classify_exception(
+             %RuntimeError{message: "Transaction retry limit exceeded after 0 attempts. Last error: :aborted"},
+             observations
+           ) == :aborted
+
+    assert Driver.classify_exception(%RuntimeError{message: "unrelated failure. Last error: :aborted"}, observations) ==
+             :unknown
+
+    assert Driver.classify_exception(%RuntimeError{message: "timeout"}, observations) == :unknown
+    assert Driver.classify_exception(%RuntimeError{message: "read timeout before callback completes"}, nil) == :aborted
+  end
+
+  test "disarming a consumed gate releases its blocked participant" do
+    gates = start_supervised!({Agent, fn -> nil end})
+    Gates.arm(gates, %{stage: :test, match: fn _ -> true end, owner: self()})
+    task = Task.async(fn -> Gates.pause(gates, :test, "key") end)
+    assert_receive {:history_gate, :test, _, _, "key"}
+    assert :ok = Gates.disarm(gates)
+    assert :ok = Task.await(task, 1_000)
+  end
+end

--- a/test/bedrock/distributed/peer_history_test.exs
+++ b/test/bedrock/distributed/peer_history_test.exs
@@ -1,0 +1,141 @@
+defmodule Bedrock.Distributed.PeerHistoryTest do
+  use ExUnit.Case, async: false
+
+  alias Bedrock.Test.History.Oracle
+  alias Bedrock.Test.History.PeerCluster
+
+  @moduletag :distributed
+  @moduletag timeout: 120_000
+
+  test "acknowledged writes survive coupled coordinator and log VM loss with retained WAL" do
+    scenario("log_restart", fn cluster, record ->
+      before = PeerCluster.ready(cluster)
+      record.({:placement_before, before})
+      {first, before_entries} = successful_attempt(cluster, record, "before", [{:put, "history/peer/a", "durable"}])
+      assert first.status == :committed
+      wal = PeerCluster.wal_files(cluster)
+      assert wal != []
+      record.({:wal_before_stop, wal})
+      # bedrock-t0k: a live coordinator can restart a failed director in the same epoch.
+      # Keep that standalone reproduction available; the normal schedule includes
+      # coordinator loss explicitly and obtains a genuine new Raft term.
+      coupled = System.get_env("BEDROCK_HISTORY_SINGLE_LOG_REPRO") != "1"
+
+      if coupled do
+        PeerCluster.suspend_coordinator(cluster)
+        record.({:coordinator_suspended, :before_log_loss})
+      end
+
+      PeerCluster.stop_log(cluster)
+      record.({:log_stopped, PeerCluster.nodes(cluster)})
+      assert PeerCluster.log_down?(cluster)
+      assert Enum.all?(wal, &File.exists?/1), "log node loss must retain its original WAL files"
+
+      if coupled do
+        PeerCluster.stop_coordinator(cluster)
+        record.({:coordinator_stopped, :after_log_loss})
+      end
+
+      PeerCluster.restart_log(cluster)
+
+      if coupled do
+        PeerCluster.restart_coordinator(cluster)
+        record.({:coordinator_restarted, :after_log_return})
+      end
+
+      record.({:log_restarted, PeerCluster.wal_files(cluster)})
+      after_recovery = PeerCluster.ready(cluster, before.epoch)
+      record.({:placement_after, after_recovery})
+      assert after_recovery.epoch > before.epoch
+
+      {second, after_entries} =
+        successful_attempt(cluster, record, "after", [{:get, "history/peer/a"}, {:put, "history/peer/b", "after"}])
+
+      assert second.status == :committed
+      assert second.reads == [{:get, "history/peer/a", "durable"}]
+      final = PeerCluster.final(cluster)
+      record.({:final, final})
+      assert {:ok, _} = Oracle.check(%{}, before_entries ++ after_entries, final)
+    end)
+  end
+
+  test "a live log VM is isolated across every cut edge then recovers after heal and coordinator restart" do
+    scenario("partition", fn cluster, record ->
+      before = PeerCluster.ready(cluster)
+      record.({:placement_before, before})
+      {first, before_entries} = successful_attempt(cluster, record, "before", [{:put, "history/peer/a", "durable"}])
+      assert first.status == :committed
+      connected = PeerCluster.connected_edges(cluster)
+      record.({:connected_before_cut, connected})
+      assert Enum.all?(connected, fn {_, _, reply} -> reply == :pong end)
+      PeerCluster.suspend_coordinator(cluster)
+      record.({:coordinator_suspended, :before_partition})
+
+      try do
+        record.({:cut, PeerCluster.partition_log(cluster)})
+        proof = PeerCluster.partition_proof(cluster)
+        record.({:partition_proof, proof})
+        assert Enum.all?(proof, fn edge -> edge.alive and edge.disconnected and edge.ping == :pang end)
+        assert length(proof) == 4
+      after
+        record.({:heal, PeerCluster.heal(cluster)})
+        PeerCluster.stop_coordinator(cluster)
+        PeerCluster.restart_coordinator(cluster)
+        record.({:coordinator_restarted, :after_heal})
+      end
+
+      after_recovery = PeerCluster.ready(cluster, before.epoch)
+      record.({:placement_after, after_recovery})
+      assert after_recovery.epoch > before.epoch
+
+      {second, after_entries} =
+        successful_attempt(cluster, record, "after", [{:get, "history/peer/a"}, {:put, "history/peer/b", "healed"}])
+
+      assert second.status == :committed
+      assert second.reads == [{:get, "history/peer/a", "durable"}]
+      final = PeerCluster.final(cluster)
+      record.({:final, final})
+      assert {:ok, _} = Oracle.check(%{}, before_entries ++ after_entries, final)
+    end)
+  end
+
+  defp successful_attempt(cluster, record, prefix, operations) do
+    entries =
+      Enum.reduce_while(1..4, [], fn index, entries ->
+        entry = PeerCluster.attempt(cluster, "#{prefix}-#{index}", operations)
+        record.({:attempt, entry})
+        entries = entries ++ [entry]
+
+        if entry.status == :committed do
+          {:halt, entries}
+        else
+          record.({:retry_delay_ms, 1_000})
+          Process.sleep(1_000)
+          {:cont, entries}
+        end
+      end)
+
+    {List.last(entries), entries}
+  end
+
+  defp scenario(name, run) do
+    assert Node.alive?(), "run with elixir --sname bedrock_peer_history -S mix test --include distributed"
+    root = Path.join(System.tmp_dir!(), "bedrock-peer-#{name}-#{System.system_time(:nanosecond)}")
+    {:ok, events} = Agent.start_link(fn -> [] end)
+    record = fn event -> Agent.update(events, &[{System.monotonic_time(), event} | &1]) end
+    cluster = PeerCluster.start(root)
+
+    try do
+      run.(cluster, record)
+    catch
+      kind, reason ->
+        record.({:failure, kind, reason, __STACKTRACE__})
+        :erlang.raise(kind, reason, __STACKTRACE__)
+    after
+      record.({:cleanup_state, PeerCluster.diagnostics(cluster)})
+      path = PeerCluster.artifact(root, name, Agent.get(events, &Enum.reverse/1))
+      IO.puts("Peer history artifact: #{path}")
+      PeerCluster.stop(cluster)
+    end
+  end
+end

--- a/test/bedrock/distributed/snapshot_history_test.exs
+++ b/test/bedrock/distributed/snapshot_history_test.exs
@@ -1,0 +1,256 @@
+defmodule Bedrock.Distributed.SnapshotHistoryTest do
+  use ExUnit.Case, async: false
+
+  alias Bedrock.DataPlane.Materializer.Olivine.Database
+  alias Bedrock.DataPlane.Version
+  alias Bedrock.ObjectStorage.Snapshot
+  alias Bedrock.ObjectStorage.SnapshotBundle
+  alias Bedrock.Service.Foreman
+  alias Bedrock.Test.History.Driver
+  alias Bedrock.Test.History.Gates
+  alias Bedrock.Test.History.SnapshotFixture
+
+  defmodule BeforeCluster do
+    @moduledoc false
+    use Bedrock.Cluster, otp_app: :bedrock, name: "snapshot_history_before"
+  end
+
+  defmodule BeforeRepo do
+    use Bedrock.Repo, cluster: BeforeCluster
+  end
+
+  defmodule AfterCluster do
+    @moduledoc false
+    use Bedrock.Cluster, otp_app: :bedrock, name: "snapshot_history_after"
+  end
+
+  defmodule AfterRepo do
+    use Bedrock.Repo, cluster: AfterCluster
+  end
+
+  @moduletag :distributed
+  @moduletag timeout: 90_000
+
+  for {stage, cluster, repo} <- [
+        {:before_snapshot_publication, BeforeCluster, BeforeRepo},
+        {:after_snapshot_publication, AfterCluster, AfterRepo}
+      ] do
+    test "exact historical snapshot and acknowledged tail survive #{stage}" do
+      cluster = unquote(cluster)
+      repo = unquote(repo)
+      stage = unquote(stage)
+      assert Node.alive?()
+      root = Path.join(System.tmp_dir!(), "snapshot-history-#{System.unique_integer([:positive])}")
+      File.mkdir_p!(root)
+      previous = Application.get_env(:bedrock, cluster)
+      previous_storage = Application.get_env(:bedrock, Bedrock.ObjectStorage)
+      snapshots = start_supervised!({Agent, fn -> nil end}, id: :snapshot_gates)
+      startups = start_supervised!({Agent, fn -> nil end}, id: :startup_gates)
+      wal = start_supervised!({Agent, fn -> nil end}, id: :wal_gates)
+      backend = {Gates, root: Path.join(root, "objects"), gates: snapshots}
+      Application.put_env(:bedrock, Bedrock.ObjectStorage, backend: backend)
+
+      Application.put_env(:bedrock, cluster,
+        capabilities: [:coordination, :log, :materializer],
+        durability_mode: :relaxed,
+        path_to_descriptor: Path.join(root, "descriptor"),
+        object_storage: backend,
+        coordinator: [path: root],
+        materializer: [path: root, object_storage: backend],
+        log: [path: root, object_storage: backend]
+      )
+
+      start_supervised!({cluster, []})
+
+      on_exit(fn ->
+        if previous,
+          do: Application.put_env(:bedrock, cluster, previous),
+          else: Application.delete_env(:bedrock, cluster)
+
+        if previous_storage,
+          do: Application.put_env(:bedrock, Bedrock.ObjectStorage, previous_storage),
+          else: Application.delete_env(:bedrock, Bedrock.ObjectStorage)
+
+        File.rm_rf!(root)
+      end)
+
+      repo.transact(fn -> repo.put("ready", "yes") end, timeout_in_ms: 15_000)
+      assert repo.transact(fn -> repo.get("ready") end, timeout_in_ms: 15_000) == "yes"
+      {:ok, recorder} = Driver.start_recorder()
+      Process.unlink(recorder)
+
+      on_exit(fn ->
+        path = Driver.artifact(recorder, "snapshot-#{stage}", %{seed: 239, stage: stage})
+        IO.puts("Snapshot history artifact: #{path}")
+        Agent.stop(recorder)
+      end)
+
+      trace = Driver.attach(recorder)
+      on_exit(fn -> :telemetry.detach(trace) end)
+
+      seed =
+        Driver.attempt(repo, recorder, "snapshot-seed", [
+          {:put, "history/counter", <<10::64-little>>},
+          {:put, "history/value", "baseline"},
+          {:put, "history/clear/a", "a"},
+          {:put, "history/clear/b", "b"}
+        ])
+
+      assert seed.status == :committed
+      seed_version = SnapshotFixture.baseline_batch(cluster, repo, recorder)
+      {worker_id, materializer} = SnapshotFixture.await(fn -> SnapshotFixture.materializer(cluster) end)
+      SnapshotFixture.await(fn -> Database.durable_version(:sys.get_state(materializer).database) >= seed_version end)
+
+      gate_trace = {__MODULE__, self()}
+
+      :ok =
+        :telemetry.attach(
+          gate_trace,
+          [:bedrock, :log, :push],
+          &SnapshotFixture.after_tail_event/4,
+          {wal, self(), "history/meta/snapshot-tail"}
+        )
+
+      on_exit(fn -> :telemetry.detach(gate_trace) end)
+
+      try do
+        tail =
+          Driver.attempt(repo, recorder, "snapshot-tail", [
+            {:add, "history/counter", 5},
+            {:put, "history/value", "later"},
+            {:clear_range, "history/clear/a", "history/clear/b"}
+          ])
+
+        assert tail.status == :committed
+        tail_version = SnapshotFixture.version(recorder, tail.id)
+        assert_receive {:history_gate, :after_wal_sync, log, wal_token, _}, 5_000
+
+        try do
+          state =
+            SnapshotFixture.await(fn ->
+              state = :sys.get_state(materializer)
+              if state.index_manager.current_version >= tail_version, do: state
+            end)
+
+          durable = Database.durable_version(state.database)
+          assert durable <= state.known_committed_version
+          assert state.known_committed_version < state.index_manager.current_version
+          assert durable < tail_version
+
+          SnapshotFixture.record(recorder, %{
+            event: :applied_tail,
+            durable: durable,
+            kcv: state.known_committed_version,
+            applied: state.index_manager.current_version
+          })
+
+          expected = SnapshotFixture.expected_prefix(recorder, durable)
+          assert expected["history/counter"] == <<13::64-little>>
+          assert expected["history/value"] == "baseline"
+          snapshot = state.snapshot
+          Gates.arm(snapshots, %{stage: stage, owner: self(), match: &String.starts_with?(&1, "s/1/")})
+          assert :ok = GenServer.call(materializer, :compact)
+          assert_receive {:history_gate, ^stage, uploader, upload_token, key}, 5_000
+
+          try do
+            SnapshotFixture.record(recorder, %{event: stage, key: key, uploader: uploader, materializer: materializer})
+            assert uploader != materializer
+            checkpoint = Path.join(root, "cold")
+            File.mkdir_p!(checkpoint)
+            compacted = :sys.get_state(materializer)
+            {data, idx} = compacted.database
+            File.cp!(to_string(data.file_name), Path.join(checkpoint, "data"))
+            File.cp!(to_string(idx.file_name), Path.join(checkpoint, "idx"))
+            assert {^durable, ^expected} = SnapshotFixture.cold_map(checkpoint)
+            assert_publication(stage, snapshot, durable, expected, root, checkpoint)
+            # The unlinked upload task must die too: a materializer crash alone
+            # would leave it able to publish after the selected boundary.
+            startup_trace = {__MODULE__, :startup, self()}
+
+            :ok =
+              :telemetry.attach(
+                startup_trace,
+                [:bedrock, :materializer, :startup_complete],
+                &SnapshotFixture.startup_event/4,
+                startups
+              )
+
+            Gates.arm(startups, %{stage: :cold_replacement_started, owner: self(), match: &(&1 != worker_id)})
+            on_exit(fn -> :telemetry.detach(startup_trace) end)
+            upload_down = Process.monitor(uploader)
+            Process.exit(uploader, :kill)
+            assert_receive {:DOWN, ^upload_down, :process, ^uploader, :killed}
+            worker_down = Process.monitor(materializer)
+            Process.exit(materializer, :kill)
+            assert_receive {:DOWN, ^worker_down, :process, ^materializer, :killed}
+
+            SnapshotFixture.await(fn ->
+              workers = :sys.get_state(cluster.otp_name(:foreman)).workers
+
+              case Map.get(workers, worker_id) do
+                %{health: {:ok, restarted}} when is_pid(restarted) and restarted != materializer -> restarted
+                _ -> nil
+              end
+            end)
+
+            # Reclaim any automatic restart of this disposable cache and force
+            # the distributor to create a worker with no local data/idx files.
+            assert :ok = Foreman.remove_worker(cluster.otp_name(:foreman), worker_id)
+            send(log, {:release_history_gate, wal_token})
+            assert_receive {:history_gate, :cold_replacement_started, replacement, startup_token, new_id}, 10_000
+
+            try do
+              SnapshotFixture.record(recorder, %{event: :cold_replacement_started, id: new_id})
+              path = Path.join(Path.dirname(state.path), new_id)
+              assert_cold_replacement(stage, path, durable, expected)
+            after
+              send(replacement, {:release_history_gate, startup_token})
+            end
+
+            artifact =
+              SnapshotFixture.assert_final(repo, recorder, Atom.to_string(stage), %{
+                seed: 239,
+                durable: durable,
+                kcv: state.known_committed_version,
+                applied: state.index_manager.current_version,
+                snapshot_key: key,
+                stage: stage
+              })
+
+            assert File.exists?(artifact)
+          after
+            send(uploader, {:release_history_gate, upload_token})
+          end
+        after
+          send(log, {:release_history_gate, wal_token})
+        end
+      after
+        :telemetry.detach(gate_trace)
+        Enum.each([snapshots, startups, wal], &Gates.disarm/1)
+      end
+    end
+  end
+
+  defp assert_cold_replacement(:before_snapshot_publication, path, _durable, _expected) do
+    {version, values} = SnapshotFixture.cold_map(path)
+    assert version == Version.zero()
+    assert values == %{}
+  end
+
+  defp assert_cold_replacement(:after_snapshot_publication, path, durable, expected) do
+    assert {^durable, ^expected} = SnapshotFixture.cold_map(path)
+  end
+
+  defp assert_publication(:before_snapshot_publication, snapshot, _durable, _expected, _root, _checkpoint) do
+    assert {:error, :not_found} = Snapshot.read_latest(snapshot)
+  end
+
+  defp assert_publication(:after_snapshot_publication, snapshot, durable, expected, root, checkpoint) do
+    assert {:ok, version, bytes} = Snapshot.read_latest(snapshot)
+    assert version == Version.to_integer(durable)
+    bundle = Path.join(root, "snapshot.bundle")
+    File.write!(bundle, bytes)
+    assert {:ok, _, _} = SnapshotBundle.split(bundle, Path.join(checkpoint, "data"), Path.join(checkpoint, "idx"))
+    assert {^durable, ^expected} = SnapshotFixture.cold_map(checkpoint)
+  end
+end

--- a/test/bedrock/distributed/transaction_history_test.exs
+++ b/test/bedrock/distributed/transaction_history_test.exs
@@ -1,0 +1,379 @@
+defmodule Bedrock.Distributed.TransactionHistoryTest do
+  use ExUnit.Case, async: false
+
+  alias Bedrock.DataPlane.Transaction
+  alias Bedrock.Test.History.Driver
+  alias Bedrock.Test.History.Gates
+  alias Bedrock.Test.History.Oracle
+
+  defmodule Cluster do
+    @moduledoc false
+    use Bedrock.Cluster, otp_app: :bedrock, name: "transaction_history"
+  end
+
+  defmodule Repo do
+    use Bedrock.Repo, cluster: Cluster
+  end
+
+  @moduletag :distributed
+  @moduletag timeout: 60_000
+
+  setup_all do
+    assert Node.alive?(), "run with elixir --sname bedrock_history -S mix test --include distributed"
+    root = Path.join(System.tmp_dir!(), "bedrock-history-#{System.unique_integer([:positive])}")
+    File.mkdir_p!(root)
+    previous = Application.get_env(:bedrock, Cluster)
+    previous_storage = Application.get_env(:bedrock, Bedrock.ObjectStorage)
+    gates = start_supervised!({Agent, fn -> nil end})
+    backend = {Gates, root: Path.join(root, "objects"), gates: gates}
+    Application.put_env(:bedrock, Bedrock.ObjectStorage, backend: backend)
+
+    Application.put_env(:bedrock, Cluster,
+      capabilities: [:coordination, :log, :materializer],
+      durability_mode: :relaxed,
+      path_to_descriptor: Path.join(root, "descriptor"),
+      object_storage: backend,
+      coordinator: [path: root],
+      materializer: [path: root, object_storage: backend],
+      log: [path: root, object_storage: backend]
+    )
+
+    supervisor = start_supervised!({Cluster, []})
+
+    on_exit(fn ->
+      if previous, do: Application.put_env(:bedrock, Cluster, previous), else: Application.delete_env(:bedrock, Cluster)
+
+      if previous_storage,
+        do: Application.put_env(:bedrock, Bedrock.ObjectStorage, previous_storage),
+        else: Application.delete_env(:bedrock, Bedrock.ObjectStorage)
+
+      File.rm_rf!(root)
+    end)
+
+    Repo.transact(fn -> Repo.put("ready", "yes") end, timeout_in_ms: 15_000)
+    assert Repo.transact(fn -> Repo.get("ready") end, timeout_in_ms: 15_000) == "yes"
+    %{root: root, supervisor: supervisor, gates: gates, backend: backend}
+  end
+
+  setup context do
+    {:ok, recorder} = Driver.start_recorder()
+    Process.unlink(recorder)
+    Driver.metadata(recorder, %{scenario: context.test, seed: Map.get(context, :history_seed, 239)})
+    id = Driver.attach(recorder)
+
+    on_exit(fn ->
+      :telemetry.detach(id)
+      path = Driver.artifact(recorder, "transaction-history")
+      IO.puts("Transaction history artifact: #{path}")
+      Agent.stop(recorder)
+    end)
+
+    Repo.transact(fn -> Repo.clear_range({"history/", "history0"}) end)
+    %{recorder: recorder}
+  end
+
+  @tag counterexample: true
+  test "acknowledged atomic increments in a shared batch match sequential arithmetic", %{recorder: recorder} do
+    %{proxies: [proxy]} = Cluster.transaction_system_layout!()
+    :ok = :sys.suspend(proxy)
+
+    tasks =
+      try do
+        tasks =
+          for n <- 1..8 do
+            Task.async(fn -> Driver.attempt(Repo, recorder, "atomic-#{n}", [{:add, "history/atomic/counter", 1}]) end)
+          end
+
+        wait_until(fn -> elem(Process.info(proxy, :message_queue_len), 1) >= 8 end)
+        tasks
+      after
+        :sys.resume(proxy)
+      end
+
+    entries = Enum.map(tasks, &Task.await(&1, 15_000))
+    assert Enum.all?(entries, &(&1.status == :committed))
+    batches = Agent.get(recorder, & &1.batches)
+    assert Enum.any?(batches, &(length(&1.ids) == 8)), inspect(batches)
+    assert_history(recorder, "atomic", entries)
+  end
+
+  @tag counterexample: true
+  test "half-open range clears preserve their endpoint through the complete transaction path", %{recorder: recorder} do
+    first =
+      Driver.attempt(Repo, recorder, "bounds-seed", [
+        {:put, "history/bounds/a", "a"},
+        {:put, "history/bounds/b", "b"},
+        {:put, "history/bounds/c", "c"}
+      ])
+
+    second = Driver.attempt(Repo, recorder, "bounds-clear", [{:clear_range, "history/bounds/a", "history/bounds/b"}])
+    third = Driver.attempt(Repo, recorder, "bounds-read", [{:range, "history/bounds/a", "history/bounds/d"}])
+    assert Enum.all?([first, second, third], &(&1.status == :committed))
+    assert_history(recorder, "bounds", [first, second, third])
+  end
+
+  @tag counterexample: true
+  test "concurrent conditional reservations based on absence admit only one key", %{recorder: recorder} do
+    parent = self()
+
+    tasks =
+      for key <- ["a", "b"] do
+        Task.async(fn ->
+          barrier = fn _ ->
+            send(parent, {:read_complete, self()})
+
+            receive do
+              :release -> :ok
+            after
+              5_000 -> raise "read barrier timed out"
+            end
+          end
+
+          Driver.attempt(
+            Repo,
+            recorder,
+            "reservation-#{key}",
+            [{:reserve, {"history/reservation/", "history/reservation0"}, "history/reservation/" <> key}],
+            after_read: barrier
+          )
+        end)
+      end
+
+    await_and_release_readers(tasks, fn ->
+      attempts = Agent.get(recorder, &Map.values(&1.attempts))
+      assert length(attempts) == 2
+      assert Enum.all?(attempts, &(&1.status == :in_flight and not &1.callback_complete))
+      assert Enum.all?(attempts, &(&1.reads == [{:reserve, true}]))
+    end)
+
+    entries = Enum.map(tasks, &Task.await(&1, 15_000))
+    assert Enum.count(entries, &(&1.status == :committed)) == 1
+    assert Enum.count(entries, &(&1.status == :aborted)) == 1
+
+    retry =
+      Driver.attempt(Repo, recorder, "reservation-retry", [
+        {:reserve, {"history/reservation/", "history/reservation0"}, "history/reservation/retry"}
+      ])
+
+    assert retry.status == :committed
+    assert retry.reads == [{:reserve, false}]
+    assert_history(recorder, "reservation", entries ++ [retry])
+  end
+
+  test "point-dependent transfers preserve a multi-key invariant", %{recorder: recorder} do
+    seed = Driver.attempt(Repo, recorder, "transfer-seed", [{:put, "history/alice", <<10::64-little>>}])
+    parent = self()
+
+    tasks =
+      for n <- 1..2,
+          do:
+            Task.async(fn ->
+              barrier = fn _ ->
+                send(parent, {:read_complete, self()})
+
+                receive do
+                  :release -> :ok
+                after
+                  5_000 -> raise "read barrier timed out"
+                end
+              end
+
+              Driver.attempt(Repo, recorder, "transfer-#{n}", [{:transfer, "history/alice", "history/bob", 7}],
+                after_read: barrier
+              )
+            end)
+
+    await_and_release_readers(tasks)
+    entries = Enum.map(tasks, &Task.await(&1, 15_000))
+    assert Enum.count(entries, &(&1.status == :committed)) == 1
+    assert Enum.count(entries, &(&1.status == :aborted)) == 1
+    assert_history(recorder, "transfer", [seed | entries])
+  end
+
+  @tag counterexample: true
+  test "public pending writes are included in an otherwise empty range", %{recorder: recorder} do
+    entry =
+      Driver.attempt(Repo, recorder, "pending", [
+        {:put, "history/local/b", "new"},
+        {:range, "history/local/a", "history/local/c"}
+      ])
+
+    assert entry.status == :committed
+    assert_history(recorder, "pending", [entry])
+  end
+
+  for seed_value <- [239, 240, 241] do
+    @tag history_seed: seed_value
+    test "mixed mutation history seed #{seed_value} agrees with the sequential model", %{
+      recorder: recorder,
+      history_seed: seed_value
+    } do
+      seed =
+        Driver.attempt(Repo, recorder, "mixed-seed", [
+          {:put, "history/mixed/a", <<7::64-little>>},
+          {:put, "history/mixed/b", <<11::64-little>>}
+        ])
+
+      choices = [
+        {:put, "history/mixed/b", <<19::64-little>>},
+        {:clear, "history/mixed/a"},
+        {:clear_range, "history/mixed/a", "history/mixed/b"},
+        {:add, "history/mixed/b", 1}
+      ]
+
+      rng = :rand.seed_s(:exsss, {seed_value, seed_value + 1, seed_value + 2})
+
+      {operations, _} =
+        Enum.map_reduce(1..3, rng, fn _, rng ->
+          {index, rng} = :rand.uniform_s(length(choices), rng)
+          {Enum.at(choices, index - 1), rng}
+        end)
+
+      entries =
+        operations
+        |> Enum.with_index()
+        |> Enum.map(fn {op, i} ->
+          Task.async(fn -> Driver.attempt(Repo, recorder, "mixed-#{i}", [op]) end)
+        end)
+        |> Enum.map(&Task.await(&1, 15_000))
+
+      assert Enum.all?([seed | entries], &(&1.status == :committed))
+      Driver.artifact(recorder, "mixed", %{seed: seed_value})
+      assert_history(recorder, "mixed-#{seed_value}", [seed | entries])
+    end
+  end
+
+  defp await_and_release_readers(tasks, inspect_pending \\ fn -> :ok end) do
+    for _ <- tasks, do: assert_receive({:read_complete, _}, 5_000)
+    inspect_pending.()
+  after
+    Enum.each(tasks, &send(&1.pid, :release))
+  end
+
+  test "failed callbacks retain partial read evidence without committing", %{recorder: recorder} do
+    entry =
+      Driver.attempt(Repo, recorder, "failed-callback", [{:put, "history/fail", "local"}, {:get, "history/fail"}],
+        after_read: fn _ -> raise "controlled callback failure" end
+      )
+
+    assert entry.status == :aborted
+    refute entry.callback_complete
+    assert entry.reads == [{:get, "history/fail", "local"}]
+    assert_history(recorder, "failed-callback", [entry])
+  end
+
+  for boundary <- [:before_wal_append, :after_wal_sync] do
+    @tag boundary: boundary
+    test "coupled coordinator and log crash at #{boundary} preserves acknowledged history across an epoch", %{
+      recorder: recorder,
+      boundary: boundary
+    } do
+      seed = Driver.attempt(Repo, recorder, "crash-seed", [{:put, "history/safe", "acknowledged"}])
+      assert seed.status == :committed
+      %{epoch: epoch, logs: logs} = Cluster.transaction_system_layout!()
+      [log_id] = Map.keys(logs)
+      log = Process.whereis(Cluster.otp_name_for_worker(log_id))
+      assert is_pid(log)
+      {:ok, wal_gate} = Agent.start_link(fn -> nil end)
+      handler_id = {__MODULE__, boundary, make_ref()}
+      :ok = :telemetry.attach(handler_id, [:bedrock, :log, :push], &Gates.log_event/4, wal_gate)
+      marker = "history/meta/crash-tail"
+
+      match = fn encoded ->
+        {:ok, tx} = Transaction.decode(encoded)
+        Enum.any?(tx.mutations, &match?({:set, ^marker, _}, &1))
+      end
+
+      if boundary == :before_wal_append,
+        do: :sys.suspend(log),
+        else: Gates.arm(wal_gate, %{stage: :after_wal_sync, match: match, owner: self()})
+
+      task =
+        Task.async(fn ->
+          Driver.attempt(Repo, recorder, "crash-tail", [{:add, "history/tail", 1}], timeout_in_ms: 2_000)
+        end)
+
+      coordinator = Process.whereis(Cluster.otp_name(:coordinator))
+      coupled = System.get_env("BEDROCK_HISTORY_SINGLE_LOG_REPRO") != "1"
+      Driver.metadata(recorder, %{epoch_before: epoch, boundary: boundary, coordinator_crashed: coupled})
+
+      try do
+        gate_evidence =
+          case boundary do
+            :before_wal_append ->
+              wait_until(fn -> elem(Process.info(log, :message_queue_len), 1) > 0 end)
+              :queued_before_append
+
+            :after_wal_sync ->
+              assert_receive {:history_gate, :after_wal_sync, ^log, _token, encoded}, 5_000
+              {:after_sync_before_reply, encoded}
+          end
+
+        Driver.metadata(recorder, %{fault: gate_evidence})
+        if coupled, do: :sys.suspend(coordinator)
+        monitor = Process.monitor(log)
+        Process.exit(log, :kill)
+        assert_receive {:DOWN, ^monitor, :process, ^log, :killed}, 5_000
+
+        if coupled do
+          coordinator_monitor = Process.monitor(coordinator)
+          Process.exit(coordinator, :kill)
+          assert_receive {:DOWN, ^coordinator_monitor, :process, ^coordinator, :killed}, 5_000
+        end
+
+        tail = Task.await(task, 10_000)
+        assert tail.status in [:unknown, :aborted]
+
+        wait_until(
+          fn ->
+            case Cluster.fetch_transaction_system_layout() do
+              {:ok, %{epoch: current}} -> current > epoch
+              _ -> false
+            end
+          end,
+          3_000
+        )
+
+        assert Repo.transact(fn -> Repo.get("history/safe") end, timeout_in_ms: 15_000) == "acknowledged"
+
+        if boundary == :before_wal_append do
+          assert Repo.transact(fn -> Repo.get("history/tail") end) == nil
+        end
+
+        Driver.artifact(recorder, "wal-#{boundary}", %{
+          seed: 239,
+          epoch_before: epoch,
+          epoch_after: Cluster.transaction_system_layout!().epoch,
+          coordinator_crashed: coupled,
+          fault: gate_evidence
+        })
+
+        assert_history(recorder, "wal-#{boundary}", [seed, tail])
+      after
+        :telemetry.detach(handler_id)
+        Gates.disarm(wal_gate)
+        if Process.alive?(log), do: :sys.resume(log)
+        if coupled and Process.alive?(coordinator), do: :sys.resume(coordinator)
+      end
+    end
+  end
+
+  defp assert_history(recorder, scenario, entries) do
+    final = Repo.transact(fn -> {"history/", "history0"} |> Repo.get_range() |> Enum.to_list() |> Map.new() end)
+    artifact = Driver.artifact(recorder, scenario, %{final: final})
+    assert {:ok, _} = Oracle.check(%{}, entries, final), "history has no legal serialization: #{artifact}"
+  end
+
+  defp wait_until(predicate, attempts \\ 200)
+  defp wait_until(_predicate, 0), do: flunk("condition did not become true")
+
+  defp wait_until(predicate, attempts) do
+    if predicate.(),
+      do: :ok,
+      else:
+        (
+          Process.sleep(10)
+          wait_until(predicate, attempts - 1)
+        )
+  end
+end

--- a/test/support/history/driver.ex
+++ b/test/support/history/driver.ex
@@ -1,0 +1,202 @@
+defmodule Bedrock.Test.History.Driver do
+  @moduledoc "Runs and records individual public Repo attempts without hiding ambiguous retries."
+  alias Bedrock.DataPlane.Transaction
+
+  def start_recorder do
+    {revision, _} = System.cmd("git", ["rev-parse", "HEAD"], stderr_to_stdout: true)
+
+    Agent.start_link(fn ->
+      %{
+        attempts: %{},
+        batches: [],
+        faults: [],
+        initial: %{},
+        seed: 239,
+        revision: String.trim(revision),
+        exunit_seed: Application.get_env(:ex_unit, :seed)
+      }
+    end)
+  end
+
+  def attach(recorder) do
+    id = {__MODULE__, recorder}
+    :ok = :telemetry.attach(id, [:bedrock, :log, :push], &__MODULE__.log_event/4, recorder)
+    id
+  end
+
+  def log_event(_event, _measurements, %{transaction: encoded}, recorder) do
+    {:ok, decoded} = Transaction.decode(encoded)
+    ids = for {:set, "history/meta/" <> id, _} <- decoded.mutations, do: id
+
+    if ids != [] do
+      Agent.update(recorder, fn state ->
+        %{state | batches: [%{version: decoded.commit_version, ids: ids} | state.batches]}
+      end)
+    end
+  end
+
+  def attempt(repo, recorder, id, operations, opts \\ []) do
+    invoke = System.monotonic_time()
+    Process.delete({__MODULE__, :observations})
+    marker = {:put, "history/meta/" <> id, "attempt"}
+    ops = operations ++ [marker]
+
+    pending = %{
+      id: id,
+      invoke: invoke,
+      complete: nil,
+      status: :in_flight,
+      ops: ops,
+      reads: [],
+      callback_complete: false,
+      error: nil
+    }
+
+    Agent.update(recorder, &put_in(&1, [:attempts, id], pending))
+
+    observe = fn observation ->
+      Agent.update(recorder, &update_in(&1, [:attempts, id, :reads], fn reads -> reads ++ [observation] end))
+    end
+
+    opts = Keyword.put(opts, :observe, observe)
+
+    {status, error} =
+      try do
+        result =
+          repo.transact(
+            fn ->
+              observations = execute(repo, operations, opts)
+              repo.put("history/meta/" <> id, "attempt")
+              Process.put({__MODULE__, :observations}, observations)
+              Agent.update(recorder, &put_in(&1, [:attempts, id, :callback_complete], true))
+              observations
+            end,
+            retry_limit: 0,
+            timeout_in_ms: Keyword.get(opts, :timeout_in_ms, 5_000)
+          )
+
+        {classify_return(result, Process.get({__MODULE__, :observations})), nil}
+      rescue
+        exception ->
+          message = Exception.message(exception)
+          status = classify_exception(exception, Process.get({__MODULE__, :observations}))
+          {status, message}
+      catch
+        kind, reason ->
+          status = if Process.get({__MODULE__, :observations}) == nil, do: :aborted, else: :unknown
+          {status, inspect({kind, reason})}
+      end
+
+    entry = %{
+      id: id,
+      invoke: invoke,
+      complete: System.monotonic_time(),
+      status: status,
+      ops: ops,
+      reads: Agent.get(recorder, & &1.attempts[id].reads),
+      callback_complete: Process.get({__MODULE__, :observations}) != nil,
+      error: error
+    }
+
+    Agent.update(recorder, &put_in(&1, [:attempts, id], entry))
+    entry
+  end
+
+  def classify_return(result, observations) when is_list(observations) and result == observations, do: :committed
+  def classify_return({:error, _reason}, _observations), do: :aborted
+  def classify_return(_result, _observations), do: :unknown
+
+  def classify_exception(_exception, nil), do: :aborted
+
+  def classify_exception(
+        %RuntimeError{message: "Transaction retry limit exceeded after 0 attempts. Last error: :aborted"},
+        _observations
+      ), do: :aborted
+
+  def classify_exception(_exception, _observations), do: :unknown
+
+  def metadata(recorder, fields), do: Agent.update(recorder, &Map.merge(&1, fields))
+
+  def execute(repo, operations, opts \\ []) do
+    operations
+    |> Enum.reduce([], fn op, observations ->
+      case execute_operation(repo, op) do
+        :mutation ->
+          observations
+
+        observation ->
+          Keyword.get(opts, :observe, fn _ -> :ok end).(observation)
+          Keyword.get(opts, :after_read, fn _ -> :ok end).(observation)
+          [observation | observations]
+      end
+    end)
+    |> Enum.reverse()
+  end
+
+  defp execute_operation(repo, {:put, key, value}),
+    do:
+      (
+        repo.put(key, value)
+        :mutation
+      )
+
+  defp execute_operation(repo, {:clear, key}),
+    do:
+      (
+        repo.clear(key)
+        :mutation
+      )
+
+  defp execute_operation(repo, {:clear_range, first, last}),
+    do:
+      (
+        repo.clear_range({first, last})
+        :mutation
+      )
+
+  defp execute_operation(repo, {:add, key, amount}),
+    do:
+      (
+        repo.add(key, <<amount::64-little>>)
+        :mutation
+      )
+
+  defp execute_operation(repo, {:get, key}), do: {:get, key, repo.get(key)}
+  defp execute_operation(repo, {:range, first, last}), do: {:range, Enum.to_list(repo.get_range({first, last}))}
+
+  defp execute_operation(repo, {:reserve, range, key}) do
+    empty = Enum.to_list(repo.get_range(range)) == []
+    if empty, do: repo.put(key, "reserved")
+    {:reserve, empty}
+  end
+
+  defp execute_operation(repo, {:transfer, from, to, amount}) do
+    source = repo.get(from)
+    balance = number(source)
+    enough = balance >= amount
+    destination = if enough, do: repo.get(to), else: :unread
+
+    if enough do
+      repo.put(from, <<balance - amount::64-little>>)
+      repo.put(to, <<number(destination) + amount::64-little>>)
+    end
+
+    {:transfer, source, destination, enough}
+  end
+
+  defp number(nil), do: 0
+  defp number(<<value::64-little>>), do: value
+
+  def artifact(recorder, scenario, extra \\ %{}) do
+    directory =
+      System.get_env("BEDROCK_HISTORY_ARTIFACT_DIR") || Path.join(System.tmp_dir!(), "bedrock-history-artifacts")
+
+    File.mkdir_p!(directory)
+    path = Path.join(directory, "#{scenario}-#{System.unique_integer([:positive])}.term")
+    metadata(recorder, extra)
+    data = Agent.get(recorder, & &1)
+    File.write!(path, :erlang.term_to_binary(data))
+    File.write!(path <> ".txt", inspect(data, pretty: true, limit: :infinity, printable_limit: :infinity))
+    path
+  end
+end

--- a/test/support/history/gates.ex
+++ b/test/support/history/gates.ex
@@ -1,0 +1,79 @@
+defmodule Bedrock.Test.History.Gates do
+  @moduledoc "One-shot deterministic pauses at real I/O boundaries; every operation still uses LocalFilesystem."
+  @behaviour Bedrock.ObjectStorage
+
+  alias Bedrock.ObjectStorage.LocalFilesystem
+
+  def arm(gates, rule), do: Agent.update(gates, &(&1 |> normalize() |> Map.put(:rule, rule)))
+
+  def disarm(gates) do
+    active =
+      Agent.get_and_update(gates, fn state ->
+        state = normalize(state)
+        {state.active, %{rule: nil, active: %{}}}
+      end)
+
+    Enum.each(active, fn {token, pid} -> send(pid, {:release_history_gate, token}) end)
+    :ok
+  end
+
+  def pause(gates, stage, key) do
+    token = make_ref()
+    pid = self()
+
+    owner =
+      Agent.get_and_update(gates, fn state ->
+        state = normalize(state)
+
+        case state.rule do
+          %{stage: ^stage, match: match, owner: owner} ->
+            if match.(key), do: {owner, %{rule: nil, active: Map.put(state.active, token, pid)}}, else: {nil, state}
+
+          _ ->
+            {nil, state}
+        end
+      end)
+
+    if owner do
+      send(owner, {:history_gate, stage, self(), token, key})
+
+      try do
+        receive do
+          {:release_history_gate, ^token} -> :ok
+        after
+          15_000 -> raise "history gate was not released: #{inspect({stage, key})}"
+        end
+      after
+        Agent.update(gates, fn state -> Map.update!(normalize(state), :active, &Map.delete(&1, token)) end)
+      end
+    end
+  end
+
+  defp normalize(%{rule: _, active: _} = state), do: state
+  defp normalize(rule), do: %{rule: rule, active: %{}}
+
+  def log_event(_event, _measurements, %{transaction: transaction}, gates),
+    do: pause(gates, :after_wal_sync, transaction)
+
+  @impl true
+  def put_if_not_exists(config, key, data, opts) do
+    pause(config[:gates], :before_snapshot_publication, key)
+    result = LocalFilesystem.put_if_not_exists(config, key, data, opts)
+    pause(config[:gates], :after_snapshot_publication, key)
+    result
+  end
+
+  @impl true
+  def put(config, key, data, opts), do: LocalFilesystem.put(config, key, data, opts)
+  @impl true
+  def get(config, key), do: LocalFilesystem.get(config, key)
+  @impl true
+  def delete(config, key), do: LocalFilesystem.delete(config, key)
+  @impl true
+  def list(config, prefix, opts), do: LocalFilesystem.list(config, prefix, opts)
+  @impl true
+  def get_with_version(config, key), do: LocalFilesystem.get_with_version(config, key)
+  @impl true
+  def put_if_version_matches(config, key, data, version, opts),
+    do: LocalFilesystem.put_if_version_matches(config, key, data, version, opts)
+end

--- a/test/support/history/oracle.ex
+++ b/test/support/history/oracle.ex
@@ -1,0 +1,97 @@
+defmodule Bedrock.Test.History.Oracle do
+  @moduledoc "Independent sequential model and bounded strict-serializability checker for transaction attempts."
+  import Bitwise
+
+  def evaluate(initial, operations) do
+    {state, observations} = Enum.reduce(operations, {initial, []}, &apply_operation/2)
+    {state, Enum.reverse(observations)}
+  end
+
+  def check(initial, history, final) do
+    valid =
+      length(history) <= 8 and length(Enum.uniq_by(history, & &1.id)) == length(history) and
+        Enum.all?(history, &(&1.status in [:committed, :aborted, :unknown]))
+
+    if valid, do: search(initial, history, final, []), else: {:error, :invalid_history}
+  end
+
+  defp search(state, [], final, order) when state == final, do: {:ok, Enum.reverse(order)}
+  defp search(_state, [], _final, _order), do: {:error, :no_serialization}
+
+  defp search(state, remaining, final, order) do
+    Enum.find_value(remaining, {:error, :no_serialization}, fn candidate ->
+      eligible =
+        not Enum.any?(remaining, fn other ->
+          other.id != candidate.id and other.status != :unknown and other.complete < candidate.invoke
+        end)
+
+      if eligible do
+        rest = Enum.reject(remaining, &(&1.id == candidate.id))
+
+        state
+        |> choices(candidate)
+        |> Enum.find_value(fn {next, applied} ->
+          next_order = if applied, do: [candidate.id | order], else: order
+
+          case search(next, rest, final, next_order) do
+            {:ok, _} = accepted -> accepted
+            {:error, _} -> nil
+          end
+        end)
+      end
+    end)
+  end
+
+  defp choices(state, %{status: :aborted}), do: [{state, false}]
+
+  defp choices(state, attempt) do
+    {next, observations} = evaluate(state, attempt.ops)
+    apply = if observations == attempt.reads, do: [{next, true}], else: []
+    if attempt.status == :unknown, do: [{state, false} | apply], else: apply
+  end
+
+  defp apply_operation({:put, key, value}, {state, reads}), do: {Map.put(state, key, value), reads}
+  defp apply_operation({:clear, key}, {state, reads}), do: {Map.delete(state, key), reads}
+
+  defp apply_operation({:clear_range, first, last}, {state, reads}),
+    do: {Map.reject(state, fn {key, _} -> first <= key and key < last end), reads}
+
+  defp apply_operation({:add, key, increment}, {state, reads}) do
+    value = rem(number(state[key]) + increment, 1 <<< 64)
+    {Map.put(state, key, <<value::64-little>>), reads}
+  end
+
+  defp apply_operation({:get, key}, {state, reads}), do: {state, [{:get, key, state[key]} | reads]}
+
+  defp apply_operation({:range, first, last}, {state, reads}),
+    do: {state, [{:range, range(state, first, last)} | reads]}
+
+  defp apply_operation({:reserve, {first, last}, key}, {state, reads}) do
+    empty = range(state, first, last) == []
+    next = if empty, do: Map.put(state, key, "reserved"), else: state
+    {next, [{:reserve, empty} | reads]}
+  end
+
+  defp apply_operation({:transfer, from, to, amount}, {state, reads}) do
+    source = state[from]
+    balance = number(source)
+    enough = balance >= amount
+    destination = if enough, do: state[to], else: :unread
+
+    next =
+      if enough,
+        do:
+          state
+          |> Map.put(from, <<balance - amount::64-little>>)
+          |> Map.put(to, <<number(state[to]) + amount::64-little>>),
+        else: state
+
+    {next, [{:transfer, source, destination, enough} | reads]}
+  end
+
+  defp number(nil), do: 0
+  defp number(<<value::64-little>>), do: value
+
+  defp range(state, first, last),
+    do: state |> Enum.filter(fn {key, _} -> first <= key and key < last end) |> Enum.sort()
+end

--- a/test/support/history/peer_cluster.ex
+++ b/test/support/history/peer_cluster.ex
@@ -1,0 +1,325 @@
+defmodule Bedrock.Test.History.PeerCluster do
+  @moduledoc "Real three-VM history fixture with stdio control independent of distribution."
+
+  alias Bedrock.Service.Foreman
+  alias Bedrock.Test.History.Driver
+
+  defmodule Cluster do
+    @moduledoc false
+    use Bedrock.Cluster, otp_app: :bedrock, name: "peer_history"
+  end
+
+  defmodule Repo do
+    @moduledoc false
+    use Bedrock.Repo, cluster: Cluster
+  end
+
+  def start(root) do
+    File.mkdir_p!(root)
+    {:ok, state} = Agent.start_link(fn -> %{root: root, peers: %{}, cookie: Node.get_cookie()} end)
+
+    try do
+      for role <- [:coordination, :log, :materializer], do: start_peer(state, role)
+      coordinator = get_peer(state, :coordination).node
+      File.write!(Path.join(root, "descriptor"), "peer_history:#{coordinator}")
+      for role <- [:coordination, :log, :materializer], do: boot(state, role)
+      state
+    catch
+      kind, reason ->
+        path = artifact(root, "boot_failure", [{kind, reason}])
+        IO.puts("Peer boot failure artifact: #{path}")
+        stop(state)
+        :erlang.raise(kind, reason, __STACKTRACE__)
+    end
+  end
+
+  defp start_peer(state, role) do
+    %{root: root, cookie: cookie} = Agent.get(state, & &1)
+    name = String.to_atom("history_#{role}_#{:erlang.phash2(root)}")
+
+    args =
+      [
+        ~c"+S",
+        ~c"2:2",
+        ~c"-setcookie",
+        Atom.to_charlist(cookie),
+        ~c"-kernel",
+        ~c"prevent_overlapping_partitions",
+        ~c"false",
+        ~c"-pa"
+      ] ++ :code.get_path()
+
+    {:ok, control, peer_node} = :peer.start_link(%{name: name, connection: :standard_io, args: args})
+    peer = %{control: control, node: peer_node, role: role}
+    Agent.update(state, &put_in(&1, [:peers, role], peer))
+    peer
+  end
+
+  defp boot(state, role) do
+    root = Agent.get(state, & &1.root)
+    call(state, role, :boot_remote, [root, role])
+  end
+
+  def boot_remote(root, role) do
+    Application.ensure_all_started(:bedrock)
+    Logger.configure(level: :warning)
+    backend = {Bedrock.ObjectStorage.LocalFilesystem, root: Path.join(root, "objects")}
+    local = Path.join(root, Atom.to_string(role))
+    File.mkdir_p!(local)
+    Application.put_env(:bedrock, Bedrock.ObjectStorage, backend: backend)
+
+    Application.put_env(:bedrock, Cluster,
+      capabilities: [role],
+      durability_mode: :relaxed,
+      path_to_descriptor: Path.join(root, "descriptor"),
+      object_storage: backend,
+      coordination: [path: local],
+      coordinator: [path: local],
+      materializer: [path: local, object_storage: backend],
+      log: [path: local, object_storage: backend]
+    )
+
+    {:ok, sup} = Supervisor.start_link([{Cluster, []}], strategy: :one_for_one)
+    Process.unlink(sup)
+    :ok
+  end
+
+  def nodes(state), do: Agent.get(state, &Map.new(&1.peers, fn {role, peer} -> {role, peer.node} end))
+  defp get_peer(state, role), do: Agent.get(state, & &1.peers[role])
+
+  defp call(state, role, function, args \\ []),
+    do: :peer.call(get_peer(state, role).control, __MODULE__, function, args, 20_000)
+
+  def ready(state, previous_epoch \\ -1) do
+    deadline = System.monotonic_time(:millisecond) + 40_000
+
+    await(
+      fn ->
+        try do
+          layout = call(state, :coordination, :layout_remote)
+          placement = Map.new([:log, :materializer], fn role -> {role, call(state, role, :services_remote)} end)
+          expected = nodes(state)
+          log_ids = Enum.map(placement.log, & &1.id)
+
+          valid = layout.epoch > previous_epoch and valid_placement?(layout, placement, expected, log_ids)
+
+          if valid, do: %{epoch: layout.epoch, layout: layout, services: placement, nodes: expected}, else: false
+        catch
+          _, _ -> false
+        end
+      end,
+      deadline
+    )
+  end
+
+  defp valid_placement?(layout, placement, expected, log_ids) do
+    checks = [
+      map_size(layout.logs) > 0,
+      Enum.all?(Map.keys(layout.logs), &(&1 in log_ids)),
+      Enum.all?(placement.log, &(&1.node == expected.log and &1.kind == :log)),
+      Enum.sort(Enum.map(placement.materializer, & &1.shard_num)) == [0, 1],
+      Enum.all?(placement.materializer, &(&1.node == expected.materializer and &1.kind == :materializer)),
+      Enum.all?(placement.materializer, &(&1.epoch == layout.epoch and &1.mode == :running)),
+      node(layout.sequencer) == expected.coordination,
+      layout.resolvers != [],
+      Enum.all?(layout.resolvers, &(node(elem(&1, 1)) == expected.coordination)),
+      layout.proxies != [],
+      Enum.all?(layout.proxies, &(node(&1) == expected.coordination))
+    ]
+
+    Enum.all?(checks)
+  end
+
+  def layout_remote, do: Cluster.transaction_system_layout!()
+
+  def services_remote do
+    {:ok, services} = Foreman.get_all_running_services(Cluster.otp_name(:foreman))
+
+    Enum.map(services, fn {id, kind, name} ->
+      pid = Process.whereis(name)
+      worker = :sys.get_state(pid)
+
+      %{
+        id: id,
+        kind: kind,
+        node: node(pid),
+        pid: pid,
+        shard_num: Map.get(worker, :shard_num),
+        epoch: worker.epoch,
+        mode: worker.mode
+      }
+    end)
+  end
+
+  def attempt(state, id, operations) do
+    # A restarted VM has a different monotonic clock origin. Order every RPC
+    # attempt on the surviving controller clock, retaining remote times as evidence.
+    invoke = System.monotonic_time()
+    entry = call(state, :coordination, :attempt_remote, [id, operations])
+
+    entry
+    |> Map.put(:remote_times, {entry.invoke, entry.complete})
+    |> Map.put(:invoke, invoke)
+    |> Map.put(:complete, System.monotonic_time())
+  end
+
+  def attempt_remote(id, operations) do
+    {:ok, recorder} = Driver.start_recorder()
+
+    try do
+      Driver.attempt(Repo, recorder, id, operations, timeout_in_ms: 15_000)
+    after
+      Agent.stop(recorder)
+    end
+  end
+
+  def final(state), do: call(state, :coordination, :final_remote)
+
+  def final_remote,
+    do:
+      Repo.transact(fn -> {"history/", "history0"} |> Repo.get_range() |> Enum.to_list() |> Map.new() end,
+        timeout_in_ms: 15_000
+      )
+
+  def wal_files(state) do
+    root = Agent.get(state, & &1.root)
+    root |> Path.join("log/**/wal_*") |> Path.wildcard() |> Enum.filter(&File.regular?/1)
+  end
+
+  def stop_log(state), do: :peer.stop(get_peer(state, :log).control)
+  def log_down?(state), do: Node.ping(get_peer(state, :log).node) == :pang
+
+  def restart_log(state) do
+    start_peer(state, :log)
+    boot(state, :log)
+  end
+
+  def suspend_coordinator(state), do: call(state, :coordination, :suspend_coordinator_remote)
+  def suspend_coordinator_remote, do: :sys.suspend(Cluster.coordinator!())
+  def stop_coordinator(state), do: :peer.stop(get_peer(state, :coordination).control)
+
+  def restart_coordinator(state) do
+    start_peer(state, :coordination)
+    boot(state, :coordination)
+  end
+
+  defp edges, do: [{:log, :coordination}, {:coordination, :log}, {:log, :materializer}, {:materializer, :log}]
+
+  def partition_log(state) do
+    # Install all four directional cookie barriers before disconnecting any edge.
+    cookies =
+      for {from, to} <- edges() do
+        true = call(state, from, :cookie_remote, [get_peer(state, to).node, String.to_atom("history_wrong_#{from}")])
+        {System.monotonic_time(), :cookie_barrier, from, to}
+      end
+
+    disconnects =
+      for {from, to} <- edges() do
+        result = call(state, from, :disconnect_remote, [get_peer(state, to).node])
+        {System.monotonic_time(), :disconnect, from, to, result}
+      end
+
+    cookies ++ disconnects
+  end
+
+  def partition_proof(state) do
+    for {from, to} <- edges() do
+      target = get_peer(state, to).node
+      state |> call(from, :proof_remote, [target]) |> Map.merge(%{from: from, to: to})
+    end
+  end
+
+  def cookie_remote(target, cookie), do: Node.set_cookie(target, cookie)
+  def disconnect_remote(target), do: Node.disconnect(target)
+
+  def proof_remote(target) do
+    disconnected = target not in Node.list()
+    ping = Node.ping(target)
+    %{alive: Node.alive?(), disconnected: disconnected and target not in Node.list(), ping: ping}
+  end
+
+  def connected_edges(state) do
+    for {from, to} <- edges() do
+      {from, to, call(state, from, :ping_remote, [get_peer(state, to).node])}
+    end
+  end
+
+  def heal(state) do
+    cookie = Agent.get(state, & &1.cookie)
+    for {from, to} <- edges(), do: call(state, from, :cookie_remote, [get_peer(state, to).node, cookie])
+    for {from, to} <- edges(), do: call(state, from, :ping_remote, [get_peer(state, to).node])
+  end
+
+  def ping_remote(target), do: Node.ping(target)
+
+  def stop(state) do
+    for {_role, peer} <- Agent.get(state, & &1.peers) do
+      try do
+        :peer.stop(peer.control)
+      catch
+        _, _ -> :ok
+      end
+    end
+
+    Agent.stop(state)
+  end
+
+  def diagnostics(state) do
+    Map.new([:coordination, :log, :materializer], fn role ->
+      value =
+        try do
+          :peer.call(get_peer(state, role).control, __MODULE__, :diagnostics_remote, [], 2_000)
+        catch
+          kind, reason -> {kind, reason}
+        end
+
+      {role, value}
+    end)
+  end
+
+  def diagnostics_remote do
+    coordinator = Process.whereis(Cluster.otp_name(:coordinator))
+    coordinator_state = if coordinator, do: :sys.get_state(coordinator, 1_000)
+    %{node: node(), connected: Node.list(), coordinator: coordinator_state}
+  end
+
+  def artifact(root, scenario, events) do
+    directory =
+      System.get_env("BEDROCK_HISTORY_ARTIFACT_DIR") || Path.join(System.tmp_dir!(), "bedrock-history-artifacts")
+
+    File.mkdir_p!(directory)
+    path = Path.join(directory, "peer-#{scenario}-#{:erlang.phash2(root)}.term")
+    {revision, 0} = System.cmd("git", ["rev-parse", "HEAD"])
+
+    File.write!(
+      path,
+      :erlang.term_to_binary(%{
+        seed: 239,
+        exunit_seed: ExUnit.configuration()[:seed],
+        scenario: scenario,
+        revision: String.trim(revision),
+        initial: %{},
+        root: root,
+        events: events
+      })
+    )
+
+    path
+  end
+
+  defp await(predicate, deadline) do
+    result = predicate.()
+
+    cond do
+      result ->
+        result
+
+      System.monotonic_time(:millisecond) >= deadline ->
+        raise "peer cluster did not publish the required recovered placement"
+
+      true ->
+        Process.sleep(50)
+        await(predicate, deadline)
+    end
+  end
+end

--- a/test/support/history/snapshot_fixture.ex
+++ b/test/support/history/snapshot_fixture.ex
@@ -1,0 +1,161 @@
+defmodule Bedrock.Test.History.SnapshotFixture do
+  @moduledoc false
+  import ExUnit.Assertions
+
+  alias Bedrock.DataPlane.Materializer.Olivine.Database
+  alias Bedrock.DataPlane.Materializer.Olivine.Index
+  alias Bedrock.DataPlane.Materializer.Olivine.IndexManager
+  alias Bedrock.DataPlane.Transaction
+  alias Bedrock.Service.Foreman
+  alias Bedrock.Test.History.Driver
+  alias Bedrock.Test.History.Gates
+  alias Bedrock.Test.History.Oracle
+
+  def materializer(cluster) do
+    {:ok, services} = Foreman.get_all_running_services(cluster.otp_name(:foreman))
+
+    Enum.find_value(services, fn
+      {id, :materializer, name} ->
+        pid = Process.whereis(name)
+        if pid && :sys.get_state(pid).shard_num == 1, do: {id, pid}
+
+      _ ->
+        nil
+    end)
+  end
+
+  def await(function, attempts \\ 1_500)
+  def await(_function, 0), do: flunk("snapshot fixture did not reach its observed boundary")
+
+  def await(function, attempts) do
+    case function.() do
+      nil ->
+        Process.sleep(10)
+        await(function, attempts - 1)
+
+      false ->
+        Process.sleep(10)
+        await(function, attempts - 1)
+
+      value ->
+        value
+    end
+  end
+
+  def baseline_batch(cluster, repo, recorder) do
+    %{proxies: [proxy]} = cluster.transaction_system_layout!()
+    :ok = :sys.suspend(proxy)
+
+    tasks =
+      try do
+        tasks =
+          for n <- [1, 2] do
+            Task.async(fn ->
+              Driver.attempt(repo, recorder, "snapshot-batch-#{n}", [
+                {:add, "history/counter", n},
+                {:put, "history/batch_order", Integer.to_string(n)}
+              ])
+            end)
+          end
+
+        await(fn -> elem(Process.info(proxy, :message_queue_len), 1) >= 2 end)
+        tasks
+      after
+        :sys.resume(proxy)
+      end
+
+    entries = Enum.map(tasks, &Task.await(&1, 15_000))
+    assert Enum.all?(entries, &(&1.status == :committed))
+    ids = MapSet.new(entries, & &1.id)
+
+    batch =
+      Agent.get(recorder, fn history ->
+        Enum.find(history.batches, &(MapSet.new(&1.ids) == ids))
+      end)
+
+    assert batch, "snapshot prefix transactions did not share one real log batch"
+    batch.version
+  end
+
+  def record(recorder, event), do: Agent.update(recorder, &Map.update!(&1, :faults, fn events -> [event | events] end))
+
+  def version(recorder, id) do
+    await(fn ->
+      Agent.get(recorder, fn state ->
+        Enum.find_value(state.batches, fn batch -> if id in batch.ids, do: batch.version end)
+      end)
+    end)
+  end
+
+  # Decode only marker placement and version. Expected mutations stay in the
+  # independent driver history and are interpreted exclusively by Oracle.
+  def after_tail_event(_event, _measurements, %{transaction: encoded}, {gate, owner, marker}) do
+    {:ok, decoded} = Transaction.decode(encoded)
+
+    marker_seen =
+      Enum.any?(decoded.mutations, fn
+        {:set, ^marker, _} -> true
+        _ -> false
+      end)
+
+    if marker_seen do
+      Gates.arm(gate, %{stage: :after_wal_sync, match: fn _ -> true end, owner: owner})
+    else
+      Gates.pause(gate, :after_wal_sync, encoded)
+    end
+  end
+
+  def startup_event(_event, _measurements, %{storage_id: id}, gate),
+    do: Gates.pause(gate, :cold_replacement_started, id)
+
+  def expected_prefix(recorder, version) do
+    history = Agent.get(recorder, & &1)
+
+    history.batches
+    |> Enum.reverse()
+    |> Enum.filter(&(&1.version <= version))
+    |> Enum.flat_map(& &1.ids)
+    |> Enum.reduce(%{}, fn id, state ->
+      entry = Map.fetch!(history.attempts, id)
+      assert entry.status == :committed
+      {next, observations} = Oracle.evaluate(state, entry.ops)
+      assert observations == entry.reads
+      next
+    end)
+  end
+
+  def cold_map(path) do
+    name = String.to_atom("snapshot_cold_#{System.unique_integer([:positive])}")
+    {:ok, database} = Database.open(name, Path.join(path, "dets"), pool_size: 1)
+
+    try do
+      {:ok, manager} = IndexManager.recover_from_database(database)
+      [{version, {index, _}}] = manager.versions
+
+      values =
+        for {_, {page, _}} <- index.page_map,
+            {key, locator} <- Index.Page.key_locators(page),
+            key >= "history/" and key < "history0",
+            into: %{} do
+          {:ok, value} = Database.load_value(database, locator)
+          {key, value}
+        end
+
+      {version, values}
+    after
+      Database.close(database)
+    end
+  end
+
+  def assert_final(repo, recorder, scenario, extra) do
+    final =
+      repo.transact(fn -> {"history/", "history0"} |> repo.get_range() |> Enum.to_list() |> Map.new() end,
+        timeout_in_ms: 15_000
+      )
+
+    artifact = Driver.artifact(recorder, scenario, Map.put(extra, :final, final))
+    entries = Agent.get(recorder, &Map.values(&1.attempts))
+    assert {:ok, _} = Oracle.check(%{}, entries, final), "history mismatch: #{artifact}"
+    artifact
+  end
+end


### PR DESCRIPTION
The suite could stay green while a real transaction lost an ordered mutation, deleted a range clear's exclusive endpoint, missed a conflict on an empty range, or published a snapshot ahead of its durable version. The harness added here drives the public `Repo` API against a real cluster, injects faults at real persistence boundaries, and checks every read and the final key range against an independent model.

Ticket: bedrock-tux
Closes #239
Stacked on: `bedrock-g2e/history-base` (integration branch, no PR of its own)

## Why

Existing tests assert local invariants of one component, usually computing the expected value with that component's own helpers, so a helper wrong in the same way as the code agrees with it. Nothing tied what a client observed to what the cluster served afterwards, or carried a history through log loss, snapshot publication, or an epoch change.

That gap hid four defects found later by targeted reproduction at `8f962e09`: reordered atomics and range clears in batch application (#234), a clear deleting its exclusive endpoint (#236), empty range reads missing pending writes and conflict ranges (#235), and compaction persisting applied-but-not-durable state (#233). The missing piece was an oracle plus failure schedules, not coverage percentage (#8).

## What changed

Everything is under `test/`, `scripts/` and `guides/`; no `lib/` file is touched and no core component is mocked. It adds an oracle, a driver that runs one attempt at `retry_limit: 0` while recording its reads and outcome, and gates that pause real I/O around snapshot publication and between a log's fsync and its reply.

## How it works

Every attempt writes a unique marker key, so the served final range says which attempts landed. Outcomes are three-valued: committed, aborted, or unknown when the client timed out after its callback ran. The checker searches for a serial order that respects real time between known outcomes, replays each applied attempt against its recorded reads, lets an unknown attempt apply once or not at all, and ends in exactly the observed state. An unknown attempt skips real-time ordering: a timeout is not evidence the server did nothing.

```
1: invoke 0, complete 3, committed, add "c" 1
2: invoke 1, complete 2, committed, add "c" 1
final "c" == 2 legal in either order; "c" == 1 rejected, an acknowledged commit vanished
```

Suspending the commit proxy until eight increments queue forces one real log batch, and read barriers expose conflicting reads. The log dies before WAL append and again after fsync but before reply, together with the coordinator; recovery must advance the epoch and still serve the acknowledged write. The materializer and its unlinked uploader die around snapshot publication, and the cold replacement must start at exactly the durable prefix. Three peer VMs cover a log-node restart and a distribution cut.

## Verification

Author-reported. The four `:counterexample` tests fail semantically against `cfaab90a` and pass on the integration base; the original snapshot code, loaded in an isolated VM, fails both durable-prefix comparisons. Full history run 27 tests, 0 failures; ordinary suite and `mix quality` pass. Logs `/tmp/bedrock-239-snapshot-baseline-red.log` and `/tmp/bedrock-239-release.log`; audit `/tmp/bedrock-issue-team-20260905/239-final-audit.md`. No checks run on this non-develop base. Limits: replication factor one, local-filesystem storage, bounded schedules.

Follow-up: #259 / bedrock-t0k, autonomous recovery reuses the epoch.
Follow-up: bedrock-gu0.5, Foreman eviction-before-restart race.
Rebase onto develop once #241, #242, #245, #247, #254 and #255 land.
