### PR TITLE
bedrock-ljh: refuse a non-monotonic commit version in IndexManager.apply_transaction/3

### DIFF
--- a/lib/bedrock/data_plane/materializer/olivine/index_manager.ex
+++ b/lib/bedrock/data_plane/materializer/olivine/index_manager.ex
@@ -180,13 +180,29 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.IndexManager do
   Creates a new version and applies all mutations in the transaction.
   Uses a two-pass approach: first collect all instructions, then process each page.
   """
-  @spec apply_transaction(t(), binary(), Database.t()) :: {t(), Database.t()}
+  @spec apply_transaction(t(), binary(), Database.t()) :: {t(), Database.t()} | no_return()
   def apply_transaction(
         %{versions: [{_version, {current_index, _prev_modified}} | _]} = index_manager,
         transaction,
         database
       ) do
     commit_version = Transaction.commit_version!(transaction)
+
+    # The applied position only ever advances. Every rewind rejoins the
+    # stream strictly above it — recovery unlock resumes at
+    # `Version.increment(current_version)` and so does the compaction
+    # cutover (`streaming.ex:65`, `logic.ex:238`, `server.ex:528`) — so
+    # neither a re-delivered nor an out-of-order commit version can reach
+    # here. This is an assertion, not a guard: `versions` is descending by
+    # construction and `find_target/2`, `rollback_to/2` and the eviction
+    # queue all read it that way, so prepending a version at or below the
+    # head corrupts the MVCC window silently rather than crashing. FDB
+    # asserts the same thing on the same edge —
+    # `ASSERT(cloneCursor2->version().version > data->version.get())`,
+    # `storageserver.actor.cpp:12318`.
+    if commit_version <= index_manager.current_version do
+      exit({:non_monotonic_commit_version, %{applied: index_manager.current_version, got: commit_version}})
+    end
 
     update =
       current_index

--- a/lib/bedrock/data_plane/materializer/olivine/index_manager.ex
+++ b/lib/bedrock/data_plane/materializer/olivine/index_manager.ex
@@ -188,16 +188,17 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.IndexManager do
       ) do
     commit_version = Transaction.commit_version!(transaction)
 
-    # The applied position only ever advances. Every rewind rejoins the
-    # stream strictly above it — recovery unlock resumes at
-    # `Version.increment(current_version)` and so does the compaction
-    # cutover (`streaming.ex:65`, `logic.ex:238`, `server.ex:528`) — so
-    # neither a re-delivered nor an out-of-order commit version can reach
-    # here. This is an assertion, not a guard: `versions` is descending by
-    # construction and `find_target/2`, `rollback_to/2` and the eviction
-    # queue all read it that way, so prepending a version at or below the
-    # head corrupts the MVCC window silently rather than crashing. FDB
-    # asserts the same thing on the same edge —
+    # The applied position only ever advances. Every rewind — recovery
+    # unlock and the compaction cutover alike — hands the applied version
+    # to `Streaming.start_pulling/4`, which joins at
+    # `Version.increment/1` of it, and `ShardServer.pull/3` is inclusive
+    # of its `from_version`; so neither a re-delivered nor an
+    # out-of-order commit version can reach here. This is an assertion,
+    # not a guard: `versions` is descending by construction and
+    # `find_target/2`, `rollback_to/2` and the eviction queue all read it
+    # that way, so prepending a version at or below the head corrupts the
+    # MVCC window silently rather than crashing. FDB asserts the same
+    # thing on the same edge —
     # `ASSERT(cloneCursor2->version().version > data->version.get())`,
     # `storageserver.actor.cpp:12318`.
     if commit_version <= index_manager.current_version do

--- a/test/bedrock/data_plane/materializer/olivine/index_manager_test.exs
+++ b/test/bedrock/data_plane/materializer/olivine/index_manager_test.exs
@@ -668,6 +668,61 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.IndexManagerTest do
     end
   end
 
+  describe "commit version monotonicity" do
+    test "a commit version below the applied version is refused" do
+      db = create_test_database()
+
+      try do
+        v10 = Version.from_integer(10_000)
+        v5 = Version.from_integer(5_000)
+
+        {im, db} =
+          IndexManager.apply_transaction(IndexManager.new(), test_transaction([{:set, "a", "1"}], v10), db)
+
+        assert catch_exit(IndexManager.apply_transaction(im, test_transaction([{:set, "a", "2"}], v5), db)) ==
+                 {:non_monotonic_commit_version, %{applied: v10, got: v5}}
+      after
+        Database.close(db)
+      end
+    end
+
+    test "the applied commit version re-presented is refused" do
+      db = create_test_database()
+
+      try do
+        v10 = Version.from_integer(10_000)
+
+        {im, db} =
+          IndexManager.apply_transaction(IndexManager.new(), test_transaction([{:set, "a", "1"}], v10), db)
+
+        assert catch_exit(IndexManager.apply_transaction(im, test_transaction([{:set, "b", "2"}], v10), db)) ==
+                 {:non_monotonic_commit_version, %{applied: v10, got: v10}}
+      after
+        Database.close(db)
+      end
+    end
+
+    test "a batch stops at the offending transaction, leaving the chain intact" do
+      db = create_test_database()
+
+      try do
+        v10 = Version.from_integer(10_000)
+        v20 = Version.from_integer(20_000)
+
+        transactions = [
+          test_transaction([{:set, "a", "1"}], v10),
+          test_transaction([{:set, "b", "2"}], v20),
+          test_transaction([{:set, "c", "3"}], v10)
+        ]
+
+        assert catch_exit(IndexManager.apply_transactions(IndexManager.new(), transactions, db)) ==
+                 {:non_monotonic_commit_version, %{applied: v20, got: v10}}
+      after
+        Database.close(db)
+      end
+    end
+  end
+
   describe "version management and windowing" do
     test "version_in_window?/2 correctly identifies versions in window" do
       window_start = Version.from_integer(5_000_000)

--- a/test/bedrock/data_plane/materializer/olivine/index_manager_test.exs
+++ b/test/bedrock/data_plane/materializer/olivine/index_manager_test.exs
@@ -702,7 +702,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.IndexManagerTest do
       end
     end
 
-    test "a batch stops at the offending transaction, leaving the chain intact" do
+    test "a batch stops at the offending transaction" do
       db = create_test_database()
 
       try do

--- a/test/bedrock/data_plane/materializer/olivine/persistence_integration_test.exs
+++ b/test/bedrock/data_plane/materializer/olivine/persistence_integration_test.exs
@@ -156,9 +156,11 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.PersistenceIntegrationTest do
       {index_manager_with_both, database_with_both} =
         IndexManager.apply_transactions(index_manager_with_old, [recent_transaction], database_with_old)
 
-      # Create many more transactions to fill the buffer tracking queue
+      # Create many more transactions to fill the buffer tracking queue.
+      # They continue above the recent transaction: the applied position
+      # only ever advances.
       buffer_fill_transactions =
-        for i <- 2..50 do
+        for i <- 1001..1049 do
           create_transaction([{:set, "key_#{i}", "value_#{i}"}], i)
         end
 


### PR DESCRIPTION
The Olivine materializer keeps its in-memory MVCC state as a version chain that every reader assumes is strictly descending, but nothing checked that an applied transaction actually advanced it. A re-delivered or out-of-order commit version would have been prepended anyway, corrupting snapshot reads and rollbacks without a crash. `apply_transaction/3` now exits with a named reason when the commit version is at or below the applied position.

Ticket: bedrock-ljh
Stacked on: #262 (bedrock-q67.19/olivine-clear-range-exclusive-end)

## Why

The index manager holds `{commit_version, index}` entries newest first, plus a mirror of the head version. Snapshot lookup takes the first entry at or below the read version; rollback strips entries above the target and returns unchanged when the head is already at or below it; window eviction reads the chain the same way.

With v10000 applied and then v5000 delivered, the chain becomes `[5000, 10000, 0]` and the head mirror regresses to 5000. A read at v10000 that succeeded a moment earlier is refused as too new. A read at v5000 lands on the head entry, whose index includes v10000's writes, so the snapshot leaks a later version. A rollback to v7000 returns the manager untouched, leaving the v10000 entry alive. All three are silent.

No current path can deliver such a transaction. Both rewinds, recovery unlock and the compaction cutover, hand the applied version to the stream puller, which joins one version above it, and the shard server's pull is inclusive of its start. Heartbeats only synthesize versions above the puller's position, and an ingest from a superseded puller is discarded by pid. The hazard is latent, which is exactly when silent corruption deserves an assertion.

## What changed

`apply_transaction/3` compares the incoming commit version against the applied position before any page work and exits with `{:non_monotonic_commit_version, %{applied: ..., got: ...}}` unless it is strictly greater. Equal is refused rather than treated as an idempotent replay: no legitimate path re-presents the applied version, so accepting it would hide the same bug class. One integration test that filled its buffer with versions below an earlier transaction now uses ascending versions.

`rollback_to/2`, database recovery, and the compaction cutover are untouched; each lands on an existing entry or builds a fresh single-entry chain. The `n_keys` double-count in the ticket no longer applies on this stack, where the count is a delta from live page state (#253).

## How it works

The invariant is that the applied position only advances, enforced at the single point where the chain grows. The check runs before the index update is built, so a refused transaction leaves the manager, id allocator, and data file untouched. For a batch, the fold stops at the first offender and reports the last version applied.

FoundationDB's storage server asserts the same edge (`version > data->version.get()`), and crashing into recovery is the intended outcome here too: the only production caller is the materializer server's apply loop, and an exit there restarts the worker.

## Verification

Three new unit tests cover a lower version, the applied version re-presented, and a batch of `[v10, v20, v10]` that must exit naming `applied: v20`. All three fail on the base with nothing caught. Full suite, format, credo, and dialyzer were reported clean; no CI checks run on the stacked branch.

The adjusted eviction integration test still never reaches its evict branch: the window edge underflows at versions near zero, and the branch matches a 3-tuple against a 5-tuple return. Follow-up: bedrock-v4e, dead eviction branch in the persistence test.
