### PR TITLE
bedrock-s1zr: prune a shard's snapshots past a keep-last limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## Unreleased
 
+- **Snapshots can be pruned once they are written.** Every snapshot a
+  materializer ever wrote stayed in object storage forever; nothing in
+  `lib/` called `Snapshot.delete_older_than/2`. A new manifest param,
+  `snapshot_keep_last`, says how many of a shard's newest snapshots to
+  keep, and the prune runs after a snapshot has durably landed — so a
+  shard can never be left without a baseline, and the newest snapshot is
+  never the one deleted. A worker without the param deletes nothing and
+  does not even list. A prune that cannot complete its listing says so
+  rather than reporting nothing to delete. Shard chunks are untouched:
+  they are the history, and reclaiming them needs a replay floor
+  (bedrock-wxf.6.11).
+
 - **Snapshot uploads answer to a policy.** A materializer uploaded a
   snapshot whenever a compaction happened to finish, with no way to say how
   much of that cadence was worth paying for. Three new manifest params say

--- a/lib/bedrock/data_plane/materializer/olivine/logic.ex
+++ b/lib/bedrock/data_plane/materializer/olivine/logic.ex
@@ -11,6 +11,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Logic do
   alias Bedrock.DataPlane.Materializer.Olivine.IndexManager
   alias Bedrock.DataPlane.Materializer.Olivine.IntakeQueue
   alias Bedrock.DataPlane.Materializer.Olivine.SnapshotPolicy
+  alias Bedrock.DataPlane.Materializer.Olivine.SnapshotRetention
   alias Bedrock.DataPlane.Materializer.Olivine.State
   alias Bedrock.DataPlane.Materializer.Olivine.Streaming
   alias Bedrock.DataPlane.Materializer.Olivine.Telemetry, as: OlivineTelemetry
@@ -35,6 +36,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Logic do
     idle_timeout = Keyword.get(opts, :idle_timeout, :infinity)
 
     snapshot_policy = Keyword.get(opts, :snapshot_policy, %SnapshotPolicy{})
+    snapshot_retention = Keyword.get(opts, :snapshot_retention, %SnapshotRetention{})
     snapshot = build_snapshot_handle(cluster, shard_tag)
 
     with :ok <- ensure_directory_exists(path),
@@ -53,6 +55,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Logic do
          index_manager: index_manager,
          snapshot: snapshot,
          snapshot_policy: snapshot_policy,
+         snapshot_retention: snapshot_retention,
          idle_timeout: idle_timeout,
          last_read_at: System.monotonic_time(:millisecond)
        }}
@@ -542,6 +545,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Logic do
            {:ok, idx} <- File.read(to_string(spindown_idx_path)),
            :ok <- Snapshot.write(snapshot, version_int, [data, idx]) do
         Logger.info("Snapshot uploaded to ObjectStorage before idle spin-down", version: version_int)
+        prune_snapshots(snapshot, t.snapshot_retention)
         :ok
       else
         {:error, reason} ->
@@ -589,6 +593,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Logic do
 
       :upload ->
         version_int = Version.to_integer(durable_version)
+        retention = t.snapshot_retention
 
         Task.start(fn ->
           # Read files and upload as iodata (no intermediate bundle file)
@@ -596,6 +601,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Logic do
                {:ok, idx} <- File.read(to_string(idx_path)),
                :ok <- Snapshot.write(snapshot, version_int, [data, idx]) do
             Logger.info("Snapshot uploaded to ObjectStorage", version: version_int)
+            prune_snapshots(snapshot, retention)
           else
             {:error, reason} ->
               Logger.warning("Snapshot upload failed", version: version_int, reason: inspect(reason))
@@ -605,4 +611,51 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Logic do
         %{t | snapshot_policy: SnapshotPolicy.uploaded(t.snapshot_policy, now_in_ms)}
     end
   end
+
+  # Retention runs only AFTER a snapshot has landed, which is what makes
+  # it safe: the newest object is already durable, so pruning behind it
+  # can never leave the shard without a baseline to cold start from. It
+  # is best-effort cleanup and never a reason to fail the upload it
+  # follows — but a failure is REPORTED, not swallowed. An unconfigured
+  # policy costs the shard nothing, not even a listing.
+  @spec prune_snapshots(Snapshot.t(), SnapshotRetention.t()) :: :ok
+  defp prune_snapshots(snapshot, retention) do
+    if SnapshotRetention.configured?(retention) do
+      snapshot |> delete_below_retention(retention) |> log_prune_outcome()
+    else
+      :ok
+    end
+  end
+
+  @spec delete_below_retention(Snapshot.t(), SnapshotRetention.t()) :: {:ok, non_neg_integer()} | {:error, term()}
+  defp delete_below_retention(snapshot, retention) do
+    with {:ok, versions} <- snapshot_versions(snapshot),
+         {:ok, oldest_to_keep} <- SnapshotRetention.oldest_to_keep(retention, versions) do
+      Snapshot.delete_older_than(snapshot, oldest_to_keep)
+    else
+      :keep_all -> {:ok, 0}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  @spec snapshot_versions(Snapshot.t()) :: {:ok, [non_neg_integer()]} | {:error, term()}
+  defp snapshot_versions(snapshot) do
+    {:ok, snapshot |> Snapshot.list() |> Enum.map(fn {version, _key} -> version end)}
+  rescue
+    # `Snapshot.list/2` raises when the listing itself failed, and (once
+    # bedrock-q67.21.19 lands) when an object under the shard's prefix
+    # carries a name it cannot parse. Neither is an empty history:
+    # deciding retention on a listing we know is short would delete a
+    # snapshot the shard still keeps, and reporting "nothing to delete"
+    # would hide a prefix growing without bound. Both say so instead.
+    e -> {:error, {:snapshot_listing_failed, Exception.message(e)}}
+  end
+
+  @spec log_prune_outcome({:ok, non_neg_integer()} | {:error, term()}) :: :ok
+  defp log_prune_outcome({:ok, 0}), do: :ok
+
+  defp log_prune_outcome({:ok, deleted}), do: Logger.info("Pruned snapshots past the retention limit", deleted: deleted)
+
+  defp log_prune_outcome({:error, reason}),
+    do: Logger.warning("Snapshot retention pruning failed", reason: inspect(reason))
 end

--- a/lib/bedrock/data_plane/materializer/olivine/logic.ex
+++ b/lib/bedrock/data_plane/materializer/olivine/logic.ex
@@ -627,28 +627,31 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Logic do
     end
   end
 
+  # The rescue covers the WHOLE prune, not just the listing it starts
+  # with: `Snapshot.delete_older_than/2` lists again to walk the
+  # deletions, and on the spin-down path this all runs in the worker, so
+  # an exception escaping from either listing would take down a
+  # materializer that had already written its snapshot successfully.
+  #
+  # It is deliberately broad. `Snapshot.list/2` raises when the listing
+  # failed, and once bedrock-q67.21.19 lands it raises again — a
+  # different exception this branch cannot yet name — for an object under
+  # the shard's prefix whose name will not parse. Neither is an empty
+  # history: deciding retention on a listing known to be short would
+  # delete a snapshot the shard still wants, and reporting "nothing to
+  # delete" would hide a prefix growing without bound. The exception
+  # itself goes into the reason, so a genuine bug caught here is still
+  # named for what it is rather than blending into a backend outage.
   @spec delete_below_retention(Snapshot.t(), SnapshotRetention.t()) :: {:ok, non_neg_integer()} | {:error, term()}
   defp delete_below_retention(snapshot, retention) do
-    with {:ok, versions} <- snapshot_versions(snapshot),
-         {:ok, oldest_to_keep} <- SnapshotRetention.oldest_to_keep(retention, versions) do
-      Snapshot.delete_older_than(snapshot, oldest_to_keep)
-    else
-      :keep_all -> {:ok, 0}
-      {:error, reason} -> {:error, reason}
-    end
-  end
+    versions = snapshot |> Snapshot.list() |> Enum.map(fn {version, _key} -> version end)
 
-  @spec snapshot_versions(Snapshot.t()) :: {:ok, [non_neg_integer()]} | {:error, term()}
-  defp snapshot_versions(snapshot) do
-    {:ok, snapshot |> Snapshot.list() |> Enum.map(fn {version, _key} -> version end)}
+    case SnapshotRetention.oldest_to_keep(retention, versions) do
+      :keep_all -> {:ok, 0}
+      {:ok, oldest_to_keep} -> Snapshot.delete_older_than(snapshot, oldest_to_keep)
+    end
   rescue
-    # `Snapshot.list/2` raises when the listing itself failed, and (once
-    # bedrock-q67.21.19 lands) when an object under the shard's prefix
-    # carries a name it cannot parse. Neither is an empty history:
-    # deciding retention on a listing we know is short would delete a
-    # snapshot the shard still keeps, and reporting "nothing to delete"
-    # would hide a prefix growing without bound. Both say so instead.
-    e -> {:error, {:snapshot_listing_failed, Exception.message(e)}}
+    e -> {:error, {:snapshot_prune_failed, e}}
   end
 
   @spec log_prune_outcome({:ok, non_neg_integer()} | {:error, term()}) :: :ok

--- a/lib/bedrock/data_plane/materializer/olivine/server.ex
+++ b/lib/bedrock/data_plane/materializer/olivine/server.ex
@@ -15,6 +15,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Server do
   alias Bedrock.DataPlane.Materializer.Olivine.Logic
   alias Bedrock.DataPlane.Materializer.Olivine.Reading
   alias Bedrock.DataPlane.Materializer.Olivine.SnapshotPolicy
+  alias Bedrock.DataPlane.Materializer.Olivine.SnapshotRetention
   alias Bedrock.DataPlane.Materializer.Olivine.State
   alias Bedrock.DataPlane.Materializer.Olivine.Telemetry, as: OlivineTelemetry
   alias Bedrock.DataPlane.Materializer.Telemetry
@@ -63,10 +64,15 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Server do
   # explicit positive idle_timeout the worker never spins down, which is
   # what exempts the system shard (its bootstrap never sets the param).
   # The snapshot upload policy is opt-in the same way, one knob at a
-  # time (bedrock-zi44).
+  # time (bedrock-zi44), and so is snapshot retention (bedrock-s1zr).
   @spec startup_opts(cluster :: module() | nil, params :: map()) :: keyword()
   defp startup_opts(cluster, params) do
-    base = [cluster: cluster, shard_id: params["shard_id"], snapshot_policy: SnapshotPolicy.from_params(params)]
+    base = [
+      cluster: cluster,
+      shard_id: params["shard_id"],
+      snapshot_policy: SnapshotPolicy.from_params(params),
+      snapshot_retention: SnapshotRetention.from_params(params)
+    ]
 
     case params["idle_timeout"] do
       idle_timeout when is_integer(idle_timeout) and idle_timeout > 0 ->

--- a/lib/bedrock/data_plane/materializer/olivine/snapshot_policy.ex
+++ b/lib/bedrock/data_plane/materializer/olivine/snapshot_policy.ex
@@ -38,8 +38,8 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.SnapshotPolicy do
   floor, which is no sooner than `min_interval_ms` away.
 
   This policy is only about how often a snapshot is WRITTEN. Which of
-  the written snapshots survive is retention, and that lives on the
-  ObjectStorage side (bedrock-s1zr).
+  the written snapshots survive is retention, and that is
+  `SnapshotRetention` (bedrock-s1zr).
   """
 
   @type t :: %__MODULE__{

--- a/lib/bedrock/data_plane/materializer/olivine/snapshot_retention.ex
+++ b/lib/bedrock/data_plane/materializer/olivine/snapshot_retention.ex
@@ -1,0 +1,92 @@
+defmodule Bedrock.DataPlane.Materializer.Olivine.SnapshotRetention do
+  @moduledoc """
+  Decides which of a shard's written snapshots are still worth keeping.
+
+  `SnapshotPolicy` decides how often a snapshot is WRITTEN. This decides
+  which of the written ones SURVIVE, and it is the other half of the same
+  cost: an object that is never pruned is stored, billed and listed
+  forever.
+
+  A snapshot is derived state, not history. It is a compaction output —
+  the coalesced contents of the shard at one version — so deleting one
+  loses nothing that cannot be rebuilt by replaying the chunks from an
+  older snapshot forward. That is what separates this from the chunks
+  themselves, which ARE the history and are never deleted (bedrock-wxf.6;
+  reclaiming them needs a replay floor, bedrock-wxf.6.11). The only
+  invariant retention owes anyone is that a shard never ends up with zero
+  snapshots: a cold start with no baseline has to replay the whole shard.
+
+  One knob, `keep_last` — the number of newest snapshots to keep. Unset,
+  nothing is ever deleted and the shard behaves exactly as it did before
+  retention existed.
+
+  ## Why there is no "keep anything newer than N minutes"
+
+  Because nothing here can honestly answer it. `ObjectStorage.list/3`
+  yields keys and nothing else — no modification times — and a snapshot's
+  key carries its VERSION, which is a Lamport clock: the sequencer
+  advances it by elapsed microseconds *while a cluster is up*
+  (`Sequencer.Server.handle_call({:next_commit_version, _}, ...)`) and not
+  at all across a restart or an outage. A knob named for wall-clock time
+  would silently mean cluster uptime, and would keep or drop a different
+  amount after every incident. Counting objects is a question the listing
+  can actually answer.
+  """
+
+  @type version :: non_neg_integer()
+
+  @type t :: %__MODULE__{
+          keep_last: pos_integer() | nil
+        }
+  defstruct keep_last: nil
+
+  @doc """
+  Builds a retention policy from a worker's manifest params.
+
+  Same discipline as `SnapshotPolicy.from_params/1`: a knob is set only by
+  an explicit positive integer, so a missing or malformed param leaves
+  retention off rather than turning into an accidental deletion.
+  """
+  @spec from_params(%{optional(String.t()) => term()}) :: t()
+  def from_params(params) do
+    %__MODULE__{keep_last: knob(params["snapshot_keep_last"])}
+  end
+
+  @spec knob(term()) :: pos_integer() | nil
+  defp knob(value) when is_integer(value) and value > 0, do: value
+  defp knob(_value), do: nil
+
+  @doc """
+  Whether this policy would ever delete anything.
+
+  Callers ask before listing: an unconfigured policy must not cost a
+  shard so much as one extra request.
+  """
+  @spec configured?(t()) :: boolean()
+  def configured?(%__MODULE__{keep_last: nil}), do: false
+  def configured?(%__MODULE__{}), do: true
+
+  @doc """
+  The oldest version this policy still wants, given the shard's snapshot
+  versions in the newest-first order `Snapshot.list/2` yields them.
+
+  Returns `{:ok, version}` — everything strictly below it may go — or
+  `:keep_all` when the policy is unset, or the shard holds no more
+  snapshots than the policy keeps and there is nothing below the floor to
+  delete anyway.
+
+  The floor is always an EXISTING version from the list — the Kth newest
+  — so the newest snapshot can never be the one deleted: with
+  `keep_last: 1` the floor is the newest version itself, and nothing is
+  strictly below it.
+  """
+  @spec oldest_to_keep(t(), [version()]) :: {:ok, version()} | :keep_all
+  def oldest_to_keep(%__MODULE__{keep_last: nil}, _newest_first), do: :keep_all
+
+  def oldest_to_keep(%__MODULE__{keep_last: keep_last}, newest_first) do
+    case Enum.drop(newest_first, keep_last - 1) do
+      [oldest_kept, _at_least_one_older | _rest] -> {:ok, oldest_kept}
+      _nothing_older -> :keep_all
+    end
+  end
+end

--- a/lib/bedrock/data_plane/materializer/olivine/state.ex
+++ b/lib/bedrock/data_plane/materializer/olivine/state.ex
@@ -8,6 +8,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.State do
   alias Bedrock.DataPlane.Materializer.Olivine.IntakeQueue
   alias Bedrock.DataPlane.Materializer.Olivine.Reading
   alias Bedrock.DataPlane.Materializer.Olivine.SnapshotPolicy
+  alias Bedrock.DataPlane.Materializer.Olivine.SnapshotRetention
   alias Bedrock.ObjectStorage.Snapshot
   alias Bedrock.Service.Foreman
   alias Bedrock.Service.Worker
@@ -31,6 +32,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.State do
           allow_window_advancement: boolean(),
           snapshot: Snapshot.t() | nil,
           snapshot_policy: SnapshotPolicy.t(),
+          snapshot_retention: SnapshotRetention.t(),
           pull_sources: [{Log.id(), Log.ref()}] | nil,
           shard_num: non_neg_integer() | nil,
           idle_timeout: pos_integer() | :infinity,
@@ -56,6 +58,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.State do
             allow_window_advancement: true,
             snapshot: nil,
             snapshot_policy: %SnapshotPolicy{},
+            snapshot_retention: %SnapshotRetention{},
             pull_sources: nil,
             shard_num: nil,
             idle_timeout: :infinity,

--- a/test/bedrock/data_plane/materializer/olivine/idle_spindown_test.exs
+++ b/test/bedrock/data_plane/materializer/olivine/idle_spindown_test.exs
@@ -18,6 +18,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.IdleSpindownTest do
   alias Bedrock.DataPlane.Materializer.Olivine.Database
   alias Bedrock.DataPlane.Materializer.Olivine.IndexManager
   alias Bedrock.DataPlane.Materializer.Olivine.Logic
+  alias Bedrock.DataPlane.Materializer.Olivine.SnapshotRetention
   alias Bedrock.DataPlane.Transaction
   alias Bedrock.DataPlane.Version
   alias Bedrock.ObjectStorage
@@ -328,6 +329,45 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.IdleSpindownTest do
                  shard_id: 42
                )
 
+      Logic.shutdown(restored)
+    end
+
+    # Spin-down is the only path that writes a snapshot in production
+    # (bedrock-zi44, bedrock-947), so it is where retention has to run
+    # or a shard accumulates one object per spin-down forever.
+    test "retention prunes the shard's older snapshots behind the one just written",
+         %{tmp_dir: tmp_dir, test_id: test_id} do
+      {_root, dir_a, dir_b} = object_storage_and_dirs(tmp_dir, test_id)
+
+      {:ok, state} =
+        Logic.startup(:"idle_ret_a_#{test_id}", self(), "ret_wkr_a", dir_a,
+          cluster: TestCluster,
+          shard_id: 42,
+          snapshot_retention: %SnapshotRetention{keep_last: 1}
+        )
+
+      # Seeded after startup: these stand in for earlier spin-downs, and
+      # this worker must not try to restore from one.
+      snapshot = snapshot_handle_for(42)
+      for version <- [1, 2], do: assert(:ok = Snapshot.write(snapshot, version, "stale bundle #{version}"))
+
+      state = apply_and_flush(state, "k1", "v1", 10_000_000)
+      state = apply_and_flush(state, "k2", "v2", 20_000_000)
+      durable = Version.to_integer(Database.durable_version(state.database))
+      assert durable > 2
+
+      assert :ok = Logic.upload_snapshot_before_spindown(state)
+      Logic.shutdown(state)
+
+      # The prune runs in the caller on this path, so by the time the
+      # upload returns the stale objects are gone.
+      assert [^durable] = snapshot |> Snapshot.list() |> Enum.map(fn {version, _key} -> version end)
+
+      # And the survivor is still the baseline a cold start revives from.
+      {:ok, restored} =
+        Logic.startup(:"idle_ret_b_#{test_id}", self(), "ret_wkr_b", dir_b, cluster: TestCluster, shard_id: 42)
+
+      assert Database.durable_version(restored.database) == Version.from_integer(durable)
       Logic.shutdown(restored)
     end
   end

--- a/test/bedrock/data_plane/materializer/olivine/logic_test.exs
+++ b/test/bedrock/data_plane/materializer/olivine/logic_test.exs
@@ -17,34 +17,44 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.LogicTest do
   alias Bedrock.ObjectStorage.LocalFilesystem
   alias Bedrock.ObjectStorage.Snapshot
 
-  # Writes land, but the listing raises the way a real backend does when
-  # it cannot complete one (bedrock-q67.21.17). Lazy on purpose: the
-  # raise has to happen where the stream is CONSUMED.
-  defmodule UnlistableBackend do
+  # A LocalFilesystem whose listing starts raising after `list_ok`
+  # successful calls, the way a real backend does when it cannot complete
+  # one (bedrock-q67.21.17). Lazy on purpose: the raise has to happen
+  # where the stream is CONSUMED. The counter is per-process, which is
+  # all the retention tests need — they drive the synchronous prune.
+  defmodule FlakyListBackend do
     @moduledoc false
     @behaviour ObjectStorage
 
     @impl true
-    def list(_config, prefix, _opts \\ []) do
-      Stream.resource(
-        fn -> :start end,
-        fn :start -> raise(ObjectStorage.ListError, reason: :econnrefused, prefix: prefix) end,
-        fn _ -> :ok end
-      )
+    def list(config, prefix, opts \\ []) do
+      calls = (Process.get(__MODULE__) || 0) + 1
+      Process.put(__MODULE__, calls)
+
+      if calls > Keyword.fetch!(config, :list_ok) do
+        Stream.resource(
+          fn -> :start end,
+          fn :start -> raise(ObjectStorage.ListError, reason: :econnrefused, prefix: prefix) end,
+          fn _ -> :ok end
+        )
+      else
+        LocalFilesystem.list(config, prefix, opts)
+      end
     end
 
     @impl true
-    def get(_config, _key), do: {:error, :not_found}
+    def get(config, key), do: LocalFilesystem.get(config, key)
     @impl true
-    def put(_config, _key, _data, _opts \\ []), do: :ok
+    def put(config, key, data, opts \\ []), do: LocalFilesystem.put(config, key, data, opts)
     @impl true
-    def delete(_config, _key), do: :ok
+    def delete(config, key), do: LocalFilesystem.delete(config, key)
     @impl true
-    def put_if_not_exists(_config, _key, _data, _opts \\ []), do: :ok
+    def put_if_not_exists(config, key, data, opts \\ []), do: LocalFilesystem.put_if_not_exists(config, key, data, opts)
     @impl true
-    def get_with_version(_config, _key), do: {:error, :not_found}
+    def get_with_version(config, key), do: LocalFilesystem.get_with_version(config, key)
     @impl true
-    def put_if_version_matches(_config, _key, _data, _version, _opts \\ []), do: :ok
+    def put_if_version_matches(config, key, data, version, opts \\ []),
+      do: LocalFilesystem.put_if_version_matches(config, key, data, version, opts)
   end
 
   setup do
@@ -646,10 +656,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.LogicTest do
     end
 
     test "a listing it could not complete is reported, not read as nothing to delete", %{test_dir: test_dir} do
-      snapshot = Snapshot.new({UnlistableBackend, []}, "logic-unlistable-shard")
-
-      state = create_test_state(Path.join(test_dir, "storage"), :snapshot_retention_unlistable)
-      state = %{state | snapshot: snapshot, snapshot_retention: %SnapshotRetention{keep_last: 1}}
+      state = flaky_listing_state(test_dir, :snapshot_retention_unlistable, %SnapshotRetention{keep_last: 1}, 0)
 
       # The snapshot itself is written, so the spin-down still succeeds:
       # retention is cleanup, never a reason to keep the worker up. But
@@ -658,6 +665,34 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.LogicTest do
       # prune, which is how a prefix grows without bound unnoticed.
       log = capture_log(fn -> assert :ok = Logic.upload_snapshot_before_spindown(state) end)
       assert log =~ "Snapshot retention pruning failed"
+
+      Logic.shutdown(state)
+    end
+
+    # The prune lists twice — once to find the floor, and again inside
+    # Snapshot.delete_older_than/2 to walk the deletions. On the
+    # spin-down path all of it runs in the worker, so a raise from the
+    # SECOND listing would crash a materializer that had already written
+    # its snapshot.
+    test "a listing that fails partway through the prune is reported, not raised", %{test_dir: test_dir} do
+      state = flaky_listing_state(test_dir, :snapshot_retention_flaky, %SnapshotRetention{keep_last: 1}, 1)
+
+      # Enough snapshots that a floor exists and the deletion walk is reached.
+      for version <- [1, 2, 3], do: assert(:ok = Snapshot.write(state.snapshot, version, "stale #{version}"))
+
+      log = capture_log(fn -> assert :ok = Logic.upload_snapshot_before_spindown(state) end)
+      assert log =~ "Snapshot retention pruning failed"
+
+      Logic.shutdown(state)
+    end
+
+    test "with no retention configured the prune does not so much as list", %{test_dir: test_dir} do
+      state = flaky_listing_state(test_dir, :snapshot_retention_unconfigured, %SnapshotRetention{}, 0)
+
+      # Any listing at all would raise and be reported. Silence is the
+      # assertion: an unconfigured worker costs its shard no request.
+      log = capture_log(fn -> assert :ok = Logic.upload_snapshot_before_spindown(state) end)
+      refute log =~ "Snapshot retention pruning failed"
 
       Logic.shutdown(state)
     end
@@ -706,6 +741,18 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.LogicTest do
     end
 
     {state, snapshot, upload}
+  end
+
+  # A state whose snapshot handle tolerates `list_ok` listings and raises
+  # on every one after that.
+  defp flaky_listing_state(test_dir, otp_name, retention, list_ok) do
+    root = Path.join(test_dir, "object_storage")
+    File.mkdir_p!(root)
+
+    snapshot = Snapshot.new({FlakyListBackend, [root: root, list_ok: list_ok]}, "logic-flaky-shard")
+    state = create_test_state(Path.join(test_dir, "storage"), otp_name)
+
+    %{state | snapshot: snapshot, snapshot_retention: retention}
   end
 
   defp snapshot_versions(snapshot), do: snapshot |> Snapshot.list() |> Enum.map(fn {version, _key} -> version end)

--- a/test/bedrock/data_plane/materializer/olivine/logic_test.exs
+++ b/test/bedrock/data_plane/materializer/olivine/logic_test.exs
@@ -8,6 +8,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.LogicTest do
   alias Bedrock.DataPlane.Materializer.Olivine.Logic
   alias Bedrock.DataPlane.Materializer.Olivine.ReadingTestHelpers
   alias Bedrock.DataPlane.Materializer.Olivine.SnapshotPolicy
+  alias Bedrock.DataPlane.Materializer.Olivine.SnapshotRetention
   alias Bedrock.DataPlane.Materializer.Olivine.State
   alias Bedrock.DataPlane.Transaction
   alias Bedrock.DataPlane.Version
@@ -15,6 +16,36 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.LogicTest do
   alias Bedrock.ObjectStorage
   alias Bedrock.ObjectStorage.LocalFilesystem
   alias Bedrock.ObjectStorage.Snapshot
+
+  # Writes land, but the listing raises the way a real backend does when
+  # it cannot complete one (bedrock-q67.21.17). Lazy on purpose: the
+  # raise has to happen where the stream is CONSUMED.
+  defmodule UnlistableBackend do
+    @moduledoc false
+    @behaviour ObjectStorage
+
+    @impl true
+    def list(_config, prefix, _opts \\ []) do
+      Stream.resource(
+        fn -> :start end,
+        fn :start -> raise(ObjectStorage.ListError, reason: :econnrefused, prefix: prefix) end,
+        fn _ -> :ok end
+      )
+    end
+
+    @impl true
+    def get(_config, _key), do: {:error, :not_found}
+    @impl true
+    def put(_config, _key, _data, _opts \\ []), do: :ok
+    @impl true
+    def delete(_config, _key), do: :ok
+    @impl true
+    def put_if_not_exists(_config, _key, _data, _opts \\ []), do: :ok
+    @impl true
+    def get_with_version(_config, _key), do: {:error, :not_found}
+    @impl true
+    def put_if_version_matches(_config, _key, _data, _version, _opts \\ []), do: :ok
+  end
 
   setup do
     test_dir = Path.join(System.tmp_dir!(), "olivine_logic_test_#{:rand.uniform(100_000)}")
@@ -581,6 +612,114 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.LogicTest do
       assert {:ok, _} = await_snapshot_version(snapshot, 3, 100)
 
       Logic.shutdown(state)
+    end
+  end
+
+  describe "snapshot retention" do
+    test "with no retention configured every uploaded snapshot is kept", %{test_dir: test_dir} do
+      {state, snapshot, upload} = retention_fixture(test_dir, "logic-no-retention-shard", %SnapshotRetention{})
+
+      state = Enum.reduce(1..4, state, &upload.(&2, &1))
+      for version <- 1..4, do: assert({:ok, _} = await_snapshot_version(snapshot, version, 100))
+
+      assert [4, 3, 2, 1] = snapshot_versions(snapshot)
+
+      Logic.shutdown(state)
+    end
+
+    test "keep_last prunes everything past the newest K after an upload", %{test_dir: test_dir} do
+      {state, snapshot, upload} =
+        retention_fixture(test_dir, "logic-retention-shard", %SnapshotRetention{keep_last: 2})
+
+      state =
+        Enum.reduce(1..4, state, fn version, state ->
+          state = upload.(state, version)
+          assert {:ok, _} = await_snapshot_version(snapshot, version, 100)
+          state
+        end)
+
+      # The prune rides the same fire-and-forget task as the upload, so
+      # the deletions land just behind the write that triggered them.
+      assert [4, 3] = await_snapshot_versions(snapshot, [4, 3], 100)
+
+      Logic.shutdown(state)
+    end
+
+    test "a listing it could not complete is reported, not read as nothing to delete", %{test_dir: test_dir} do
+      snapshot = Snapshot.new({UnlistableBackend, []}, "logic-unlistable-shard")
+
+      state = create_test_state(Path.join(test_dir, "storage"), :snapshot_retention_unlistable)
+      state = %{state | snapshot: snapshot, snapshot_retention: %SnapshotRetention{keep_last: 1}}
+
+      # The snapshot itself is written, so the spin-down still succeeds:
+      # retention is cleanup, never a reason to keep the worker up. But
+      # the prune says out loud that it could not see what is there —
+      # silence would be indistinguishable from a shard with nothing to
+      # prune, which is how a prefix grows without bound unnoticed.
+      log = capture_log(fn -> assert :ok = Logic.upload_snapshot_before_spindown(state) end)
+      assert log =~ "Snapshot retention pruning failed"
+
+      Logic.shutdown(state)
+    end
+
+    test "keep_last: 1 still never deletes the newest snapshot", %{test_dir: test_dir} do
+      {state, snapshot, upload} =
+        retention_fixture(test_dir, "logic-retention-one-shard", %SnapshotRetention{keep_last: 1})
+
+      state = upload.(state, 700)
+      assert {:ok, _} = await_snapshot_version(snapshot, 700, 100)
+      assert [700] = await_snapshot_versions(snapshot, [700], 100)
+
+      state = upload.(state, 900)
+      assert {:ok, _} = await_snapshot_version(snapshot, 900, 100)
+      assert [900] = await_snapshot_versions(snapshot, [900], 100)
+
+      Logic.shutdown(state)
+    end
+  end
+
+  # A state wired to a real LocalFilesystem-backed snapshot handle, plus
+  # the upload closure the retention tests drive it with. The default
+  # upload policy uploads at every opportunity, so each call writes.
+  defp retention_fixture(test_dir, shard_tag, retention) do
+    object_storage_root = Path.join(test_dir, "object_storage")
+    File.mkdir_p!(object_storage_root)
+
+    backend = ObjectStorage.backend(LocalFilesystem, root: object_storage_root)
+    snapshot = Snapshot.new(backend, shard_tag)
+
+    state = create_test_state(Path.join(test_dir, "storage"), :"snapshot_retention_#{shard_tag}")
+    state = %{state | snapshot: snapshot, snapshot_retention: retention}
+
+    data_path = Path.join(test_dir, "retention_data")
+    idx_path = Path.join(test_dir, "retention_idx")
+    File.write!(data_path, "data contents")
+    File.write!(idx_path, "idx contents")
+
+    upload = fn state, version ->
+      Logic.maybe_upload_snapshot(
+        state,
+        String.to_charlist(data_path),
+        String.to_charlist(idx_path),
+        Version.from_integer(version)
+      )
+    end
+
+    {state, snapshot, upload}
+  end
+
+  defp snapshot_versions(snapshot), do: snapshot |> Snapshot.list() |> Enum.map(fn {version, _key} -> version end)
+
+  defp await_snapshot_versions(snapshot, _expected, 0), do: snapshot_versions(snapshot)
+
+  defp await_snapshot_versions(snapshot, expected, attempts_left) do
+    case snapshot_versions(snapshot) do
+      ^expected ->
+        expected
+
+      _other ->
+        Process.sleep(50)
+        await_snapshot_versions(snapshot, expected, attempts_left - 1)
     end
   end
 

--- a/test/bedrock/data_plane/materializer/olivine/snapshot_retention_test.exs
+++ b/test/bedrock/data_plane/materializer/olivine/snapshot_retention_test.exs
@@ -1,0 +1,58 @@
+defmodule Bedrock.DataPlane.Materializer.Olivine.SnapshotRetentionTest do
+  use ExUnit.Case, async: true
+
+  alias Bedrock.DataPlane.Materializer.Olivine.SnapshotRetention
+
+  describe "from_params/1" do
+    test "reads the keep-last knob" do
+      assert %SnapshotRetention{keep_last: 3} = SnapshotRetention.from_params(%{"snapshot_keep_last" => 3})
+    end
+
+    test "leaves retention off for a missing or malformed knob" do
+      for params <- [
+            %{},
+            %{"snapshot_keep_last" => 0},
+            %{"snapshot_keep_last" => -1},
+            %{"snapshot_keep_last" => "3"},
+            %{"snapshot_keep_last" => nil}
+          ] do
+        assert %SnapshotRetention{keep_last: nil} = SnapshotRetention.from_params(params)
+      end
+    end
+  end
+
+  describe "configured?/1" do
+    test "an unset policy would never delete anything" do
+      refute SnapshotRetention.configured?(%SnapshotRetention{})
+    end
+
+    test "a keep-last policy would" do
+      assert SnapshotRetention.configured?(%SnapshotRetention{keep_last: 1})
+    end
+  end
+
+  describe "oldest_to_keep/2" do
+    test "an unset policy keeps everything" do
+      assert :keep_all = SnapshotRetention.oldest_to_keep(%SnapshotRetention{}, [40, 30, 20, 10])
+    end
+
+    test "keeps everything until the shard has more snapshots than it keeps" do
+      policy = %SnapshotRetention{keep_last: 3}
+
+      assert :keep_all = SnapshotRetention.oldest_to_keep(policy, [])
+      assert :keep_all = SnapshotRetention.oldest_to_keep(policy, [30, 20])
+      assert :keep_all = SnapshotRetention.oldest_to_keep(policy, [30, 20, 10])
+    end
+
+    test "floors at the Kth newest once there are more" do
+      assert {:ok, 20} = SnapshotRetention.oldest_to_keep(%SnapshotRetention{keep_last: 3}, [40, 30, 20, 10])
+      assert {:ok, 30} = SnapshotRetention.oldest_to_keep(%SnapshotRetention{keep_last: 2}, [40, 30, 20, 10])
+    end
+
+    test "keep_last: 1 floors at the newest, which is never strictly below itself" do
+      versions = [40, 30, 20, 10]
+      assert {:ok, 40} = SnapshotRetention.oldest_to_keep(%SnapshotRetention{keep_last: 1}, versions)
+      assert Enum.reject(versions, &(&1 < 40)) == [40]
+    end
+  end
+end

--- a/test/bedrock/data_plane/materializer/olivine/snapshot_retention_test.exs
+++ b/test/bedrock/data_plane/materializer/olivine/snapshot_retention_test.exs
@@ -50,9 +50,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.SnapshotRetentionTest do
     end
 
     test "keep_last: 1 floors at the newest, which is never strictly below itself" do
-      versions = [40, 30, 20, 10]
-      assert {:ok, 40} = SnapshotRetention.oldest_to_keep(%SnapshotRetention{keep_last: 1}, versions)
-      assert Enum.reject(versions, &(&1 < 40)) == [40]
+      assert {:ok, 40} = SnapshotRetention.oldest_to_keep(%SnapshotRetention{keep_last: 1}, [40, 30, 20, 10])
     end
   end
 end

--- a/test/bedrock/data_plane/materializer/olivine/snapshot_upload_policy_test.exs
+++ b/test/bedrock/data_plane/materializer/olivine/snapshot_upload_policy_test.exs
@@ -1,18 +1,20 @@
 defmodule Bedrock.DataPlane.Materializer.Olivine.SnapshotUploadPolicyTest do
   @moduledoc """
-  Snapshot upload policy (bedrock-zi44) as the worker sees it: the
-  manifest params a materializer is created with have to reach its
-  `snapshot_policy`, one knob at a time, and a worker created without
-  them has to end up with the policy that uploads at every opportunity —
-  the behaviour every materializer had before the policy existed.
+  Snapshot upload policy (bedrock-zi44) and snapshot retention
+  (bedrock-s1zr) as the worker sees them: the manifest params a
+  materializer is created with have to reach its `snapshot_policy` and
+  `snapshot_retention`, one knob at a time, and a worker created without
+  them has to end up uploading at every opportunity and deleting
+  nothing — the behaviour every materializer had before either existed.
 
-  What the policy DOES with those knobs is `SnapshotPolicyTest`; where
-  it is consulted is `LogicTest`.
+  What the policies DO with those knobs is `SnapshotPolicyTest` and
+  `SnapshotRetentionTest`; where they are consulted is `LogicTest`.
   """
   use ExUnit.Case, async: false
 
   alias Bedrock.DataPlane.Materializer.Olivine
   alias Bedrock.DataPlane.Materializer.Olivine.SnapshotPolicy
+  alias Bedrock.DataPlane.Materializer.Olivine.SnapshotRetention
 
   defmodule TestCluster do
     @moduledoc false
@@ -81,6 +83,20 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.SnapshotUploadPolicyTest do
 
       assert %SnapshotPolicy{min_interval_ms: nil, after_bytes: nil, after_transactions: nil} = policy
       assert :upload = SnapshotPolicy.decide(policy, System.monotonic_time(:millisecond))
+    end
+
+    test "set the worker's retention", %{tmp_dir: tmp_dir} do
+      pid = start_worker(tmp_dir, %{"shard_id" => 42, "snapshot_keep_last" => 3})
+
+      assert %SnapshotRetention{keep_last: 3} = :sys.get_state(pid).snapshot_retention
+    end
+
+    test "left out leave the worker deleting nothing", %{tmp_dir: tmp_dir} do
+      pid = start_worker(tmp_dir, %{"shard_id" => 42})
+      retention = :sys.get_state(pid).snapshot_retention
+
+      assert %SnapshotRetention{keep_last: nil} = retention
+      refute SnapshotRetention.configured?(retention)
     end
   end
 end


### PR DESCRIPTION
Every snapshot an Olivine materializer wrote stayed in object storage forever: the deletion primitive existed but nothing in `lib/` called it. This change adds a keep-last-K retention policy, set by one manifest param, and prunes a shard's older snapshots right after each successful upload.

Ticket: bedrock-s1zr
Stacked on: #269 (bedrock-zi44/snapshot-upload-policy)

## Why

A materializer uploads a snapshot synchronously before an idle spin-down and in a fire-and-forget task after a compaction cutover. Both write a put-if-not-exists object under `s/{tag}/` keyed by inverted version; neither removed anything. #269 throttled how often a snapshot is written, but the objects still accumulated without bound, one per spin-down in practice (bedrock-947).

Deleting a snapshot is safe because it is derived state: anything it held can be rebuilt by replaying chunks forward from an older snapshot. Chunks stay untouched (bedrock-wxf.6.11). Retention owes one thing: a shard is never left with zero snapshots, since a cold start with no baseline replays from version zero.

## What changed

- New pure policy `SnapshotRetention` with one field, `keep_last`, read from the manifest param `snapshot_keep_last`. Only an explicit positive integer sets it.
- The knob rides the same path as `idle_timeout`: manifest params, worker startup opts, a new `State` field.
- Both upload sites prune immediately after the write returns `:ok`. No scheduled prune exists.

A worker without the param deletes nothing and issues no listing. With it set, an upload may log `Pruned snapshots past the retention limit` or warn `Snapshot retention pruning failed`. Neither changes the upload's result or the spin-down decision.

## How it works

The prune lists the shard's snapshots, newest-first because keys are inverted versions, and the policy returns the Kth newest existing version as a floor, or `:keep_all` when nothing is older. Everything strictly below the floor is deleted.

```
listing after four uploads, keep_last: 2   [4, 3, 2, 1]
floor = 2nd newest                          3
delete strictly below 3                     [4, 3]
```

The newest snapshot cannot be deleted by construction: the floor is always a version from the listing, and with `keep_last: 1` it is the newest itself. The prune runs only after the write succeeded, so the object it keeps is durable before anything is removed.

A listing that cannot complete raises rather than yielding a short list; reading it as empty could floor on a truncated history and delete a wanted snapshot while reporting success. The rescue spans the whole prune, including the second listing inside the deletion walk, because on the spin-down path an escaped raise would crash a worker that had already landed its snapshot. The upload still returns `:ok`.

Merge order matters: land after #268. Before it, a foreign object under `s/{tag}/` whose name parses as base36 but is not canonical width yields a fabricated version up to 2^64-1, which as a floor would delete every real snapshot. #268 rejects such keys at the listing.

## Verification

Integration tests drive both upload paths with `keep_last` set and assert the surviving listing, including a cold start from the lone survivor after a spin-down prune. A backend whose listing raises on consumption proves the failure is logged while the upload returns `:ok`, whether the first or only the second listing fails, and that an unconfigured worker never lists. Unit tests pin the knob and floor arithmetic. Author reported suite, format, credo and dialyzer clean; no CI checks on this stacked draft.

Follow-up: bedrock-q67.21.19 (#268), canonical key parsing, land first.
Follow-up: bedrock-947, nothing drives compaction today.
Follow-up: bedrock-wxf.6.11, chunk reclamation below replay floor.
