### PR TITLE
bedrock-9mo: remove unreachable page-0-as-middle-page branch in clear_range

### DIFF
--- a/lib/bedrock/data_plane/materializer/olivine/index_update.ex
+++ b/lib/bedrock/data_plane/materializer/olivine/index_update.ex
@@ -190,26 +190,21 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.IndexUpdate do
           |> Enum.map(&Page.key_count/1)
           |> Enum.sum()
 
+        # Page 0 is the chain head: `continue_to_next_page/5` and
+        # `include_page_and_continue/5` treat `next_id == 0` as the
+        # end-of-chain sentinel and stop without ever making 0 the current
+        # page, so 0 can only enter the collected list as `first_page_id`
+        # (via `Tree.page_for_key/2`), never as a middle or last page.
         final_operations =
-          if 0 in middle_page_ids do
-            page_0 = Index.get_page!(index_update.index, 0)
-            page_0_keys = extract_keys_in_range(page_0, start_key, end_key)
-
-            index_update.pending_operations
-            |> Map.drop(middle_page_ids_excluding_page_zero)
-            |> add_clear_operations_for_keys(first_page_id, first_keys_to_clear)
-            |> add_clear_operations_for_keys(last_page_id, last_keys_to_clear)
-            |> add_clear_operations_for_keys(0, page_0_keys)
-          else
-            index_update.pending_operations
-            |> Map.drop(middle_page_ids_excluding_page_zero)
-            |> add_clear_operations_for_keys(first_page_id, first_keys_to_clear)
-            |> add_clear_operations_for_keys(last_page_id, last_keys_to_clear)
-          end
+          index_update.pending_operations
+          |> Map.drop(middle_page_ids_excluding_page_zero)
+          |> add_clear_operations_for_keys(first_page_id, first_keys_to_clear)
+          |> add_clear_operations_for_keys(last_page_id, last_keys_to_clear)
 
         # Only the wholesale-deleted middle pages are accounted for here: the
-        # boundary (and page 0) keys become pending clears on pages that
-        # survive, and are counted when those pages are processed.
+        # boundary keys (first_page_id may be page 0) become pending clears
+        # on pages that survive, and are counted when those pages are
+        # processed.
         %{
           index_update
           | index: Index.delete_pages(index_update.index, middle_page_ids_excluding_page_zero),

--- a/test/bedrock/data_plane/materializer/olivine/index_update_test.exs
+++ b/test/bedrock/data_plane/materializer/olivine/index_update_test.exs
@@ -220,8 +220,8 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.IndexUpdateTest do
     # Note: page 0 can never appear as a MIDDLE page of a chain traversal.
     # next_id == 0 is the chain terminator, so traversal always stops before
     # visiting page 0 as a successor; page 0 is only ever the first collected
-    # page. The `0 in middle_page_ids` branch in apply_mutation is therefore
-    # defensive and unreachable through the public API.
+    # page (bedrock-9mo removed the dead `0 in middle_page_ids` branch this
+    # once guarded).
     test "page 0 as the first page of a multi-page range clear survives even when fully cleared", %{
       database: database
     } do


### PR DESCRIPTION
The multi-page arm of the Olivine range clear special-cased page 0 appearing in the middle of the cleared page list, a state the chain walk that builds that list cannot produce. The dead branch is removed and a comment records why; the surviving code is the former `else` body unchanged.

Ticket: bedrock-9mo
Stacked on: #272 (bedrock-ljh/index-manager-monotonic-versions)

## Why

An Olivine index is a set of pages linked by `next_id` pointers. Page 0 is the permanent head of that chain, and the chain terminates by pointing back at 0. Page 0 is never deleted, so a range clear must not treat it like an ordinary middle page.

A range clear collects the pages it touches by starting at the page the tree returns for the start key and walking `next_id` forward. Every step checks the pointer before following it, and a pointer of 0 means end of chain, so the walk returns rather than visiting page 0 as a successor. Page 0 can therefore enter the collected list only as its first element, seeded by the tree lookup, never as a middle or last page.

The audit for bedrock-zsw (PR #78) found the `0 in middle_page_ids` branch impossible to cover for this reason. Under the repo's precluded-states convention a shape impossibility gets fallthrough plus a comment, not a guard.

## What changed

The conditional is gone; the pending-operation map is built unconditionally by dropping the deleted middle pages and queueing in-range clears on the first and last pages. The `Enum.reject(&(&1 == 0))` on the middle list stays, since it also feeds page deletion and id recycling.

The ticket's note about a `keys_removed` versus `track_statistics` asymmetry is stale; neither identifier exists on the base. That accounting became `key_count_delta` in the bedrock-jb4 stack (PR #253).

## How it works

The multi-page arm now does one thing for every collected list. Pages strictly between the first and last are deleted outright, because the clear covers them end to end; the first and last pages keep their out-of-range keys, so each gets a queued partial clear instead.

Page 0 needs no special handling under that rule. If the tree seeds the walk at page 0 it is the first page, so it takes the partial-clear path and survives; it can never reach the middle list, which is the only path that deletes. The explicit reject of 0 on the middle list is what makes that guarantee local rather than something a reader has to reconstruct from the chain walk.

## Verification

Before the change, a `raise` inserted inside the branch never fired across the full suite. After it, the suite passes with identical counts, and the existing page-0-as-first-page test still covers the surviving path. No CI checks on this stacked draft branch. Follow-ups: none.

