### PR TITLE
bedrock-vih: publish preallocated segments atomically and prove pool membership

### DIFF
--- a/lib/bedrock/data_plane/log/shale/segment_recycler.ex
+++ b/lib/bedrock/data_plane/log/shale/segment_recycler.ex
@@ -80,6 +80,10 @@ defmodule Bedrock.DataPlane.Log.Shale.SegmentRecycler do
     @spec generate_unused_file_name(non_neg_integer()) :: String.t()
     def generate_unused_file_name(id), do: "#{unused_file_prefix()}.#{id}"
 
+    # A segment is preallocated under this name and published into the
+    # pool by rename, so it must not match the pool's own glob.
+    @scratch_prefix ".partial."
+
     @spec new(
             path_to_dir :: binary(),
             size :: non_neg_integer(),
@@ -101,7 +105,13 @@ defmodule Bedrock.DataPlane.Log.Shale.SegmentRecycler do
           {:error, :path_is_not_a_directory}
 
         true ->
-          segments = find_existing_preallocated_files(path_to_dir)
+          discard_scratch_files(path_to_dir)
+
+          segments =
+            path_to_dir
+            |> find_existing_preallocated_files()
+            |> adopt_whole_segments(size)
+
           highest_id = find_highest_id(segments)
 
           {:ok,
@@ -134,6 +144,40 @@ defmodule Bedrock.DataPlane.Log.Shale.SegmentRecycler do
     @spec find_existing_preallocated_files(dir_path :: binary()) ::
             [path_to_file :: String.t()]
     def find_existing_preallocated_files(path), do: Path.wildcard(Path.join(path, "#{unused_file_prefix()}.*"))
+
+    # Membership in the pool has to be provable, not inferred from the
+    # name — the same reasoning that makes a manifest, not a directory
+    # entry, the proof that a worker directory holds a worker.
+    # `check_out/2` renames a pooled file straight into service and
+    # `Writer.open/3` derives its write budget from `File.stat/1`, so a
+    # file that is not exactly one segment long would present as a
+    # healthy segment carrying a budget it cannot honour. Discard it and
+    # let the min-refill preallocate a real one in its place.
+    @spec adopt_whole_segments([String.t()], non_neg_integer()) :: [String.t()]
+    defp adopt_whole_segments(paths, size) do
+      Enum.filter(paths, fn path ->
+        case File.stat(path) do
+          {:ok, %{size: ^size}} ->
+            true
+
+          _not_a_whole_segment ->
+            _ = File.rm(path)
+            false
+        end
+      end)
+    end
+
+    # The pool directory has exactly one owner — the recycler of the log
+    # worker that owns the directory — so a scratch file present at
+    # startup is always wreckage from an incarnation that died mid
+    # allocation, never a live writer's.
+    @spec discard_scratch_files(dir_path :: binary()) :: :ok
+    defp discard_scratch_files(path) do
+      path
+      |> Path.join("#{@scratch_prefix}*")
+      |> Path.wildcard(match_dot: true)
+      |> Enum.each(&File.rm/1)
+    end
 
     @spec check_out(State.t(), new_name :: String.t()) ::
             {:ok, State.t()}
@@ -199,19 +243,32 @@ defmodule Bedrock.DataPlane.Log.Shale.SegmentRecycler do
       |> Enum.max()
     end
 
+    # Preallocation is create-then-extend, so the file exists at zero
+    # length before it is a segment. Doing that under a scratch name and
+    # publishing by rename only once it is fully sized and synced keeps
+    # the partial state out of the pool: an :enospc, or a kill between
+    # the two steps, leaves a scratch file the next incarnation sweeps,
+    # never a `preallocated.N` the next incarnation adopts as a whole
+    # segment it does not have. Same publish-atomically shape as
+    # `LocalFilesystem.put/4`, and with the same caveat — the content is
+    # synced but the parent directory entry cannot be, so a power loss
+    # can lose the rename and leave the pool short, which the min-refill
+    # already handles.
     @spec allocate_file(String.t(), non_neg_integer()) :: {:ok, String.t()} | {:error, atom()}
     def allocate_file(path, size_in_bytes) do
-      case File.open(path, [:write, :binary, :raw, :exclusive]) do
+      scratch = scratch_path(path)
+
+      case File.open(scratch, [:write, :binary, :raw, :exclusive]) do
         {:ok, fd} ->
           # Ensure fd is always closed, even if allocate fails
-          try do
-            case :file.allocate(fd, 0, size_in_bytes) do
-              :ok -> {:ok, path}
-              {:error, reason} -> {:error, reason}
+          result =
+            try do
+              with :ok <- :file.allocate(fd, 0, size_in_bytes), do: :file.sync(fd)
+            after
+              File.close(fd)
             end
-          after
-            File.close(fd)
-          end
+
+          publish(result, scratch, path)
 
         {:error, :eisdir} ->
           raise "not implemented"
@@ -222,6 +279,25 @@ defmodule Bedrock.DataPlane.Log.Shale.SegmentRecycler do
         {:error, reason} ->
           {:error, reason}
       end
+    end
+
+    @spec scratch_path(String.t()) :: String.t()
+    defp scratch_path(path), do: Path.join(Path.dirname(path), "#{@scratch_prefix}#{Path.basename(path)}")
+
+    @spec publish(:ok | {:error, atom()}, String.t(), String.t()) :: {:ok, String.t()} | {:error, atom()}
+    defp publish(:ok, scratch, path) do
+      case File.rename(scratch, path) do
+        :ok -> {:ok, path}
+        {:error, reason} -> discard_scratch(scratch, reason)
+      end
+    end
+
+    defp publish({:error, reason}, scratch, _path), do: discard_scratch(scratch, reason)
+
+    @spec discard_scratch(String.t(), atom()) :: {:error, atom()}
+    defp discard_scratch(scratch, reason) do
+      _ = File.rm(scratch)
+      {:error, reason}
     end
   end
 

--- a/lib/bedrock/data_plane/log/shale/segment_recycler.ex
+++ b/lib/bedrock/data_plane/log/shale/segment_recycler.ex
@@ -75,14 +75,16 @@ defmodule Bedrock.DataPlane.Log.Shale.SegmentRecycler do
   defmodule Logic do
     @moduledoc false
 
+    # A segment is preallocated under this name and published into the
+    # pool by rename, so it must match neither the pool's own glob nor
+    # `Segment.file_prefix()`, which is what `reload_segments_at_path/1`
+    # picks out of this same directory.
+    @scratch_prefix ".partial."
+
     @spec unused_file_prefix() :: String.t()
     def unused_file_prefix, do: "preallocated"
     @spec generate_unused_file_name(non_neg_integer()) :: String.t()
     def generate_unused_file_name(id), do: "#{unused_file_prefix()}.#{id}"
-
-    # A segment is preallocated under this name and published into the
-    # pool by rename, so it must not match the pool's own glob.
-    @scratch_prefix ".partial."
 
     @spec new(
             path_to_dir :: binary(),
@@ -151,20 +153,22 @@ defmodule Bedrock.DataPlane.Log.Shale.SegmentRecycler do
     # `check_out/2` renames a pooled file straight into service and
     # `Writer.open/3` derives its write budget from `File.stat/1`, so a
     # file that is not exactly one segment long would present as a
-    # healthy segment carrying a budget it cannot honour. Discard it and
-    # let the min-refill preallocate a real one in its place.
+    # healthy segment carrying a budget it cannot honour.
+    #
+    # Reachable from three directions, which is why both entrances to the
+    # pool check: a `preallocated.N` left short on disk by a version
+    # without the atomic publish below, a `segment_size` changed between
+    # incarnations, and a short segment handed back to `check_in/2`.
+    # Discard it and let the min-refill preallocate a real one in its
+    # place — the pool is a cache, so discarding is free.
+    @spec whole_segment?(String.t(), non_neg_integer()) :: boolean()
+    defp whole_segment?(path, size), do: match?({:ok, %{size: ^size}}, File.stat(path))
+
     @spec adopt_whole_segments([String.t()], non_neg_integer()) :: [String.t()]
     defp adopt_whole_segments(paths, size) do
-      Enum.filter(paths, fn path ->
-        case File.stat(path) do
-          {:ok, %{size: ^size}} ->
-            true
-
-          _not_a_whole_segment ->
-            _ = File.rm(path)
-            false
-        end
-      end)
+      {whole, wreckage} = Enum.split_with(paths, &whole_segment?(&1, size))
+      Enum.each(wreckage, &File.rm/1)
+      whole
     end
 
     # The pool directory has exactly one owner — the recycler of the log
@@ -205,11 +209,22 @@ defmodule Bedrock.DataPlane.Log.Shale.SegmentRecycler do
       with :ok <- File.rm(path_to_file), do: {:ok, t}
     end
 
+    # Ordinarily every returned file came out of `check_out/2` and is
+    # still exactly `size` bytes. A log recovering over the wreckage a
+    # pre-atomic-publish version left behind is the exception: the
+    # 28-byte stub a zero-length pool file becomes once `Writer.open/3`
+    # has put a header on it loads as a segment, and
+    # `Recovery.discard_all_segments/1` checks it straight back in. Take
+    # the same exit as the cap: unlink it rather than pool it.
     def check_in(t, path_to_file) do
-      new_path_to_file = Path.join(t.path, generate_unused_file_name(t.next_id))
+      if whole_segment?(path_to_file, t.size) do
+        new_path_to_file = Path.join(t.path, generate_unused_file_name(t.next_id))
 
-      with :ok <- File.rename(path_to_file, new_path_to_file) do
-        {:ok, %{t | segments: [new_path_to_file | t.segments], next_id: t.next_id + 1}}
+        with :ok <- File.rename(path_to_file, new_path_to_file) do
+          {:ok, %{t | segments: [new_path_to_file | t.segments], next_id: t.next_id + 1}}
+        end
+      else
+        with :ok <- File.rm(path_to_file), do: {:ok, t}
       end
     end
 
@@ -250,10 +265,23 @@ defmodule Bedrock.DataPlane.Log.Shale.SegmentRecycler do
     # the two steps, leaves a scratch file the next incarnation sweeps,
     # never a `preallocated.N` the next incarnation adopts as a whole
     # segment it does not have. Same publish-atomically shape as
-    # `LocalFilesystem.put/4`, and with the same caveat — the content is
-    # synced but the parent directory entry cannot be, so a power loss
-    # can lose the rename and leave the pool short, which the min-refill
-    # already handles.
+    # `LocalFilesystem.put/4`, and with the same caveat — the extent is
+    # synced but the parent directory entry cannot be from the BEAM, so
+    # a power loss can lose the rename and leave the pool short, which
+    # the min-refill already handles.
+    #
+    # The sync is what lets a pool file survive a power loss instead of
+    # being discarded and reallocated by the next incarnation's scan; it
+    # costs single-digit milliseconds of metadata, off the reply path.
+    #
+    # The scratch name is fixed rather than kernel-arbitrated the way
+    # `LocalFilesystem` needs — its root has many writers; this pool
+    # directory has exactly one — and a leftover would wedge the
+    # :exclusive open only until the stop-and-restart that any allocation
+    # failure already forces, whose scan sweeps it. Note the target is no
+    # longer opened :exclusive, so the publishing rename overwrites a
+    # `preallocated.N` the discard in `new/4` failed to remove, which is
+    # what we want from it.
     @spec allocate_file(String.t(), non_neg_integer()) :: {:ok, String.t()} | {:error, atom()}
     def allocate_file(path, size_in_bytes) do
       scratch = scratch_path(path)

--- a/test/bedrock/data_plane/log/shale/segment_recycler_test.exs
+++ b/test/bedrock/data_plane/log/shale/segment_recycler_test.exs
@@ -25,11 +25,11 @@ defmodule Bedrock.DataPlane.Log.Shale.SegmentRecyclerTest do
   end
 
   # A stand-in for a retired WAL segment: check_in either renames it into
-  # the pool or unlinks it, so the contents are irrelevant and the size
-  # need not be realistic.
-  defp retired_segment(dir, name) do
+  # the pool or unlinks it, so the contents are irrelevant — but the size
+  # is not, since only a whole segment is worth pooling.
+  defp retired_segment(dir, name, size \\ @segment_size) do
     path = Path.join(dir, name)
-    :ok = File.write(path, "retired")
+    :ok = File.write(path, :binary.copy(<<0>>, size))
     path
   end
 
@@ -91,6 +91,23 @@ defmodule Bedrock.DataPlane.Log.Shale.SegmentRecyclerTest do
 
       assert Path.wildcard(Path.join(dir, "wal_*")) == [],
              "every checked-in segment must be either pooled or unlinked"
+    end
+  end
+
+  # A log recovering over the wreckage a pre-atomic-publish version left
+  # behind checks that wreckage back in: the 28-byte stub a zero-length
+  # pool file becomes once Writer.open/3 has written a header loads as a
+  # segment, and Recovery.discard_all_segments/1 returns it to the pool.
+  # new/4 never sees it — it arrives under a `wal_` name, after the scan.
+  describe "check_in/2 of something that is not a whole segment" do
+    test "unlinks it instead of pooling it", %{dir: dir, state: state} do
+      stub = retired_segment(dir, "wal_stub", 28)
+
+      {:ok, state} = Logic.check_in(state, stub)
+
+      assert state.segments == []
+      refute File.exists?(stub)
+      assert pooled_files(dir) == []
     end
   end
 

--- a/test/bedrock/data_plane/log/shale/segment_recycler_test.exs
+++ b/test/bedrock/data_plane/log/shale/segment_recycler_test.exs
@@ -14,6 +14,11 @@ defmodule Bedrock.DataPlane.Log.Shale.SegmentRecyclerTest do
   @segment_size 1024
   @max_available 3
 
+  # Large enough that no filesystem can satisfy it, so `:file.allocate/3`
+  # fails *after* the open has already created the file — the ENOSPC
+  # shape, without needing a full disk.
+  @unallocatable_size Bitwise.bsl(1, 62)
+
   setup %{tmp_dir: dir} do
     {:ok, state} = Logic.new(dir, @segment_size, 1, @max_available)
     %{dir: dir, state: state}
@@ -89,6 +94,83 @@ defmodule Bedrock.DataPlane.Log.Shale.SegmentRecyclerTest do
     end
   end
 
+  describe "a successful allocation" do
+    test "publishes a whole segment and nothing else", %{tmp_dir: dir, state: state} do
+      {:ok, state} = Logic.ensure_min_available(state, 1)
+
+      assert [pooled] = state.segments
+      assert File.stat!(pooled).size == @segment_size
+
+      assert File.ls!(dir) == [Path.basename(pooled)],
+             "the scratch name must be consumed by the publish, not left alongside the pool file"
+    end
+  end
+
+  # Preallocation is create-then-extend: the file exists at zero length
+  # before it is a segment. A failure between those two steps must leave
+  # nothing behind that a later scan can mistake for a whole segment.
+  describe "an allocation that fails partway" do
+    test "publishes nothing into the pool", %{tmp_dir: dir} do
+      {:ok, state} = Logic.new(dir, @unallocatable_size, 1, @max_available)
+
+      assert {:error, _reason} = Logic.ensure_min_available(state, 1)
+
+      assert pooled_files(dir) == [],
+             "a preallocation that never reached full size must not appear in the pool"
+    end
+
+    test "leaves nothing on disk at all", %{tmp_dir: dir} do
+      {:ok, state} = Logic.new(dir, @unallocatable_size, 1, @max_available)
+
+      assert {:error, _reason} = Logic.ensure_min_available(state, 1)
+
+      assert File.ls!(dir) == [], "the scratch file must be removed when the allocation fails"
+    end
+  end
+
+  # bedrock-61c.2's doctrine for worker directories applies to the pool:
+  # membership must be provable, not assumed from the name. `check_out`
+  # renames a pooled file straight into service and `Writer.open/3`
+  # derives its write budget from `File.stat/1`, so a short file adopted
+  # here presents as a healthy segment with a nonsense budget.
+  describe "new/4 adoption" do
+    test "adopts a pool file of the configured size", %{tmp_dir: dir} do
+      whole = Path.join(dir, "preallocated.1")
+      :ok = File.write(whole, :binary.copy(<<0>>, @segment_size))
+
+      assert {:ok, %{segments: [^whole], next_id: 2}} = Logic.new(dir, @segment_size, 1, @max_available)
+    end
+
+    test "discards a zero-length pool file", %{tmp_dir: dir} do
+      orphan = Path.join(dir, "preallocated.1")
+      :ok = File.write(orphan, "")
+
+      assert {:ok, %{segments: []}} = Logic.new(dir, @segment_size, 1, @max_available)
+
+      refute File.exists?(orphan),
+             "a file that is not a whole segment must be discarded, not left for the next scan to re-adopt"
+    end
+
+    test "discards a pool file that is short of the configured size", %{tmp_dir: dir} do
+      short = Path.join(dir, "preallocated.2")
+      :ok = File.write(short, :binary.copy(<<0>>, div(@segment_size, 2)))
+
+      assert {:ok, %{segments: []}} = Logic.new(dir, @segment_size, 1, @max_available)
+      refute File.exists?(short)
+    end
+
+    # A scratch file cannot be adopted — it does not match the pool's
+    # glob — but it must not accumulate either: at 64 MiB apiece, one
+    # per incarnation that dies mid-allocation.
+    test "sweeps a scratch file left behind by a previous incarnation", %{tmp_dir: dir} do
+      scratch = Path.join(dir, ".partial.preallocated.1")
+      :ok = File.write(scratch, "")
+
+      assert {:ok, %{segments: []}} = Logic.new(dir, @segment_size, 1, @max_available)
+      refute File.exists?(scratch)
+    end
+  end
+
   describe "new/4 configuration" do
     test "refuses a pool with no slack between min and max", %{tmp_dir: dir} do
       assert {:error, :max_available_must_exceed_min_available} = Logic.new(dir, @segment_size, 1, 1)
@@ -132,6 +214,28 @@ defmodule Bedrock.DataPlane.Log.Shale.SegmentRecyclerTest do
       # the very checkout the pool exists to serve.
       assert :ok = SegmentRecycler.check_out(recycler, Path.join(dir, "wal_next"))
       assert File.exists?(Path.join(dir, "wal_next"))
+    end
+  end
+
+  # The two ends joined up: wreckage left in the pool directory by a
+  # previous incarnation must never reach a WAL segment.
+  describe "a fresh incarnation over a poisoned pool directory" do
+    test "never checks out a file that is not a whole segment", %{tmp_dir: dir} do
+      :ok = File.write(Path.join(dir, "preallocated.1"), "")
+
+      {:ok, recycler} =
+        SegmentRecycler.start_link(
+          path: dir,
+          min_available: 1,
+          max_available: @max_available,
+          segment_size: @segment_size
+        )
+
+      handed_out = Path.join(dir, "wal_next")
+      assert :ok = SegmentRecycler.check_out(recycler, handed_out)
+
+      assert File.stat!(handed_out).size == @segment_size,
+             "the recycler handed out a file that is not a whole segment"
     end
   end
 end


### PR DESCRIPTION
The Shale segment recycler keeps a small pool of preallocated 64 MiB files so the WAL never waits on allocation. Preallocation was create-then-extend under the final name, so a failure between the two steps left a zero-length `preallocated.N` that the next incarnation adopted as a whole segment and handed to the writer. Files are now sized and synced under a scratch name and published by rename, and both entrances to the pool admit only files of exactly the configured size.

Ticket: bedrock-vih
Closes bedrock-vih.

## Why

The old allocation opened `preallocated.N` with `:exclusive`, which creates it empty, then extended it with `:file.allocate/3`. When the extension failed (a full volume is the realistic cause) the descriptor was closed and the recycler stopped, but the empty file stayed on disk.

At the next start the recycler globbed `preallocated.*` and pooled every match without looking at it. The first checkout renamed the empty file into service, and `Writer.open/3` derived its write budget from the file size: 0 minus the 28-byte header and EOF marker, so every append failed with `:segment_full` on a segment the pool had reported as healthy.

There is a second route into the same state on a machine that has already hit this once. The writer stamps the 28-byte header onto the empty file, which makes it a valid-looking `wal_` segment. Cold start loads it, recovery discards all loaded segments back into the recycler, and `check_in/2` renamed it into the pool unconditionally. A startup-only size check never sees it, because it arrives after the scan and under a name the scan does not match.

## What changed

- `allocate_file/2` opens `.partial.preallocated.N`, allocates, syncs, closes, then renames onto the real name. Any failure unlinks the scratch and returns the original reason.
- `new/4` sweeps `.partial.*` first, then keeps only `preallocated.*` files that are exactly `segment_size` bytes, unlinking the rest.
- `check_in/2` below the cap applies the same size test and unlinks a short file instead of pooling it.
- The test fixture for a retired segment now writes `segment_size` bytes, since size is load-bearing.

The public API and return shapes are unchanged. Discarded files are not tracked for id reuse: the publishing rename overwrites rather than colliding, so a stale file whose unlink failed is replaced by a whole one. Unlink failures in the discard paths are not surfaced; the file is excluded from the pool either way and the min-refill compensates.

## How it works

The invariant is that every path in the pool names a file of exactly `size` bytes. Publish-by-rename means `preallocated.N` never exists in any other state. A kill between open and rename leaves only the scratch file, which the next start sweeps before scanning. The scratch prefix is dot-prefixed and starts with neither `preallocated` nor `wal_`, so neither directory scan over this shared directory can pick it up.

```
open  .partial.preallocated.7   (0 bytes)
allocate + sync                 (64 MiB)
rename -> preallocated.7        (visible only now)
```

The size test also handles a `segment_size` changed between incarnations: the old pool is discarded wholesale and rebuilt, which is correct because the pool is a cache of interchangeable files.

## Verification

Allocation failure is forced with a `1 <<< 62` size, which fails after the open has created the file; the errno is not asserted because it varies by platform. Six new tests fail on the base, one per mechanism: nothing pooled and nothing on disk after a failed allocation; zero-length, short, and scratch files discarded at startup; and an end-to-end test that plants an empty pool file, starts a real recycler, and asserts the checked-out file is whole. A seventh pins the recovery path by checking in a 28-byte `wal_` stub and asserting it is unlinked. Two guards confirm a successful allocation leaves only the published file and that whole files are still adopted with `next_id` following.

CI is green on OTP 27/28/29 and the S3 MinIO job. The cold audit's must-fix (the `check_in/2` hole) was closed in b1660750. Related: bedrock-m7j (#216, the audit that found this), bedrock-ck3, bedrock-61c.2.
