### PR TITLE
bedrock-93j: Make GenServerApi-generated start_link usable for tuple-init servers

### DIFF
--- a/lib/bedrock/internal/gen_server_api.ex
+++ b/lib/bedrock/internal/gen_server_api.ex
@@ -13,8 +13,8 @@ defmodule Bedrock.Internal.GenServerApi do
             @doc false
             defdelegate child_spec(opts), to: unquote(module)
 
-            def start_link(opts) do
-              GenServer.start_link(unquote(module), opts)
+            def start_link(init_arg, opts \\ []) do
+              GenServer.start_link(unquote(module), init_arg, opts)
             end
           end
         end

--- a/test/bedrock/internal/gen_server_api_test.exs
+++ b/test/bedrock/internal/gen_server_api_test.exs
@@ -1,6 +1,8 @@
 defmodule Bedrock.Internal.GenServerApiTest do
   use ExUnit.Case, async: true
 
+  alias Bedrock.Internal.GenServerApi
+
   # Test module that uses GenServerApi with :for option
   defmodule TestServer do
     @moduledoc false
@@ -12,7 +14,7 @@ defmodule Bedrock.Internal.GenServerApiTest do
 
   defmodule TestApi do
     @moduledoc false
-    use Bedrock.Internal.GenServerApi, for: TestServer
+    use GenServerApi, for: TestServer
   end
 
   describe "GenServerApi with :for option" do
@@ -25,6 +27,37 @@ defmodule Bedrock.Internal.GenServerApiTest do
       # Should be able to start via the API module
       {:ok, pid} = TestApi.start_link(%{test: true})
       assert Process.alive?(pid)
+      GenServer.stop(pid)
+    end
+  end
+
+  # Facades whose real GenServer expects a positional tuple, matching the
+  # pattern used throughout the data/control plane (Sequencer, Director,
+  # Coordinator, Placeholder, ...): child_spec/1 takes keyword opts but
+  # init/1 takes a tuple assembled from them.
+  defmodule TupleInitServer do
+    @moduledoc false
+    use GenServer
+
+    def init({a, b}), do: {:ok, {a, b}}
+  end
+
+  defmodule TupleInitApi do
+    @moduledoc false
+    use GenServerApi, for: TupleInitServer
+  end
+
+  describe "GenServerApi start_link with a tuple-init server" do
+    test "start_link/1 forwards keyword opts unchanged, crashing init/1" do
+      Process.flag(:trap_exit, true)
+
+      assert {:error, {:function_clause, _stacktrace}} =
+               TupleInitApi.start_link(a: 1, b: 2)
+    end
+
+    test "start_link/2 forwards the tuple init arg and GenServer options" do
+      {:ok, pid} = TupleInitApi.start_link({1, 2}, name: :gen_server_api_tuple_init_test)
+      assert Process.whereis(:gen_server_api_tuple_init_test) == pid
       GenServer.stop(pid)
     end
   end


### PR DESCRIPTION
Facades built with `use Bedrock.Internal.GenServerApi, for: Server` got a generated `start_link/1` that forwarded its one argument as the init argument and offered no way to pass start options such as `:name`. The generated function now has the shape of `GenServer.start_link/3`. Nothing in production called the old one, so the change is confined to the macro and its test.

Ticket: bedrock-93j

## Why

Six of the seven facades that use `for:` front a GenServer whose `init/1` matches a positional tuple, for example `Sequencer.Server` matching `{director, epoch, known_committed_version}`. Each server's `child_spec/1` builds that tuple from keyword options and passes it to `GenServer.start_link/3` with `[name: otp_name]`.

The generated function fit neither half. Passing keyword options crashed a tuple-matching `init/1` with a function clause error; passing the tuple left no parameter for start options, so the process could not be registered. That is why every child spec hand-builds its start MFA instead of going through the facade.

## What changed

The generated function is now `start_link(init_arg, opts \\ [])`, forwarding both to `GenServer.start_link/3`. The default keeps `start_link/1` exported, so single-argument callers and supervisor routing through `child_spec/1` are unchanged.

Deliberately not changed: no keyword-to-tuple translation was added, because the mapping differs per facade and lives in each `child_spec/1`. `Log` and `Worker` use the macro without `for:` and generate no `start_link`.

## How it works

```elixir
Placeholder.start_link({cluster, distributor, layout, hold_ms}, name: otp_name)
# == GenServer.start_link(Placeholder.Server, {cluster, distributor, layout, hold_ms}, name: otp_name)
```

A keyword list handed to a tuple-init facade still fails in `init/1`. `Foreman` targets a supervisor module with no `init/1`, so its generated function remains unusable, as before.

## Verification

A test facade wraps a server whose `init/1` matches only `{a, b}`. One test pins the misuse: a keyword list returns `{:error, {:function_clause, _}}`. The other proves the fix: `start_link({1, 2}, name: ...)` returns a pid registered under that name, which on `develop` raised `UndefinedFunctionError` for `start_link/2`. CI green on OTP 27, 28, 29 and the MinIO job. Follow-ups: none.
