### PR TITLE
bedrock-jq8: keep a failed worker start from taking the foreman down

### DIFF
--- a/lib/bedrock/service/foreman/starting_workers.ex
+++ b/lib/bedrock/service/foreman/starting_workers.ex
@@ -12,6 +12,8 @@ defmodule Bedrock.Service.Foreman.StartingWorkers do
   alias Bedrock.Service.Manifest
   alias Bedrock.Service.Worker
 
+  require Logger
+
   @spec worker_info_from_path(Path.t(), otp_namer :: (Worker.id() -> Worker.otp_name())) ::
           [WorkerInfo.t()]
   def worker_info_from_path(path, otp_namer) do
@@ -92,16 +94,72 @@ defmodule Bedrock.Service.Foreman.StartingWorkers do
   def worker_info_for_id(id, path, otp_namer),
     do: %WorkerInfo{id: id, path: path, otp_name: otp_namer.(id), health: :stopped}
 
-  @spec try_to_start_workers([WorkerInfo.t()], cluster :: Cluster.t(), object_storage :: term()) ::
-          [WorkerInfo.t()]
-  def try_to_start_workers(worker_info, cluster, object_storage) do
+  # A worker's start is not a quick function call: it runs the worker
+  # module's own code, and Shale opens its WAL and may preallocate
+  # segment files before its init returns. Every worker on the node
+  # starts at once, so `Task.async_stream`'s 5s default is a time a cold,
+  # loaded node can plausibly exceed — and a timeout here is not a
+  # diagnosis, the worker may be starting perfectly well. Give it room.
+  # Still bounded, though: spin-up runs in a `handle_continue`, so an
+  # unbounded wait would leave the foreman answering nothing at all.
+  @start_timeout_ms 30_000
+
+  @doc """
+  Starts each stopped worker, concurrently, and records what happened to
+  each one.
+
+  A start runs arbitrary worker-module code — `child_spec/1` from a
+  manifest, an `init/1` that touches the disk — so it can raise, and it
+  can overrun. Neither is the foreman's death: `Task.async_stream` links
+  its tasks, so an uncaught exception reaches the foreman as an exit
+  signal and takes down every OTHER worker it hosts, and the default
+  `on_timeout: :exit` does the same to a worker that is merely slow.
+
+  Both are caught here and become `{:failed_to_start, reason}` for the
+  one worker id they belong to, which is the verdict `recompute_health/1`
+  already knows how to read. The exception is caught inside the task, so
+  no signal is ever raised; the timeout cannot be, so `:kill_task` turns
+  it into a result instead. `zip_input_on_exit` is what carries the
+  worker the result belongs to — the stream is the only thing that knows.
+  """
+  @spec try_to_start_workers(
+          [WorkerInfo.t()],
+          cluster :: Cluster.t(),
+          object_storage :: term(),
+          timeout()
+        ) :: [WorkerInfo.t()]
+  def try_to_start_workers(worker_info, cluster, object_storage, timeout \\ @start_timeout_ms) do
     worker_info
-    |> Task.async_stream(&try_to_start_worker(&1, cluster, object_storage))
+    |> Task.async_stream(
+      fn worker_info ->
+        try do
+          try_to_start_worker(worker_info, cluster, object_storage)
+        catch
+          # The crash report the task used to emit on its way out went
+          # with it. It is the only place the stacktrace exists, so say
+          # it here — a health field an operator has to go looking for is
+          # not a substitute for knowing which worker blew up and where.
+          kind, reason ->
+            Logger.error(
+              "Bedrock foreman: worker #{worker_info.id} raised while starting\n" <>
+                Exception.format(kind, reason, __STACKTRACE__)
+            )
+
+            put_health(worker_info, {:failed_to_start, {kind, reason}})
+        end
+      end,
+      timeout: timeout,
+      on_timeout: :kill_task,
+      zip_input_on_exit: true
+    )
     |> Enum.map(fn
-      {:ok, worker_info} -> worker_info
-      {:error, reason} -> put_health(worker_info, {:failed_to_start, reason})
+      {:ok, worker_info} ->
+        worker_info
+
+      {:exit, {worker_info, reason}} ->
+        Logger.error("Bedrock foreman: worker #{worker_info.id} failed to start (#{inspect(reason)})")
+        put_health(worker_info, {:failed_to_start, reason})
     end)
-    |> Enum.to_list()
   end
 
   defmodule(StartWorkerOp) do

--- a/lib/bedrock/service/foreman/starting_workers.ex
+++ b/lib/bedrock/service/foreman/starting_workers.ex
@@ -101,26 +101,30 @@ defmodule Bedrock.Service.Foreman.StartingWorkers do
   # loaded node can plausibly exceed — and a timeout here is not a
   # diagnosis, the worker may be starting perfectly well. Give it room.
   # Still bounded, though: spin-up runs in a `handle_continue`, so an
-  # unbounded wait would leave the foreman answering nothing at all.
+  # unbounded wait would leave the foreman answering nothing at all. What
+  # it costs is that window, once per batch of concurrent starts, on a
+  # boot that has a stuck worker in it.
   @start_timeout_ms 30_000
 
   @doc """
   Starts each stopped worker, concurrently, and records what happened to
   each one.
 
-  A start runs arbitrary worker-module code — `child_spec/1` from a
-  manifest, an `init/1` that touches the disk — so it can raise, and it
-  can overrun. Neither is the foreman's death: `Task.async_stream` links
-  its tasks, so an uncaught exception reaches the foreman as an exit
-  signal and takes down every OTHER worker it hosts, and the default
-  `on_timeout: :exit` does the same to a worker that is merely slow.
+  A start that overruns is not the foreman's death. `Task.async_stream`'s
+  default is `on_timeout: :exit`, which exits the CALLER — spin-up runs
+  in a `handle_continue`, so the foreman dies before a single result is
+  mapped, and it dies over a worker that may be starting perfectly well.
+  Restarting does not help: `do_spin_up/1` re-reads the same directory
+  and stalls on the same worker, so the foreman crash-loops until the
+  supervisor's restart intensity gives out and takes the worker
+  `DynamicSupervisor` — and every worker under it — down with it.
 
-  Both are caught here and become `{:failed_to_start, reason}` for the
-  one worker id they belong to, which is the verdict `recompute_health/1`
-  already knows how to read. The exception is caught inside the task, so
-  no signal is ever raised; the timeout cannot be, so `:kill_task` turns
-  it into a result instead. `zip_input_on_exit` is what carries the
-  worker the result belongs to — the stream is the only thing that knows.
+  `:kill_task` turns the overrun into a result for the one worker it
+  belongs to instead, and `zip_input_on_exit` carries the worker that
+  result belongs to, since the stream is the only thing that knows it.
+  Raising is handled a level down, in `try_to_start_worker/3`, because
+  `do_new_worker/4` calls that one directly and is exposed to the same
+  thing.
   """
   @spec try_to_start_workers(
           [WorkerInfo.t()],
@@ -130,24 +134,7 @@ defmodule Bedrock.Service.Foreman.StartingWorkers do
         ) :: [WorkerInfo.t()]
   def try_to_start_workers(worker_info, cluster, object_storage, timeout \\ @start_timeout_ms) do
     worker_info
-    |> Task.async_stream(
-      fn worker_info ->
-        try do
-          try_to_start_worker(worker_info, cluster, object_storage)
-        catch
-          # The crash report the task used to emit on its way out went
-          # with it. It is the only place the stacktrace exists, so say
-          # it here — a health field an operator has to go looking for is
-          # not a substitute for knowing which worker blew up and where.
-          kind, reason ->
-            Logger.error(
-              "Bedrock foreman: worker #{worker_info.id} raised while starting\n" <>
-                Exception.format(kind, reason, __STACKTRACE__)
-            )
-
-            put_health(worker_info, {:failed_to_start, {kind, reason}})
-        end
-      end,
+    |> Task.async_stream(&try_to_start_worker(&1, cluster, object_storage),
       timeout: timeout,
       on_timeout: :kill_task,
       zip_input_on_exit: true
@@ -156,6 +143,8 @@ defmodule Bedrock.Service.Foreman.StartingWorkers do
       {:ok, worker_info} ->
         worker_info
 
+      # `:kill_task` emits no report of its own, so this is the only
+      # record that a worker was given up on.
       {:exit, {worker_info, reason}} ->
         Logger.error("Bedrock foreman: worker #{worker_info.id} failed to start (#{inspect(reason)})")
         put_health(worker_info, {:failed_to_start, reason})
@@ -169,6 +158,24 @@ defmodule Bedrock.Service.Foreman.StartingWorkers do
     defstruct [:path, :id, :otp_name, :cluster, :manifest, :child_spec, :pid, :error, :object_storage]
   end
 
+  @doc """
+  Attempts one worker's start and answers with its health, whatever
+  happened.
+
+  Answering is the contract, and the pipeline below only honours it for
+  failures it can see coming — every step it runs is the worker module's
+  own code, named by a manifest on disk. `child_spec/1` may not exist or
+  may raise; `start_link/1` may exit on a `GenServer.call` of its own.
+  Uncaught, that reaches the caller: the foreman itself in
+  `do_new_worker/4`, or a linked task in `try_to_start_workers/4`, which
+  signals the foreman just the same. One unstartable worker is not a
+  reason for a node to lose the workers that started fine.
+
+  The reason is kept as `{kind, reason}` — nothing reads it, but the
+  stacktrace exists nowhere else once the crash report is suppressed, and
+  a health field an operator has to go looking for is no substitute for
+  knowing which worker blew up and where.
+  """
   @spec try_to_start_worker(WorkerInfo.t(), cluster :: Cluster.t(), object_storage :: term()) ::
           WorkerInfo.t()
   def try_to_start_worker(worker_info, cluster, object_storage) do
@@ -194,6 +201,14 @@ defmodule Bedrock.Service.Foreman.StartingWorkers do
         end
       )
     end)
+  catch
+    kind, reason ->
+      Logger.error(
+        "Bedrock foreman: worker #{worker_info.id} failed to start\n" <>
+          Exception.format(kind, reason, __STACKTRACE__)
+      )
+
+      put_health(worker_info, {:failed_to_start, {kind, reason}})
   end
 
   @spec load_manifest(StartWorkerOp.t()) :: StartWorkerOp.t()

--- a/lib/bedrock/service/foreman/worker_info.ex
+++ b/lib/bedrock/service/foreman/worker_info.ex
@@ -4,9 +4,15 @@ defmodule Bedrock.Service.Foreman.WorkerInfo do
   alias Bedrock.Service.Manifest
   alias Bedrock.Service.Worker
 
+  # A start failure carries whatever explained it, and the set is open:
+  # a posix error from the working directory, a validation atom from the
+  # manifest, `:timeout` or an exit reason from the start task, or an
+  # exception raised by the worker module's own code. Nothing matches on
+  # the reason — the verdict only asks whether there IS one — so naming a
+  # closed set here would only be a claim we cannot keep.
   @type health ::
           {:ok, Worker.ref()}
-          | {:failed_to_start, File.posix() | :timeout | :already_started}
+          | {:failed_to_start, reason :: term()}
           | :stopped
   @type t :: %__MODULE__{}
   @enforce_keys [:id, :path, :health]

--- a/test/bedrock/service/foreman/spin_up_health_test.exs
+++ b/test/bedrock/service/foreman/spin_up_health_test.exs
@@ -1,6 +1,8 @@
 defmodule Bedrock.Service.Foreman.SpinUpHealthTest do
   use ExUnit.Case, async: true
 
+  import ExUnit.CaptureLog, only: [with_log: 1]
+
   alias Bedrock.Service.Foreman.Impl
   alias Bedrock.Service.Foreman.State
   alias Bedrock.Service.WorkerBehaviour
@@ -128,9 +130,11 @@ defmodule Bedrock.Service.Foreman.SpinUpHealthTest do
     end
 
     # Starting runs in a linked task, so a worker whose start RAISES used
-    # to reach the foreman as an exit signal — spin-up never returned,
-    # and every other worker on the node went down with it. One bad
-    # manifest is one bad worker.
+    # to reach the foreman as an exit signal: spin-up never returned, the
+    # foreman died, and — since it re-reads the same directory on restart
+    # — it did so again on every restart until the supervisor gave up and
+    # took the node's other workers with it. One bad manifest is one bad
+    # worker, and spin-up has to finish.
     test "a worker whose start raises does not take its siblings down", %{tmp_dir: dir} do
       start_supervised!(
         {DynamicSupervisor, strategy: :one_for_one, name: SpinUpTestCluster.otp_name(:worker_supervisor)}
@@ -139,7 +143,7 @@ defmodule Bedrock.Service.Foreman.SpinUpHealthTest do
       write_worker(dir, "aaaaaaaa")
       write_worker(dir, "bbbbbbbb", SpinUpRaisingWorker)
 
-      state = Impl.do_spin_up(base_state(dir))
+      {state, _log} = with_log(fn -> Impl.do_spin_up(base_state(dir)) end)
 
       assert %{health: {:ok, pid}} = state.workers["aaaaaaaa"]
       assert Process.alive?(pid)

--- a/test/bedrock/service/foreman/spin_up_health_test.exs
+++ b/test/bedrock/service/foreman/spin_up_health_test.exs
@@ -3,6 +3,7 @@ defmodule Bedrock.Service.Foreman.SpinUpHealthTest do
 
   alias Bedrock.Service.Foreman.Impl
   alias Bedrock.Service.Foreman.State
+  alias Bedrock.Service.WorkerBehaviour
 
   # Spin-up is where a foreman learns what it has and starts it. If the
   # verdict is not recomputed there, the foreman keeps the :starting it
@@ -23,7 +24,7 @@ defmodule Bedrock.Service.Foreman.SpinUpHealthTest do
 
   defmodule SpinUpTestWorker do
     @moduledoc false
-    use Bedrock.Service.WorkerBehaviour, kind: :log
+    use WorkerBehaviour, kind: :log
     use GenServer
 
     def child_spec(opts), do: %{id: {__MODULE__, opts[:id]}, start: {__MODULE__, :start_link, [opts]}}
@@ -33,14 +34,21 @@ defmodule Bedrock.Service.Foreman.SpinUpHealthTest do
     def init(opts), do: {:ok, opts}
   end
 
-  defp write_worker(dir, id) do
+  defmodule SpinUpRaisingWorker do
+    @moduledoc false
+    use WorkerBehaviour, kind: :log
+
+    def child_spec(_opts), do: raise("this worker cannot be started")
+  end
+
+  defp write_worker(dir, id, worker \\ SpinUpTestWorker) do
     path = Path.join(dir, id)
     File.mkdir_p!(path)
 
     File.write!(
       Path.join(path, "manifest.json"),
       ~s({"id":"#{id}","cluster":"spin_up_test_cluster",) <>
-        ~s("worker":"Bedrock.Service.Foreman.SpinUpHealthTest.SpinUpTestWorker","params":{}})
+        ~s("worker":"#{inspect(worker)}","params":{}})
     )
   end
 
@@ -117,6 +125,26 @@ defmodule Bedrock.Service.Foreman.SpinUpHealthTest do
       assert %{health: health} = Impl.do_spin_up(base_state(dir))
 
       refute health == :ok, "a worker that cannot start must not be reported as healthy"
+    end
+
+    # Starting runs in a linked task, so a worker whose start RAISES used
+    # to reach the foreman as an exit signal — spin-up never returned,
+    # and every other worker on the node went down with it. One bad
+    # manifest is one bad worker.
+    test "a worker whose start raises does not take its siblings down", %{tmp_dir: dir} do
+      start_supervised!(
+        {DynamicSupervisor, strategy: :one_for_one, name: SpinUpTestCluster.otp_name(:worker_supervisor)}
+      )
+
+      write_worker(dir, "aaaaaaaa")
+      write_worker(dir, "bbbbbbbb", SpinUpRaisingWorker)
+
+      state = Impl.do_spin_up(base_state(dir))
+
+      assert %{health: {:ok, pid}} = state.workers["aaaaaaaa"]
+      assert Process.alive?(pid)
+      assert %{health: {:failed_to_start, _reason}} = state.workers["bbbbbbbb"]
+      assert state.health == {:failed_to_start, :at_least_one_failed_to_start}
     end
   end
 end

--- a/test/bedrock/service/foreman/starting_workers_test.exs
+++ b/test/bedrock/service/foreman/starting_workers_test.exs
@@ -3,6 +3,7 @@ defmodule Bedrock.Service.Foreman.StartingWorkersTest do
 
   alias Bedrock.Service.Foreman.StartingWorkers
   alias Bedrock.Service.Foreman.StartingWorkers.StartWorkerOp
+  alias Bedrock.Service.WorkerBehaviour
 
   # Define mock modules at compile time
   defmodule MockWorker do
@@ -15,8 +16,51 @@ defmodule Bedrock.Service.Foreman.StartingWorkersTest do
 
   defmodule MockCluster do
     @moduledoc false
+    def name, do: "starting_workers_test_cluster"
     def otp_name(:foreman), do: :test_foreman
     def otp_name(:worker_supervisor), do: :test_worker_supervisor
+  end
+
+  defmodule StartsWorker do
+    @moduledoc false
+    use WorkerBehaviour, kind: :log
+    use GenServer
+
+    def child_spec(opts), do: %{id: {__MODULE__, opts[:id]}, start: {__MODULE__, :start_link, [opts]}}
+    def start_link(opts), do: GenServer.start_link(__MODULE__, opts, name: opts[:otp_name])
+
+    @impl GenServer
+    def init(opts), do: {:ok, opts}
+  end
+
+  defmodule RaisesWorker do
+    @moduledoc false
+    use WorkerBehaviour, kind: :log
+
+    def child_spec(_opts), do: raise("this worker cannot be started")
+  end
+
+  defmodule SlowWorker do
+    @moduledoc false
+    use WorkerBehaviour, kind: :log
+
+    def child_spec(_opts) do
+      Process.sleep(500)
+      %{id: __MODULE__, start: {__MODULE__, :start_link, []}}
+    end
+  end
+
+  defp write_worker(dir, id, worker) do
+    path = Path.join(dir, id)
+    File.mkdir_p!(path)
+
+    File.write!(
+      Path.join(path, "manifest.json"),
+      ~s({"id":"#{id}","cluster":"starting_workers_test_cluster",) <>
+        ~s("worker":"#{inspect(worker)}","params":{}})
+    )
+
+    StartingWorkers.worker_info_for_id(id, path, &:"starting_workers_test_#{&1}")
   end
 
   describe "build_child_spec/1" do
@@ -44,6 +88,50 @@ defmodule Bedrock.Service.Foreman.StartingWorkersTest do
       %{start: {_mod, :start_link, [opts]}} = result.child_spec
 
       assert Keyword.get(opts, :object_storage) == object_storage
+    end
+  end
+
+  describe "try_to_start_workers/4" do
+    setup %{tmp_dir: dir} do
+      start_supervised!({DynamicSupervisor, strategy: :one_for_one, name: MockCluster.otp_name(:worker_supervisor)})
+      %{dir: dir}
+    end
+
+    # Starting happens inside a linked task, so a start that raises used
+    # to reach the FOREMAN as an exit signal — before any result was
+    # mapped — and take every other worker on the node with it. The
+    # failure belongs to the one worker that could not start.
+    @tag :tmp_dir
+    test "a start that raises fails that worker alone", %{dir: dir} do
+      health =
+        [
+          write_worker(dir, "aaaaaaaa", StartsWorker),
+          write_worker(dir, "bbbbbbbb", RaisesWorker)
+        ]
+        |> StartingWorkers.try_to_start_workers(MockCluster, nil)
+        |> Map.new(&{&1.id, &1.health})
+
+      assert {:ok, pid} = health["aaaaaaaa"]
+      assert Process.alive?(pid)
+      assert {:failed_to_start, _reason} = health["bbbbbbbb"]
+    end
+
+    # The timeout is the reachable half: a worker that opens a WAL and
+    # preallocates segments is exactly the one that overruns, and the
+    # overrun is not a diagnosis of the whole node.
+    @tag :tmp_dir
+    test "a start that overruns the timeout fails that worker alone", %{dir: dir} do
+      health =
+        [
+          write_worker(dir, "cccccccc", StartsWorker),
+          write_worker(dir, "dddddddd", SlowWorker)
+        ]
+        |> StartingWorkers.try_to_start_workers(MockCluster, nil, 50)
+        |> Map.new(&{&1.id, &1.health})
+
+      assert {:ok, pid} = health["cccccccc"]
+      assert Process.alive?(pid)
+      assert {:failed_to_start, :timeout} = health["dddddddd"]
     end
   end
 end

--- a/test/bedrock/service/foreman/starting_workers_test.exs
+++ b/test/bedrock/service/foreman/starting_workers_test.exs
@@ -1,6 +1,8 @@
 defmodule Bedrock.Service.Foreman.StartingWorkersTest do
   use ExUnit.Case, async: true
 
+  import ExUnit.CaptureLog, only: [with_log: 1]
+
   alias Bedrock.Service.Foreman.StartingWorkers
   alias Bedrock.Service.Foreman.StartingWorkers.StartWorkerOp
   alias Bedrock.Service.WorkerBehaviour
@@ -45,7 +47,7 @@ defmodule Bedrock.Service.Foreman.StartingWorkersTest do
     use WorkerBehaviour, kind: :log
 
     def child_spec(_opts) do
-      Process.sleep(500)
+      Process.sleep(2_000)
       %{id: __MODULE__, start: {__MODULE__, :start_link, []}}
     end
   end
@@ -98,36 +100,42 @@ defmodule Bedrock.Service.Foreman.StartingWorkersTest do
     end
 
     # Starting happens inside a linked task, so a start that raises used
-    # to reach the FOREMAN as an exit signal — before any result was
-    # mapped — and take every other worker on the node with it. The
-    # failure belongs to the one worker that could not start.
+    # to reach the CALLER as an exit signal — before any result was
+    # mapped — and there is no result at all for the workers that started
+    # fine. The exception is the one worker's, and so is the verdict.
     @tag :tmp_dir
     test "a start that raises fails that worker alone", %{dir: dir} do
-      health =
-        [
-          write_worker(dir, "aaaaaaaa", StartsWorker),
-          write_worker(dir, "bbbbbbbb", RaisesWorker)
-        ]
-        |> StartingWorkers.try_to_start_workers(MockCluster, nil)
-        |> Map.new(&{&1.id, &1.health})
+      {health, _log} =
+        with_log(fn ->
+          [
+            write_worker(dir, "aaaaaaaa", StartsWorker),
+            write_worker(dir, "bbbbbbbb", RaisesWorker)
+          ]
+          |> StartingWorkers.try_to_start_workers(MockCluster, nil)
+          |> Map.new(&{&1.id, &1.health})
+        end)
 
       assert {:ok, pid} = health["aaaaaaaa"]
       assert Process.alive?(pid)
-      assert {:failed_to_start, _reason} = health["bbbbbbbb"]
+
+      assert {:failed_to_start, {:error, %RuntimeError{message: "this worker cannot be started"}}} =
+               health["bbbbbbbb"]
     end
 
-    # The timeout is the reachable half: a worker that opens a WAL and
-    # preallocates segments is exactly the one that overruns, and the
-    # overrun is not a diagnosis of the whole node.
+    # The timeout is the half that needs no bug at all to reach: a worker
+    # that opens a WAL and preallocates segments is exactly the one that
+    # overruns, and an overrun is not a diagnosis of the whole node.
     @tag :tmp_dir
     test "a start that overruns the timeout fails that worker alone", %{dir: dir} do
-      health =
-        [
-          write_worker(dir, "cccccccc", StartsWorker),
-          write_worker(dir, "dddddddd", SlowWorker)
-        ]
-        |> StartingWorkers.try_to_start_workers(MockCluster, nil, 50)
-        |> Map.new(&{&1.id, &1.health})
+      {health, _log} =
+        with_log(fn ->
+          [
+            write_worker(dir, "cccccccc", StartsWorker),
+            write_worker(dir, "dddddddd", SlowWorker)
+          ]
+          |> StartingWorkers.try_to_start_workers(MockCluster, nil, 200)
+          |> Map.new(&{&1.id, &1.health})
+        end)
 
       assert {:ok, pid} = health["cccccccc"]
       assert Process.alive?(pid)


### PR DESCRIPTION
The foreman started its workers inside a `Task.async_stream`, whose tasks are linked to the caller, so a worker whose start raised or merely took too long killed the foreman, and after a crash loop cost the node every other worker. A failed start is now recorded as `{:failed_to_start, reason}` against the worker it belongs to.

Ticket: bedrock-jq8

## Why

A foreman owns every log and materializer worker on a node. At boot, from inside a `handle_continue`, it reads each worker directory's manifest and concurrently starts the module it names.

Two ways out of that were fatal. A `child_spec/1` or `start_link/1` that raised took the linked task down, and the exit signal reached the foreman, which does not trap exits. And `Task.async_stream` defaults to `on_timeout: :exit`, which exits the caller after five seconds. Either way nothing was mapped, so the workers that started fine produced no result either.

The foreman and the worker `DynamicSupervisor` are `:one_for_one` siblings, so the running workers do not die with the foreman directly. Spin-up re-reads the same directory on restart and stalls on the same worker, so the foreman crash-loops until restart intensity gives out and the parent escalates, taking every worker with it.

The timeout half needs no bug at all: Shale opens its WAL and may preallocate segments before init returns, and every worker starts at once, so five seconds on a cold, loaded node is reachable by a worker starting perfectly well.

The ticket predicted a `CaseClauseError` from the map's unreachable `{:error, _}` clause. The clause was indeed dead, but it was never the failure: the exit signal arrived first.

## What changed

- `try_to_start_worker/3` wraps its pipeline in a `catch`, records `{:failed_to_start, {kind, reason}}`, and logs the formatted stacktrace, which exists nowhere else now.
- The stream passes `on_timeout: :kill_task` and `zip_input_on_exit: true`; the dead clause becomes `{:exit, {worker_info, reason}}` with a `Logger.error`.
- The timeout goes from 5s to 30s, a defaulted fourth parameter no caller in `lib/` sets.
- `WorkerInfo`'s failure reason widens to `term()`; nothing matches on it.

The catch sits in the single-worker function so `do_new_worker/4`, which calls it from a `handle_call`, is covered too. Deliberately unchanged: the foreman still does not trap exits, and a failed start is not retried.

## How it works

A directory naming a module whose `child_spec/1` raises now comes back as a health like any other result:

```elixir
state.workers["aaaaaaaa"].health  #=> {:ok, #PID<0.496.0>}
state.workers["bbbbbbbb"].health  #=> {:failed_to_start, {:error, %RuntimeError{}}}
state.health                      #=> {:failed_to_start, :at_least_one_failed_to_start}
```

An overrun cannot be caught from inside the task, so the stream handles it. `:kill_task` yields a result rather than exiting the caller, and `zip_input_on_exit` carries the input back with the reason, which is the only way the map learns whose timeout it was. Advertising and monitoring act only on `{:ok, pid}`, so a failed worker is neither published nor watched.

## Verification

Three tests. A raising start and a slow start each fail alone while their sibling comes back `{:ok, pid}` and alive; on develop the first kills the caller with the raised exception as an exit signal, the second with a `Task.Supervised.stream` timeout. An end-to-end spin-up leaves the node at `{:failed_to_start, :at_least_one_failed_to_start}`. Each was checked non-vacuous by reverting the fix. CI green; cold audit PASS-WITH-NOTES, addressed.

Follow-up: bedrock-gu0.6, a killed start can leave a live unmonitored worker.
