### PR TITLE
bedrock-q67.21.19: An unreadable object key is not an empty shard

### DIFF
--- a/lib/bedrock/data_plane/demux/shard_server.ex
+++ b/lib/bedrock/data_plane/demux/shard_server.ex
@@ -506,6 +506,10 @@ defmodule Bedrock.DataPlane.Demux.ShardServer do
     # struct. Named explicitly so it does not ride the catch-all below,
     # which exists for genuine bugs and should stay visible as such.
     e in ObjectStorage.ListError -> {:error, {:storage_read_failed, e.reason}}
+    # Likewise a chunk whose key names no version we can read: the object
+    # is there and it is ours, so it is not absence, and the offending
+    # key is what an operator needs to see.
+    e in ObjectStorage.UnparseableKeyError -> {:error, {:storage_read_failed, {:unparseable_key, e.key}}}
     e -> {:error, {:storage_read_failed, e}}
   end
 

--- a/lib/bedrock/object_storage.ex
+++ b/lib/bedrock/object_storage.ex
@@ -116,6 +116,30 @@ defmodule Bedrock.ObjectStorage do
       do: "failed to list objects under #{inspect(prefix)}: #{inspect(reason)}"
   end
 
+  defmodule UnparseableKeyError do
+    @moduledoc """
+    Raised when an object in a prefix only Bedrock writes to carries a
+    name this build cannot read a version out of.
+
+    The listing itself succeeded, so this is not `ListError`: the object
+    is there, and it is ours — a nested object that merely shares the
+    prefix is foreign and is passed over instead (see
+    `Bedrock.ObjectStorage.Keys.extract_version/2`). What we do not know
+    is which version it holds, because the name is either corrupt or
+    written in a format a later build understands and this one does not.
+
+    Dropping it would shorten the history and make the shard look older
+    or emptier than it is — the same lie `ListError` exists to prevent,
+    one layer up. Absence and ignorance are different answers and must
+    not share a representation.
+    """
+    defexception [:key, :prefix]
+
+    @impl true
+    def message(%__MODULE__{key: key, prefix: prefix}),
+      do: "unparseable object key #{inspect(key)} under #{inspect(prefix)}"
+  end
+
   @doc """
   List objects with the given prefix.
 

--- a/lib/bedrock/object_storage/chunk_reader.ex
+++ b/lib/bedrock/object_storage/chunk_reader.ex
@@ -72,6 +72,9 @@ defmodule Bedrock.ObjectStorage.ChunkReader do
   Returns a lazy stream of chunk keys in lexicographic order.
   Due to inverted version keys, this means newest chunks first.
 
+  Objects that merely share the prefix are passed over; a chunk key that
+  will not parse raises `ObjectStorage.UnparseableKeyError`.
+
   ## Options
 
   - `:limit` - Maximum number of chunks to return
@@ -85,7 +88,23 @@ defmodule Bedrock.ObjectStorage.ChunkReader do
     # a silent replay gap, which is the very thing this module raises to
     # prevent when a header will not decode. A caller cannot tell a short
     # listing from an empty shard, so it must not be handed one.
-    ObjectStorage.list(reader.backend, prefix, opts)
+    reader.backend
+    |> ObjectStorage.list(prefix, opts)
+    |> Stream.filter(&chunk_key?(&1, prefix))
+  end
+
+  # Which of the listed objects are this shard's chunks. A key that names
+  # no version we can read is not dropped for the same reason a short
+  # listing is not: the caller cannot tell the difference between a chunk
+  # we refused to understand and a chunk that was never written, and it
+  # would read the shorter history as fact.
+  @spec chunk_key?(String.t(), String.t()) :: boolean()
+  defp chunk_key?(key, prefix) do
+    case Keys.extract_version(key, prefix) do
+      {:ok, _version} -> true
+      :foreign -> false
+      {:error, _reason} -> raise ObjectStorage.UnparseableKeyError, key: key, prefix: prefix
+    end
   end
 
   @doc """
@@ -255,22 +274,21 @@ defmodule Bedrock.ObjectStorage.ChunkReader do
   @doc """
   Gets the latest (highest) version in the shard.
 
-  Returns `nil` if no chunks exist.
+  Returns `nil` if no chunks exist — which now means only that, since a
+  key this build cannot read raises rather than counting as absence.
   """
   @spec latest_version(t()) :: version() | nil
   def latest_version(%__MODULE__{} = reader) do
+    # No `:limit` on the listing: the backend applies it before foreign
+    # objects are passed over, so a single co-located object would be the
+    # whole page and the shard would read as empty. The stream is lazy, so
+    # taking one still costs one page.
     reader
-    |> list_chunks(limit: 1)
+    |> list_chunks()
     |> Enum.take(1)
     |> case do
-      [key] ->
-        case Keys.extract_version(key) do
-          {:ok, version} -> version
-          {:error, _} -> nil
-        end
-
-      [] ->
-        nil
+      [key] -> max_version_from_key(key)
+      [] -> nil
     end
   end
 

--- a/lib/bedrock/object_storage/chunk_reader.ex
+++ b/lib/bedrock/object_storage/chunk_reader.ex
@@ -88,9 +88,20 @@ defmodule Bedrock.ObjectStorage.ChunkReader do
     # a silent replay gap, which is the very thing this module raises to
     # prevent when a header will not decode. A caller cannot tell a short
     # listing from an empty shard, so it must not be handed one.
-    reader.backend
-    |> ObjectStorage.list(prefix, opts)
-    |> Stream.filter(&chunk_key?(&1, prefix))
+    #
+    # `:limit` is counted AFTER classification for the same reason: the
+    # backend would spend it on objects that merely share the prefix, and
+    # a caller asking for the newest N chunks would quietly get fewer.
+    # The stream stays lazy, so nothing beyond the first page is read.
+    stream =
+      reader.backend
+      |> ObjectStorage.list(prefix, Keyword.delete(opts, :limit))
+      |> Stream.filter(&chunk_key?(&1, prefix))
+
+    case Keyword.get(opts, :limit) do
+      nil -> stream
+      limit -> Stream.take(stream, limit)
+    end
   end
 
   # Which of the listed objects are this shard's chunks. A key that names
@@ -274,17 +285,13 @@ defmodule Bedrock.ObjectStorage.ChunkReader do
   @doc """
   Gets the latest (highest) version in the shard.
 
-  Returns `nil` if no chunks exist — which now means only that, since a
-  key this build cannot read raises rather than counting as absence.
+  Returns `nil` only if no chunks exist: a key this build cannot read
+  raises rather than counting as absence.
   """
   @spec latest_version(t()) :: version() | nil
   def latest_version(%__MODULE__{} = reader) do
-    # No `:limit` on the listing: the backend applies it before foreign
-    # objects are passed over, so a single co-located object would be the
-    # whole page and the shard would read as empty. The stream is lazy, so
-    # taking one still costs one page.
     reader
-    |> list_chunks()
+    |> list_chunks(limit: 1)
     |> Enum.take(1)
     |> case do
       [key] -> max_version_from_key(key)

--- a/lib/bedrock/object_storage/keys.ex
+++ b/lib/bedrock/object_storage/keys.ex
@@ -86,6 +86,14 @@ defmodule Bedrock.ObjectStorage.Keys do
   @doc """
   Parses a base36-encoded inverted version string back to an integer.
 
+  Only the canonical rendering of `format_inverted_version/1` is accepted:
+  a 13-character, zero-padded, lowercase uint64. A name of another width
+  or case is not one this build wrote, and base36 is forgiving enough to
+  read a plausible number out of nearly anything — `"rs"` would come back
+  as version 18446744073709550615. A number we invented must never stand
+  in for a durable fact, so anything non-canonical is reported as
+  unparseable instead.
+
   ## Examples
 
       iex> Keys.parse_inverted_version("0000000000000")
@@ -94,14 +102,22 @@ defmodule Bedrock.ObjectStorage.Keys do
       iex> Keys.parse_inverted_version("00000000000rs")
       {:ok, 1000}
 
+      iex> Keys.parse_inverted_version("rs")
+      {:error, :invalid_format}
+
       iex> Keys.parse_inverted_version("invalid!")
       {:error, :invalid_format}
   """
   @spec parse_inverted_version(String.t()) :: {:ok, non_neg_integer()} | {:error, :invalid_format}
   def parse_inverted_version(str) when is_binary(str) do
     case Integer.parse(str, 36) do
-      {value, ""} when value >= 0 -> {:ok, value}
-      _ -> {:error, :invalid_format}
+      # 13 base36 characters reach past uint64, so the range still has to
+      # be checked: `restore_version/1` only accepts an inverted uint64.
+      {value, ""} when value >= 0 and value <= @max_version ->
+        if format_inverted_version(value) == str, do: {:ok, value}, else: {:error, :invalid_format}
+
+      _ ->
+        {:error, :invalid_format}
     end
   end
 
@@ -244,20 +260,39 @@ defmodule Bedrock.ObjectStorage.Keys do
   end
 
   @doc """
-  Extracts the version from a chunk or snapshot key.
+  Extracts the version from a key listed under `prefix`.
+
+  A listing is a string prefix match over a bucket Bedrock does not own
+  exclusively, so it can turn up objects that merely share the prefix.
+  The objects that are OURS under a chunks or snapshots prefix are its
+  DIRECT children — the only thing the path builders above ever write
+  there — so a key nested any deeper is `:foreign`, and is not judged by
+  a shape it was never given. Reading the last path segment alone cannot
+  make that distinction: it sees `c/a/backup/3w5e11264sg0n` as a chunk
+  of shard `a`.
+
+  A direct child that will not parse is the opposite answer. It sits in a
+  namespace only Bedrock writes to, so it is either corrupt or named by a
+  format this build does not understand — an unknown, and an unknown must
+  not be quietly turned into absence.
 
   ## Examples
 
-      iex> Keys.extract_version("c/a/3w5e11264sg0n")
+      iex> Keys.extract_version("c/a/3w5e11264sg0n", "c/a/")
       {:ok, 1000}
 
-      iex> Keys.extract_version("invalid!")
+      iex> Keys.extract_version("c/a/backup/3w5e11264sg0n", "c/a/")
+      :foreign
+
+      iex> Keys.extract_version("c/a/manifest.json", "c/a/")
       {:error, :invalid_format}
   """
-  @spec extract_version(String.t()) :: {:ok, non_neg_integer()} | {:error, :invalid_format}
-  def extract_version(key) when is_binary(key) do
-    key
-    |> Path.basename()
-    |> key_to_version()
+  @spec extract_version(String.t(), String.t()) ::
+          {:ok, non_neg_integer()} | :foreign | {:error, :invalid_format}
+  def extract_version(key, prefix) when is_binary(key) and is_binary(prefix) do
+    case String.replace_prefix(key, prefix, "") do
+      ^key -> :foreign
+      name -> if String.contains?(name, "/"), do: :foreign, else: key_to_version(name)
+    end
   end
 end

--- a/lib/bedrock/object_storage/keys.ex
+++ b/lib/bedrock/object_storage/keys.ex
@@ -284,6 +284,9 @@ defmodule Bedrock.ObjectStorage.Keys do
       iex> Keys.extract_version("c/a/backup/3w5e11264sg0n", "c/a/")
       :foreign
 
+      iex> Keys.extract_version("c/a/", "c/a/")
+      :foreign
+
       iex> Keys.extract_version("c/a/manifest.json", "c/a/")
       {:error, :invalid_format}
   """
@@ -292,7 +295,15 @@ defmodule Bedrock.ObjectStorage.Keys do
   def extract_version(key, prefix) when is_binary(key) and is_binary(prefix) do
     case String.replace_prefix(key, prefix, "") do
       ^key -> :foreign
-      name -> if String.contains?(name, "/"), do: :foreign, else: key_to_version(name)
+      name -> classify_name(name)
     end
   end
+
+  # An empty name is the prefix itself: the zero-byte folder marker a
+  # console or sync tool leaves behind. It has no name to misread and
+  # Bedrock never writes one, so it is foreign like any other object that
+  # is not ours — not a chunk we failed to understand.
+  @spec classify_name(String.t()) :: {:ok, non_neg_integer()} | :foreign | {:error, :invalid_format}
+  defp classify_name(""), do: :foreign
+  defp classify_name(name), do: if(String.contains?(name, "/"), do: :foreign, else: key_to_version(name))
 end

--- a/lib/bedrock/object_storage/snapshot.ex
+++ b/lib/bedrock/object_storage/snapshot.ex
@@ -98,7 +98,7 @@ defmodule Bedrock.ObjectStorage.Snapshot do
   """
   @spec read_latest(t()) :: {:ok, version(), snapshot_data()} | {:error, :not_found | term()}
   def read_latest(%__MODULE__{} = snapshot) do
-    with [{version, key}] <- snapshot |> list() |> Enum.take(1),
+    with [{version, key}] <- snapshot |> list(limit: 1) |> Enum.take(1),
          {:ok, data} <- ObjectStorage.get(snapshot.backend, key) do
       {:ok, version, data}
     else
@@ -148,15 +148,23 @@ defmodule Bedrock.ObjectStorage.Snapshot do
   def list(%__MODULE__{} = snapshot, opts \\ []) do
     prefix = Keys.snapshots_prefix(snapshot.shard_tag)
 
-    snapshot.backend
-    |> ObjectStorage.list(prefix, opts)
-    |> Stream.flat_map(fn key ->
-      case Keys.extract_version(key, prefix) do
-        {:ok, version} -> [{version, key}]
-        :foreign -> []
-        {:error, _reason} -> raise ObjectStorage.UnparseableKeyError, key: key, prefix: prefix
-      end
-    end)
+    # `:limit` is counted after classification, so objects that merely
+    # share the prefix cannot spend it and hand back a shorter history.
+    stream =
+      snapshot.backend
+      |> ObjectStorage.list(prefix, Keyword.delete(opts, :limit))
+      |> Stream.flat_map(fn key ->
+        case Keys.extract_version(key, prefix) do
+          {:ok, version} -> [{version, key}]
+          :foreign -> []
+          {:error, _reason} -> raise ObjectStorage.UnparseableKeyError, key: key, prefix: prefix
+        end
+      end)
+
+    case Keyword.get(opts, :limit) do
+      nil -> stream
+      limit -> Stream.take(stream, limit)
+    end
   end
 
   @doc """
@@ -169,19 +177,23 @@ defmodule Bedrock.ObjectStorage.Snapshot do
   - `{:error, {:list_failed, reason}}` - The listing could not be
     completed, so whether snapshots exist is UNKNOWN. Distinct from
     `:not_found`, which is a fact.
-
-  RAISES `ObjectStorage.UnparseableKeyError` if a snapshot is there under
-  a name this build cannot read. As with `exists?/1`, there is no honest
-  answer to give: it is neither a version nor absence.
+  - `{:error, {:unparseable_key, key}}` - A snapshot is there under a name
+    this build cannot read, so its version is UNKNOWN. Also distinct from
+    `:not_found`.
   """
-  @spec latest_version(t()) :: {:ok, version()} | {:error, :not_found} | {:error, {:list_failed, term()}}
+  @spec latest_version(t()) ::
+          {:ok, version()}
+          | {:error, :not_found}
+          | {:error, {:list_failed, term()}}
+          | {:error, {:unparseable_key, String.t()}}
   def latest_version(%__MODULE__{} = snapshot) do
-    case snapshot |> list() |> Enum.take(1) do
+    case snapshot |> list(limit: 1) |> Enum.take(1) do
       [{version, _key}] -> {:ok, version}
       [] -> {:error, :not_found}
     end
   rescue
     e in ObjectStorage.ListError -> {:error, {:list_failed, e.reason}}
+    e in ObjectStorage.UnparseableKeyError -> {:error, {:unparseable_key, e.key}}
   end
 
   @doc """
@@ -243,9 +255,17 @@ defmodule Bedrock.ObjectStorage.Snapshot do
   @spec exists?(t()) :: boolean()
   def exists?(%__MODULE__{} = snapshot) do
     case latest_version(snapshot) do
-      {:ok, _} -> true
-      {:error, :not_found} -> false
-      {:error, {:list_failed, reason}} -> raise ObjectStorage.ListError, reason: reason, prefix: snapshot.shard_tag
+      {:ok, _} ->
+        true
+
+      {:error, :not_found} ->
+        false
+
+      {:error, {:list_failed, reason}} ->
+        raise ObjectStorage.ListError, reason: reason, prefix: snapshot.shard_tag
+
+      {:error, {:unparseable_key, key}} ->
+        raise ObjectStorage.UnparseableKeyError, key: key, prefix: Keys.snapshots_prefix(snapshot.shard_tag)
     end
   end
 

--- a/lib/bedrock/object_storage/snapshot.ex
+++ b/lib/bedrock/object_storage/snapshot.ex
@@ -91,14 +91,14 @@ defmodule Bedrock.ObjectStorage.Snapshot do
 
   - `{:ok, version, data}` - Latest snapshot found
   - `{:error, :not_found}` - No snapshots exist
+  - `{:error, {:unparseable_key, key}}` - A snapshot is there but this
+    build cannot read its version, so whether a newer baseline exists is
+    UNKNOWN. Distinct from `:not_found`, which is a fact.
   - `{:error, reason}` - Read failed
   """
   @spec read_latest(t()) :: {:ok, version(), snapshot_data()} | {:error, :not_found | term()}
   def read_latest(%__MODULE__{} = snapshot) do
-    prefix = Keys.snapshots_prefix(snapshot.shard_tag)
-
-    with [key] <- snapshot.backend |> ObjectStorage.list(prefix, limit: 1) |> Enum.take(1),
-         {:ok, version} <- Keys.extract_version(key),
+    with [{version, key}] <- snapshot |> list() |> Enum.take(1),
          {:ok, data} <- ObjectStorage.get(snapshot.backend, key) do
       {:ok, version, data}
     else
@@ -108,9 +108,11 @@ defmodule Bedrock.ObjectStorage.Snapshot do
   rescue
     # :not_found is a FACT — this shard has no durable baseline, and a
     # materializer may legitimately start empty on it. A listing that
-    # failed knows nothing, and must never be able to say that: it
-    # surfaces as an ordinary error so callers fail rather than assume.
+    # failed, or one holding a name we could not read, knows nothing, and
+    # must never be able to say that: both surface as ordinary errors so
+    # callers fail rather than assume.
     e in ObjectStorage.ListError -> {:error, {:list_failed, e.reason}}
+    e in ObjectStorage.UnparseableKeyError -> {:error, {:unparseable_key, e.key}}
   end
 
   @doc """
@@ -133,6 +135,11 @@ defmodule Bedrock.ObjectStorage.Snapshot do
 
   Returns a lazy stream of `{version, key}` tuples.
 
+  Objects that merely share the prefix are passed over. A snapshot whose
+  version this build cannot read raises
+  `ObjectStorage.UnparseableKeyError`: skipping it would hand the caller
+  a shorter history as fact, which is what a listing must never do.
+
   ## Options
 
   - `:limit` - Maximum number of snapshots to return
@@ -143,13 +150,13 @@ defmodule Bedrock.ObjectStorage.Snapshot do
 
     snapshot.backend
     |> ObjectStorage.list(prefix, opts)
-    |> Stream.map(fn key ->
-      case Keys.extract_version(key) do
-        {:ok, version} -> {version, key}
-        {:error, _} -> nil
+    |> Stream.flat_map(fn key ->
+      case Keys.extract_version(key, prefix) do
+        {:ok, version} -> [{version, key}]
+        :foreign -> []
+        {:error, _reason} -> raise ObjectStorage.UnparseableKeyError, key: key, prefix: prefix
       end
     end)
-    |> Stream.reject(&is_nil/1)
   end
 
   @doc """
@@ -162,17 +169,16 @@ defmodule Bedrock.ObjectStorage.Snapshot do
   - `{:error, {:list_failed, reason}}` - The listing could not be
     completed, so whether snapshots exist is UNKNOWN. Distinct from
     `:not_found`, which is a fact.
+
+  RAISES `ObjectStorage.UnparseableKeyError` if a snapshot is there under
+  a name this build cannot read. As with `exists?/1`, there is no honest
+  answer to give: it is neither a version nor absence.
   """
   @spec latest_version(t()) :: {:ok, version()} | {:error, :not_found} | {:error, {:list_failed, term()}}
   def latest_version(%__MODULE__{} = snapshot) do
-    prefix = Keys.snapshots_prefix(snapshot.shard_tag)
-
-    case snapshot.backend |> ObjectStorage.list(prefix, limit: 1) |> Enum.take(1) do
-      [key] ->
-        Keys.extract_version(key)
-
-      [] ->
-        {:error, :not_found}
+    case snapshot |> list() |> Enum.take(1) do
+      [{version, _key}] -> {:ok, version}
+      [] -> {:error, :not_found}
     end
   rescue
     e in ObjectStorage.ListError -> {:error, {:list_failed, e.reason}}
@@ -227,10 +233,12 @@ defmodule Bedrock.ObjectStorage.Snapshot do
   @doc """
   Checks if any snapshots exist for this shard.
 
-  RAISES `ObjectStorage.ListError` if the listing cannot be completed.
-  There is no honest boolean for "I could not look": returning `false`
-  would be the very lie this module exists to prevent — a caller would
-  read it as "no baseline" and start a materializer empty.
+  RAISES `ObjectStorage.ListError` if the listing cannot be completed,
+  or `ObjectStorage.UnparseableKeyError` if it turned up a snapshot this
+  build cannot read a version out of. There is no honest boolean for "I
+  could not look": returning `false` would be the very lie this module
+  exists to prevent — a caller would read it as "no baseline" and start a
+  materializer empty.
   """
   @spec exists?(t()) :: boolean()
   def exists?(%__MODULE__{} = snapshot) do
@@ -247,8 +255,9 @@ defmodule Bedrock.ObjectStorage.Snapshot do
   Note: This reads the full list, so it's not efficient for shards with
   many snapshots. Use `exists?/1` to just check for presence.
 
-  RAISES `ObjectStorage.ListError` if the listing cannot be completed:
-  no count is honest when the listing is incomplete.
+  RAISES `ObjectStorage.ListError` if the listing cannot be completed, or
+  `ObjectStorage.UnparseableKeyError` if one of the snapshots will not
+  parse: no count is honest when the listing is incomplete.
   """
   @spec count(t()) :: non_neg_integer()
   def count(%__MODULE__{} = snapshot) do

--- a/test/bedrock/object_storage/chunk_reader_test.exs
+++ b/test/bedrock/object_storage/chunk_reader_test.exs
@@ -34,6 +34,11 @@ defmodule Bedrock.ObjectStorage.ChunkReaderTest do
     key
   end
 
+  defp write_object(backend, key) do
+    :ok = ObjectStorage.put(backend, key, "whatever")
+    key
+  end
+
   defmodule CountingBackend do
     @moduledoc false
     @behaviour ObjectStorage
@@ -50,6 +55,39 @@ defmodule Bedrock.ObjectStorage.ChunkReaderTest do
     def delete(config, key), do: LocalFilesystem.delete(config, key)
     @impl true
     def list(config, prefix, opts \\ []), do: LocalFilesystem.list(config, prefix, opts)
+    @impl true
+    def put_if_not_exists(config, key, data, opts \\ []), do: LocalFilesystem.put_if_not_exists(config, key, data, opts)
+    @impl true
+    def get_with_version(config, key), do: LocalFilesystem.get_with_version(config, key)
+
+    @impl true
+    def put_if_version_matches(config, key, version_token, data, opts \\ []),
+      do: LocalFilesystem.put_if_version_matches(config, key, version_token, data, opts)
+  end
+
+  defmodule ForeignFirstBackend do
+    @moduledoc false
+    # A bucket Bedrock shares with something else, whose object sorts
+    # ahead of every chunk. The backend applies `:limit` before anyone
+    # downstream can tell the two apart.
+    @behaviour ObjectStorage
+
+    @impl true
+    def list(config, prefix, opts \\ []) do
+      stream = Stream.concat([Keyword.fetch!(config, :foreign)], LocalFilesystem.list(config, prefix, opts))
+
+      case Keyword.get(opts, :limit) do
+        nil -> stream
+        limit -> Stream.take(stream, limit)
+      end
+    end
+
+    @impl true
+    def get(config, key), do: LocalFilesystem.get(config, key)
+    @impl true
+    def put(config, key, data, opts \\ []), do: LocalFilesystem.put(config, key, data, opts)
+    @impl true
+    def delete(config, key), do: LocalFilesystem.delete(config, key)
     @impl true
     def put_if_not_exists(config, key, data, opts \\ []), do: LocalFilesystem.put_if_not_exists(config, key, data, opts)
     @impl true
@@ -136,7 +174,7 @@ defmodule Bedrock.ObjectStorage.ChunkReaderTest do
       # Should be newest first (300, 200, 100)
       versions =
         Enum.map(keys, fn key ->
-          {:ok, v} = Keys.extract_version(key)
+          {:ok, v} = Keys.extract_version(key, Keys.chunks_prefix("shard"))
           v
         end)
 
@@ -237,12 +275,12 @@ defmodule Bedrock.ObjectStorage.ChunkReaderTest do
 
       # Find in first chunk
       key1 = ChunkReader.find_chunk_for_version(reader, 125)
-      {:ok, v1} = Keys.extract_version(key1)
+      {:ok, v1} = Keys.extract_version(key1, Keys.chunks_prefix("shard"))
       assert v1 == 150
 
       # Find in second chunk
       key2 = ChunkReader.find_chunk_for_version(reader, 225)
-      {:ok, v2} = Keys.extract_version(key2)
+      {:ok, v2} = Keys.extract_version(key2, Keys.chunks_prefix("shard"))
       assert v2 == 250
     end
 
@@ -369,6 +407,71 @@ defmodule Bedrock.ObjectStorage.ChunkReaderTest do
     test "returns nil for empty shard", %{backend: backend} do
       reader = ChunkReader.new(backend, "shard")
       assert nil == ChunkReader.latest_version(reader)
+    end
+  end
+
+  describe "keys the shard's prefix turns up" do
+    # A name this build cannot read is not absence. Sorted ahead of every
+    # real chunk (it starts with "0"), it used to be the one key a
+    # limit-of-one listing returned, and `latest_version/1` reported the
+    # shard as empty while it held version 500.
+    @unreadable_name "0000000000000.tmp"
+
+    test "latest_version raises rather than reporting an empty shard", %{backend: backend} do
+      write_chunk(backend, "shard", [{500, "a"}])
+      key = write_object(backend, Keys.chunks_prefix("shard") <> @unreadable_name)
+
+      reader = ChunkReader.new(backend, "shard")
+
+      assert_raise ObjectStorage.UnparseableKeyError, ~r/#{Regex.escape(key)}/, fn ->
+        ChunkReader.latest_version(reader)
+      end
+    end
+
+    test "a non-canonical version is unreadable, not a version", %{backend: backend} do
+      # 12 base36 characters, not 13: base36 reads 1000 out of it happily,
+      # which would name a version 18446744073709550615 that was never
+      # written.
+      key = write_object(backend, Keys.chunks_prefix("shard") <> "0000000000rs")
+
+      reader = ChunkReader.new(backend, "shard")
+
+      assert_raise ObjectStorage.UnparseableKeyError, ~r/#{Regex.escape(key)}/, fn ->
+        ChunkReader.latest_version(reader)
+      end
+    end
+
+    test "list_chunks raises rather than yielding a shorter listing", %{backend: backend} do
+      write_chunk(backend, "shard", [{500, "a"}])
+      write_object(backend, Keys.chunks_prefix("shard") <> @unreadable_name)
+
+      reader = ChunkReader.new(backend, "shard")
+
+      assert_raise ObjectStorage.UnparseableKeyError, fn ->
+        reader |> ChunkReader.list_chunks() |> Enum.to_list()
+      end
+    end
+
+    test "an object nested below the prefix is not this shard's chunk", %{backend: backend} do
+      key = write_chunk(backend, "shard", [{500, "a"}])
+      # Somebody else's object, co-located in the bucket: it shares the
+      # prefix but is not a chunk, and judging it by its last path
+      # segment would break a healthy shard.
+      write_object(backend, Keys.chunks_prefix("shard") <> "vendor/manifest.json")
+
+      reader = ChunkReader.new(backend, "shard")
+
+      assert [key] == reader |> ChunkReader.list_chunks() |> Enum.to_list()
+      assert 500 == ChunkReader.latest_version(reader)
+    end
+
+    test "a foreign object sorting first does not consume the listing", %{backend: backend, root: root} do
+      write_chunk(backend, "shard", [{500, "a"}])
+
+      sharing = ObjectStorage.backend(ForeignFirstBackend, root: root, foreign: "c/shard/00-vendor/index")
+      reader = ChunkReader.new(sharing, "shard")
+
+      assert 500 == ChunkReader.latest_version(reader)
     end
   end
 

--- a/test/bedrock/object_storage/chunk_reader_test.exs
+++ b/test/bedrock/object_storage/chunk_reader_test.exs
@@ -465,12 +465,15 @@ defmodule Bedrock.ObjectStorage.ChunkReaderTest do
       assert 500 == ChunkReader.latest_version(reader)
     end
 
-    test "a foreign object sorting first does not consume the listing", %{backend: backend, root: root} do
-      write_chunk(backend, "shard", [{500, "a"}])
+    test "a foreign object sorting first does not consume the limit", %{backend: backend, root: root} do
+      key = write_chunk(backend, "shard", [{500, "a"}])
 
       sharing = ObjectStorage.backend(ForeignFirstBackend, root: root, foreign: "c/shard/00-vendor/index")
       reader = ChunkReader.new(sharing, "shard")
 
+      # The backend would spend a limit of one on the co-located object,
+      # leaving nothing — so the limit is counted after classification.
+      assert [key] == reader |> ChunkReader.list_chunks(limit: 1) |> Enum.to_list()
       assert 500 == ChunkReader.latest_version(reader)
     end
   end

--- a/test/bedrock/object_storage/keys_test.exs
+++ b/test/bedrock/object_storage/keys_test.exs
@@ -193,5 +193,12 @@ defmodule Bedrock.ObjectStorage.KeysTest do
     test "reports a key outside the prefix as foreign" do
       assert :foreign = Keys.extract_version("c/b/" <> Keys.version_to_key(1000), "c/a/")
     end
+
+    test "reports the prefix's own folder marker as foreign" do
+      # S3 consoles and sync tools leave a zero-byte object whose key IS
+      # the prefix. Bedrock never writes one, and there is no name in it
+      # to misread, so it is not a chunk we failed to understand.
+      assert :foreign = Keys.extract_version("c/a/", "c/a/")
+    end
   end
 end

--- a/test/bedrock/object_storage/keys_test.exs
+++ b/test/bedrock/object_storage/keys_test.exs
@@ -56,6 +56,22 @@ defmodule Bedrock.ObjectStorage.KeysTest do
       assert Keys.parse_inverted_version("123@abc") == {:error, :invalid_format}
       assert Keys.parse_inverted_version("-1") == {:error, :invalid_format}
     end
+
+    test "rejects non-canonical renderings rather than inventing a version" do
+      # base36 will read a number out of nearly anything; only the exact
+      # 13-character lowercase padding this module writes is a version.
+      assert Keys.parse_inverted_version("rs") == {:error, :invalid_format}
+      assert Keys.parse_inverted_version("0000000000rs") == {:error, :invalid_format}
+      assert Keys.parse_inverted_version("000000000000rs") == {:error, :invalid_format}
+      assert Keys.parse_inverted_version("3W5E11264SGSF") == {:error, :invalid_format}
+      assert Keys.parse_inverted_version("+000000000rs") == {:error, :invalid_format}
+    end
+
+    test "rejects a 13-character value past uint64" do
+      # "zzzzzzzzzzzzz" is 13 base36 digits but 36^13-1, well past the
+      # inverted uint64 `restore_version/1` accepts.
+      assert Keys.parse_inverted_version("zzzzzzzzzzzzz") == {:error, :invalid_format}
+    end
   end
 
   describe "version_to_key/1 and key_to_version/1" do
@@ -127,7 +143,7 @@ defmodule Bedrock.ObjectStorage.KeysTest do
     test "builds correct path with inverted version" do
       path = Keys.chunk_path("a", 1000)
       assert String.starts_with?(path, "c/a/")
-      assert {:ok, 1000} = Keys.extract_version(path)
+      assert {:ok, 1000} = Keys.extract_version(path, Keys.chunks_prefix("a"))
     end
   end
 
@@ -141,7 +157,7 @@ defmodule Bedrock.ObjectStorage.KeysTest do
     test "builds correct path with inverted version" do
       path = Keys.snapshot_path("b", 2000)
       assert String.starts_with?(path, "s/b/")
-      assert {:ok, 2000} = Keys.extract_version(path)
+      assert {:ok, 2000} = Keys.extract_version(path, Keys.snapshots_prefix("b"))
     end
   end
 
@@ -151,20 +167,31 @@ defmodule Bedrock.ObjectStorage.KeysTest do
     end
   end
 
-  describe "extract_version/1" do
+  describe "extract_version/2" do
     test "extracts version from chunk path" do
       path = Keys.chunk_path("c", 12_345)
-      assert {:ok, 12_345} = Keys.extract_version(path)
+      assert {:ok, 12_345} = Keys.extract_version(path, Keys.chunks_prefix("c"))
     end
 
     test "extracts version from snapshot path" do
       path = Keys.snapshot_path("d", 67_890)
-      assert {:ok, 67_890} = Keys.extract_version(path)
+      assert {:ok, 67_890} = Keys.extract_version(path, Keys.snapshots_prefix("d"))
     end
 
-    test "returns error for invalid path" do
-      # Path basename must contain invalid base36 chars
-      assert {:error, :invalid_format} = Keys.extract_version("invalid/path/abc!")
+    test "returns error for a direct child that will not parse" do
+      assert {:error, :invalid_format} = Keys.extract_version("c/a/manifest.json", "c/a/")
+    end
+
+    test "reports an object nested below the prefix as foreign" do
+      # Bedrock only ever writes direct children here, so anything deeper
+      # belongs to someone else who happens to share the bucket — and its
+      # last path segment must not be mistaken for one of our versions.
+      assert :foreign = Keys.extract_version("c/a/backup/" <> Keys.version_to_key(1000), "c/a/")
+      assert :foreign = Keys.extract_version("c/a/vendor/notes.txt", "c/a/")
+    end
+
+    test "reports a key outside the prefix as foreign" do
+      assert :foreign = Keys.extract_version("c/b/" <> Keys.version_to_key(1000), "c/a/")
     end
   end
 end

--- a/test/bedrock/object_storage/local_filesystem_test.exs
+++ b/test/bedrock/object_storage/local_filesystem_test.exs
@@ -276,7 +276,7 @@ defmodule Bedrock.ObjectStorage.LocalFilesystemTest do
       # Keys should be sorted, and due to version inversion, highest versions come first
       extracted_versions =
         Enum.map(keys, fn key ->
-          {:ok, v} = Keys.extract_version(key)
+          {:ok, v} = Keys.extract_version(key, prefix)
           v
         end)
 

--- a/test/bedrock/object_storage/snapshot_test.exs
+++ b/test/bedrock/object_storage/snapshot_test.exs
@@ -2,6 +2,7 @@ defmodule Bedrock.ObjectStorage.SnapshotTest do
   use ExUnit.Case, async: true
 
   alias Bedrock.ObjectStorage
+  alias Bedrock.ObjectStorage.Keys
   alias Bedrock.ObjectStorage.LocalFilesystem
   alias Bedrock.ObjectStorage.Snapshot
 
@@ -162,15 +163,18 @@ defmodule Bedrock.ObjectStorage.SnapshotTest do
 
       :ok = ObjectStorage.put(backend, @unreadable_key, "written by a build we do not know")
 
+      assert {:error, {:unparseable_key, @unreadable_key}} = Snapshot.latest_version(snapshot)
       assert_raise ObjectStorage.UnparseableKeyError, fn -> Snapshot.exists?(snapshot) end
-      assert_raise ObjectStorage.UnparseableKeyError, fn -> Snapshot.latest_version(snapshot) end
     end
 
     test "an object nested below the prefix is not this shard's snapshot", %{backend: backend} do
       snapshot = Snapshot.new(backend, "shard")
 
       :ok = Snapshot.write(snapshot, 300, "state at 300")
-      :ok = ObjectStorage.put(backend, "s/shard/vendor/manifest.json", "not ours")
+      # Somebody else's object, co-located in the bucket. Its last path
+      # segment reads as a perfectly good version, which is exactly why
+      # the last path segment cannot be what decides.
+      :ok = ObjectStorage.put(backend, "s/shard/archive/" <> Keys.version_to_key(9999), "not ours")
 
       assert [{300, _key}] = snapshot |> Snapshot.list() |> Enum.to_list()
       assert {:ok, 300} = Snapshot.latest_version(snapshot)

--- a/test/bedrock/object_storage/snapshot_test.exs
+++ b/test/bedrock/object_storage/snapshot_test.exs
@@ -130,6 +130,53 @@ defmodule Bedrock.ObjectStorage.SnapshotTest do
     end
   end
 
+  describe "keys the shard's prefix turns up" do
+    # Sorted ahead of every real snapshot, so it is also the first key a
+    # limit-of-one listing sees.
+    @unreadable_key "s/shard/0000000000000.tmp"
+
+    test "list drops nothing: an unreadable name raises", %{backend: backend} do
+      snapshot = Snapshot.new(backend, "shard")
+
+      :ok = Snapshot.write(snapshot, 300, "state at 300")
+      :ok = ObjectStorage.put(backend, @unreadable_key, "written by a build we do not know")
+
+      # Before: the stream yielded [{300, _}] and the caller read a
+      # one-snapshot history as fact.
+      assert_raise ObjectStorage.UnparseableKeyError, ~r/#{Regex.escape(@unreadable_key)}/, fn ->
+        snapshot |> Snapshot.list() |> Enum.to_list()
+      end
+    end
+
+    test "read_latest names the offending key instead of a baseline", %{backend: backend} do
+      snapshot = Snapshot.new(backend, "shard")
+
+      :ok = Snapshot.write(snapshot, 300, "state at 300")
+      :ok = ObjectStorage.put(backend, @unreadable_key, "written by a build we do not know")
+
+      assert {:error, {:unparseable_key, @unreadable_key}} = Snapshot.read_latest(snapshot)
+    end
+
+    test "exists? refuses a boolean it cannot stand behind", %{backend: backend} do
+      snapshot = Snapshot.new(backend, "shard")
+
+      :ok = ObjectStorage.put(backend, @unreadable_key, "written by a build we do not know")
+
+      assert_raise ObjectStorage.UnparseableKeyError, fn -> Snapshot.exists?(snapshot) end
+      assert_raise ObjectStorage.UnparseableKeyError, fn -> Snapshot.latest_version(snapshot) end
+    end
+
+    test "an object nested below the prefix is not this shard's snapshot", %{backend: backend} do
+      snapshot = Snapshot.new(backend, "shard")
+
+      :ok = Snapshot.write(snapshot, 300, "state at 300")
+      :ok = ObjectStorage.put(backend, "s/shard/vendor/manifest.json", "not ours")
+
+      assert [{300, _key}] = snapshot |> Snapshot.list() |> Enum.to_list()
+      assert {:ok, 300} = Snapshot.latest_version(snapshot)
+    end
+  end
+
   describe "delete/2" do
     test "deletes snapshot", %{backend: backend} do
       snapshot = Snapshot.new(backend, "shard")


### PR DESCRIPTION
A chunk or snapshot listing that turned up a key whose version would not parse threw the key away: `ChunkReader.latest_version/1` answered `nil` and `Snapshot.list/2` dropped the entry, so a populated shard read as empty and a long history read as short. Listings now classify each key against the prefix it was listed under, and a key that is ours but unreadable raises `ObjectStorage.UnparseableKeyError` naming it.

Ticket: bedrock-q67.21.19
Closes bedrock-q67.21.19

## Why

Chunks and snapshots are named `c/{shard}/{version}` and `s/{shard}/{version}`, with the version rendered as 13 base36 characters of an inverted uint64, so ascending key order is newest first. PR #202 made `ObjectStorage.list/3` raise rather than end a stream early, so an empty listing means the prefix is empty and not unknown. One layer up, absence and ignorance still shared a representation: a failed parse became `nil`, and `nil` was documented as "no chunks exist". The snapshot stream rejected those nils and handed back a shorter history as fact, and `Snapshot.exists?/1` crashed outright on the parse error.

The parser underneath was loose in both directions. It ran `Integer.parse/2` in base 36 over the key's last path segment, which reads a plausible number out of almost any lowercase alphanumeric name. And a bare basename cannot tell our object from a neighbour's: a bucket is not exclusively Bedrock's, both backends list by string prefix, and `c/a/backup/3w5e11264sg0n` looks like a fine chunk of shard `a`.

## What changed

`Keys.extract_version/2` replaces the basename-only `extract_version/1`. It answers `{:ok, version}` for a direct child that parses, `:foreign` for a key nested deeper, outside the prefix, or equal to it (S3's zero-byte folder marker), and an error for one that will not. Direct children are the only thing the path builders ever write. `parse_inverted_version/1` now accepts only canonical output: within uint64, and re-rendering must reproduce the input exactly.

Both listings filter through that classification and raise `UnparseableKeyError`. `Snapshot.read_latest/1` and `latest_version/1` rescue it into `{:error, {:unparseable_key, key}}`, while `exists?/1` and `count/1` re-raise and the demux shard read reports a `:storage_read_failed` reason. No tolerance option was added: no caller has a use for a history it knows is short.

## How it works

```
c/shard/3w5e11264sgej      version 500, canonical
c/shard/0000000000rs       12 chars: was read as version 18446744073709550615
c/shard/0000000000000.tmp  trailing ".tmp": was dropped, latest_version said nil
```

Both bad names sort ahead of the real chunk, so a listing of one returned only the bad key, and the shard holding 500 reported a version nobody wrote or none at all. Round-tripping closes that hole: `"00000000000rs"` renders back to itself, while a short padding, an uppercase rendering or a leading `+` do not. A nested `c/shard/vendor/manifest.json` is passed over rather than reported, because it was never ours.

A backend would also spend a limit of one on the foreign object, so both listings now apply `Stream.take/2` after classification instead, staying lazy.

## Verification

New tests cover each path: a shard reported empty, a 12-character name inflated into a version, a nested object counted as ours, and a test double applying `:limit` itself to prove a foreign object no longer consumes it. Key tests add canonicity rejection and the four-way classification. All four CI jobs pass, including S3 MinIO. A cold audit reproduced 12 of 14 assertions against pre-fix code; its three findings were fixed in a505e1dc. No follow-up tickets.
