### PR TITLE
bedrock-v65: abandon a partitioned-but-alive coordinator leader

### DIFF
--- a/lib/bedrock/cluster.ex
+++ b/lib/bedrock/cluster.ex
@@ -27,6 +27,7 @@ defmodule Bedrock.Cluster do
   @callback config!() :: Config.t()
   @callback coordinator_nodes!() :: [node()]
   @callback coordinator_ping_timeout_in_ms() :: non_neg_integer()
+  @callback coordinator_revalidation_interval_in_ms() :: pos_integer()
   @callback fetch_config() :: {:ok, Config.t()} | {:error, :unavailable}
   @callback fetch_coordinator() :: {:ok, Coordinator.ref()} | {:error, :unavailable}
   @callback fetch_coordinator_nodes() :: {:ok, [node()]} | {:error, :unavailable}
@@ -154,6 +155,17 @@ defmodule Bedrock.Cluster do
       @spec coordinator_ping_timeout_in_ms() :: non_neg_integer()
       def coordinator_ping_timeout_in_ms,
         do: ClusterSupervisor.coordinator_ping_timeout_in_ms(__MODULE__, @otp_app, @static_config)
+
+      @doc """
+      Get the interval (in milliseconds) at which a link re-asks the whole
+      coordinator set who the leader is. A leader partitioned from its peers
+      but still alive keeps answering as leader of its own, superseded,
+      epoch; only asking the set again reveals the newer one.
+      """
+      @impl true
+      @spec coordinator_revalidation_interval_in_ms() :: pos_integer()
+      def coordinator_revalidation_interval_in_ms,
+        do: ClusterSupervisor.coordinator_revalidation_interval_in_ms(__MODULE__, @otp_app, @static_config)
 
       @doc """
       Get the timeout (in milliseconds) for a gateway process waiting to

--- a/lib/bedrock/cluster/link/discovery.ex
+++ b/lib/bedrock/cluster/link/discovery.ex
@@ -19,9 +19,13 @@ defmodule Bedrock.Cluster.Link.Discovery do
   the wiring push (epoch, sequencer, proxies) rides this link, so a Link
   left pinned to it never learns the new epoch.
 
-  This is what FDB's clients do: `monitorLeaderOneGeneration` keeps a
-  `monitorNominee` loop against every coordinator and re-picks the leader
-  whenever any nominee changes (`fdbclient/MonitorLeader.actor.cpp`).
+  FDB's clients ask the same question of the same set:
+  `monitorLeaderOneGeneration` keeps a `monitorNominee` loop against every
+  coordinator and re-picks the leader whenever any nominee changes
+  (`fdbclient/MonitorLeader.actor.cpp`). The mechanism differs — FDB
+  long-polls (`GetLeaderRequest` carries the `changeID` it already knows
+  and the coordinator holds the reply until the nominee changes, breaking
+  only for a 600s jittered keepalive) where we re-ask on a timer.
   """
   @spec find_a_live_coordinator(State.t()) ::
           {State.t(), :ok}
@@ -38,7 +42,7 @@ defmodule Bedrock.Cluster.Link.Discovery do
     trace_found_coordinator(t.cluster, coordinator_ref)
 
     t
-    |> rearm_discovery_timer()
+    |> rearm_discovery_timer(t.cluster.coordinator_revalidation_interval_in_ms())
     |> change_coordinator(coordinator_ref)
     |> then(&{&1, :ok})
   end
@@ -49,15 +53,18 @@ defmodule Bedrock.Cluster.Link.Discovery do
   # death still arrives as a DOWN) and poll again.
   defp handle_coordinator_discovery_result({:error, _reason} = error, t) do
     t
-    |> rearm_discovery_timer()
+    |> rearm_discovery_timer(t.cluster.gateway_ping_timeout_in_ms())
     |> then(&{&1, error})
   end
 
-  @spec rearm_discovery_timer(State.t()) :: State.t()
-  defp rearm_discovery_timer(t) do
+  # Jittered: every node in the fleet polls every coordinator, and they
+  # must not do it in lockstep. FDB jitters the equivalent keepalive for
+  # the same reason (`delayJittered`, `fdbserver/Coordination.actor.cpp`).
+  @spec rearm_discovery_timer(State.t(), pos_integer()) :: State.t()
+  defp rearm_discovery_timer(t, interval_in_ms) do
     t
     |> cancel_timer(:find_a_live_coordinator)
-    |> set_timer(:find_a_live_coordinator, t.cluster.gateway_ping_timeout_in_ms())
+    |> set_timer(:find_a_live_coordinator, interval_in_ms + :rand.uniform(div(interval_in_ms, 4) + 1))
   end
 
   @spec multi_call_coordinator_discovery(module(), [node()]) ::
@@ -115,10 +122,12 @@ defmodule Bedrock.Cluster.Link.Discovery do
     |> register_node_capabilities()
   end
 
+  # Switching leaders is routine now that the set is re-polled, so the
+  # monitor on the coordinator we just left has to go with it.
   @spec monitor_known_coordinator(State.t()) :: State.t()
   defp monitor_known_coordinator(t) do
-    Process.monitor(t.known_coordinator)
-    t
+    t.coordinator_monitor && Process.demonitor(t.coordinator_monitor, [:flush])
+    %{t | coordinator_monitor: Process.monitor(t.known_coordinator)}
   end
 
   @spec register_node_capabilities(State.t()) :: State.t()

--- a/lib/bedrock/cluster/link/discovery.ex
+++ b/lib/bedrock/cluster/link/discovery.ex
@@ -9,10 +9,19 @@ defmodule Bedrock.Cluster.Link.Discovery do
   alias Bedrock.ControlPlane.Coordinator
 
   @doc """
-  Find the leader coordinator. This implements enhanced two-phase discovery:
-  - If we have a known leader, try direct call first
-  - If direct call fails or no known leader, use multi_call discovery
-  - Select leader with highest epoch and non-nil leader pid
+  Find the leader coordinator: ping EVERY coordinator named in the
+  descriptor and take the one reporting the highest epoch.
+
+  The whole set is polled on every pass, including when we are already
+  pinned to a leader that still answers. A leader that is partitioned
+  from its peers but alive keeps answering as leader of its own, now
+  superseded, epoch — only the set can tell us a newer one exists, and
+  the wiring push (epoch, sequencer, proxies) rides this link, so a Link
+  left pinned to it never learns the new epoch.
+
+  This is what FDB's clients do: `monitorLeaderOneGeneration` keeps a
+  `monitorNominee` loop against every coordinator and re-picks the leader
+  whenever any nominee changes (`fdbclient/MonitorLeader.actor.cpp`).
   """
   @spec find_a_live_coordinator(State.t()) ::
           {State.t(), :ok}
@@ -20,93 +29,35 @@ defmodule Bedrock.Cluster.Link.Discovery do
   def find_a_live_coordinator(t) do
     trace_searching_for_coordinator(t.cluster)
 
-    t
-    |> search_for_coordinator()
+    t.cluster
+    |> multi_call_coordinator_discovery(t.descriptor.coordinator_nodes)
     |> handle_coordinator_discovery_result(t)
   end
-
-  defp search_for_coordinator(t) do
-    t.known_coordinator
-    |> try_known_coordinator_first(t)
-    |> fallback_to_discovery_if_needed(t)
-  end
-
-  defp try_known_coordinator_first(:unavailable, _t), do: :fallback_needed
-
-  defp try_known_coordinator_first(coordinator_ref, t) do
-    coordinator_ref
-    |> try_direct_coordinator_call(t.cluster)
-    |> case do
-      {:ok, _} = success -> success
-      {:error, _} -> :fallback_needed
-    end
-  end
-
-  defp fallback_to_discovery_if_needed(
-         :fallback_needed,
-         %{descriptor: %Bedrock.Cluster.Descriptor{coordinator_nodes: nodes}} = t
-       ), do: discover_leader_coordinator(t.cluster, nodes)
-
-  defp fallback_to_discovery_if_needed(result, _t), do: result
 
   defp handle_coordinator_discovery_result({:ok, {coordinator_ref, _epoch}}, t) do
     trace_found_coordinator(t.cluster, coordinator_ref)
 
     t
-    |> cancel_timer(:find_a_live_coordinator)
+    |> rearm_discovery_timer()
     |> change_coordinator(coordinator_ref)
     |> then(&{&1, :ok})
   end
 
+  # Silence is not evidence of a newer leader: FDB abandons the leader it
+  # holds only when the set nominates a different one, never because the
+  # old one stopped answering. Keep whatever we are pinned to (an actual
+  # death still arrives as a DOWN) and poll again.
   defp handle_coordinator_discovery_result({:error, _reason} = error, t) do
     t
-    |> cancel_timer(:find_a_live_coordinator)
-    |> set_timer(:find_a_live_coordinator, t.cluster.gateway_ping_timeout_in_ms())
-    |> change_coordinator(:unavailable)
+    |> rearm_discovery_timer()
     |> then(&{&1, error})
   end
 
-  @spec try_direct_coordinator_call(Coordinator.ref(), module()) ::
-          {:ok, {Coordinator.ref(), Bedrock.epoch()}} | {:error, :unavailable}
-  defp try_direct_coordinator_call(coordinator_ref, cluster) do
-    coordinator_ref
-    |> GenServer.call(:ping, cluster.coordinator_ping_timeout_in_ms())
-    |> case do
-      {:pong, _epoch, nil} ->
-        {:error, :unavailable}
-
-      {:pong, epoch, leader_pid} ->
-        {:ok, {leader_pid, epoch}}
-
-      _ ->
-        {:error, :unavailable}
-    end
-  catch
-    :exit, _ -> {:error, :unavailable}
-  end
-
-  @spec discover_leader_coordinator(module(), [node()]) ::
-          {:ok, {Coordinator.ref(), Bedrock.epoch()}} | {:error, :unavailable}
-  defp discover_leader_coordinator(cluster, coordinator_nodes) do
-    coordinator_nodes
-    |> try_local_coordinator_first(cluster)
-    |> case do
-      {:ok, _} = success ->
-        success
-
-      {:error, _reason} ->
-        multi_call_coordinator_discovery(cluster, coordinator_nodes)
-    end
-  end
-
-  defp try_local_coordinator_first(coordinator_nodes, cluster) do
-    if Node.self() in coordinator_nodes do
-      :coordinator
-      |> cluster.otp_name()
-      |> try_direct_coordinator_call(cluster)
-    else
-      {:error, :not_local}
-    end
+  @spec rearm_discovery_timer(State.t()) :: State.t()
+  defp rearm_discovery_timer(t) do
+    t
+    |> cancel_timer(:find_a_live_coordinator)
+    |> set_timer(:find_a_live_coordinator, t.cluster.gateway_ping_timeout_in_ms())
   end
 
   @spec multi_call_coordinator_discovery(module(), [node()]) ::

--- a/lib/bedrock/cluster/link/server.ex
+++ b/lib/bedrock/cluster/link/server.ex
@@ -16,6 +16,7 @@ defmodule Bedrock.Cluster.Link.Server do
   alias Bedrock.Cluster.Descriptor
   alias Bedrock.Cluster.Link.RoutingCache
   alias Bedrock.Cluster.Link.State
+  alias Bedrock.ControlPlane.Config.TransactionSystemLayout
 
   @spec child_spec(
           opts :: [
@@ -148,13 +149,16 @@ defmodule Bedrock.Cluster.Link.Server do
           {:noreply, State.t(), {:continue, :find_a_live_coordinator}}
   def handle_info({:timeout, :find_a_live_coordinator}, t), do: noreply(t, continue: :find_a_live_coordinator)
 
-  # A coordinator we have abandoned still holds us in its subscriber set,
-  # so a partitioned-but-alive old leader can push the wiring of its own
-  # epoch after we have moved on. Wiring only ever moves forward: a push
-  # carrying an epoch we have already passed is dropped, not installed.
+  # A coordinator we have abandoned still holds us in its subscriber set —
+  # there is no unsubscribe — so a partitioned-but-alive old leader can
+  # push the wiring of its own epoch after we have moved on. Wiring only
+  # ever moves forward: a push carrying an epoch we have already passed is
+  # dropped, not installed. Compared against the high-water mark rather
+  # than the cached layout, so a clear can't be used to slip an old layout
+  # in behind it.
   @spec handle_info({:tsl_updated, term()}, State.t()) :: {:noreply, State.t()}
-  def handle_info({:tsl_updated, %{epoch: epoch}}, %{transaction_system_layout: %{epoch: current}} = t)
-      when epoch < current, do: noreply(t)
+  def handle_info({:tsl_updated, %{epoch: epoch}}, %{wiring_epoch: seen} = t) when is_integer(seen) and epoch < seen,
+    do: noreply(t)
 
   def handle_info({:tsl_updated, new_tsl}, t) do
     # Update cached TSL when coordinator broadcasts updates, and forward to
@@ -169,7 +173,7 @@ defmodule Bedrock.Cluster.Link.Server do
     # A wiring push means a recovery happened: drop the routing cache so
     # new-epoch wiring can never pair with old-epoch routing.
     RoutingCache.clear(t.routing_table)
-    noreply(%{t | transaction_system_layout: new_tsl})
+    noreply(%{t | transaction_system_layout: new_tsl, wiring_epoch: wiring_epoch(new_tsl, t.wiring_epoch)})
   end
 
   @spec handle_info({:DOWN, reference(), :process, term(), term()}, State.t()) ::
@@ -193,4 +197,10 @@ defmodule Bedrock.Cluster.Link.Server do
       noreply(t)
     end
   end
+
+  # A clear carries no epoch, so it can't be attributed to a coordinator:
+  # it drops the layout but never lowers the mark.
+  @spec wiring_epoch(TransactionSystemLayout.t() | nil, Bedrock.epoch() | nil) :: Bedrock.epoch() | nil
+  defp wiring_epoch(nil, seen), do: seen
+  defp wiring_epoch(%{epoch: epoch}, _seen), do: epoch
 end

--- a/lib/bedrock/cluster/link/server.ex
+++ b/lib/bedrock/cluster/link/server.ex
@@ -148,7 +148,14 @@ defmodule Bedrock.Cluster.Link.Server do
           {:noreply, State.t(), {:continue, :find_a_live_coordinator}}
   def handle_info({:timeout, :find_a_live_coordinator}, t), do: noreply(t, continue: :find_a_live_coordinator)
 
+  # A coordinator we have abandoned still holds us in its subscriber set,
+  # so a partitioned-but-alive old leader can push the wiring of its own
+  # epoch after we have moved on. Wiring only ever moves forward: a push
+  # carrying an epoch we have already passed is dropped, not installed.
   @spec handle_info({:tsl_updated, term()}, State.t()) :: {:noreply, State.t()}
+  def handle_info({:tsl_updated, %{epoch: epoch}}, %{transaction_system_layout: %{epoch: current}} = t)
+      when epoch < current, do: noreply(t)
+
   def handle_info({:tsl_updated, new_tsl}, t) do
     # Update cached TSL when coordinator broadcasts updates, and forward to
     # this node's foreman (if any), which relays it to hosted workers: a

--- a/lib/bedrock/cluster/link/state.ex
+++ b/lib/bedrock/cluster/link/state.ex
@@ -11,10 +11,12 @@ defmodule Bedrock.Cluster.Link.State do
           path_to_descriptor: Path.t(),
           descriptor: Descriptor.t(),
           known_coordinator: Coordinator.ref() | :unavailable,
+          coordinator_monitor: reference() | nil,
           timers: %{atom() => reference()} | nil,
           mode: :passive | :active,
           capabilities: [Bedrock.Cluster.capability()],
           transaction_system_layout: TransactionSystemLayout.t() | nil,
+          wiring_epoch: Bedrock.epoch() | nil,
           routing_table: :ets.table()
         }
   defstruct node: nil,
@@ -22,9 +24,14 @@ defmodule Bedrock.Cluster.Link.State do
             path_to_descriptor: nil,
             descriptor: nil,
             known_coordinator: :unavailable,
+            coordinator_monitor: nil,
             timers: nil,
             mode: :active,
             capabilities: [],
             transaction_system_layout: nil,
+            # High-water mark of the wiring we have seen. Separate from
+            # the cached layout because a clear drops the layout without
+            # lowering the mark.
+            wiring_epoch: nil,
             routing_table: nil
 end

--- a/lib/bedrock/internal/cluster_supervisor.ex
+++ b/lib/bedrock/internal/cluster_supervisor.ex
@@ -407,6 +407,17 @@ defmodule Bedrock.Internal.ClusterSupervisor do
     |> Keyword.get(:coordinator_ping_timeout_in_ms, 300)
   end
 
+  @spec coordinator_revalidation_interval_in_ms(
+          Cluster.t(),
+          otp_app :: atom() | nil,
+          static_config :: Keyword.t() | nil
+        ) :: pos_integer()
+  def coordinator_revalidation_interval_in_ms(module, otp_app, static_config) do
+    module
+    |> node_config(otp_app, static_config)
+    |> Keyword.get(:coordinator_revalidation_interval_in_ms, 5_000)
+  end
+
   @spec gateway_ping_timeout_in_ms(
           Cluster.t(),
           otp_app :: atom() | nil,

--- a/test/bedrock/cluster/link/leader_revalidation_test.exs
+++ b/test/bedrock/cluster/link/leader_revalidation_test.exs
@@ -12,6 +12,7 @@ defmodule Bedrock.Cluster.Link.LeaderRevalidationTest do
     def name, do: "v65"
     def otp_name(component), do: :"v65_#{component}"
     def coordinator_ping_timeout_in_ms, do: 100
+    def coordinator_revalidation_interval_in_ms, do: 200
     def gateway_ping_timeout_in_ms, do: 50
   end
 
@@ -49,14 +50,18 @@ defmodule Bedrock.Cluster.Link.LeaderRevalidationTest do
     )
   end
 
+  defp holding_epoch(state, epoch), do: %{state | transaction_system_layout: %{epoch: epoch}, wiring_epoch: epoch}
+
   describe "leader revalidation against the coordinator set" do
-    test "abandons a partitioned-but-alive leader once the set reports a newer epoch" do
-      # A: the leader we are pinned to. Partitioned from B but perfectly
-      # alive, and still answering as leader of its own (old) epoch.
+    test "abandons a partitioned-but-alive leader for the one the set nominates" do
+      # A: the leader we are pinned to. Alive, answering direct pings as
+      # leader of its own (old) epoch — but partitioned away from the set
+      # the descriptor names, so it is not among the coordinators polled.
       {:ok, old_leader} = start_supervised(Supervisor.child_spec({FakeCoordinator, epoch: 5}, id: :a))
 
-      # B: elected in a newer epoch, reachable through the coordinator set
-      # named in the descriptor.
+      # B: elected in a newer epoch, and reachable through that set.
+      # (Picking the highest epoch among several answers is covered by
+      # `select_leader_from_responses/1` in DiscoveryTest.)
       {:ok, new_leader} =
         start_supervised(
           Supervisor.child_spec({FakeCoordinator, [epoch: 7, name: Cluster.otp_name(:coordinator)]}, id: :b)
@@ -74,13 +79,29 @@ defmodule Bedrock.Cluster.Link.LeaderRevalidationTest do
                Discovery.find_a_live_coordinator(link_state([]))
     end
 
-    test "keeps the pinned leader when the set has nothing newer to say" do
+    test "keeps the pinned leader when the set is silent" do
       # No coordinator is registered, so every member of the set is silent.
-      # Silence is not evidence of a new leader.
+      # Silence is not evidence of a newer leader.
       {:ok, old_leader} = start_supervised({FakeCoordinator, epoch: 5})
 
       assert {%State{known_coordinator: ^old_leader}, {:error, :unavailable}} =
                Discovery.find_a_live_coordinator(link_state(known_coordinator: old_leader))
+    end
+
+    test "drops the monitor on the leader it leaves" do
+      {:ok, _leader} =
+        start_supervised({FakeCoordinator, [epoch: 7, name: Cluster.otp_name(:coordinator)]})
+
+      {:ok, abandoned} = start_supervised(Supervisor.child_spec({FakeCoordinator, epoch: 5}, id: :a))
+      abandoned_monitor = Process.monitor(abandoned)
+
+      {%State{coordinator_monitor: monitor}, :ok} =
+        Discovery.find_a_live_coordinator(
+          link_state(known_coordinator: abandoned, coordinator_monitor: abandoned_monitor)
+        )
+
+      refute monitor == abandoned_monitor
+      assert Process.demonitor(abandoned_monitor, [:info]) == false
     end
   end
 
@@ -90,7 +111,7 @@ defmodule Bedrock.Cluster.Link.LeaderRevalidationTest do
     end
 
     test "drops a push that carries an epoch we have already passed", %{state: state} do
-      state = %{state | transaction_system_layout: %{epoch: 7}}
+      state = holding_epoch(state, 7)
       RoutingCache.insert(state.routing_table, "a", "b", :materializer)
 
       assert {:noreply, %State{transaction_system_layout: %{epoch: 7}}} =
@@ -100,20 +121,25 @@ defmodule Bedrock.Cluster.Link.LeaderRevalidationTest do
     end
 
     test "installs a push that carries a newer epoch", %{state: state} do
-      state = %{state | transaction_system_layout: %{epoch: 7}}
+      state = holding_epoch(state, 7)
       RoutingCache.insert(state.routing_table, "a", "b", :materializer)
 
-      assert {:noreply, %State{transaction_system_layout: %{epoch: 9}}} =
+      assert {:noreply, %State{transaction_system_layout: %{epoch: 9}, wiring_epoch: 9}} =
                Server.handle_info({:tsl_updated, %{epoch: 9}}, state)
 
       assert :not_cached = RoutingCache.lookup(state.routing_table, "a")
     end
 
-    test "installs a clear, which carries no epoch to compare", %{state: state} do
-      state = %{state | transaction_system_layout: %{epoch: 7}}
+    test "applies a clear without lowering the high-water mark", %{state: state} do
+      # A clear carries no epoch, so it cannot be attributed to a
+      # coordinator and is applied. It must not re-open the door: the old
+      # leader that cleared us can otherwise follow it with its own layout.
+      {:noreply, cleared} = Server.handle_info({:tsl_updated, nil}, holding_epoch(state, 7))
+
+      assert %State{transaction_system_layout: nil, wiring_epoch: 7} = cleared
 
       assert {:noreply, %State{transaction_system_layout: nil}} =
-               Server.handle_info({:tsl_updated, nil}, state)
+               Server.handle_info({:tsl_updated, %{epoch: 5}}, cleared)
     end
   end
 end

--- a/test/bedrock/cluster/link/leader_revalidation_test.exs
+++ b/test/bedrock/cluster/link/leader_revalidation_test.exs
@@ -1,0 +1,119 @@
+defmodule Bedrock.Cluster.Link.LeaderRevalidationTest do
+  use ExUnit.Case, async: true
+
+  alias Bedrock.Cluster.Descriptor
+  alias Bedrock.Cluster.Link.Discovery
+  alias Bedrock.Cluster.Link.RoutingCache
+  alias Bedrock.Cluster.Link.Server
+  alias Bedrock.Cluster.Link.State
+
+  defmodule Cluster do
+    @moduledoc false
+    def name, do: "v65"
+    def otp_name(component), do: :"v65_#{component}"
+    def coordinator_ping_timeout_in_ms, do: 100
+    def gateway_ping_timeout_in_ms, do: 50
+  end
+
+  defmodule FakeCoordinator do
+    @moduledoc false
+    use GenServer
+
+    def start_link(opts) do
+      case opts[:name] do
+        nil -> GenServer.start_link(__MODULE__, opts)
+        name -> GenServer.start_link(__MODULE__, opts, name: name)
+      end
+    end
+
+    @impl true
+    def init(opts), do: {:ok, %{epoch: opts[:epoch], leader?: Keyword.get(opts, :leader?, true)}}
+
+    @impl true
+    def handle_call(:ping, _from, t) do
+      leader = if t.leader?, do: self()
+      {:reply, {:pong, t.epoch, leader}, t}
+    end
+  end
+
+  defp link_state(fields) do
+    struct!(
+      %State{
+        node: Node.self(),
+        cluster: Cluster,
+        descriptor: Descriptor.new("v65", [Node.self()]),
+        known_coordinator: :unavailable,
+        capabilities: []
+      },
+      fields
+    )
+  end
+
+  describe "leader revalidation against the coordinator set" do
+    test "abandons a partitioned-but-alive leader once the set reports a newer epoch" do
+      # A: the leader we are pinned to. Partitioned from B but perfectly
+      # alive, and still answering as leader of its own (old) epoch.
+      {:ok, old_leader} = start_supervised(Supervisor.child_spec({FakeCoordinator, epoch: 5}, id: :a))
+
+      # B: elected in a newer epoch, reachable through the coordinator set
+      # named in the descriptor.
+      {:ok, new_leader} =
+        start_supervised(
+          Supervisor.child_spec({FakeCoordinator, [epoch: 7, name: Cluster.otp_name(:coordinator)]}, id: :b)
+        )
+
+      assert {%State{known_coordinator: ^new_leader}, :ok} =
+               Discovery.find_a_live_coordinator(link_state(known_coordinator: old_leader))
+    end
+
+    test "keeps polling after a successful discovery" do
+      {:ok, _leader} =
+        start_supervised({FakeCoordinator, [epoch: 7, name: Cluster.otp_name(:coordinator)]})
+
+      assert {%State{timers: %{find_a_live_coordinator: _}}, :ok} =
+               Discovery.find_a_live_coordinator(link_state([]))
+    end
+
+    test "keeps the pinned leader when the set has nothing newer to say" do
+      # No coordinator is registered, so every member of the set is silent.
+      # Silence is not evidence of a new leader.
+      {:ok, old_leader} = start_supervised({FakeCoordinator, epoch: 5})
+
+      assert {%State{known_coordinator: ^old_leader}, {:error, :unavailable}} =
+               Discovery.find_a_live_coordinator(link_state(known_coordinator: old_leader))
+    end
+  end
+
+  describe "wiring pushes from a superseded leader" do
+    setup do
+      %{state: link_state(routing_table: RoutingCache.new(:v65_link_routing))}
+    end
+
+    test "drops a push that carries an epoch we have already passed", %{state: state} do
+      state = %{state | transaction_system_layout: %{epoch: 7}}
+      RoutingCache.insert(state.routing_table, "a", "b", :materializer)
+
+      assert {:noreply, %State{transaction_system_layout: %{epoch: 7}}} =
+               Server.handle_info({:tsl_updated, %{epoch: 5}}, state)
+
+      assert {:ok, _entry} = RoutingCache.lookup(state.routing_table, "a")
+    end
+
+    test "installs a push that carries a newer epoch", %{state: state} do
+      state = %{state | transaction_system_layout: %{epoch: 7}}
+      RoutingCache.insert(state.routing_table, "a", "b", :materializer)
+
+      assert {:noreply, %State{transaction_system_layout: %{epoch: 9}}} =
+               Server.handle_info({:tsl_updated, %{epoch: 9}}, state)
+
+      assert :not_cached = RoutingCache.lookup(state.routing_table, "a")
+    end
+
+    test "installs a clear, which carries no epoch to compare", %{state: state} do
+      state = %{state | transaction_system_layout: %{epoch: 7}}
+
+      assert {:noreply, %State{transaction_system_layout: nil}} =
+               Server.handle_info({:tsl_updated, nil}, state)
+    end
+  end
+end


### PR DESCRIPTION
A client `Link` pinned itself to one coordinator and only looked for another when that coordinator died. A coordinator cut off from its Raft peers but still running keeps answering as leader of its old epoch, so every Link it held stayed on stale wiring while the cluster moved on. Discovery now polls the whole coordinator set every few seconds and follows the highest epoch, and the Link drops any wiring push older than the one it has installed.

Ticket: bedrock-v65

## Why

The Link caches the layout (epoch, sequencer, commit proxies) its coordinator pushes to it and hands that layout to every transaction on the node. Discovery pinged the pinned coordinator first, then the co-located one, and asked the whole set only when both were silent. After a success it cancelled its timer; the only way back in was a `:DOWN` on the pinned coordinator.

That treats losing leadership as dying. A coordinator's ping reply comes from its own view of who leads and at what epoch, and a partitioned coordinator never revises that view. A Link it held kept the epoch-N layout while the survivors elected a leader at N+1, and sent transactions to a sequencer and proxies that recovery had already fenced. FDB's client switches leaders when the coordinator set nominates someone else, never because the old leader went quiet.

## What changed

- Discovery multi-calls every coordinator in the descriptor on every pass and takes the highest-epoch leader; the pinned-first and local-first short-circuits are gone.
- The poll re-arms after success too, jittered, on a new config key `coordinator_revalidation_interval_in_ms` (default 5000; failures retry at the 300ms gateway timeout).
- A silent set no longer marks the coordinator `:unavailable`; a real death still arrives as `:DOWN`.
- Switching leaders demonitors the one being left.
- The Link keeps a `wiring_epoch` high-water mark and discards a `{:tsl_updated, _}` push carrying a lower epoch. The push shape is untouched.

## How it works

Two coordinators, A leading at epoch 5 with the Link pinned to it. A is partitioned, B wins epoch 7, A stays up. On the next poll the Link picks B, demonitors A, monitors B and re-registers. B replays the epoch-7 layout; the Link installs it, sets the mark to 7 and clears its routing cache.

A still lists the Link as a subscriber, because only a subscriber's death removes it. If A pushes its epoch-5 layout, the push is dropped before touching the cache, routing table or foreman. If A's director fails first, A broadcasts a `nil` clear; the clear installs (it carries no epoch to attribute) but the mark stays at 7, so the epoch-5 layout that follows is still refused. A fence keyed on the cached layout would have nothing to compare against after that clear. The comparison is strict, so an equal-epoch replay on re-registration still installs.

The interval is jittered so Links do not poll in lockstep, and long enough that a 300ms multi-call timeout under partition blocks the Link only a few percent of the time.

## Verification

`test/bedrock/cluster/link/leader_revalidation_test.exs` drives discovery and the push handler against a fake coordinator, covering the leader switch, the re-armed timer, silence, the dropped monitor, and the fence's three cases (stale push, newer push, `nil` clear). Four of the seven fail on the previous code. CI is green on OTP 27.3, 28.3 and 29.0; the S3 MinIO (OTP 29) job is red on `test/bedrock/internal/repo_transact_test.exs:507`, a name-registration collision in a test this change does not touch.

Follow-up: bedrock-ued, a stale nil clear can still blank the cached layout.
Follow-up: bedrock-ltc, a passive Link never subscribes, so its cache stays nil.
