### PR TITLE
bedrock-ck3: Reclaim scratch files left by a killed object-storage writer

### DIFF
--- a/lib/bedrock/object_storage/local_filesystem.ex
+++ b/lib/bedrock/object_storage/local_filesystem.ex
@@ -31,12 +31,16 @@ defmodule Bedrock.ObjectStorage.LocalFilesystem do
 
   In-process failures clean up after themselves. A process killed
   between the scratch write and the publish cannot, so its scratch file
-  survives — full size, hidden from `list/3`, and reclaimed by nothing.
-  That is the deliberate trade: before, the same crash left wreckage
-  visible under the real key, where it was permanent and poisonous;
-  now it is inert but invisible. Reclaiming it needs a sweep that can
-  tell a dead scratch file from a live writer's, which is a separate
-  piece of work (bedrock-ck3).
+  survives — full size and hidden from `list/3`. It is reclaimed the
+  next time anything writes into the same directory: before opening a
+  new scratch file, that directory is swept for scratch files old
+  enough to predate any plausible in-flight write, and those are
+  deleted outright. A scratch file within the window is left alone,
+  since age is a heuristic, not a signal, and deleting a live writer's
+  scratch file would corrupt its write — a slow enough write can in
+  principle outlive the window, trading a bounded, self-inflicted leak
+  for never touching a write that might still be running. This backend
+  is not the production path (S3 has no scratch state to leak).
 
   ## Durability boundary
 
@@ -75,6 +79,12 @@ defmodule Bedrock.ObjectStorage.LocalFilesystem do
   # repeatedly, which is not a real filesystem state — surfacing :eexist
   # beats looping.
   @scratch_attempts 5
+
+  # A scratch file this old cannot belong to a write still in progress
+  # in any realistic scenario, and is reclaimed on sight. Anything
+  # younger is left alone: age is a heuristic, not proof of death, and
+  # deleting a live writer's scratch file would corrupt that write.
+  @scratch_reap_after_seconds 3_600
 
   @impl true
   def put(config, key, data, _opts \\ []) do
@@ -221,6 +231,8 @@ defmodule Bedrock.ObjectStorage.LocalFilesystem do
   # retry can still take it.
   @spec write_scratch(Path.t(), iodata()) :: {:ok, Path.t()} | {:error, File.posix()}
   defp write_scratch(path, data) do
+    path |> Path.dirname() |> reap_stale_scratch_files()
+
     # :exclusive makes the kernel arbitrate the scratch name, which is the
     # only thing that can. A root directory is routinely shared by more
     # than one node — the default one (`ObjectStorage.Config`) is derived
@@ -273,6 +285,38 @@ defmodule Bedrock.ObjectStorage.LocalFilesystem do
   end
 
   defp scratch_file?(path), do: path |> Path.basename() |> String.starts_with?(@scratch_prefix)
+
+  # Reclaims stale scratch wreckage from `dir` before a new scratch file
+  # is opened there. This is the only reclamation path: it costs nothing
+  # when there is nothing to reap, and it runs at the one moment a dead
+  # scratch file would otherwise collide with something — a retry
+  # writing into the same directory.
+  @spec reap_stale_scratch_files(Path.t()) :: :ok
+  defp reap_stale_scratch_files(dir) do
+    case File.ls(dir) do
+      {:ok, entries} ->
+        entries
+        |> Enum.filter(&String.starts_with?(&1, @scratch_prefix))
+        |> Enum.each(fn name ->
+          path = Path.join(dir, name)
+
+          if stale_scratch?(path) do
+            _ = File.rm(path)
+          end
+        end)
+
+      {:error, _reason} ->
+        :ok
+    end
+  end
+
+  @spec stale_scratch?(Path.t()) :: boolean()
+  defp stale_scratch?(path) do
+    case File.stat(path, time: :posix) do
+      {:ok, %File.Stat{mtime: mtime}} -> System.system_time(:second) - mtime >= @scratch_reap_after_seconds
+      {:error, _reason} -> false
+    end
+  end
 
   # List state: {root, dirs_to_visit, files_collected, prefix, remaining_limit}
   defp init_list_state(root, prefix_path, prefix, limit) do

--- a/test/bedrock/object_storage/local_filesystem_atomicity_test.exs
+++ b/test/bedrock/object_storage/local_filesystem_atomicity_test.exs
@@ -182,4 +182,61 @@ defmodule Bedrock.ObjectStorage.LocalFilesystemAtomicityTest do
              "a failed overwrite must not destroy the object it was replacing"
     end
   end
+
+  describe "reclaiming scratch files left by a killed writer" do
+    # A process killed between the scratch write and the publish leaves
+    # its scratch file behind at full payload size. list/3 already hides
+    # it (tested above), but hiding it is not reclaiming it — nothing
+    # freed the disk space. bedrock-ck3.
+
+    # Plants a scratch file using the writer's exact naming scheme
+    # (see open_scratch/2 in local_filesystem.ex), backdated to `age`
+    # seconds old.
+    defp plant_scratch(root, key, age_seconds) do
+      dir = Path.join(root, Path.dirname(key))
+      File.mkdir_p!(dir)
+
+      scratch =
+        Path.join(
+          dir,
+          ".bedrock-tmp.#{Path.basename(key)}.#{node()}.#{System.pid()}.#{:erlang.unique_integer([:positive])}"
+        )
+
+      File.write!(scratch, :binary.copy(<<0>>, 1024))
+      File.touch!(scratch, System.os_time(:second) - age_seconds)
+      scratch
+    end
+
+    test "a scratch file older than the reap window is deleted by the next write into its directory", %{
+      backend: backend,
+      root: root
+    } do
+      stale = plant_scratch(root, "c/0/obj", 7_200)
+
+      assert File.exists?(stale), "the wreckage must exist before the fix can be judged"
+
+      :ok = ObjectStorage.put(backend, "c/0/other", "payload")
+
+      refute File.exists?(stale),
+             "a scratch file old enough to predate any plausible in-flight write must be reclaimed"
+    end
+
+    test "a fresh scratch file is left alone by a write into its directory", %{backend: backend, root: root} do
+      fresh = plant_scratch(root, "c/0/obj", 5)
+
+      :ok = ObjectStorage.put(backend, "c/0/other", "payload")
+
+      assert File.exists?(fresh), "a scratch file young enough to be a live writer's must not be touched"
+    end
+
+    test "reclaiming stale scratch files never removes a real object", %{backend: backend, root: root} do
+      :ok = ObjectStorage.put(backend, "c/0/obj", "payload")
+      stale = plant_scratch(root, "c/0/obj", 7_200)
+
+      :ok = ObjectStorage.put(backend, "c/0/other", "payload")
+
+      refute File.exists?(stale)
+      assert {:ok, "payload"} = ObjectStorage.get(backend, "c/0/obj")
+    end
+  end
 end


### PR DESCRIPTION
A local-filesystem writer killed between fsyncing its scratch file and publishing it leaves that scratch file behind at full payload size, hidden from listing and reclaimed by nothing. The writer now sweeps the target directory for scratch files older than one hour and deletes them before it opens a new scratch file, so the next write into a directory reclaims any wreckage there while leaving anything young enough to be a live write untouched.

Ticket: bedrock-ck3

## Why

`LocalFilesystem` makes every write all-or-nothing: the payload goes to a scratch file named `.bedrock-tmp.<basename>.<node>.<ospid>.<n>` in the target's own directory, is fsynced, and is published in one step, by rename for a plain put and by hard link for a create-only put. That keeps a crash from leaving a short object under a real key, where a create-only put would answer already-exists forever and the chunk and snapshot writers would read that as success.

The trade it accepted is the kill window. Every in-process failure removes its scratch file; a process killed between the fsync and the publish cannot. The bedrock-ghd audit measured it: killing a writer mid-put of a 300 MB payload left a full-size scratch file whose prefix listing returned nothing. Listing hides scratch files by design, delete is key-addressed, and the only reclamation routine walks the listing, so the file is unreachable. A crash loop accumulates them without bound.

Liveness checks on the embedded node and pid, an in-flight registry, or a sweep at backend start would all be heavier than a stateless dev/test backend warrants, so age is the signal.

## What changed

Before opening a scratch file, `write_scratch/2` lists the target directory, keeps only entries with the scratch prefix, stats each one, and removes those whose mtime is at least `@scratch_reap_after_seconds` (3600) in the past. A listing error, a stat error, or a remove error is ignored, so reclamation can never turn a healthy write into a failure. The moduledoc section on killed writers now describes this behaviour and its limits.

Nothing else changes: no configuration knob, no startup sweep, no liveness check, and no change to the public behaviour or its return values. S3 is untouched, since an aborted PUT there leaves nothing.

## How it works

The sweep is attached to the one moment the backend is guaranteed to have code running in a given directory: a new write into it. It considers only the immediate directory, never recurses, and never touches an entry without the scratch prefix, so real objects are not candidates at any age.

```
c/0/.bedrock-tmp.00000000000rs.node@host.4242.17   mtime 2h ago  -> removed
c/0/.bedrock-tmp.00000000000rt.node@host.4242.18   mtime 10s ago -> kept
c/0/00000000000rq                                  (real object) -> never considered
```

Only a write that actually opens a scratch file triggers the sweep. A create-only put whose key already exists returns already-exists from its advisory existence check before reaching `write_scratch/2`, so the ordinary idempotent re-put of an existing chunk does not sweep. A directory never written to again keeps its wreckage; the ticket accepted that as bounded by crash frequency.

Age errs toward leaking rather than corrupting: deleting a live writer's scratch file would unlink the inode under an open descriptor and fail its publish. An hour is far beyond any plausible single write here. Concurrent sweeps are safe, since a stat or remove that loses the race is ignored.

## Verification

Three new tests plant a scratch file with the writer's exact naming scheme and backdate it. One backdated two hours is gone after the next put into its directory, which fails on unmodified `develop`. One backdated five seconds survives. A stale scratch file beside a real object is removed while the object still reads back. CI is green on OTP 27, 28 and 29 and the S3 MinIO job.

No follow-up tickets.
