### PR TITLE
bedrock-aa5: extract shared olivine test fixtures build_index/1 and open_test_database/1

### DIFF
--- a/test/bedrock/data_plane/materializer/olivine/atomic_operations_test.exs
+++ b/test/bedrock/data_plane/materializer/olivine/atomic_operations_test.exs
@@ -16,21 +16,12 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.AtomicOperationsTest do
   alias Bedrock.DataPlane.Materializer.Olivine.IndexManager
   alias Bedrock.DataPlane.Transaction
   alias Bedrock.DataPlane.Version
+  alias Bedrock.Test.Materializer.Olivine.IndexTestHelpers
 
   describe "Olivine IndexManager atomic operations" do
     setup do
-      # Create temporary directory for test database
-      temp_dir = System.tmp_dir!() <> "/test_olivine_#{System.unique_integer()}"
-      File.mkdir_p!(temp_dir)
-
-      db_file_path = Path.join(temp_dir, "olivine_test.dets")
-      {:ok, database} = OlivineDatabase.open(:"test_db_#{System.unique_integer()}", db_file_path)
+      database = IndexTestHelpers.open_test_database("olivine_test")
       index_manager = IndexManager.new()
-
-      on_exit(fn ->
-        :ok = OlivineDatabase.close(database)
-        File.rm_rf!(temp_dir)
-      end)
 
       {:ok, database: database, index_manager: index_manager}
     end

--- a/test/bedrock/data_plane/materializer/olivine/index_test.exs
+++ b/test/bedrock/data_plane/materializer/olivine/index_test.exs
@@ -2,31 +2,18 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.IndexTest do
   use ExUnit.Case, async: true
 
   alias Bedrock.DataPlane.Materializer.Olivine.Index
-  alias Bedrock.DataPlane.Materializer.Olivine.Index.Page
-  alias Bedrock.DataPlane.Materializer.Olivine.Index.Tree
+  alias Bedrock.Test.Materializer.Olivine.IndexTestHelpers
 
   # Helper to create a locator (8-byte binary)
   defp locator(n), do: <<n::unsigned-big-64>>
 
   # Helper to build an index with pages
   defp build_index_with_pages(page_tuples) do
-    # page_tuples is a list of {page_id, kvs, next_id}
-    page_map =
-      Enum.reduce(page_tuples, %{}, fn {page_id, kvs, next_id}, acc ->
-        page = Page.new(page_id, kvs)
-        Map.put(acc, page_id, {page, next_id})
-      end)
-
-    tree =
-      Enum.reduce(page_tuples, :gb_trees.empty(), fn {page_id, kvs, _next_id}, tree_acc ->
-        page = Page.new(page_id, kvs)
-        Tree.add_page_to_tree(tree_acc, page)
-      end)
-
-    %Index{
-      tree: tree,
-      page_map: page_map
-    }
+    # page_tuples is a list of {page_id, kvs, next_id}; the chain implied by
+    # next_id already matches key order, so the shared helper's rebuild is a no-op.
+    page_specs = Enum.map(page_tuples, fn {page_id, kvs, _next_id} -> {page_id, kvs} end)
+    {index, _allocator} = IndexTestHelpers.build_index(page_specs)
+    index
   end
 
   describe "delete_pages/2" do

--- a/test/bedrock/data_plane/materializer/olivine/index_update_test.exs
+++ b/test/bedrock/data_plane/materializer/olivine/index_update_test.exs
@@ -7,57 +7,14 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.IndexUpdateTest do
   use ExUnit.Case, async: true
 
   alias Bedrock.DataPlane.Materializer.Olivine.Database
-  alias Bedrock.DataPlane.Materializer.Olivine.IdAllocator
   alias Bedrock.DataPlane.Materializer.Olivine.Index
   alias Bedrock.DataPlane.Materializer.Olivine.Index.Page
-  alias Bedrock.DataPlane.Materializer.Olivine.Index.Tree
   alias Bedrock.DataPlane.Materializer.Olivine.IndexUpdate
   alias Bedrock.DataPlane.Version
   alias Bedrock.Test.Materializer.Olivine.IndexTestHelpers
 
   setup do
-    temp_dir = System.tmp_dir!() <> "/test_index_update_#{System.unique_integer()}"
-    File.mkdir_p!(temp_dir)
-
-    db_file_path = Path.join(temp_dir, "index_update_test.dets")
-    {:ok, database} = Database.open(:"test_db_#{System.unique_integer()}", db_file_path)
-
-    on_exit(fn ->
-      :ok = Database.close(database)
-      File.rm_rf!(temp_dir)
-    end)
-
-    {:ok, database: database}
-  end
-
-  # Builds an index from a page spec like [{1, ["a", "b"]}, {2, ["c", "d"]}].
-  # Page ids may include 0 to place keys directly on page 0. Pages are entered
-  # into the tree in key order and the chain is rebuilt for consistency.
-  defp build_index(page_specs) do
-    base_version = Version.zero()
-    initial_index = Index.new()
-
-    pages =
-      Enum.map(page_specs, fn {page_id, keys} ->
-        Page.new(page_id, Enum.map(keys, &{&1, base_version}))
-      end)
-
-    page_map =
-      Enum.reduce(pages, initial_index.page_map, fn page, acc ->
-        Map.put(acc, Page.id(page), {page, 0})
-      end)
-
-    tree =
-      Enum.reduce(pages, initial_index.tree, fn page, acc ->
-        Tree.add_page_to_tree(acc, page)
-      end)
-
-    index = IndexTestHelpers.rebuild_page_chain_consistency(%{initial_index | tree: tree, page_map: page_map})
-
-    max_page_id = page_specs |> Enum.map(&elem(&1, 0)) |> Enum.max(fn -> 0 end)
-    allocator = IdAllocator.new(max_page_id, [])
-
-    {index, allocator}
+    {:ok, database: IndexTestHelpers.open_test_database("index_update_test")}
   end
 
   defp new_update(index, allocator, database, opts \\ []) do
@@ -81,7 +38,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.IndexUpdateTest do
 
   describe "pending-operation merging" do
     test "two clears targeting keys on the same page merge into one pending map", %{database: database} do
-      {index, allocator} = build_index([{0, ["a", "b", "c"]}])
+      {index, allocator} = IndexTestHelpers.build_index([{0, ["a", "b", "c"]}])
 
       update =
         index
@@ -98,7 +55,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.IndexUpdateTest do
     end
 
     test "a set followed by a clear on the same page share one pending map", %{database: database} do
-      {index, allocator} = build_index([{0, ["a", "c"]}])
+      {index, allocator} = IndexTestHelpers.build_index([{0, ["a", "c"]}])
 
       update =
         index
@@ -120,7 +77,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.IndexUpdateTest do
   describe "clear_range across a multi-page chain" do
     test "middle pages are deleted and recycled while boundary pages keep out-of-range keys", %{database: database} do
       {index, allocator} =
-        build_index([
+        IndexTestHelpers.build_index([
           {1, ["a", "b", "c"]},
           {2, ["d", "e", "f"]},
           {3, ["g", "h", "i"]}
@@ -154,7 +111,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.IndexUpdateTest do
       # family, then re-writes the current entries. The re-set keys must
       # survive (set overwrites the pending :clear for the same key) and
       # subset keys that are not re-written must be gone.
-      {index, allocator} = build_index([{1, ["a", "b", "c"]}])
+      {index, allocator} = IndexTestHelpers.build_index([{1, ["a", "b", "c"]}])
 
       update =
         run_mutations(index, allocator, database, [
@@ -173,7 +130,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.IndexUpdateTest do
 
   describe "clear_range end key is exclusive" do
     test "the key at the range end survives a single-page clear", %{database: database} do
-      {index, allocator} = build_index([{0, ["a", "b", "c"]}])
+      {index, allocator} = IndexTestHelpers.build_index([{0, ["a", "b", "c"]}])
 
       update = run_mutations(index, allocator, database, [{:clear_range, "a", "c"}])
       {final_index, _db, _allocator, _modified} = IndexUpdate.finish(update)
@@ -187,7 +144,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.IndexUpdateTest do
       # range; "g" is the left key of the last page and sits exactly on the
       # exclusive end.
       {index, allocator} =
-        build_index([
+        IndexTestHelpers.build_index([
           {1, ["a", "b", "c"]},
           {2, ["d", "e", "f"]},
           {3, ["g", "h", "i"]}
@@ -206,7 +163,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.IndexUpdateTest do
     end
 
     test "an empty range clears nothing", %{database: database} do
-      {index, allocator} = build_index([{0, ["a", "b", "c"]}])
+      {index, allocator} = IndexTestHelpers.build_index([{0, ["a", "b", "c"]}])
 
       update = run_mutations(index, allocator, database, [{:clear_range, "b", "b"}])
       {final_index, _db, _allocator, _modified} = IndexUpdate.finish(update)
@@ -226,7 +183,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.IndexUpdateTest do
       database: database
     } do
       {index, allocator} =
-        build_index([
+        IndexTestHelpers.build_index([
           {0, ["a", "b"]},
           {1, ["c", "d"]},
           {2, ["e", "f"]}
@@ -256,7 +213,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.IndexUpdateTest do
       # page_for_key falls back to page 0 (the empty head), so the chain walk
       # skips every real page as entirely-before-range until the chain ends.
       {index, allocator} =
-        build_index([
+        IndexTestHelpers.build_index([
           {1, ["a", "b"]},
           {2, ["d", "e"]}
         ])
@@ -273,7 +230,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.IndexUpdateTest do
     test "range extending past the end of the chain clears only existing keys", %{database: database} do
       # The chain ends (next_id == 0) before the range end is reached
       {index, allocator} =
-        build_index([
+        IndexTestHelpers.build_index([
           {1, ["a", "b"]},
           {2, ["d", "e"]}
         ])
@@ -291,7 +248,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.IndexUpdateTest do
 
     test "range spanning from before the first key through the whole chain clears everything", %{database: database} do
       {index, allocator} =
-        build_index([
+        IndexTestHelpers.build_index([
           {1, ["b", "c"]},
           {2, ["d", "e"]},
           {3, ["f", "g"]}
@@ -311,7 +268,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.IndexUpdateTest do
 
   describe "empty-page handling after processing" do
     test "clearing all keys of a non-zero page deletes it and recycles its id", %{database: database} do
-      {index, allocator} = build_index([{1, ["a", "b"]}])
+      {index, allocator} = IndexTestHelpers.build_index([{1, ["a", "b"]}])
 
       update = run_mutations(index, allocator, database, [{:clear, "a"}, {:clear, "b"}])
       {final_index, _db, final_allocator, _modified} = IndexUpdate.finish(update)
@@ -325,7 +282,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.IndexUpdateTest do
     end
 
     test "clearing all keys of page 0 keeps page 0 in the index with zero keys", %{database: database} do
-      {index, allocator} = build_index([{0, ["a", "b"]}])
+      {index, allocator} = IndexTestHelpers.build_index([{0, ["a", "b"]}])
 
       update = run_mutations(index, allocator, database, [{:clear, "a"}, {:clear, "b"}])
       {final_index, _db, final_allocator, _modified} = IndexUpdate.finish(update)
@@ -339,7 +296,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.IndexUpdateTest do
 
   describe "key-count accounting" do
     test "only sets that introduce a key raise the count", %{database: database} do
-      {index, allocator} = build_index([{0, ["k1", "k2", "k3"]}])
+      {index, allocator} = IndexTestHelpers.build_index([{0, ["k1", "k2", "k3"]}])
 
       update =
         run_mutations(index, allocator, database, [
@@ -357,7 +314,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.IndexUpdateTest do
     end
 
     test "a clear of a key that was never there costs nothing", %{database: database} do
-      {index, allocator} = build_index([{0, ["k1", "k2", "k3"]}])
+      {index, allocator} = IndexTestHelpers.build_index([{0, ["k1", "k2", "k3"]}])
 
       update =
         run_mutations(index, allocator, database, [
@@ -373,7 +330,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.IndexUpdateTest do
     end
 
     test "sets and clears in the same batch net out", %{database: database} do
-      {index, allocator} = build_index([{0, ["k1", "k2", "k3"]}])
+      {index, allocator} = IndexTestHelpers.build_index([{0, ["k1", "k2", "k3"]}])
 
       update =
         run_mutations(index, allocator, database, [
@@ -392,7 +349,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.IndexUpdateTest do
     # so the delta must still be the number of keys the batch introduced.
     test "a batch that splits a page counts the added keys once", %{database: database} do
       existing = for i <- 1..200, do: "k#{String.pad_leading(to_string(i), 4, "0")}"
-      {index, allocator} = build_index([{0, existing}])
+      {index, allocator} = IndexTestHelpers.build_index([{0, existing}])
 
       new_keys = for i <- 1..100, do: "n#{String.pad_leading(to_string(i), 4, "0")}"
       update = run_mutations(index, allocator, database, Enum.map(new_keys, &{:set, &1, "v"}))
@@ -405,7 +362,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.IndexUpdateTest do
     end
 
     test "emptying a non-zero page counts every key it held", %{database: database} do
-      {index, allocator} = build_index([{1, ["a", "b"]}])
+      {index, allocator} = IndexTestHelpers.build_index([{1, ["a", "b"]}])
 
       update = run_mutations(index, allocator, database, [{:clear, "a"}, {:clear, "b"}])
 
@@ -415,7 +372,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.IndexUpdateTest do
 
   describe "atomic mutations" do
     test "atomic add on a missing key treats the current value as empty", %{database: database} do
-      {index, allocator} = build_index([])
+      {index, allocator} = IndexTestHelpers.build_index([])
 
       update = run_mutations(index, allocator, database, [{:atomic, :add, "counter", <<5>>}])
 
@@ -429,7 +386,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.IndexUpdateTest do
     end
 
     test "atomic add on an existing key loads and combines the stored value", %{database: database} do
-      {index, allocator} = build_index([])
+      {index, allocator} = IndexTestHelpers.build_index([])
 
       # First round: establish an existing value through the public API
       first_update =

--- a/test/bedrock/data_plane/materializer/olivine/page_split_tree_ordering_test.exs
+++ b/test/bedrock/data_plane/materializer/olivine/page_split_tree_ordering_test.exs
@@ -3,7 +3,6 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.PageSplitTreeOrderingTest do
 
   import Bedrock.Test.Materializer.Olivine.InvariantChecks
 
-  alias Bedrock.DataPlane.Materializer.Olivine.Database
   alias Bedrock.DataPlane.Materializer.Olivine.IdAllocator
   alias Bedrock.DataPlane.Materializer.Olivine.Index
   alias Bedrock.DataPlane.Materializer.Olivine.Index.Page
@@ -12,19 +11,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.PageSplitTreeOrderingTest do
   alias Bedrock.Test.Materializer.Olivine.IndexTestHelpers
 
   setup do
-    # Create temporary directory for test database
-    temp_dir = System.tmp_dir!() <> "/test_page_split_#{System.unique_integer()}"
-    File.mkdir_p!(temp_dir)
-
-    db_file_path = Path.join(temp_dir, "page_split_test.dets")
-    {:ok, database} = Database.open(:"test_db_#{System.unique_integer()}", db_file_path)
-
-    on_exit(fn ->
-      :ok = Database.close(database)
-      File.rm_rf!(temp_dir)
-    end)
-
-    {:ok, database: database}
+    {:ok, database: IndexTestHelpers.open_test_database("page_split_test")}
   end
 
   describe "page splitting maintains tree ordering" do

--- a/test/bedrock/data_plane/materializer/olivine/range_clear_ordering_property_test.exs
+++ b/test/bedrock/data_plane/materializer/olivine/range_clear_ordering_property_test.exs
@@ -5,10 +5,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.RangeClearOrderingPropertyTest 
   import Bedrock.Test.Materializer.Olivine.InvariantChecks
 
   alias Bedrock.DataPlane.Materializer.Olivine.Database
-  alias Bedrock.DataPlane.Materializer.Olivine.IdAllocator
-  alias Bedrock.DataPlane.Materializer.Olivine.Index
   alias Bedrock.DataPlane.Materializer.Olivine.Index.Page
-  alias Bedrock.DataPlane.Materializer.Olivine.Index.Tree
   alias Bedrock.DataPlane.Materializer.Olivine.IndexUpdate
   alias Bedrock.DataPlane.Version
   alias Bedrock.Test.Materializer.Olivine.IndexTestHelpers
@@ -17,19 +14,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.RangeClearOrderingPropertyTest 
   @max_keys 300
 
   setup do
-    # Create temporary directory for test database
-    temp_dir = System.tmp_dir!() <> "/test_range_clear_#{System.unique_integer()}"
-    File.mkdir_p!(temp_dir)
-
-    db_file_path = Path.join(temp_dir, "range_clear_test.dets")
-    {:ok, database} = Database.open(:"test_db_#{System.unique_integer()}", db_file_path)
-
-    on_exit(fn ->
-      :ok = Database.close(database)
-      File.rm_rf!(temp_dir)
-    end)
-
-    {:ok, database: database}
+    {:ok, database: IndexTestHelpers.open_test_database("range_clear_test")}
   end
 
   describe "range clearing preserves key ordering invariants" do
@@ -180,50 +165,16 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.RangeClearOrderingPropertyTest 
   # Helper functions
 
   defp build_index_from_keys(keys) do
-    base_version = Version.zero()
+    # Split into chunks of max 200 keys per page to ensure multiple pages.
+    # The shared helper rebuilds the chain from tree order, so next_id here
+    # doesn't need to be computed by hand.
+    page_specs =
+      keys
+      |> Enum.chunk_every(200)
+      |> Enum.with_index(1)
+      |> Enum.map(fn {chunk, page_id} -> {page_id, chunk} end)
 
-    # Create key-version pairs
-    key_locators = Enum.map(keys, &{&1, base_version})
-
-    # Build pages with controlled size to ensure multiple pages
-    pages = build_pages_from_key_locators(key_locators, 1)
-
-    # Build index efficiently by constructing page_map and tree directly
-    initial_index = Index.new()
-
-    # Build page_map with all pages
-    page_map =
-      Enum.reduce(pages, initial_index.page_map, fn {page, next_id}, acc_map ->
-        Map.put(acc_map, Page.id(page), {page, next_id})
-      end)
-
-    # Build tree with all pages
-    tree =
-      Enum.reduce(pages, initial_index.tree, fn {page, _next_id}, acc_tree ->
-        Tree.add_page_to_tree(acc_tree, page)
-      end)
-
-    # Create temporary index and ensure chain consistency once at the end
-    temp_index = %{initial_index | tree: tree, page_map: page_map}
-    index = IndexTestHelpers.rebuild_page_chain_consistency(temp_index)
-
-    # Create allocator with next available ID
-    max_page_id = pages |> Enum.map(fn {page, _next_id} -> Page.id(page) end) |> Enum.max(fn -> 0 end)
-    allocator = IdAllocator.new(max_page_id, [])
-
-    {index, allocator}
-  end
-
-  defp build_pages_from_key_locators(key_locators, start_id) do
-    # Split into chunks of max 200 keys per page to ensure multiple pages
-    key_locators
-    |> Enum.chunk_every(200)
-    |> Enum.with_index(start_id)
-    |> Enum.map(fn {chunk, page_id} ->
-      next_id = if page_id == start_id + div(length(key_locators), 200), do: 0, else: page_id + 1
-      page = Page.new(page_id, chunk)
-      {page, next_id}
-    end)
+    IndexTestHelpers.build_index(page_specs)
   end
 
   defp apply_clear_ranges_with_checks(index, allocator, clear_ranges, database) do

--- a/test/support/materializer/olivine/index_test_helpers.ex
+++ b/test/support/materializer/olivine/index_test_helpers.ex
@@ -3,8 +3,72 @@ defmodule Bedrock.Test.Materializer.Olivine.IndexTestHelpers do
   Test helper functions for Index operations that are only used in tests.
   """
 
+  alias Bedrock.DataPlane.Materializer.Olivine.Database
+  alias Bedrock.DataPlane.Materializer.Olivine.IdAllocator
   alias Bedrock.DataPlane.Materializer.Olivine.Index
   alias Bedrock.DataPlane.Materializer.Olivine.Index.Page
+  alias Bedrock.DataPlane.Materializer.Olivine.Index.Tree
+  alias Bedrock.DataPlane.Version
+
+  @doc """
+  Builds an index from a page spec like [{1, ["a", "b"]}, {2, ["c", "d"]}].
+
+  Page ids may include 0 to place keys directly on page 0. A key may also be
+  given as a `{key, locator}` tuple to control its locator explicitly;
+  a bare key defaults to `Version.zero/0` as its locator. Pages are entered
+  into the tree in key order and the chain is rebuilt for consistency.
+  """
+  @spec build_index([{Page.id(), [binary() | {binary(), Database.locator()}]}]) :: {Index.t(), IdAllocator.t()}
+  def build_index(page_specs) do
+    base_version = Version.zero()
+    initial_index = Index.new()
+
+    pages =
+      Enum.map(page_specs, fn {page_id, keys} ->
+        key_locators = Enum.map(keys, &to_key_locator(&1, base_version))
+        Page.new(page_id, key_locators)
+      end)
+
+    page_map =
+      Enum.reduce(pages, initial_index.page_map, fn page, acc ->
+        Map.put(acc, Page.id(page), {page, 0})
+      end)
+
+    tree =
+      Enum.reduce(pages, initial_index.tree, fn page, acc ->
+        Tree.add_page_to_tree(acc, page)
+      end)
+
+    index = rebuild_page_chain_consistency(%{initial_index | tree: tree, page_map: page_map})
+
+    max_page_id = page_specs |> Enum.map(&elem(&1, 0)) |> Enum.max(fn -> 0 end)
+    allocator = IdAllocator.new(max_page_id, [])
+
+    {index, allocator}
+  end
+
+  defp to_key_locator({key, locator}, _base_version), do: {key, locator}
+  defp to_key_locator(key, base_version), do: {key, base_version}
+
+  @doc """
+  Opens a temporary Database for a test and registers `on_exit` cleanup of
+  the database and its backing temp directory.
+  """
+  @spec open_test_database(String.t()) :: Database.t()
+  def open_test_database(name) do
+    temp_dir = System.tmp_dir!() <> "/test_#{name}_#{System.unique_integer()}"
+    File.mkdir_p!(temp_dir)
+
+    db_file_path = Path.join(temp_dir, "#{name}.dets")
+    {:ok, database} = Database.open(:"test_db_#{System.unique_integer()}", db_file_path)
+
+    ExUnit.Callbacks.on_exit(fn ->
+      :ok = Database.close(database)
+      File.rm_rf!(temp_dir)
+    end)
+
+    database
+  end
 
   @doc """
   Rebuilds page chain consistency from the tree structure.


### PR DESCRIPTION
The Olivine index tests had grown three private index builders and four copies of the same temporary-DETS setup block, all doing the same work with small differences in input shape. This change moves that work into two functions on the existing `IndexTestHelpers` module and points the tests at them. No assertion changes.

Ticket: bedrock-aa5
Stacked on: #275 (bedrock-w0c/info-unwrap-unsupported)

## Why

Nearly every Olivine index test needs an `Index` populated with known pages and a `Database` backed by a throwaway DETS file. Three modules assembled `page_map` and `tree` by hand from slightly different spec shapes; four opened their database with the same ten lines of setup and `on_exit` cleanup.

Duplicated fixtures drift. Two builders computed a per-page `next_id` that the trailing chain rebuild then overwrote, and one formula was wrong when the key count was an exact multiple of the page size. The rebuild hid it.

## What changed

- `build_index/1` takes `[{page_id, keys}]`, where a key is a bare binary (locator `Version.zero()`) or an explicit `{key, locator}` pair, and returns `{index, allocator}`.
- `open_test_database/1` takes a name fragment, opens a DETS database under a unique path and table atom, and registers cleanup with `ExUnit.Callbacks.on_exit/1`.
- The three builders and four setup blocks become calls; two builders survive as one-line adapters.

Left alone: the per-iteration databases inside the range-clear property bodies (different lifecycle), the page-split builder that takes pre-encoded pages, and the local `create_transaction/2` copies, which #256 (bedrock-tz1) handles.

## How it works

`build_index/1` starts from `Index.new()`, encodes each spec into a page, enters every page into the tree by its rightmost key, and rebuilds the chain from tree order so page 0 points at the first real page and the last page points back at 0. The allocator's `max_id` is the largest spec id.

```
build_index([{1, ["a","b","c"]}, {2, ["d","e","f"]}])
  tree:  <<>> => 0, "c" => 1, "f" => 2
  chain: 0 -> 1 -> 2 -> 0
```

The one caller that previously stored its own `next_id` without a rebuild lists every chain in ascending key order, so the derived chain matches its tuples.

## Verification

The migrated tests pass unchanged; the old body reports 23 properties, 331 tests, 0 failures for the Olivine directory, with format, credo, and dialyzer clean. A cold audit confirmed the forced rebuild is behaviour-preserving at every call site. Draft on a stacked branch, no CI checks reported.
