### PR TITLE
bedrock-uvk: drive ShardServer retry-telemetry test off an injected drain

### DIFF
--- a/test/bedrock/data_plane/demux/shard_server_test.exs
+++ b/test/bedrock/data_plane/demux/shard_server_test.exs
@@ -521,6 +521,8 @@ defmodule Bedrock.DataPlane.Demux.ShardServerTest do
           persistence_retry_tick_ms: 1
         )
 
+      %{persistence_worker: worker} = :sys.get_state(server)
+
       slice = make_slice([{:set, "key", "value"}])
       v1000 = Version.from_integer(1000)
       v1200 = Version.from_integer(1200)
@@ -539,6 +541,16 @@ defmodule Bedrock.DataPlane.Demux.ShardServerTest do
       assert retry_meas.attempt == 1
       assert retry_meas.delay_ms >= 1
       assert retry_meta.reason == {:write_failed, :transient_write_failure}
+
+      # The worker already re-drains itself after scheduling a retry, but
+      # under full-suite scheduler load that only races the same
+      # Process.send_after backoff timer we're trying not to depend on
+      # (bedrock-uvk). Drive the retry directly instead: PersistenceQueue
+      # only promotes a scheduled entry once real time has passed its
+      # due_at_ms, which the relay above already satisfies, so this either
+      # fires the retry immediately or is a harmless no-op that falls back
+      # to the worker's own timer.
+      send(worker, :drain)
 
       assert_receive {:telemetry, [:bedrock, :demux, :persistence, :write, :ok], _ok_meas, ok_meta}, 1_500
       assert ok_meta.shard_id == shard_id


### PR DESCRIPTION
The ShardServer retry-telemetry test occasionally missed its final 1.5 s `assert_receive` under full-suite load, because the retried write ran only after the persistence worker's own backoff timer fired. The test now sends the worker a `:drain` tick itself once it has seen the retry scheduled. That bypasses the timer service but does not remove the dependence on real time.

Ticket: bedrock-uvk
Closes bedrock-uvk.

## Why

The test runs a real `ShardServer` over a backend whose first conditional put fails transiently and whose second succeeds, with backoff and tick both 1 ms, then waits on three telemetry events: write error, retry scheduled, write ok. The first two are emitted synchronously inside the drain that performed the failed write. The third waits on the clock: the worker arms a 1 ms `Process.send_after` and re-sends itself an eager drain, but that drain usually lands in the same millisecond, finds the entry not yet due, and arms another timer. Under load, timer delivery plus a scheduler slot occasionally exceeded 1.5 s.

## What changed

The test reads the worker pid from the server's state and, after asserting the `retry_scheduled` event, sends the worker `:drain` before waiting for the ok event. No `lib/` code changed; the 1.5 s budgets stay (PR #228 widened other windows for a different, multi-hop mechanism).

## How it works

The injected message takes the same path as a timer tick. `PersistenceQueue.dequeue` promotes a scheduled entry only once monotonic time has reached its `due_at_ms`. If a millisecond has elapsed since the failed attempt, the tick performs the retry immediately and the assertion waits only on the real write. If it arrives within the same millisecond, the tick finds nothing due, arms one more harmless timer, and the test is exactly as timer dependent as before. An entry is promoted once and only when due, so no duplicate write is possible. Full determinism would need a clock seam through the worker into the queue.

## Verification

The flake could not be reproduced on demand: the file alone under `--repeat-until-failure` (up to 80 iterations, with and without CPU load) and about 9 loaded full-suite runs showed no failures, short of the ticket's 20-run bar. The ticket's latest audit rated the fix PARTIAL for the same-millisecond reason above. CI (run 34005822582): OTP 28.3, OTP 29.0, and S3 MinIO green; OTP 27.3 red on the unrelated flake at `test/bedrock/internal/repo_transact_test.exs:605`.

Follow-up: none filed; remaining options are a clock seam or a load-scaled budget.
