### PR TITLE
bedrock-zi44: throttle snapshot uploads with a configurable floor and thresholds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## Unreleased
 
+- **Snapshots follow a policy instead of a coincidence.** A materializer
+  uploaded a snapshot whenever a compaction happened to finish — the moment
+  the bundle-shaped files exist, and the only moment one was ever taken.
+  Three new manifest params arm a policy instead: `snapshot_interval_ms`,
+  `snapshot_after_bytes`, and `snapshot_after_transactions`, a disjunction
+  over the time and the work since the last upload. An armed worker checks
+  on a timer and starts the compaction that produces the snapshot; at any
+  compaction the same policy decides whether the free opportunity is worth
+  an upload. A worker with none of the params set is unchanged: no timer,
+  and an upload at every compaction. The spin-down snapshot stays
+  unconditional — it is the only artifact bridging spin-down to revival.
+
 - **Olivine keeps append-only workloads readable after page splits.** Keys
   above every stored page boundary now extend the actual rightmost page
   instead of returning to page 0 and overlapping later ranges. Recovery

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,17 +2,15 @@
 
 ## Unreleased
 
-- **Snapshots follow a policy instead of a coincidence.** A materializer
-  uploaded a snapshot whenever a compaction happened to finish — the moment
-  the bundle-shaped files exist, and the only moment one was ever taken.
-  Three new manifest params arm a policy instead: `snapshot_interval_ms`,
-  `snapshot_after_bytes`, and `snapshot_after_transactions`, a disjunction
-  over the time and the work since the last upload. An armed worker checks
-  on a timer and starts the compaction that produces the snapshot; at any
-  compaction the same policy decides whether the free opportunity is worth
-  an upload. A worker with none of the params set is unchanged: no timer,
-  and an upload at every compaction. The spin-down snapshot stays
-  unconditional — it is the only artifact bridging spin-down to revival.
+- **Snapshot uploads answer to a policy.** A materializer uploaded a
+  snapshot whenever a compaction happened to finish, with no way to say how
+  much of that cadence was worth paying for. Three new manifest params say
+  it: `snapshot_min_interval_ms` is a floor on how often a snapshot may be
+  written, and `snapshot_after_bytes` / `snapshot_after_transactions`
+  require that enough work has accumulated since the last one. A worker
+  with none of them set behaves exactly as before, uploading at every
+  compaction. The spin-down snapshot stays unconditional — it is the only
+  artifact bridging spin-down to revival.
 
 - **Olivine keeps append-only workloads readable after page splits.** Keys
   above every stored page boundary now extend the actual rightmost page

--- a/lib/bedrock/data_plane/materializer/olivine/logic.ex
+++ b/lib/bedrock/data_plane/materializer/olivine/logic.ex
@@ -33,7 +33,12 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Logic do
     cluster = Keyword.get(opts, :cluster)
     {shard_tag, shard_num} = normalize_shard(Keyword.get(opts, :shard_id))
     idle_timeout = Keyword.get(opts, :idle_timeout, :infinity)
-    snapshot_policy = Keyword.get(opts, :snapshot_policy, %SnapshotPolicy{})
+
+    snapshot_policy =
+      opts
+      |> Keyword.get(:snapshot_policy, %SnapshotPolicy{})
+      |> SnapshotPolicy.started(System.monotonic_time(:millisecond))
+
     snapshot = build_snapshot_handle(cluster, shard_tag)
 
     with :ok <- ensure_directory_exists(path),

--- a/lib/bedrock/data_plane/materializer/olivine/logic.ex
+++ b/lib/bedrock/data_plane/materializer/olivine/logic.ex
@@ -10,6 +10,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Logic do
   alias Bedrock.DataPlane.Materializer.Olivine.Database
   alias Bedrock.DataPlane.Materializer.Olivine.IndexManager
   alias Bedrock.DataPlane.Materializer.Olivine.IntakeQueue
+  alias Bedrock.DataPlane.Materializer.Olivine.SnapshotPolicy
   alias Bedrock.DataPlane.Materializer.Olivine.State
   alias Bedrock.DataPlane.Materializer.Olivine.Streaming
   alias Bedrock.DataPlane.Materializer.Olivine.Telemetry, as: OlivineTelemetry
@@ -32,6 +33,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Logic do
     cluster = Keyword.get(opts, :cluster)
     {shard_tag, shard_num} = normalize_shard(Keyword.get(opts, :shard_id))
     idle_timeout = Keyword.get(opts, :idle_timeout, :infinity)
+    snapshot_policy = Keyword.get(opts, :snapshot_policy, %SnapshotPolicy{})
     snapshot = build_snapshot_handle(cluster, shard_tag)
 
     with :ok <- ensure_directory_exists(path),
@@ -49,6 +51,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Logic do
          database: database,
          index_manager: index_manager,
          snapshot: snapshot,
+         snapshot_policy: snapshot_policy,
          idle_timeout: idle_timeout,
          last_read_at: System.monotonic_time(:millisecond)
        }}
@@ -420,7 +423,13 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Logic do
     Telemetry.trace_transaction_processing_complete(batch_size, duration, batch_size_bytes)
 
     # Update state with both updated index manager and database
-    updated_state = %{t | index_manager: updated_index_manager, database: updated_database}
+    updated_state = %{
+      t
+      | index_manager: updated_index_manager,
+        database: updated_database,
+        snapshot_policy: SnapshotPolicy.observe(t.snapshot_policy, batch_size, batch_size_bytes)
+    }
+
     {:ok, updated_state, version}
   end
 
@@ -552,6 +561,13 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Logic do
   index files and upload them directly as a bundle (iodata).
 
   The task logs success or failure but does not affect the caller.
+
+  Compaction only makes the upload CHEAP — the bundle-shaped files are
+  already on disk at that instant — it is not itself a reason to pay for
+  one. `SnapshotPolicy` is what decides, from the interval and the work
+  applied since the last upload; unconfigured, it says yes every time.
+  The spin-down upload is deliberately NOT policed: it is the only
+  durable artifact bridging spin-down to revival, so it is unconditional.
   """
   @spec maybe_upload_snapshot(
           State.t(),
@@ -559,26 +575,32 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Logic do
           idx_path :: charlist(),
           durable_version :: Bedrock.version()
         ) ::
-          :ok
-  def maybe_upload_snapshot(%State{snapshot: nil}, _data_path, _idx_path, _durable_version) do
-    :ok
-  end
+          State.t()
+  def maybe_upload_snapshot(%State{snapshot: nil} = t, _data_path, _idx_path, _durable_version), do: t
 
-  def maybe_upload_snapshot(%State{snapshot: snapshot}, data_path, idx_path, durable_version) do
-    version_int = Version.to_integer(durable_version)
+  def maybe_upload_snapshot(%State{snapshot: snapshot} = t, data_path, idx_path, durable_version) do
+    now_in_ms = System.monotonic_time(:millisecond)
 
-    Task.start(fn ->
-      # Read files and upload as iodata (no intermediate bundle file)
-      with {:ok, data} <- File.read(to_string(data_path)),
-           {:ok, idx} <- File.read(to_string(idx_path)),
-           :ok <- Snapshot.write(snapshot, version_int, [data, idx]) do
-        Logger.info("Snapshot uploaded to ObjectStorage", version: version_int)
-      else
-        {:error, reason} ->
-          Logger.warning("Snapshot upload failed", version: version_int, reason: inspect(reason))
-      end
-    end)
+    case SnapshotPolicy.decide(t.snapshot_policy, now_in_ms) do
+      :wait ->
+        t
 
-    :ok
+      :upload ->
+        version_int = Version.to_integer(durable_version)
+
+        Task.start(fn ->
+          # Read files and upload as iodata (no intermediate bundle file)
+          with {:ok, data} <- File.read(to_string(data_path)),
+               {:ok, idx} <- File.read(to_string(idx_path)),
+               :ok <- Snapshot.write(snapshot, version_int, [data, idx]) do
+            Logger.info("Snapshot uploaded to ObjectStorage", version: version_int)
+          else
+            {:error, reason} ->
+              Logger.warning("Snapshot upload failed", version: version_int, reason: inspect(reason))
+          end
+        end)
+
+        %{t | snapshot_policy: SnapshotPolicy.uploaded(t.snapshot_policy, now_in_ms)}
+    end
   end
 end

--- a/lib/bedrock/data_plane/materializer/olivine/logic.ex
+++ b/lib/bedrock/data_plane/materializer/olivine/logic.ex
@@ -34,11 +34,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Logic do
     {shard_tag, shard_num} = normalize_shard(Keyword.get(opts, :shard_id))
     idle_timeout = Keyword.get(opts, :idle_timeout, :infinity)
 
-    snapshot_policy =
-      opts
-      |> Keyword.get(:snapshot_policy, %SnapshotPolicy{})
-      |> SnapshotPolicy.started(System.monotonic_time(:millisecond))
-
+    snapshot_policy = Keyword.get(opts, :snapshot_policy, %SnapshotPolicy{})
     snapshot = build_snapshot_handle(cluster, shard_tag)
 
     with :ok <- ensure_directory_exists(path),
@@ -569,10 +565,11 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Logic do
 
   Compaction only makes the upload CHEAP — the bundle-shaped files are
   already on disk at that instant — it is not itself a reason to pay for
-  one. `SnapshotPolicy` is what decides, from the interval and the work
-  applied since the last upload; unconfigured, it says yes every time.
-  The spin-down upload is deliberately NOT policed: it is the only
-  durable artifact bridging spin-down to revival, so it is unconditional.
+  one. `SnapshotPolicy` is what decides, from the minimum interval and
+  the work applied since the last upload; unconfigured, it says yes
+  every time. The spin-down upload is deliberately NOT policed: it is
+  the only durable artifact bridging spin-down to revival, so it is
+  unconditional.
   """
   @spec maybe_upload_snapshot(
           State.t(),

--- a/lib/bedrock/data_plane/materializer/olivine/server.ex
+++ b/lib/bedrock/data_plane/materializer/olivine/server.ex
@@ -303,6 +303,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Server do
       {:ok, state} ->
         Telemetry.trace_startup_complete()
         schedule_idle_check(state)
+        schedule_snapshot_check(state)
         noreply(state, continue: :report_health_to_foreman)
 
       {:error, reason} ->
@@ -364,6 +365,15 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Server do
       noreply(t, continue: :maybe_process_transactions)
     end
   end
+
+  # Periodic snapshot check (bedrock-zi44), armed only when the worker
+  # was configured with a trigger. Olivine's snapshot IS a compaction
+  # output — the bundle the materializer restores from is exactly what
+  # Database.compact/4 writes — so a scheduled snapshot starts the same
+  # background compaction the :compact call does, and the upload rides
+  # its completion, where the policy is consulted a second time.
+  def handle_info(:snapshot_check, %State{} = t),
+    do: t |> maybe_start_snapshot_compaction() |> schedule_snapshot_check() |> noreply()
 
   # Discard transactions when locked
   def handle_info({:apply_transactions, _encoded_transactions}, %State{mode: :locked} = t), do: noreply(t)
@@ -625,6 +635,41 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Server do
   defp schedule_idle_check(%State{idle_timeout: idle_timeout} = t) do
     Process.send_after(self(), :idle_check, max(div(idle_timeout, 4), 10))
     t
+  end
+
+  # An unarmed policy schedules nothing at all: a materializer that was
+  # never configured with a trigger keeps exactly the behaviour it had
+  # before bedrock-zi44 — no timer, no scheduled compaction, and an
+  # upload at every compaction someone else starts.
+  @spec schedule_snapshot_check(State.t()) :: State.t()
+  defp schedule_snapshot_check(%State{} = t) do
+    case SnapshotPolicy.check_interval_ms(t.snapshot_policy) do
+      :never ->
+        t
+
+      after_ms ->
+        Process.send_after(self(), :snapshot_check, after_ms)
+        t
+    end
+  end
+
+  # Making a snapshot costs a compaction, so the reasons NOT to start one
+  # are the same ones that defer a spin-down: no snapshot handle means
+  # nowhere to put it, a locked worker is mid-recovery, and a compaction
+  # already running would be the one this tick wanted anyway.
+  @spec maybe_start_snapshot_compaction(State.t()) :: State.t()
+  defp maybe_start_snapshot_compaction(%State{snapshot: nil} = t), do: t
+  defp maybe_start_snapshot_compaction(%State{mode: :locked} = t), do: t
+  defp maybe_start_snapshot_compaction(%State{compaction_task: task} = t) when not is_nil(task), do: t
+
+  defp maybe_start_snapshot_compaction(%State{} = t) do
+    if SnapshotPolicy.armed?(t.snapshot_policy) and
+         SnapshotPolicy.decide(t.snapshot_policy, System.monotonic_time(:millisecond)) == :upload do
+      {:ok, task} = Logic.start_compaction(t)
+      %{t | compaction_task: task, allow_window_advancement: false}
+    else
+      t
+    end
   end
 
   # The snapshot upload gates the spin-down: it is the only durable

--- a/lib/bedrock/data_plane/materializer/olivine/server.ex
+++ b/lib/bedrock/data_plane/materializer/olivine/server.ex
@@ -62,7 +62,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Server do
   # spin-down is opt-in per worker (bedrock-q67.21.5): without an
   # explicit positive idle_timeout the worker never spins down, which is
   # what exempts the system shard (its bootstrap never sets the param).
-  # The snapshot upload policy is opt-in the same way, one trigger at a
+  # The snapshot upload policy is opt-in the same way, one knob at a
   # time (bedrock-zi44).
   @spec startup_opts(cluster :: module() | nil, params :: map()) :: keyword()
   defp startup_opts(cluster, params) do
@@ -303,7 +303,6 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Server do
       {:ok, state} ->
         Telemetry.trace_startup_complete()
         schedule_idle_check(state)
-        schedule_snapshot_check(state)
         noreply(state, continue: :report_health_to_foreman)
 
       {:error, reason} ->
@@ -365,15 +364,6 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Server do
       noreply(t, continue: :maybe_process_transactions)
     end
   end
-
-  # Periodic snapshot check (bedrock-zi44), armed only when the worker
-  # was configured with a trigger. Olivine's snapshot IS a compaction
-  # output — the bundle the materializer restores from is exactly what
-  # Database.compact/4 writes — so a scheduled snapshot starts the same
-  # background compaction the :compact call does, and the upload rides
-  # its completion, where the policy is consulted a second time.
-  def handle_info(:snapshot_check, %State{} = t),
-    do: t |> maybe_start_snapshot_compaction() |> schedule_snapshot_check() |> noreply()
 
   # Discard transactions when locked
   def handle_info({:apply_transactions, _encoded_transactions}, %State{mode: :locked} = t), do: noreply(t)
@@ -635,41 +625,6 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Server do
   defp schedule_idle_check(%State{idle_timeout: idle_timeout} = t) do
     Process.send_after(self(), :idle_check, max(div(idle_timeout, 4), 10))
     t
-  end
-
-  # An unarmed policy schedules nothing at all: a materializer that was
-  # never configured with a trigger keeps exactly the behaviour it had
-  # before bedrock-zi44 — no timer, no scheduled compaction, and an
-  # upload at every compaction someone else starts.
-  @spec schedule_snapshot_check(State.t()) :: State.t()
-  defp schedule_snapshot_check(%State{} = t) do
-    case SnapshotPolicy.check_interval_ms(t.snapshot_policy) do
-      :never ->
-        t
-
-      after_ms ->
-        Process.send_after(self(), :snapshot_check, after_ms)
-        t
-    end
-  end
-
-  # Making a snapshot costs a compaction, so the reasons NOT to start one
-  # are the same ones that defer a spin-down: no snapshot handle means
-  # nowhere to put it, a locked worker is mid-recovery, and a compaction
-  # already running would be the one this tick wanted anyway.
-  @spec maybe_start_snapshot_compaction(State.t()) :: State.t()
-  defp maybe_start_snapshot_compaction(%State{snapshot: nil} = t), do: t
-  defp maybe_start_snapshot_compaction(%State{mode: :locked} = t), do: t
-  defp maybe_start_snapshot_compaction(%State{compaction_task: task} = t) when not is_nil(task), do: t
-
-  defp maybe_start_snapshot_compaction(%State{} = t) do
-    if SnapshotPolicy.armed?(t.snapshot_policy) and
-         SnapshotPolicy.decide(t.snapshot_policy, System.monotonic_time(:millisecond)) == :upload do
-      {:ok, task} = Logic.start_compaction(t)
-      %{t | compaction_task: task, allow_window_advancement: false}
-    else
-      t
-    end
   end
 
   # The snapshot upload gates the spin-down: it is the only durable

--- a/lib/bedrock/data_plane/materializer/olivine/server.ex
+++ b/lib/bedrock/data_plane/materializer/olivine/server.ex
@@ -14,6 +14,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Server do
   alias Bedrock.DataPlane.Materializer.Olivine.IntakeQueue
   alias Bedrock.DataPlane.Materializer.Olivine.Logic
   alias Bedrock.DataPlane.Materializer.Olivine.Reading
+  alias Bedrock.DataPlane.Materializer.Olivine.SnapshotPolicy
   alias Bedrock.DataPlane.Materializer.Olivine.State
   alias Bedrock.DataPlane.Materializer.Olivine.Telemetry, as: OlivineTelemetry
   alias Bedrock.DataPlane.Materializer.Telemetry
@@ -61,9 +62,11 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Server do
   # spin-down is opt-in per worker (bedrock-q67.21.5): without an
   # explicit positive idle_timeout the worker never spins down, which is
   # what exempts the system shard (its bootstrap never sets the param).
+  # The snapshot upload policy is opt-in the same way, one trigger at a
+  # time (bedrock-zi44).
   @spec startup_opts(cluster :: module() | nil, params :: map()) :: keyword()
   defp startup_opts(cluster, params) do
-    base = [cluster: cluster, shard_id: params["shard_id"]]
+    base = [cluster: cluster, shard_id: params["shard_id"], snapshot_policy: SnapshotPolicy.from_params(params)]
 
     case params["idle_timeout"] do
       idle_timeout when is_integer(idle_timeout) and idle_timeout > 0 ->
@@ -522,7 +525,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Server do
     )
 
     # Optionally upload snapshot to ObjectStorage (async, fire-and-forget)
-    Logic.maybe_upload_snapshot(new_state, data_path, idx_path, durable_version)
+    new_state = Logic.maybe_upload_snapshot(new_state, data_path, idx_path, durable_version)
 
     # Resume: a fresh puller joins the stream at the durable boundary and
     # re-delivers everything after it through the normal apply path.

--- a/lib/bedrock/data_plane/materializer/olivine/snapshot_policy.ex
+++ b/lib/bedrock/data_plane/materializer/olivine/snapshot_policy.ex
@@ -1,37 +1,41 @@
 defmodule Bedrock.DataPlane.Materializer.Olivine.SnapshotPolicy do
   @moduledoc """
-  Decides WHEN a materializer uploads a snapshot to ObjectStorage.
+  Decides whether an upload opportunity is worth a snapshot.
 
-  Snapshot uploads are opportunistic: a compaction has just produced the
-  bundle-shaped files, so the upload is nearly free at that moment. Free
-  is not the same as wanted — a shard that compacts often would ship a
-  full copy of itself every time, and every one of those objects is
+  A materializer's snapshot is a compaction output — the bundle a cold
+  start restores from is exactly what `Database.compact/4` writes — so
+  the moments an upload is possible are the moments a compaction has
+  just finished. At that instant the upload is nearly free. Free is not
+  the same as wanted: a shard that compacts often would ship a full copy
+  of itself every time, and every one of those objects is stored,
   billed, listed, and eventually reclaimed. This policy is the knob that
   says how much of that cadence is worth paying for.
 
-  Triggers are a DISJUNCTION: a scheduled interval since the last
-  upload, bytes applied since the last upload, transactions applied
-  since the last upload. Whichever fires first wins. A trigger left
-  `nil` never fires; with all three `nil` the policy is UNARMED — it
-  uploads at every opportunity and schedules nothing, which is exactly
-  the behaviour a materializer has when nothing is configured.
+  Two kinds of knob, composed as a floor AND a trigger:
 
-  An armed policy is asked twice, for two different questions. On a
-  timer (`check_interval_ms/1`) it decides whether to GO AND MAKE a
-  snapshot; at a compaction that finished for its own reasons it decides
-  whether that already-paid-for opportunity is worth an upload. Both are
-  the same `decide/2`, which is why the interval both schedules and
-  throttles.
+    * `min_interval_ms` is a FLOOR — never upload again within this many
+      milliseconds of the last one. Unset, there is no floor.
+    * `after_bytes` and `after_transactions` are TRIGGERS on the work
+      applied since the last upload — upload only once enough has
+      accumulated. They are a disjunction with each other; unset, every
+      opportunity qualifies.
+
+  With nothing set both halves are vacuously true and the policy uploads
+  at every opportunity, which is the behaviour a materializer has when
+  nothing is configured.
+
+  This is a throttle, not a scheduler. Nothing here makes an upload
+  HAPPEN; it only declines ones that would have. A running materializer
+  currently gets an opportunity when something asks it to compact and
+  when it spins down, and nothing in the tree drives the former on a
+  cadence — a scheduled snapshot needs a mechanism that produces the
+  bundle without a full compaction cutover, which is its own problem
+  (bedrock-zi44 notes).
 
   The counters advance on dispatch, not on completion: the compaction
   upload is fire-and-forget, so the policy paces ATTEMPTS. A failed
-  upload is logged and picked up by the next opportunity whose trigger
-  fires, which with an interval configured is no sooner than one
-  interval away.
-
-  `last_upload_at` is monotonic and therefore per-VM: a restart starts
-  the interval over rather than inheriting the durable snapshot's age
-  (`started/2`).
+  upload is logged and picked up at the next opportunity that clears the
+  floor, which is no sooner than `min_interval_ms` away.
 
   This policy is only about how often a snapshot is WRITTEN. Which of
   the written snapshots survive is retention, and that lives on the
@@ -39,14 +43,14 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.SnapshotPolicy do
   """
 
   @type t :: %__MODULE__{
-          interval_ms: pos_integer() | nil,
+          min_interval_ms: pos_integer() | nil,
           after_bytes: pos_integer() | nil,
           after_transactions: pos_integer() | nil,
           last_upload_at: integer() | nil,
           bytes_since_upload: non_neg_integer(),
           transactions_since_upload: non_neg_integer()
         }
-  defstruct interval_ms: nil,
+  defstruct min_interval_ms: nil,
             after_bytes: nil,
             after_transactions: nil,
             last_upload_at: nil,
@@ -56,62 +60,22 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.SnapshotPolicy do
   @doc """
   Builds a policy from a worker's manifest params.
 
-  Same discipline as `idle_timeout`: a trigger is armed only by an
-  explicit positive integer, so a missing or malformed param leaves it
-  disabled rather than turning into an accidental cadence.
+  Same discipline as `idle_timeout`: a knob is set only by an explicit
+  positive integer, so a missing or malformed param leaves it off rather
+  than turning into an accidental cadence.
   """
   @spec from_params(%{optional(String.t()) => term()}) :: t()
   def from_params(params) do
     %__MODULE__{
-      interval_ms: trigger(params["snapshot_interval_ms"]),
-      after_bytes: trigger(params["snapshot_after_bytes"]),
-      after_transactions: trigger(params["snapshot_after_transactions"])
+      min_interval_ms: knob(params["snapshot_min_interval_ms"]),
+      after_bytes: knob(params["snapshot_after_bytes"]),
+      after_transactions: knob(params["snapshot_after_transactions"])
     }
   end
 
-  @spec trigger(term()) :: pos_integer() | nil
-  defp trigger(value) when is_integer(value) and value > 0, do: value
-  defp trigger(_value), do: nil
-
-  @doc """
-  Whether any trigger is configured.
-
-  `decide/2` says `:upload` for an unarmed policy: at an opportunity
-  that has already been paid for, no configured reason to skip means
-  take it. That is emphatically not a reason to GO AND SPEND a
-  compaction, so the scheduled path asks this question first.
-  """
-  @spec armed?(t()) :: boolean()
-  def armed?(%__MODULE__{interval_ms: nil, after_bytes: nil, after_transactions: nil}), do: false
-  def armed?(%__MODULE__{}), do: true
-
-  # Thresholds only move when transactions apply, so an armed policy with
-  # no interval still has to be looked at now and then.
-  @threshold_poll_ms 1_000
-
-  @doc """
-  How long to wait before asking `decide/2` again, or `:never` when no
-  trigger is armed and there is nothing to wait for.
-
-  A quarter of the interval, so the schedule is honoured to within 25%
-  without a timer per millisecond of slack — the same ratio the idle
-  check uses.
-  """
-  @spec check_interval_ms(t()) :: pos_integer() | :never
-  def check_interval_ms(%__MODULE__{interval_ms: nil, after_bytes: nil, after_transactions: nil}), do: :never
-  def check_interval_ms(%__MODULE__{interval_ms: nil}), do: @threshold_poll_ms
-  def check_interval_ms(%__MODULE__{interval_ms: interval_ms}), do: max(div(interval_ms, 4), 10)
-
-  @doc """
-  Starts the interval clock at worker startup.
-
-  Without this the interval trigger fires on the first check of every
-  worker that has never uploaded — which is right for a policy that has
-  genuinely never run, but for a restarting worker it would turn an
-  interval into a snapshot per restart.
-  """
-  @spec started(t(), now_in_ms :: integer()) :: t()
-  def started(%__MODULE__{} = t, now_in_ms), do: %{t | last_upload_at: now_in_ms}
+  @spec knob(term()) :: pos_integer() | nil
+  defp knob(value) when is_integer(value) and value > 0, do: value
+  defp knob(_value), do: nil
 
   @doc """
   Records a batch of applied transactions against the thresholds.
@@ -126,36 +90,39 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.SnapshotPolicy do
   end
 
   @doc """
-  `:upload` if any configured trigger has fired, `:wait` otherwise.
+  `:upload` when this opportunity clears the floor and meets a
+  threshold, `:wait` otherwise.
 
   `now_in_ms` is a monotonic reading supplied by the caller, which keeps
   the decision a pure function of the policy and the clock.
   """
   @spec decide(t(), now_in_ms :: integer()) :: :upload | :wait
-  def decide(%__MODULE__{interval_ms: nil, after_bytes: nil, after_transactions: nil}, _now_in_ms), do: :upload
-
   def decide(%__MODULE__{} = t, now_in_ms) do
-    if interval_elapsed?(t, now_in_ms) or
-         reached?(t.after_bytes, t.bytes_since_upload) or
-         reached?(t.after_transactions, t.transactions_since_upload) do
-      :upload
-    else
-      :wait
-    end
+    if floor_cleared?(t, now_in_ms) and thresholds_met?(t), do: :upload, else: :wait
   end
 
-  @spec interval_elapsed?(t(), integer()) :: boolean()
-  defp interval_elapsed?(%__MODULE__{interval_ms: nil}, _now_in_ms), do: false
-  defp interval_elapsed?(%__MODULE__{last_upload_at: nil}, _now_in_ms), do: true
-  defp interval_elapsed?(%__MODULE__{} = t, now_in_ms), do: now_in_ms - t.last_upload_at >= t.interval_ms
+  # Monotonic time is per-VM, so a restart has no last upload to be too
+  # close to and the floor is clear. Erring toward a snapshot is the
+  # cheap direction: the object key is the durable version, and
+  # `Snapshot.write/3` is put-if-not-exists.
+  @spec floor_cleared?(t(), integer()) :: boolean()
+  defp floor_cleared?(%__MODULE__{min_interval_ms: nil}, _now_in_ms), do: true
+  defp floor_cleared?(%__MODULE__{last_upload_at: nil}, _now_in_ms), do: true
+  defp floor_cleared?(%__MODULE__{} = t, now_in_ms), do: now_in_ms - t.last_upload_at >= t.min_interval_ms
+
+  @spec thresholds_met?(t()) :: boolean()
+  defp thresholds_met?(%__MODULE__{after_bytes: nil, after_transactions: nil}), do: true
+
+  defp thresholds_met?(%__MODULE__{} = t),
+    do: reached?(t.after_bytes, t.bytes_since_upload) or reached?(t.after_transactions, t.transactions_since_upload)
 
   @spec reached?(pos_integer() | nil, non_neg_integer()) :: boolean()
   defp reached?(nil, _accumulated), do: false
   defp reached?(threshold, accumulated), do: accumulated >= threshold
 
   @doc """
-  Restarts the interval and clears the thresholds after an upload has
-  been dispatched.
+  Restarts the floor and clears the thresholds after an upload has been
+  dispatched.
   """
   @spec uploaded(t(), now_in_ms :: integer()) :: t()
   def uploaded(%__MODULE__{} = t, now_in_ms),

--- a/lib/bedrock/data_plane/materializer/olivine/snapshot_policy.ex
+++ b/lib/bedrock/data_plane/materializer/olivine/snapshot_policy.ex
@@ -1,0 +1,111 @@
+defmodule Bedrock.DataPlane.Materializer.Olivine.SnapshotPolicy do
+  @moduledoc """
+  Decides WHEN a materializer uploads a snapshot to ObjectStorage.
+
+  Snapshot uploads are opportunistic: a compaction has just produced the
+  bundle-shaped files, so the upload is nearly free at that moment. Free
+  is not the same as wanted — a shard that compacts often would ship a
+  full copy of itself every time, and every one of those objects is
+  billed, listed, and eventually reclaimed. This policy is the knob that
+  says how much of that cadence is worth paying for.
+
+  Triggers are a DISJUNCTION and are evaluated at each upload
+  opportunity: a scheduled interval since the last upload, bytes applied
+  since the last upload, transactions applied since the last upload.
+  Whichever fires first wins. A trigger left `nil` never fires; with all
+  three `nil` the policy uploads at every opportunity, which is the
+  behaviour a materializer has when nothing is configured.
+
+  The counters advance on dispatch, not on completion: the compaction
+  upload is fire-and-forget, so the policy paces ATTEMPTS. A failed
+  upload is logged and picked up by the next opportunity whose trigger
+  fires.
+
+  This policy is only about how often a snapshot is WRITTEN. Which of
+  the written snapshots survive is retention, and that lives on the
+  ObjectStorage side (bedrock-s1zr).
+  """
+
+  @type t :: %__MODULE__{
+          interval_ms: pos_integer() | nil,
+          after_bytes: pos_integer() | nil,
+          after_transactions: pos_integer() | nil,
+          last_upload_at: integer() | nil,
+          bytes_since_upload: non_neg_integer(),
+          transactions_since_upload: non_neg_integer()
+        }
+  defstruct interval_ms: nil,
+            after_bytes: nil,
+            after_transactions: nil,
+            last_upload_at: nil,
+            bytes_since_upload: 0,
+            transactions_since_upload: 0
+
+  @doc """
+  Builds a policy from a worker's manifest params.
+
+  Same discipline as `idle_timeout`: a trigger is armed only by an
+  explicit positive integer, so a missing or malformed param leaves it
+  disabled rather than turning into an accidental cadence.
+  """
+  @spec from_params(%{optional(String.t()) => term()}) :: t()
+  def from_params(params) do
+    %__MODULE__{
+      interval_ms: trigger(params["snapshot_interval_ms"]),
+      after_bytes: trigger(params["snapshot_after_bytes"]),
+      after_transactions: trigger(params["snapshot_after_transactions"])
+    }
+  end
+
+  @spec trigger(term()) :: pos_integer() | nil
+  defp trigger(value) when is_integer(value) and value > 0, do: value
+  defp trigger(_value), do: nil
+
+  @doc """
+  Records a batch of applied transactions against the thresholds.
+  """
+  @spec observe(t(), transactions :: non_neg_integer(), bytes :: non_neg_integer()) :: t()
+  def observe(%__MODULE__{} = t, transactions, bytes) do
+    %{
+      t
+      | transactions_since_upload: t.transactions_since_upload + transactions,
+        bytes_since_upload: t.bytes_since_upload + bytes
+    }
+  end
+
+  @doc """
+  `:upload` if any configured trigger has fired, `:wait` otherwise.
+
+  `now_in_ms` is a monotonic reading supplied by the caller, which keeps
+  the decision a pure function of the policy and the clock.
+  """
+  @spec decide(t(), now_in_ms :: integer()) :: :upload | :wait
+  def decide(%__MODULE__{interval_ms: nil, after_bytes: nil, after_transactions: nil}, _now_in_ms), do: :upload
+
+  def decide(%__MODULE__{} = t, now_in_ms) do
+    if interval_elapsed?(t, now_in_ms) or
+         reached?(t.after_bytes, t.bytes_since_upload) or
+         reached?(t.after_transactions, t.transactions_since_upload) do
+      :upload
+    else
+      :wait
+    end
+  end
+
+  @spec interval_elapsed?(t(), integer()) :: boolean()
+  defp interval_elapsed?(%__MODULE__{interval_ms: nil}, _now_in_ms), do: false
+  defp interval_elapsed?(%__MODULE__{last_upload_at: nil}, _now_in_ms), do: true
+  defp interval_elapsed?(%__MODULE__{} = t, now_in_ms), do: now_in_ms - t.last_upload_at >= t.interval_ms
+
+  @spec reached?(pos_integer() | nil, non_neg_integer()) :: boolean()
+  defp reached?(nil, _accumulated), do: false
+  defp reached?(threshold, accumulated), do: accumulated >= threshold
+
+  @doc """
+  Restarts the interval and clears the thresholds after an upload has
+  been dispatched.
+  """
+  @spec uploaded(t(), now_in_ms :: integer()) :: t()
+  def uploaded(%__MODULE__{} = t, now_in_ms),
+    do: %{t | last_upload_at: now_in_ms, bytes_since_upload: 0, transactions_since_upload: 0}
+end

--- a/lib/bedrock/data_plane/materializer/olivine/snapshot_policy.ex
+++ b/lib/bedrock/data_plane/materializer/olivine/snapshot_policy.ex
@@ -9,17 +9,29 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.SnapshotPolicy do
   billed, listed, and eventually reclaimed. This policy is the knob that
   says how much of that cadence is worth paying for.
 
-  Triggers are a DISJUNCTION and are evaluated at each upload
-  opportunity: a scheduled interval since the last upload, bytes applied
-  since the last upload, transactions applied since the last upload.
-  Whichever fires first wins. A trigger left `nil` never fires; with all
-  three `nil` the policy uploads at every opportunity, which is the
-  behaviour a materializer has when nothing is configured.
+  Triggers are a DISJUNCTION: a scheduled interval since the last
+  upload, bytes applied since the last upload, transactions applied
+  since the last upload. Whichever fires first wins. A trigger left
+  `nil` never fires; with all three `nil` the policy is UNARMED — it
+  uploads at every opportunity and schedules nothing, which is exactly
+  the behaviour a materializer has when nothing is configured.
+
+  An armed policy is asked twice, for two different questions. On a
+  timer (`check_interval_ms/1`) it decides whether to GO AND MAKE a
+  snapshot; at a compaction that finished for its own reasons it decides
+  whether that already-paid-for opportunity is worth an upload. Both are
+  the same `decide/2`, which is why the interval both schedules and
+  throttles.
 
   The counters advance on dispatch, not on completion: the compaction
   upload is fire-and-forget, so the policy paces ATTEMPTS. A failed
   upload is logged and picked up by the next opportunity whose trigger
-  fires.
+  fires, which with an interval configured is no sooner than one
+  interval away.
+
+  `last_upload_at` is monotonic and therefore per-VM: a restart starts
+  the interval over rather than inheriting the durable snapshot's age
+  (`started/2`).
 
   This policy is only about how often a snapshot is WRITTEN. Which of
   the written snapshots survive is retention, and that lives on the
@@ -60,6 +72,46 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.SnapshotPolicy do
   @spec trigger(term()) :: pos_integer() | nil
   defp trigger(value) when is_integer(value) and value > 0, do: value
   defp trigger(_value), do: nil
+
+  @doc """
+  Whether any trigger is configured.
+
+  `decide/2` says `:upload` for an unarmed policy: at an opportunity
+  that has already been paid for, no configured reason to skip means
+  take it. That is emphatically not a reason to GO AND SPEND a
+  compaction, so the scheduled path asks this question first.
+  """
+  @spec armed?(t()) :: boolean()
+  def armed?(%__MODULE__{interval_ms: nil, after_bytes: nil, after_transactions: nil}), do: false
+  def armed?(%__MODULE__{}), do: true
+
+  # Thresholds only move when transactions apply, so an armed policy with
+  # no interval still has to be looked at now and then.
+  @threshold_poll_ms 1_000
+
+  @doc """
+  How long to wait before asking `decide/2` again, or `:never` when no
+  trigger is armed and there is nothing to wait for.
+
+  A quarter of the interval, so the schedule is honoured to within 25%
+  without a timer per millisecond of slack — the same ratio the idle
+  check uses.
+  """
+  @spec check_interval_ms(t()) :: pos_integer() | :never
+  def check_interval_ms(%__MODULE__{interval_ms: nil, after_bytes: nil, after_transactions: nil}), do: :never
+  def check_interval_ms(%__MODULE__{interval_ms: nil}), do: @threshold_poll_ms
+  def check_interval_ms(%__MODULE__{interval_ms: interval_ms}), do: max(div(interval_ms, 4), 10)
+
+  @doc """
+  Starts the interval clock at worker startup.
+
+  Without this the interval trigger fires on the first check of every
+  worker that has never uploaded — which is right for a policy that has
+  genuinely never run, but for a restarting worker it would turn an
+  interval into a snapshot per restart.
+  """
+  @spec started(t(), now_in_ms :: integer()) :: t()
+  def started(%__MODULE__{} = t, now_in_ms), do: %{t | last_upload_at: now_in_ms}
 
   @doc """
   Records a batch of applied transactions against the thresholds.

--- a/lib/bedrock/data_plane/materializer/olivine/state.ex
+++ b/lib/bedrock/data_plane/materializer/olivine/state.ex
@@ -7,6 +7,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.State do
   alias Bedrock.DataPlane.Materializer.Olivine.IndexManager
   alias Bedrock.DataPlane.Materializer.Olivine.IntakeQueue
   alias Bedrock.DataPlane.Materializer.Olivine.Reading
+  alias Bedrock.DataPlane.Materializer.Olivine.SnapshotPolicy
   alias Bedrock.ObjectStorage.Snapshot
   alias Bedrock.Service.Foreman
   alias Bedrock.Service.Worker
@@ -29,6 +30,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.State do
           compaction_task: Task.t() | nil,
           allow_window_advancement: boolean(),
           snapshot: Snapshot.t() | nil,
+          snapshot_policy: SnapshotPolicy.t(),
           pull_sources: [{Log.id(), Log.ref()}] | nil,
           shard_num: non_neg_integer() | nil,
           idle_timeout: pos_integer() | :infinity,
@@ -53,6 +55,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.State do
             compaction_task: nil,
             allow_window_advancement: true,
             snapshot: nil,
+            snapshot_policy: %SnapshotPolicy{},
             pull_sources: nil,
             shard_num: nil,
             idle_timeout: :infinity,

--- a/test/bedrock/data_plane/materializer/olivine/logic_test.exs
+++ b/test/bedrock/data_plane/materializer/olivine/logic_test.exs
@@ -536,7 +536,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.LogicTest do
       Logic.shutdown(state)
     end
 
-    test "a configured interval suppresses a second upload inside the window", %{test_dir: test_dir} do
+    test "a minimum interval suppresses a second upload inside the floor", %{test_dir: test_dir} do
       object_storage_root = Path.join(test_dir, "object_storage")
       File.mkdir_p!(object_storage_root)
 
@@ -544,7 +544,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.LogicTest do
       snapshot = Snapshot.new(backend, "logic-policy-shard")
 
       state = create_test_state(Path.join(test_dir, "storage"), :snapshot_policy_test)
-      state = %{state | snapshot: snapshot, snapshot_policy: %SnapshotPolicy{interval_ms: 60_000}}
+      state = %{state | snapshot: snapshot, snapshot_policy: %SnapshotPolicy{min_interval_ms: 60_000}}
 
       data_path = Path.join(test_dir, "policy_data")
       idx_path = Path.join(test_dir, "policy_idx")
@@ -560,18 +560,18 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.LogicTest do
         )
       end
 
-      # Nothing has ever been uploaded, so the interval trigger fires.
+      # Nothing has ever been uploaded, so there is no floor to clear.
       state = upload.(state, 1)
       assert {:ok, _} = await_snapshot_version(snapshot, 1, 100)
 
-      # A second compaction inside the window is skipped: version 2 never
+      # A second compaction inside the floor is skipped: version 2 never
       # lands, and the latest snapshot is still version 1.
       state = upload.(state, 2)
       Process.sleep(100)
       assert {:error, :not_found} = Snapshot.read(snapshot, 2)
       assert {:ok, 1} = Snapshot.latest_version(snapshot)
 
-      # Rewinding the policy's clock past the interval releases the next one.
+      # Rewinding the policy's clock past the floor releases the next one.
       state = %{
         state
         | snapshot_policy: %{state.snapshot_policy | last_upload_at: state.snapshot_policy.last_upload_at - 60_000}

--- a/test/bedrock/data_plane/materializer/olivine/logic_test.exs
+++ b/test/bedrock/data_plane/materializer/olivine/logic_test.exs
@@ -7,6 +7,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.LogicTest do
   alias Bedrock.DataPlane.Materializer.Olivine.IndexManager
   alias Bedrock.DataPlane.Materializer.Olivine.Logic
   alias Bedrock.DataPlane.Materializer.Olivine.ReadingTestHelpers
+  alias Bedrock.DataPlane.Materializer.Olivine.SnapshotPolicy
   alias Bedrock.DataPlane.Materializer.Olivine.State
   alias Bedrock.DataPlane.Transaction
   alias Bedrock.DataPlane.Version
@@ -470,7 +471,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.LogicTest do
       state = create_test_state(test_dir, :snapshot_nil_test)
       assert state.snapshot == nil
 
-      assert :ok = Logic.maybe_upload_snapshot(state, ~c"unused", ~c"unused", Version.from_integer(1))
+      assert ^state = Logic.maybe_upload_snapshot(state, ~c"unused", ~c"unused", Version.from_integer(1))
 
       Logic.shutdown(state)
     end
@@ -490,7 +491,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.LogicTest do
       File.write!(data_path, "data contents")
       File.write!(idx_path, "idx contents")
 
-      assert :ok =
+      assert %State{} =
                Logic.maybe_upload_snapshot(
                  state,
                  String.to_charlist(data_path),
@@ -501,6 +502,83 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.LogicTest do
       # Upload happens in a fire-and-forget task; poll until it lands
       assert {:ok, 42, uploaded} = await_snapshot(snapshot, 100)
       assert IO.iodata_to_binary(uploaded) == "data contents" <> "idx contents"
+
+      Logic.shutdown(state)
+    end
+
+    test "with no policy configured every compaction uploads", %{test_dir: test_dir} do
+      object_storage_root = Path.join(test_dir, "object_storage")
+      File.mkdir_p!(object_storage_root)
+
+      backend = ObjectStorage.backend(LocalFilesystem, root: object_storage_root)
+      snapshot = Snapshot.new(backend, "logic-default-shard")
+
+      state = create_test_state(Path.join(test_dir, "storage"), :snapshot_default_test)
+      state = %{state | snapshot: snapshot}
+
+      data_path = Path.join(test_dir, "default_data")
+      idx_path = Path.join(test_dir, "default_idx")
+      File.write!(data_path, "data contents")
+      File.write!(idx_path, "idx contents")
+
+      state =
+        Enum.reduce(1..3, state, fn version, state ->
+          Logic.maybe_upload_snapshot(
+            state,
+            String.to_charlist(data_path),
+            String.to_charlist(idx_path),
+            Version.from_integer(version)
+          )
+        end)
+
+      for version <- 1..3, do: assert({:ok, _} = await_snapshot_version(snapshot, version, 100))
+
+      Logic.shutdown(state)
+    end
+
+    test "a configured interval suppresses a second upload inside the window", %{test_dir: test_dir} do
+      object_storage_root = Path.join(test_dir, "object_storage")
+      File.mkdir_p!(object_storage_root)
+
+      backend = ObjectStorage.backend(LocalFilesystem, root: object_storage_root)
+      snapshot = Snapshot.new(backend, "logic-policy-shard")
+
+      state = create_test_state(Path.join(test_dir, "storage"), :snapshot_policy_test)
+      state = %{state | snapshot: snapshot, snapshot_policy: %SnapshotPolicy{interval_ms: 60_000}}
+
+      data_path = Path.join(test_dir, "policy_data")
+      idx_path = Path.join(test_dir, "policy_idx")
+      File.write!(data_path, "data contents")
+      File.write!(idx_path, "idx contents")
+
+      upload = fn state, version ->
+        Logic.maybe_upload_snapshot(
+          state,
+          String.to_charlist(data_path),
+          String.to_charlist(idx_path),
+          Version.from_integer(version)
+        )
+      end
+
+      # Nothing has ever been uploaded, so the interval trigger fires.
+      state = upload.(state, 1)
+      assert {:ok, _} = await_snapshot_version(snapshot, 1, 100)
+
+      # A second compaction inside the window is skipped: version 2 never
+      # lands, and the latest snapshot is still version 1.
+      state = upload.(state, 2)
+      Process.sleep(100)
+      assert {:error, :not_found} = Snapshot.read(snapshot, 2)
+      assert {:ok, 1} = Snapshot.latest_version(snapshot)
+
+      # Rewinding the policy's clock past the interval releases the next one.
+      state = %{
+        state
+        | snapshot_policy: %{state.snapshot_policy | last_upload_at: state.snapshot_policy.last_upload_at - 60_000}
+      }
+
+      _state = upload.(state, 3)
+      assert {:ok, _} = await_snapshot_version(snapshot, 3, 100)
 
       Logic.shutdown(state)
     end
@@ -516,6 +594,19 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.LogicTest do
       {:error, :not_found} ->
         Process.sleep(50)
         await_snapshot(snapshot, attempts_left - 1)
+    end
+  end
+
+  defp await_snapshot_version(_snapshot, _version, 0), do: {:error, :timed_out}
+
+  defp await_snapshot_version(snapshot, version, attempts_left) do
+    case Snapshot.read(snapshot, version) do
+      {:ok, data} ->
+        {:ok, data}
+
+      {:error, :not_found} ->
+        Process.sleep(50)
+        await_snapshot_version(snapshot, version, attempts_left - 1)
     end
   end
 

--- a/test/bedrock/data_plane/materializer/olivine/snapshot_policy_test.exs
+++ b/test/bedrock/data_plane/materializer/olivine/snapshot_policy_test.exs
@@ -18,16 +18,16 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.SnapshotPolicyTest do
     end
   end
 
-  describe "decide/2 with a scheduled interval" do
+  describe "decide/2 with a minimum interval" do
     setup do
-      {:ok, policy: %SnapshotPolicy{interval_ms: 1_000}}
+      {:ok, policy: %SnapshotPolicy{min_interval_ms: 1_000}}
     end
 
-    test "uploads when no snapshot has been taken yet", %{policy: policy} do
+    test "uploads when there is no previous upload to be too close to", %{policy: policy} do
       assert :upload = SnapshotPolicy.decide(policy, 0)
     end
 
-    test "waits until the interval has elapsed", %{policy: policy} do
+    test "waits until the floor has been cleared", %{policy: policy} do
       policy = SnapshotPolicy.uploaded(policy, 10_000)
 
       assert :wait = SnapshotPolicy.decide(policy, 10_000)
@@ -36,7 +36,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.SnapshotPolicyTest do
       assert :upload = SnapshotPolicy.decide(policy, 50_000)
     end
 
-    test "the accumulated work is irrelevant to a pure interval policy", %{policy: policy} do
+    test "no amount of accumulated work clears the floor early", %{policy: policy} do
       policy = policy |> SnapshotPolicy.uploaded(0) |> SnapshotPolicy.observe(1_000_000, 1_000_000_000)
 
       assert :wait = SnapshotPolicy.decide(policy, 999)
@@ -44,90 +44,83 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.SnapshotPolicyTest do
   end
 
   describe "decide/2 with thresholds" do
-    test "a byte threshold fires at or above the configured size" do
-      policy = %SnapshotPolicy{after_bytes: 4_096} |> SnapshotPolicy.uploaded(0) |> SnapshotPolicy.observe(1, 4_095)
+    test "a byte threshold is met at or above the configured size" do
+      policy = SnapshotPolicy.observe(%SnapshotPolicy{after_bytes: 4_096}, 1, 4_095)
 
       assert :wait = SnapshotPolicy.decide(policy, 0)
       assert :upload = policy |> SnapshotPolicy.observe(1, 1) |> SnapshotPolicy.decide(0)
     end
 
-    test "a transaction threshold fires at or above the configured count" do
-      policy =
-        %SnapshotPolicy{after_transactions: 100} |> SnapshotPolicy.uploaded(0) |> SnapshotPolicy.observe(99, 1)
+    test "a transaction threshold is met at or above the configured count" do
+      policy = SnapshotPolicy.observe(%SnapshotPolicy{after_transactions: 100}, 99, 1)
 
       assert :wait = SnapshotPolicy.decide(policy, 0)
       assert :upload = policy |> SnapshotPolicy.observe(1, 1) |> SnapshotPolicy.decide(0)
     end
 
-    test "triggers are a disjunction: whichever fires first wins" do
-      policy =
-        SnapshotPolicy.uploaded(%SnapshotPolicy{interval_ms: 60_000, after_bytes: 4_096, after_transactions: 100}, 0)
+    test "thresholds are a disjunction with each other: either one qualifies" do
+      policy = %SnapshotPolicy{after_bytes: 4_096, after_transactions: 100}
 
-      assert :wait = policy |> SnapshotPolicy.observe(99, 4_095) |> SnapshotPolicy.decide(59_999)
-      assert :upload = policy |> SnapshotPolicy.observe(99, 4_095) |> SnapshotPolicy.decide(60_000)
+      assert :wait = policy |> SnapshotPolicy.observe(99, 4_095) |> SnapshotPolicy.decide(0)
       assert :upload = policy |> SnapshotPolicy.observe(100, 0) |> SnapshotPolicy.decide(0)
       assert :upload = policy |> SnapshotPolicy.observe(0, 4_096) |> SnapshotPolicy.decide(0)
     end
   end
 
-  describe "uploaded/2" do
-    test "restarts the clock and clears the accumulators" do
+  describe "decide/2 with both a floor and a threshold" do
+    setup do
       policy =
-        %SnapshotPolicy{interval_ms: 1_000, after_bytes: 10, after_transactions: 10}
+        SnapshotPolicy.uploaded(%SnapshotPolicy{min_interval_ms: 60_000, after_transactions: 100}, 0)
+
+      {:ok, policy: policy}
+    end
+
+    test "the floor is a floor: a met threshold does not override it", %{policy: policy} do
+      assert :wait = policy |> SnapshotPolicy.observe(1_000, 0) |> SnapshotPolicy.decide(59_999)
+      assert :upload = policy |> SnapshotPolicy.observe(1_000, 0) |> SnapshotPolicy.decide(60_000)
+    end
+
+    test "clearing the floor is not enough on its own", %{policy: policy} do
+      assert :wait = policy |> SnapshotPolicy.observe(99, 0) |> SnapshotPolicy.decide(600_000)
+      assert :upload = policy |> SnapshotPolicy.observe(100, 0) |> SnapshotPolicy.decide(600_000)
+    end
+  end
+
+  describe "uploaded/2" do
+    test "restarts the floor and clears the accumulators" do
+      policy =
+        %SnapshotPolicy{min_interval_ms: 1_000, after_transactions: 10}
         |> SnapshotPolicy.uploaded(0)
         |> SnapshotPolicy.observe(50, 50)
 
-      assert :upload = SnapshotPolicy.decide(policy, 0)
+      assert :upload = SnapshotPolicy.decide(policy, 1_000)
 
-      policy = SnapshotPolicy.uploaded(policy, 500)
+      policy = SnapshotPolicy.uploaded(policy, 1_000)
 
-      assert :wait = SnapshotPolicy.decide(policy, 500)
-      assert :upload = SnapshotPolicy.decide(policy, 1_500)
-    end
-  end
-
-  describe "check_interval_ms/1" do
-    test "an unarmed policy never schedules a check" do
-      assert :never = SnapshotPolicy.check_interval_ms(%SnapshotPolicy{})
-    end
-
-    test "an interval is checked four times per interval, with a floor" do
-      assert 15_000 = SnapshotPolicy.check_interval_ms(%SnapshotPolicy{interval_ms: 60_000})
-      assert 10 = SnapshotPolicy.check_interval_ms(%SnapshotPolicy{interval_ms: 1})
-    end
-
-    test "thresholds alone still need polling" do
-      assert 1_000 = SnapshotPolicy.check_interval_ms(%SnapshotPolicy{after_bytes: 4_096})
-      assert 1_000 = SnapshotPolicy.check_interval_ms(%SnapshotPolicy{after_transactions: 100})
-    end
-  end
-
-  describe "started/2" do
-    test "an interval measured from startup does not fire immediately" do
-      policy = SnapshotPolicy.started(%SnapshotPolicy{interval_ms: 1_000}, 5_000)
-
-      assert :wait = SnapshotPolicy.decide(policy, 5_999)
-      assert :upload = SnapshotPolicy.decide(policy, 6_000)
+      # Both halves reset: inside the floor, and with nothing accumulated.
+      assert :wait = SnapshotPolicy.decide(policy, 1_500)
+      assert :wait = SnapshotPolicy.decide(policy, 2_000)
+      assert :upload = policy |> SnapshotPolicy.observe(10, 0) |> SnapshotPolicy.decide(2_000)
     end
   end
 
   describe "from_params/1" do
     test "reads the manifest params a worker is created with" do
-      assert %SnapshotPolicy{interval_ms: 60_000, after_bytes: 4_096, after_transactions: 100} =
+      assert %SnapshotPolicy{min_interval_ms: 60_000, after_bytes: 4_096, after_transactions: 100} =
                SnapshotPolicy.from_params(%{
-                 "snapshot_interval_ms" => 60_000,
+                 "snapshot_min_interval_ms" => 60_000,
                  "snapshot_after_bytes" => 4_096,
                  "snapshot_after_transactions" => 100
                })
     end
 
-    test "absent, non-integer or non-positive params leave the trigger disabled" do
-      assert %SnapshotPolicy{interval_ms: nil, after_bytes: nil, after_transactions: nil} =
+    test "absent, non-integer or non-positive params leave the knob off" do
+      assert %SnapshotPolicy{min_interval_ms: nil, after_bytes: nil, after_transactions: nil} =
                SnapshotPolicy.from_params(%{})
 
-      assert %SnapshotPolicy{interval_ms: nil, after_bytes: nil, after_transactions: nil} =
+      assert %SnapshotPolicy{min_interval_ms: nil, after_bytes: nil, after_transactions: nil} =
                SnapshotPolicy.from_params(%{
-                 "snapshot_interval_ms" => 0,
+                 "snapshot_min_interval_ms" => 0,
                  "snapshot_after_bytes" => -1,
                  "snapshot_after_transactions" => "100"
                })

--- a/test/bedrock/data_plane/materializer/olivine/snapshot_policy_test.exs
+++ b/test/bedrock/data_plane/materializer/olivine/snapshot_policy_test.exs
@@ -1,0 +1,111 @@
+defmodule Bedrock.DataPlane.Materializer.Olivine.SnapshotPolicyTest do
+  use ExUnit.Case, async: true
+
+  alias Bedrock.DataPlane.Materializer.Olivine.SnapshotPolicy
+
+  describe "decide/2 with nothing configured" do
+    test "uploads at every opportunity" do
+      policy = %SnapshotPolicy{}
+
+      assert :upload = SnapshotPolicy.decide(policy, 0)
+      assert :upload = policy |> SnapshotPolicy.uploaded(0) |> SnapshotPolicy.decide(0)
+
+      assert :upload =
+               policy
+               |> SnapshotPolicy.uploaded(0)
+               |> SnapshotPolicy.observe(0, 0)
+               |> SnapshotPolicy.decide(1)
+    end
+  end
+
+  describe "decide/2 with a scheduled interval" do
+    setup do
+      {:ok, policy: %SnapshotPolicy{interval_ms: 1_000}}
+    end
+
+    test "uploads when no snapshot has been taken yet", %{policy: policy} do
+      assert :upload = SnapshotPolicy.decide(policy, 0)
+    end
+
+    test "waits until the interval has elapsed", %{policy: policy} do
+      policy = SnapshotPolicy.uploaded(policy, 10_000)
+
+      assert :wait = SnapshotPolicy.decide(policy, 10_000)
+      assert :wait = SnapshotPolicy.decide(policy, 10_999)
+      assert :upload = SnapshotPolicy.decide(policy, 11_000)
+      assert :upload = SnapshotPolicy.decide(policy, 50_000)
+    end
+
+    test "the accumulated work is irrelevant to a pure interval policy", %{policy: policy} do
+      policy = policy |> SnapshotPolicy.uploaded(0) |> SnapshotPolicy.observe(1_000_000, 1_000_000_000)
+
+      assert :wait = SnapshotPolicy.decide(policy, 999)
+    end
+  end
+
+  describe "decide/2 with thresholds" do
+    test "a byte threshold fires at or above the configured size" do
+      policy = %SnapshotPolicy{after_bytes: 4_096} |> SnapshotPolicy.uploaded(0) |> SnapshotPolicy.observe(1, 4_095)
+
+      assert :wait = SnapshotPolicy.decide(policy, 0)
+      assert :upload = policy |> SnapshotPolicy.observe(1, 1) |> SnapshotPolicy.decide(0)
+    end
+
+    test "a transaction threshold fires at or above the configured count" do
+      policy =
+        %SnapshotPolicy{after_transactions: 100} |> SnapshotPolicy.uploaded(0) |> SnapshotPolicy.observe(99, 1)
+
+      assert :wait = SnapshotPolicy.decide(policy, 0)
+      assert :upload = policy |> SnapshotPolicy.observe(1, 1) |> SnapshotPolicy.decide(0)
+    end
+
+    test "triggers are a disjunction: whichever fires first wins" do
+      policy =
+        SnapshotPolicy.uploaded(%SnapshotPolicy{interval_ms: 60_000, after_bytes: 4_096, after_transactions: 100}, 0)
+
+      assert :wait = policy |> SnapshotPolicy.observe(99, 4_095) |> SnapshotPolicy.decide(59_999)
+      assert :upload = policy |> SnapshotPolicy.observe(99, 4_095) |> SnapshotPolicy.decide(60_000)
+      assert :upload = policy |> SnapshotPolicy.observe(100, 0) |> SnapshotPolicy.decide(0)
+      assert :upload = policy |> SnapshotPolicy.observe(0, 4_096) |> SnapshotPolicy.decide(0)
+    end
+  end
+
+  describe "uploaded/2" do
+    test "restarts the clock and clears the accumulators" do
+      policy =
+        %SnapshotPolicy{interval_ms: 1_000, after_bytes: 10, after_transactions: 10}
+        |> SnapshotPolicy.uploaded(0)
+        |> SnapshotPolicy.observe(50, 50)
+
+      assert :upload = SnapshotPolicy.decide(policy, 0)
+
+      policy = SnapshotPolicy.uploaded(policy, 500)
+
+      assert :wait = SnapshotPolicy.decide(policy, 500)
+      assert :upload = SnapshotPolicy.decide(policy, 1_500)
+    end
+  end
+
+  describe "from_params/1" do
+    test "reads the manifest params a worker is created with" do
+      assert %SnapshotPolicy{interval_ms: 60_000, after_bytes: 4_096, after_transactions: 100} =
+               SnapshotPolicy.from_params(%{
+                 "snapshot_interval_ms" => 60_000,
+                 "snapshot_after_bytes" => 4_096,
+                 "snapshot_after_transactions" => 100
+               })
+    end
+
+    test "absent, non-integer or non-positive params leave the trigger disabled" do
+      assert %SnapshotPolicy{interval_ms: nil, after_bytes: nil, after_transactions: nil} =
+               SnapshotPolicy.from_params(%{})
+
+      assert %SnapshotPolicy{interval_ms: nil, after_bytes: nil, after_transactions: nil} =
+               SnapshotPolicy.from_params(%{
+                 "snapshot_interval_ms" => 0,
+                 "snapshot_after_bytes" => -1,
+                 "snapshot_after_transactions" => "100"
+               })
+    end
+  end
+end

--- a/test/bedrock/data_plane/materializer/olivine/snapshot_policy_test.exs
+++ b/test/bedrock/data_plane/materializer/olivine/snapshot_policy_test.exs
@@ -86,6 +86,31 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.SnapshotPolicyTest do
     end
   end
 
+  describe "check_interval_ms/1" do
+    test "an unarmed policy never schedules a check" do
+      assert :never = SnapshotPolicy.check_interval_ms(%SnapshotPolicy{})
+    end
+
+    test "an interval is checked four times per interval, with a floor" do
+      assert 15_000 = SnapshotPolicy.check_interval_ms(%SnapshotPolicy{interval_ms: 60_000})
+      assert 10 = SnapshotPolicy.check_interval_ms(%SnapshotPolicy{interval_ms: 1})
+    end
+
+    test "thresholds alone still need polling" do
+      assert 1_000 = SnapshotPolicy.check_interval_ms(%SnapshotPolicy{after_bytes: 4_096})
+      assert 1_000 = SnapshotPolicy.check_interval_ms(%SnapshotPolicy{after_transactions: 100})
+    end
+  end
+
+  describe "started/2" do
+    test "an interval measured from startup does not fire immediately" do
+      policy = SnapshotPolicy.started(%SnapshotPolicy{interval_ms: 1_000}, 5_000)
+
+      assert :wait = SnapshotPolicy.decide(policy, 5_999)
+      assert :upload = SnapshotPolicy.decide(policy, 6_000)
+    end
+  end
+
   describe "from_params/1" do
     test "reads the manifest params a worker is created with" do
       assert %SnapshotPolicy{interval_ms: 60_000, after_bytes: 4_096, after_transactions: 100} =

--- a/test/bedrock/data_plane/materializer/olivine/snapshot_upload_policy_test.exs
+++ b/test/bedrock/data_plane/materializer/olivine/snapshot_upload_policy_test.exs
@@ -1,24 +1,18 @@
 defmodule Bedrock.DataPlane.Materializer.Olivine.SnapshotUploadPolicyTest do
   @moduledoc """
   Snapshot upload policy (bedrock-zi44) as the worker sees it: the
-  manifest params a materializer is created with must reach its
-  `snapshot_policy`, an armed policy must actually produce a snapshot on
-  its own schedule, and a worker with no trigger configured must behave
-  exactly as it did before — no timer, no scheduled compaction.
+  manifest params a materializer is created with have to reach its
+  `snapshot_policy`, one knob at a time, and a worker created without
+  them has to end up with the policy that uploads at every opportunity —
+  the behaviour every materializer had before the policy existed.
 
-  The scheduled path is driven by hand (`send(pid, :snapshot_check)`)
-  wherever the assertion is about the decision rather than the timer;
-  one test lets a real short interval fire on its own.
+  What the policy DOES with those knobs is `SnapshotPolicyTest`; where
+  it is consulted is `LogicTest`.
   """
   use ExUnit.Case, async: false
 
   alias Bedrock.DataPlane.Materializer.Olivine
   alias Bedrock.DataPlane.Materializer.Olivine.SnapshotPolicy
-  alias Bedrock.ObjectStorage
-  alias Bedrock.ObjectStorage.Config, as: ObjectStorageConfig
-  alias Bedrock.ObjectStorage.Keys, as: ObjectStorageKeys
-  alias Bedrock.ObjectStorage.LocalFilesystem
-  alias Bedrock.ObjectStorage.Snapshot
 
   defmodule TestCluster do
     @moduledoc false
@@ -26,35 +20,20 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.SnapshotUploadPolicyTest do
   end
 
   setup do
-    test_id = :erlang.unique_integer([:positive])
-    tmp_dir = Path.join(System.tmp_dir!(), "olivine_snap_policy_#{test_id}")
+    tmp_dir = Path.join(System.tmp_dir!(), "olivine_snap_policy_#{:erlang.unique_integer([:positive])}")
     File.rm_rf(tmp_dir)
     File.mkdir_p!(tmp_dir)
+    on_exit(fn -> File.rm_rf(tmp_dir) end)
 
-    root = Path.join(System.tmp_dir!(), "olivine_snap_policy_objects_#{test_id}")
-    File.mkdir_p!(root)
-    old_config = Application.get_env(:bedrock, ObjectStorage)
-    Application.put_env(:bedrock, ObjectStorage, backend: ObjectStorage.backend(LocalFilesystem, root: root))
-
-    on_exit(fn ->
-      if old_config,
-        do: Application.put_env(:bedrock, ObjectStorage, old_config),
-        else: Application.delete_env(:bedrock, ObjectStorage)
-
-      File.rm_rf(root)
-      File.rm_rf(tmp_dir)
-    end)
-
-    {:ok, tmp_dir: tmp_dir, test_id: test_id}
+    {:ok, tmp_dir: tmp_dir}
   end
 
   defp start_worker(tmp_dir, params) do
     worker_id = "snap_wkr_#{System.unique_integer([:positive])}"
-    otp_name = :"olivine_snap_#{System.unique_integer([:positive])}"
 
     child_spec =
       Olivine.child_spec(
-        otp_name: otp_name,
+        otp_name: :"olivine_snap_#{System.unique_integer([:positive])}",
         foreman: self(),
         id: worker_id,
         path: tmp_dir,
@@ -72,97 +51,36 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.SnapshotUploadPolicyTest do
       5_000 -> flunk("no health report")
     end
 
-    # Workers boot :locked; a locked worker is mid-recovery and defers
-    # its snapshot check, so these tests exercise the running state.
-    :sys.replace_state(pid, &%{&1 | mode: :running})
-
     pid
   end
 
-  defp snapshot_handle_for(shard_num) do
-    Snapshot.new(ObjectStorageConfig.backend(), ObjectStorageKeys.shard_tag(shard_num))
-  end
-
-  defp await_snapshot(_snapshot, 0), do: {:error, :timed_out}
-
-  defp await_snapshot(snapshot, attempts_left) do
-    case Snapshot.latest_version(snapshot) do
-      {:ok, version} ->
-        {:ok, version}
-
-      {:error, :not_found} ->
-        Process.sleep(25)
-        await_snapshot(snapshot, attempts_left - 1)
-    end
-  end
-
   describe "manifest params" do
-    test "arm the worker's policy", %{tmp_dir: tmp_dir} do
+    test "set the worker's policy", %{tmp_dir: tmp_dir} do
       pid =
         start_worker(tmp_dir, %{
           "shard_id" => 42,
-          "snapshot_interval_ms" => 60_000,
+          "snapshot_min_interval_ms" => 60_000,
           "snapshot_after_bytes" => 4_096,
           "snapshot_after_transactions" => 100
         })
 
-      assert %SnapshotPolicy{interval_ms: 60_000, after_bytes: 4_096, after_transactions: 100, last_upload_at: at} =
-               :sys.get_state(pid).snapshot_policy
-
-      # started/2 ran at startup, so the interval is measured from boot
-      # rather than firing on the first check.
-      assert is_integer(at)
-    end
-
-    test "left out leave it unarmed", %{tmp_dir: tmp_dir} do
-      pid = start_worker(tmp_dir, %{"shard_id" => 42})
-
-      assert %SnapshotPolicy{interval_ms: nil, after_bytes: nil, after_transactions: nil} =
+      assert %SnapshotPolicy{min_interval_ms: 60_000, after_bytes: 4_096, after_transactions: 100} =
                :sys.get_state(pid).snapshot_policy
     end
-  end
 
-  describe "the scheduled trigger" do
-    test "an armed worker snapshots on its own schedule", %{tmp_dir: tmp_dir} do
-      _pid = start_worker(tmp_dir, %{"shard_id" => 42, "snapshot_interval_ms" => 40})
+    test "set only the knobs they name", %{tmp_dir: tmp_dir} do
+      pid = start_worker(tmp_dir, %{"shard_id" => 42, "snapshot_after_transactions" => 10_000})
 
-      assert {:ok, _version} = await_snapshot(snapshot_handle_for(42), 200)
+      assert %SnapshotPolicy{min_interval_ms: nil, after_bytes: nil, after_transactions: 10_000} =
+               :sys.get_state(pid).snapshot_policy
     end
 
-    test "a check inside the interval starts nothing", %{tmp_dir: tmp_dir} do
-      pid = start_worker(tmp_dir, %{"shard_id" => 42, "snapshot_interval_ms" => 600_000})
-
-      send(pid, :snapshot_check)
-      assert nil == :sys.get_state(pid).compaction_task
-
-      # Rewinding the policy's clock past the interval releases it.
-      :sys.replace_state(pid, fn t ->
-        %{t | snapshot_policy: %{t.snapshot_policy | last_upload_at: t.snapshot_policy.last_upload_at - 600_000}}
-      end)
-
-      send(pid, :snapshot_check)
-      assert {:ok, _version} = await_snapshot(snapshot_handle_for(42), 200)
-    end
-
-    test "an unarmed worker never schedules one", %{tmp_dir: tmp_dir} do
+    test "left out leave the policy uploading at every opportunity", %{tmp_dir: tmp_dir} do
       pid = start_worker(tmp_dir, %{"shard_id" => 42})
+      policy = :sys.get_state(pid).snapshot_policy
 
-      # No timer was armed, and a check delivered by hand still declines
-      # to compact: the policy has no trigger to fire.
-      send(pid, :snapshot_check)
-      assert nil == :sys.get_state(pid).compaction_task
-
-      Process.sleep(100)
-      assert {:error, :not_found} = Snapshot.latest_version(snapshot_handle_for(42))
-    end
-
-    test "a locked worker defers", %{tmp_dir: tmp_dir} do
-      pid = start_worker(tmp_dir, %{"shard_id" => 42, "snapshot_interval_ms" => 40})
-      :sys.replace_state(pid, &%{&1 | mode: :locked})
-
-      Process.sleep(100)
-      assert nil == :sys.get_state(pid).compaction_task
-      assert {:error, :not_found} = Snapshot.latest_version(snapshot_handle_for(42))
+      assert %SnapshotPolicy{min_interval_ms: nil, after_bytes: nil, after_transactions: nil} = policy
+      assert :upload = SnapshotPolicy.decide(policy, System.monotonic_time(:millisecond))
     end
   end
 end

--- a/test/bedrock/data_plane/materializer/olivine/snapshot_upload_policy_test.exs
+++ b/test/bedrock/data_plane/materializer/olivine/snapshot_upload_policy_test.exs
@@ -1,0 +1,168 @@
+defmodule Bedrock.DataPlane.Materializer.Olivine.SnapshotUploadPolicyTest do
+  @moduledoc """
+  Snapshot upload policy (bedrock-zi44) as the worker sees it: the
+  manifest params a materializer is created with must reach its
+  `snapshot_policy`, an armed policy must actually produce a snapshot on
+  its own schedule, and a worker with no trigger configured must behave
+  exactly as it did before — no timer, no scheduled compaction.
+
+  The scheduled path is driven by hand (`send(pid, :snapshot_check)`)
+  wherever the assertion is about the decision rather than the timer;
+  one test lets a real short interval fire on its own.
+  """
+  use ExUnit.Case, async: false
+
+  alias Bedrock.DataPlane.Materializer.Olivine
+  alias Bedrock.DataPlane.Materializer.Olivine.SnapshotPolicy
+  alias Bedrock.ObjectStorage
+  alias Bedrock.ObjectStorage.Config, as: ObjectStorageConfig
+  alias Bedrock.ObjectStorage.Keys, as: ObjectStorageKeys
+  alias Bedrock.ObjectStorage.LocalFilesystem
+  alias Bedrock.ObjectStorage.Snapshot
+
+  defmodule TestCluster do
+    @moduledoc false
+    def name, do: "snapshot-policy-test-cluster"
+  end
+
+  setup do
+    test_id = :erlang.unique_integer([:positive])
+    tmp_dir = Path.join(System.tmp_dir!(), "olivine_snap_policy_#{test_id}")
+    File.rm_rf(tmp_dir)
+    File.mkdir_p!(tmp_dir)
+
+    root = Path.join(System.tmp_dir!(), "olivine_snap_policy_objects_#{test_id}")
+    File.mkdir_p!(root)
+    old_config = Application.get_env(:bedrock, ObjectStorage)
+    Application.put_env(:bedrock, ObjectStorage, backend: ObjectStorage.backend(LocalFilesystem, root: root))
+
+    on_exit(fn ->
+      if old_config,
+        do: Application.put_env(:bedrock, ObjectStorage, old_config),
+        else: Application.delete_env(:bedrock, ObjectStorage)
+
+      File.rm_rf(root)
+      File.rm_rf(tmp_dir)
+    end)
+
+    {:ok, tmp_dir: tmp_dir, test_id: test_id}
+  end
+
+  defp start_worker(tmp_dir, params) do
+    worker_id = "snap_wkr_#{System.unique_integer([:positive])}"
+    otp_name = :"olivine_snap_#{System.unique_integer([:positive])}"
+
+    child_spec =
+      Olivine.child_spec(
+        otp_name: otp_name,
+        foreman: self(),
+        id: worker_id,
+        path: tmp_dir,
+        cluster: TestCluster,
+        params: params
+      )
+
+    {GenServer, :start_link, args} = child_spec.start
+    {:ok, pid} = apply(GenServer, :start, args)
+    on_exit(fn -> if Process.alive?(pid), do: GenServer.stop(pid, :normal) end)
+
+    receive do
+      {:"$gen_cast", {:worker_health, ^worker_id, {:ok, ^pid}}} -> :ok
+    after
+      5_000 -> flunk("no health report")
+    end
+
+    # Workers boot :locked; a locked worker is mid-recovery and defers
+    # its snapshot check, so these tests exercise the running state.
+    :sys.replace_state(pid, &%{&1 | mode: :running})
+
+    pid
+  end
+
+  defp snapshot_handle_for(shard_num) do
+    Snapshot.new(ObjectStorageConfig.backend(), ObjectStorageKeys.shard_tag(shard_num))
+  end
+
+  defp await_snapshot(_snapshot, 0), do: {:error, :timed_out}
+
+  defp await_snapshot(snapshot, attempts_left) do
+    case Snapshot.latest_version(snapshot) do
+      {:ok, version} ->
+        {:ok, version}
+
+      {:error, :not_found} ->
+        Process.sleep(25)
+        await_snapshot(snapshot, attempts_left - 1)
+    end
+  end
+
+  describe "manifest params" do
+    test "arm the worker's policy", %{tmp_dir: tmp_dir} do
+      pid =
+        start_worker(tmp_dir, %{
+          "shard_id" => 42,
+          "snapshot_interval_ms" => 60_000,
+          "snapshot_after_bytes" => 4_096,
+          "snapshot_after_transactions" => 100
+        })
+
+      assert %SnapshotPolicy{interval_ms: 60_000, after_bytes: 4_096, after_transactions: 100, last_upload_at: at} =
+               :sys.get_state(pid).snapshot_policy
+
+      # started/2 ran at startup, so the interval is measured from boot
+      # rather than firing on the first check.
+      assert is_integer(at)
+    end
+
+    test "left out leave it unarmed", %{tmp_dir: tmp_dir} do
+      pid = start_worker(tmp_dir, %{"shard_id" => 42})
+
+      assert %SnapshotPolicy{interval_ms: nil, after_bytes: nil, after_transactions: nil} =
+               :sys.get_state(pid).snapshot_policy
+    end
+  end
+
+  describe "the scheduled trigger" do
+    test "an armed worker snapshots on its own schedule", %{tmp_dir: tmp_dir} do
+      _pid = start_worker(tmp_dir, %{"shard_id" => 42, "snapshot_interval_ms" => 40})
+
+      assert {:ok, _version} = await_snapshot(snapshot_handle_for(42), 200)
+    end
+
+    test "a check inside the interval starts nothing", %{tmp_dir: tmp_dir} do
+      pid = start_worker(tmp_dir, %{"shard_id" => 42, "snapshot_interval_ms" => 600_000})
+
+      send(pid, :snapshot_check)
+      assert nil == :sys.get_state(pid).compaction_task
+
+      # Rewinding the policy's clock past the interval releases it.
+      :sys.replace_state(pid, fn t ->
+        %{t | snapshot_policy: %{t.snapshot_policy | last_upload_at: t.snapshot_policy.last_upload_at - 600_000}}
+      end)
+
+      send(pid, :snapshot_check)
+      assert {:ok, _version} = await_snapshot(snapshot_handle_for(42), 200)
+    end
+
+    test "an unarmed worker never schedules one", %{tmp_dir: tmp_dir} do
+      pid = start_worker(tmp_dir, %{"shard_id" => 42})
+
+      # No timer was armed, and a check delivered by hand still declines
+      # to compact: the policy has no trigger to fire.
+      send(pid, :snapshot_check)
+      assert nil == :sys.get_state(pid).compaction_task
+
+      Process.sleep(100)
+      assert {:error, :not_found} = Snapshot.latest_version(snapshot_handle_for(42))
+    end
+
+    test "a locked worker defers", %{tmp_dir: tmp_dir} do
+      pid = start_worker(tmp_dir, %{"shard_id" => 42, "snapshot_interval_ms" => 40})
+      :sys.replace_state(pid, &%{&1 | mode: :locked})
+
+      Process.sleep(100)
+      assert nil == :sys.get_state(pid).compaction_task
+      assert {:error, :not_found} = Snapshot.latest_version(snapshot_handle_for(42))
+    end
+  end
+end


### PR DESCRIPTION
An Olivine materializer wrote a full snapshot of itself to object storage every time a compaction finished, and nothing in the worker or its manifest could say how much of that cadence was wanted. `SnapshotPolicy` adds a minimum-interval floor and byte/transaction thresholds, threaded from manifest params the way `idle_timeout` already is, and consulted at the compaction-completion upload. A worker with none of the knobs set uploads at every opportunity, exactly as before.

Ticket: bedrock-zi44
Closes bedrock-zi44.

## Why

Compaction leaves the data and index files in exactly the shape a snapshot bundle wants, so uploading then is nearly free. Free is not the same as wanted. On develop the only thing between a finished compaction and a new object was whether a snapshot handle existed, so a shard that compacts often ships a full copy of itself every time, and every object is stored, billed, listed, and eventually reclaimed.

## What changed

- A pure decision struct: three knobs, three accumulators, and `decide/2` answering `:upload` or `:wait`. Materializer state carries one, fed the batch count and byte size transaction application already computes for telemetry.
- The compaction-completion upload consults it, and now returns state rather than `:ok` to carry the reset accumulators forward. Its one production caller is updated.
- Three manifest params, off by default: `snapshot_min_interval_ms`, `snapshot_after_bytes`, `snapshot_after_transactions`. A knob is set only by an explicit positive integer, so a malformed param leaves it off rather than becoming an accidental cadence.

The spin-down upload is deliberately not policed: it is the only durable artifact bridging an idle spin-down to revival, so suppressing it would trade one cheap object for a full log replay. Retention stays on the object-storage side, untouched.

## How it works

The interval is a floor and the byte/transaction knobs are triggers, composed as floor AND (either trigger). Not one flat disjunction: "one hour or 4096 bytes" would upload every 4096 bytes and violate its own minimum. Each half is vacuously true when unset, so an unconfigured policy always uploads.

```
min_interval_ms: 60_000, after_transactions: 10_000
compaction 1, 10k transactions  -> upload, accumulators reset
compaction 2, +2s               -> wait, inside the floor
compaction 3, +10s, 40 txns     -> wait, neither half satisfied
```

The floor is clear when nothing has been uploaded in this process's lifetime: monotonic time is per-VM, so a restart always gets one snapshot. That costs nothing, because the object key is the durable version and the write is put-if-not-exists.

Accumulators reset when the upload task is spawned, not when it succeeds, since the task reports nothing back. A failed upload waits out the floor and re-earns its threshold from zero.

## Verification

Unit tests pin the floor at its exact boundary, each threshold at and one below its value, and the disjunction between the triggers. A logic test uploads three versions unpoliced against a local-filesystem backend, then sets a 60s floor and asserts the second never lands while a third does once the clock is rewound. A worker-level test reads the policy back out of a real materializer started from manifest params. All four CI matrices pass.

Follow-up: bedrock-947, nothing drives compaction on a running materializer, so the scheduled half was not shipped. Follow-up: bedrock-mk2, cutover resumes pulling on a locked worker. Follow-up: bedrock-3v1, cutover double-applies atomic mutations, fixed in #276.
