### PR TITLE
bedrock-w0c: unwrap unsupported-fact error in Olivine.Logic.info/2

### DIFF
--- a/lib/bedrock/data_plane/materializer/olivine/logic.ex
+++ b/lib/bedrock/data_plane/materializer/olivine/logic.ex
@@ -274,7 +274,12 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Logic do
 
   @spec info(State.t(), Materializer.fact_name() | [Materializer.fact_name()]) ::
           {:ok, term() | %{Materializer.fact_name() => term()}} | {:error, :unsupported_info}
-  def info(%State{} = t, fact_name) when is_atom(fact_name), do: {:ok, gather_info(fact_name, t)}
+  def info(%State{} = t, fact_name) when is_atom(fact_name) do
+    case gather_info(fact_name, t) do
+      {:error, :unsupported_info} = error -> error
+      value -> {:ok, value}
+    end
+  end
 
   def info(%State{} = t, fact_names) when is_list(fact_names) do
     {:ok,

--- a/test/bedrock/data_plane/materializer/olivine/genserver_integration_test.exs
+++ b/test/bedrock/data_plane/materializer/olivine/genserver_integration_test.exs
@@ -335,6 +335,10 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.GenServerIntegrationTest do
 
       assert {:ok, %{kind: :materializer, id: ^worker_id, pid: ^pid, otp_name: ^otp_name}} =
                GenServer.call(pid, {:info, fact_names}, @timeout)
+
+      # An unsupported single fact surfaces as the bare error the @spec
+      # promises, not wrapped in an extra {:ok, ...}.
+      assert {:error, :unsupported_info} = GenServer.call(pid, {:info, :not_a_real_fact}, @timeout)
     end
 
     @tag :tmp_dir

--- a/test/bedrock/data_plane/materializer/olivine/logic_test.exs
+++ b/test/bedrock/data_plane/materializer/olivine/logic_test.exs
@@ -287,7 +287,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.LogicTest do
     test "returns error tuple for an unsupported fact", %{test_dir: test_dir} do
       state = create_test_state(test_dir, :info_unsupported_test)
 
-      assert {:ok, {:error, :unsupported_info}} = Logic.info(state, :not_a_real_fact)
+      assert {:error, :unsupported_info} = Logic.info(state, :not_a_real_fact)
 
       Logic.shutdown(state)
     end


### PR DESCRIPTION
Asking an Olivine materializer for a single fact it does not recognise returned `{:ok, {:error, :unsupported_info}}`: an error tuple delivered as the payload of a success tuple. The single-atom clause of `Logic.info/2` now returns the bare error and wraps only real values, which is the shape its spec already declared and the shape the log worker's fact provider already uses.

Ticket: bedrock-w0c
Stacked on: #274 (bedrock-9mo/remove-unreachable-page0-branch)

## Why

Facts are resolved by a private `gather_info/2` with one clause per supported name and a fallthrough returning `{:error, :unsupported_info}`. The single-atom clause wrapped that result in `{:ok, ...}` unconditionally, so the error branch of the spec was unreachable and a caller matching `{:ok, value}` would carry the error forward as a fact. Dialyzer is silent because `term()` covers the nested tuple; the bedrock-eu4 audit (PR #80) found it by reading. The sibling `Log.Shale.Facts.info/2` already unwraps, so the two worker kinds disagreed on the same request.

## What changed

The single-atom clause matches the result of `gather_info/2`, returning `{:error, :unsupported_info}` as-is and wrapping everything else in `{:ok, value}`. The spec, the list clause, and the supported-fact set are unchanged. The list clause deliberately keeps embedding the error under the offending key inside its `{:ok, map}`, which is per-key reporting and matches the log worker.

## How it works

The server replies with whatever `Logic.info/2` returns, so the fix is visible end to end:

```
{:info, :kind}             -> {:ok, :materializer}
{:info, :not_a_real_fact}  -> {:error, :unsupported_info}      (was {:ok, {:error, ...}})
{:info, [:kind, :bogus]}   -> {:ok, %{kind: :materializer, bogus: {:error, :unsupported_info}}}
```

No supported fact can evaluate to that tuple, so the match cannot misreport a real value. Every in-tree caller passes a list, so production behaviour does not shift.

## Verification

The unit test that pinned the double-wrapped shape now asserts the bare error, and the GenServer integration test asserts `{:info, :not_a_real_fact}` returns it through the server. Both fail against the base. Full suite reported green (2904 tests); format, credo, dialyzer clean. No GitHub checks run on this stacked branch.

Related: PR #263 (bedrock-q67.21.13) adds a `:mode` fact on a separate stack; the two merge cleanly in either order.
