### PR TITLE
bedrock-q67.26: gate system-keyspace reads and validate conflict-range sections

### DIFF
--- a/lib/bedrock/data_plane/commit_proxy/finalization.ex
+++ b/lib/bedrock/data_plane/commit_proxy/finalization.ex
@@ -293,7 +293,7 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization do
   # boundary failed the whole batch. clear_range ends are exclusive, so an
   # end AT the bound is legal. The mutation AND conflict sections are both
   # checked - see first_rejected_conflict_range/2 for why the declared
-  # ranges need their own gate.
+  # ranges need their own gate, and why the read conflicts get a wider one.
   #
   # Atomics are bounded like any other mutation, nothing more - FDB parity.
   # The metadata views cannot diverge from an atomic because atomics never
@@ -332,9 +332,9 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization do
   @spec first_rejection(Transaction.encoded(), Batch.commit_mode()) ::
           {:key_out_of_range, Bedrock.key()} | :invalid_transaction | nil
   defp first_rejection(transaction, commit_mode) do
-    bound = keyspace_bound(commit_mode)
+    write_bound = keyspace_bound(commit_mode)
 
-    first_rejected_mutation(transaction, bound) || first_rejected_conflict_range(transaction, bound)
+    first_rejected_mutation(transaction, write_bound) || first_rejected_conflict_range(transaction, write_bound)
   rescue
     error ->
       trace_ingress_validation_failed(error)
@@ -366,24 +366,34 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization do
   end
 
   # The conflict sections are DECLARED, not derived from the mutations: an
-  # encoded transaction can name ranges it never touches, and a user commit
-  # naming a system range would abort every system transaction that writes
-  # there - the resolver has no idea who asked. FDB bounds them in the
-  # client (ReadYourWrites.actor.cpp:1951 addReadConflictRange, :2467
-  # addWriteConflictRange, both against getMaxRead/WriteKey) and checks them
-  # again at the proxy, per transaction, before resolution
-  # (CommitProxyServer.actor.cpp:362-388). This is that second check; a
-  # transaction rejected here is replaced with an empty one, so its ranges
-  # never enter resolver history.
+  # encoded transaction can name ranges it never touches. FDB bounds them in
+  # the client (ReadYourWrites.actor.cpp:1951 addReadConflictRange, :2467
+  # addWriteConflictRange) and checks them again at the proxy, per
+  # transaction, before resolution (CommitProxyServer.actor.cpp:362-388).
+  # This is that second check; a transaction rejected here is replaced with
+  # an empty one, so its ranges never enter resolver history.
+  #
+  # The two sections get DIFFERENT bounds, as they do in FDB
+  # (getMaxWriteKey vs getMaxReadKey), because they do different damage. A
+  # write conflict is ADDED to resolver history and aborts everyone who read
+  # that range, so a user commit naming a system range would abort the
+  # system transactions writing there - that one is gated by who is
+  # committing. A read conflict is only CHECKED against history and can
+  # abort nothing but its own transaction, so it is gated only by the end of
+  # the legal keyspace. Gating it by the commit mode instead would make
+  # read_system_keys unusable: every non-snapshot system read registers its
+  # conflict, and a client commit is always :user. The narrower read bound
+  # is the client's, enforced in the transaction builder - FDB's
+  # READ_SYSTEM_KEYS, same trust model.
   #
   # Both endpoints are bounds rather than addressed keys, so either may sit
   # AT the bound: an exclusive end there covers the whole legal range, and a
   # degenerate range starting there is empty.
-  defp first_rejected_conflict_range(transaction, bound) do
+  defp first_rejected_conflict_range(transaction, write_bound) do
     case Transaction.read_write_conflicts(transaction) do
       {:ok, {{_read_version, read_conflicts}, write_conflicts}} ->
-        Enum.find_value(read_conflicts, &rejected_range(&1, bound)) ||
-          Enum.find_value(write_conflicts, &rejected_range(&1, bound))
+        Enum.find_value(read_conflicts, &rejected_range(&1, Bedrock.end_of_keyspace())) ||
+          Enum.find_value(write_conflicts, &rejected_range(&1, write_bound))
 
       {:error, _} ->
         :invalid_transaction

--- a/lib/bedrock/data_plane/commit_proxy/finalization.ex
+++ b/lib/bedrock/data_plane/commit_proxy/finalization.ex
@@ -367,28 +367,32 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization do
 
   # The conflict sections are DECLARED, not derived from the mutations: an
   # encoded transaction can name ranges it never touches. FDB bounds them in
-  # the client (ReadYourWrites.actor.cpp:1951 addReadConflictRange, :2467
-  # addWriteConflictRange) and checks them again at the proxy, per
-  # transaction, before resolution (CommitProxyServer.actor.cpp:362-388).
-  # This is that second check; a transaction rejected here is replaced with
-  # an empty one, so its ranges never enter resolver history.
+  # the client and nowhere else - addReadConflictRange against
+  # getMaxReadKey (ReadYourWrites.actor.cpp:1951), addWriteConflictRange
+  # against getMaxWriteKey (:2467); its proxy-side per-transaction check
+  # (CommitProxyServer.actor.cpp:318-392 verifyTenantPrefix) is a TENANT
+  # prefix check, not a keyspace one. Bedrock puts the bound at ingress
+  # instead, where the commit mode is known and the reply is per
+  # transaction: a transaction rejected here is replaced with an empty one,
+  # so its ranges never enter resolver history.
   #
-  # The two sections get DIFFERENT bounds, as they do in FDB
-  # (getMaxWriteKey vs getMaxReadKey), because they do different damage. A
-  # write conflict is ADDED to resolver history and aborts everyone who read
-  # that range, so a user commit naming a system range would abort the
-  # system transactions writing there - that one is gated by who is
-  # committing. A read conflict is only CHECKED against history and can
-  # abort nothing but its own transaction, so it is gated only by the end of
-  # the legal keyspace. Gating it by the commit mode instead would make
-  # read_system_keys unusable: every non-snapshot system read registers its
-  # conflict, and a client commit is always :user. The narrower read bound
-  # is the client's, enforced in the transaction builder - FDB's
-  # READ_SYSTEM_KEYS, same trust model.
+  # The two sections get DIFFERENT bounds, as they do in FDB, because they
+  # do different damage. A write conflict is ADDED to resolver history
+  # (Resolver.TransactionConflicts:59) and aborts everyone who read that
+  # range, so a user commit naming a system range would abort the system
+  # transactions reading there - that one is gated by who is committing. A
+  # read conflict is only CHECKED against history
+  # (Resolver.TransactionConflicts:63) and can abort nothing but its own
+  # transaction, so it is gated only by the end of the legal keyspace.
+  # Gating it by the commit mode instead would make read_system_keys
+  # unusable: every non-snapshot system read registers its conflict, and a
+  # client commit is always :user. The narrower READ bound is the client's,
+  # enforced in the transaction builder - FDB's READ_SYSTEM_KEYS, same trust
+  # model.
   #
   # Both endpoints are bounds rather than addressed keys, so either may sit
-  # AT the bound: an exclusive end there covers the whole legal range, and a
-  # degenerate range starting there is empty.
+  # AT the applicable bound: an exclusive end there is how a range covers
+  # the whole legal keyspace.
   defp first_rejected_conflict_range(transaction, write_bound) do
     case Transaction.read_write_conflicts(transaction) do
       {:ok, {{_read_version, read_conflicts}, write_conflicts}} ->

--- a/lib/bedrock/data_plane/commit_proxy/finalization.ex
+++ b/lib/bedrock/data_plane/commit_proxy/finalization.ex
@@ -285,13 +285,15 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization do
   # own reply and is replaced with an empty transaction, so its conflict
   # ranges never enter resolver history and its mutations never reach a log.
   #
-  # The legal write range depends on who is committing - the mode rides each
+  # The legal range depends on who is committing - the mode rides each
   # buffer entry: user commits end at the system boundary, system commits at
   # the end of the keyspace. Keys past the commit's bound belong to no shard
   # the caller may touch; before validation existed, single-key mutations
   # were silently routed into the LAST shard and a clear_range past the
   # boundary failed the whole batch. clear_range ends are exclusive, so an
-  # end AT the bound is legal.
+  # end AT the bound is legal. The mutation AND conflict sections are both
+  # checked - see first_rejected_conflict_range/2 for why the declared
+  # ranges need their own gate.
   #
   # Atomics are bounded like any other mutation, nothing more - FDB parity.
   # The metadata views cannot diverge from an atomic because atomics never
@@ -304,7 +306,7 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization do
     {transactions, replied, n_rejected} =
       Enum.reduce(plan.transactions, {plan.transactions, plan.replied_indices, 0}, fn
         {idx, {idx, reply_fn, transaction, commit_mode}}, {transactions, replied, n_rejected} = acc ->
-          case first_rejected_mutation(transaction, commit_mode) do
+          case first_rejection(transaction, commit_mode) do
             nil ->
               acc
 
@@ -323,23 +325,16 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization do
     %{plan | transactions: transactions, replied_indices: replied, aborted_count: plan.aborted_count + n_rejected}
   end
 
-  # Returns nil when valid, {reason, key} for the offending mutation, or
-  # :invalid_transaction when the mutation section decodes but its payload is
-  # corrupt (the decode stream raises lazily; unguarded, that would crash the
-  # finalization task and with it the proxy). No catch-all clause: a mutation
-  # shape this validator does not know is caught by the rescue and rejected
-  # as :invalid_transaction, so a future mutation type fails closed instead
-  # of bypassing the gate.
-  @spec first_rejected_mutation(Transaction.encoded(), Batch.commit_mode()) ::
+  # Returns nil when valid, {reason, key} for the offending mutation or
+  # conflict range, or :invalid_transaction when a section decodes but its
+  # payload is corrupt (the mutation decode stream raises lazily; unguarded,
+  # that would crash the finalization task and with it the proxy).
+  @spec first_rejection(Transaction.encoded(), Batch.commit_mode()) ::
           {:key_out_of_range, Bedrock.key()} | :invalid_transaction | nil
-  defp first_rejected_mutation(transaction, commit_mode) do
+  defp first_rejection(transaction, commit_mode) do
     bound = keyspace_bound(commit_mode)
 
-    case Transaction.mutations(transaction) do
-      {:ok, mutations} -> Enum.find_value(mutations, &rejected_mutation(&1, bound))
-      {:error, :section_not_found} -> nil
-      {:error, _} -> :invalid_transaction
-    end
+    first_rejected_mutation(transaction, bound) || first_rejected_conflict_range(transaction, bound)
   rescue
     error ->
       trace_ingress_validation_failed(error)
@@ -349,16 +344,58 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization do
   defp keyspace_bound(:user), do: Bedrock.end_of_user_keyspace()
   defp keyspace_bound(:system), do: Bedrock.end_of_keyspace()
 
+  # No catch-all clause for the mutation shapes: a mutation this validator
+  # does not know is caught by first_rejection/2's rescue and rejected as
+  # :invalid_transaction, so a future mutation type fails closed instead of
+  # bypassing the gate.
+  defp first_rejected_mutation(transaction, bound) do
+    case Transaction.mutations(transaction) do
+      {:ok, mutations} -> Enum.find_value(mutations, &rejected_mutation(&1, bound))
+      {:error, :section_not_found} -> nil
+      {:error, _} -> :invalid_transaction
+    end
+  end
+
   defp rejected_mutation({:set, key, _value}, bound), do: key_past_bound(key, bound)
   defp rejected_mutation({:clear, key}, bound), do: key_past_bound(key, bound)
 
   defp rejected_mutation({:atomic, _op, key, _value}, bound), do: key_past_bound(key, bound)
 
   defp rejected_mutation({:clear_range, start_key, end_key}, bound) do
-    key_past_bound(start_key, bound) || if end_key > bound, do: {:key_out_of_range, end_key}
+    key_past_bound(start_key, bound) || range_key_past_bound(end_key, bound)
   end
 
+  # The conflict sections are DECLARED, not derived from the mutations: an
+  # encoded transaction can name ranges it never touches, and a user commit
+  # naming a system range would abort every system transaction that writes
+  # there - the resolver has no idea who asked. FDB bounds them in the
+  # client (ReadYourWrites.actor.cpp:1951 addReadConflictRange, :2467
+  # addWriteConflictRange, both against getMaxRead/WriteKey) and checks them
+  # again at the proxy, per transaction, before resolution
+  # (CommitProxyServer.actor.cpp:362-388). This is that second check; a
+  # transaction rejected here is replaced with an empty one, so its ranges
+  # never enter resolver history.
+  #
+  # Both endpoints are bounds rather than addressed keys, so either may sit
+  # AT the bound: an exclusive end there covers the whole legal range, and a
+  # degenerate range starting there is empty.
+  defp first_rejected_conflict_range(transaction, bound) do
+    case Transaction.read_write_conflicts(transaction) do
+      {:ok, {{_read_version, read_conflicts}, write_conflicts}} ->
+        Enum.find_value(read_conflicts, &rejected_range(&1, bound)) ||
+          Enum.find_value(write_conflicts, &rejected_range(&1, bound))
+
+      {:error, _} ->
+        :invalid_transaction
+    end
+  end
+
+  defp rejected_range({start_key, end_key}, bound),
+    do: range_key_past_bound(start_key, bound) || range_key_past_bound(end_key, bound)
+
   defp key_past_bound(key, bound), do: if(key >= bound, do: {:key_out_of_range, key})
+
+  defp range_key_past_bound(key, bound), do: if(key > bound, do: {:key_out_of_range, key})
 
   # ============================================================================
   # Conflict Resolution

--- a/lib/bedrock/internal/repo.ex
+++ b/lib/bedrock/internal/repo.ex
@@ -69,6 +69,12 @@ defmodule Bedrock.Internal.Repo do
       {:error, :not_found} ->
         nil
 
+      # A read outside the transaction's legal range is a permanent client
+      # error, the read-side twin of the commit rejection below: the bound
+      # is the same on every attempt, so retrying only burns the deadline.
+      {:error, {:key_out_of_range, _key} = reason} ->
+        throw({__MODULE__, :rollback, reason})
+
       {:failure, reason} when reason in @retryable_read_failures ->
         throw({__MODULE__, t, :retryable_failure, reason})
 
@@ -90,6 +96,9 @@ defmodule Bedrock.Internal.Repo do
 
       {:error, :not_found} ->
         nil
+
+      {:error, {:key_out_of_range, _key} = reason} ->
+        throw({__MODULE__, :rollback, reason})
 
       {:failure, reason} when reason in @retryable_read_failures ->
         throw({__MODULE__, t, :retryable_failure, reason})
@@ -204,6 +213,9 @@ defmodule Bedrock.Internal.Repo do
       {:failure, reason} when reason in @retryable_read_failures ->
         throw({__MODULE__, state.txn, :retryable_failure, reason})
 
+      {:error, {:key_out_of_range, _key} = reason} ->
+        throw({__MODULE__, :rollback, reason})
+
       {:error, reason} ->
         raise "Range query failed: #{inspect(reason)}"
     end
@@ -250,6 +262,10 @@ defmodule Bedrock.Internal.Repo do
   - `:timeout_in_ms` - End-to-end transaction timeout, including retries
     (default: 5000; use `:infinity` to disable)
   - `:transaction_system_layout` - Use a specific TSL instead of fetching from coordinator
+  - `:read_system_keys` - Widen the read bound to the whole keyspace, so the
+    transaction may read `\\xFF` system keys (default: false). FDB's
+    `READ_SYSTEM_KEYS`; it does not widen the COMMIT bound, which stays
+    `:user` for every client transaction.
   """
   @spec transact(cluster :: module(), repo :: module(), (-> result) | (module() -> result), opts :: keyword()) :: result
         when result: any()
@@ -273,7 +289,13 @@ defmodule Bedrock.Internal.Repo do
       run_retryable_transaction(repo, fun, 0, retry_limit, fn last_reason ->
         maybe_invalidate_routing(link, last_reason)
         tsl = fetch_tsl_for_transaction(repo, provided_tsl, link)
-        start_transaction_builder(tsl, routing_fn_for_transaction(cluster, provided_tsl, link), repo)
+
+        start_transaction_builder(
+          tsl,
+          routing_fn_for_transaction(cluster, provided_tsl, link),
+          repo,
+          Keyword.get(opts, :read_system_keys, false)
+        )
       end)
     end)
   after
@@ -365,8 +387,12 @@ defmodule Bedrock.Internal.Repo do
     {cluster.otp_name_for_worker(worker_id), String.to_atom(node)}
   end
 
-  defp start_transaction_builder(tsl, routing_fn, repo) do
-    case TransactionBuilder.start_link(transaction_system_layout: tsl, routing_fn: routing_fn) do
+  defp start_transaction_builder(tsl, routing_fn, repo, read_system_keys) do
+    case TransactionBuilder.start_link(
+           transaction_system_layout: tsl,
+           routing_fn: routing_fn,
+           read_system_keys: read_system_keys
+         ) do
       {:ok, txn} ->
         TransactionContext.put_builder(repo, txn)
         txn

--- a/lib/bedrock/internal/transaction_builder.ex
+++ b/lib/bedrock/internal/transaction_builder.ex
@@ -76,6 +76,7 @@ defmodule Bedrock.Internal.TransactionBuilder do
             transaction_system_layout: TransactionSystemLayout.t(),
             routing_fn: (Bedrock.key() ->
                            {:ok, {Bedrock.key(), Bedrock.key(), [LayoutIndex.server_ref()]}} | {:error, atom()}),
+            read_system_keys: boolean(),
             time_fn: (-> integer())
           ]
         ) ::
@@ -85,7 +86,7 @@ defmodule Bedrock.Internal.TransactionBuilder do
 
     GenServer.start_link(
       __MODULE__,
-      {transaction_system_layout, Keyword.get(opts, :routing_fn)}
+      {transaction_system_layout, Keyword.get(opts, :routing_fn), Keyword.get(opts, :read_system_keys, false)}
     )
   end
 
@@ -93,7 +94,7 @@ defmodule Bedrock.Internal.TransactionBuilder do
   def init(arg), do: {:ok, arg, {:continue, :initialization}}
 
   @impl true
-  def handle_continue(:initialization, {transaction_system_layout, routing_fn}) do
+  def handle_continue(:initialization, {transaction_system_layout, routing_fn, read_system_keys}) do
     # Routing arrives proxy-served, by key, and LAZILY: the partial index
     # accumulates one covering entry per local miss, so a transaction that
     # never reads never fetches routing, and one that reads a single key
@@ -106,7 +107,8 @@ defmodule Bedrock.Internal.TransactionBuilder do
       transaction_system_layout: transaction_system_layout,
       layout_index: LayoutIndex.new(),
       routing_fn: routing_fn,
-      read_version: nil
+      read_version: nil,
+      max_read_key: max_read_key(read_system_keys)
     })
   end
 
@@ -135,43 +137,61 @@ defmodule Bedrock.Internal.TransactionBuilder do
   def handle_call({:get, key}, from, t) when is_binary(key), do: handle_call({:get, key, []}, from, t)
 
   def handle_call({:get, key, opts}, _from, t) when is_binary(key) and is_list(opts) do
-    t
-    |> get_key(key, opts)
-    |> then(fn
-      {t, {:error, _} = error} ->
-        reply(t, error)
+    case unreadable_key(t, key) do
+      nil ->
+        t
+        |> get_key(key, opts)
+        |> then(fn
+          {t, {:error, _} = error} ->
+            reply(t, error)
 
-      {t, {:failure, failures_by_reason}} ->
-        reply(t, {:failure, choose_a_reason(failures_by_reason)})
+          {t, {:failure, failures_by_reason}} ->
+            reply(t, {:failure, choose_a_reason(failures_by_reason)})
 
-      {t, {:ok, {^key, value}}} ->
-        reply(t, {:ok, value})
-    end)
+          {t, {:ok, {^key, value}}} ->
+            reply(t, {:ok, value})
+        end)
+
+      out_of_range ->
+        reply(t, {:error, {:key_out_of_range, out_of_range}})
+    end
   end
 
   def handle_call({:get_key_selector, %KeySelector{} = key_selector, opts}, _from, t) do
-    t
-    |> get_key_selector(key_selector, opts)
-    |> then(fn
-      {t, {:failure, failures_by_reason}} ->
-        reply(t, {:failure, choose_a_reason(failures_by_reason)})
+    case unreadable_bound(t, key_selector.key) do
+      nil ->
+        t
+        |> get_key_selector(key_selector, opts)
+        |> then(fn
+          {t, {:failure, failures_by_reason}} ->
+            reply(t, {:failure, choose_a_reason(failures_by_reason)})
 
-      {t, result} ->
-        reply(t, result)
-    end)
+          {t, result} ->
+            reply(t, result)
+        end)
+
+      out_of_range ->
+        reply(t, {:error, {:key_out_of_range, out_of_range}})
+    end
   end
 
   def handle_call({:get_range, start_key, end_key, batch_size, opts}, _from, t)
       when is_binary(start_key) and is_binary(end_key) do
-    t
-    |> get_range({start_key, end_key}, batch_size, opts)
-    |> then(fn
-      {t, {:failure, failures_by_reason}} ->
-        reply(t, {:failure, choose_a_reason(failures_by_reason)})
+    case unreadable_bound(t, start_key) || unreadable_bound(t, end_key) do
+      nil ->
+        t
+        |> get_range({start_key, end_key}, batch_size, opts)
+        |> then(fn
+          {t, {:failure, failures_by_reason}} ->
+            reply(t, {:failure, choose_a_reason(failures_by_reason)})
 
-      {t, result} ->
-        reply(t, result)
-    end)
+          {t, result} ->
+            reply(t, result)
+        end)
+
+      out_of_range ->
+        reply(t, {:error, {:key_out_of_range, out_of_range}})
+    end
   end
 
   def handle_call(
@@ -179,17 +199,23 @@ defmodule Bedrock.Internal.TransactionBuilder do
         _from,
         t
       ) do
-    batch_size = Keyword.get(opts, :limit, 10_000)
+    case unreadable_bound(t, start_selector.key) || unreadable_bound(t, end_selector.key) do
+      nil ->
+        batch_size = Keyword.get(opts, :limit, 10_000)
 
-    t
-    |> get_range_selectors(start_selector, end_selector, batch_size, opts)
-    |> then(fn
-      {t, {:failure, failures_by_reason}} ->
-        reply(t, {:failure, choose_a_reason(failures_by_reason)})
+        t
+        |> get_range_selectors(start_selector, end_selector, batch_size, opts)
+        |> then(fn
+          {t, {:failure, failures_by_reason}} ->
+            reply(t, {:failure, choose_a_reason(failures_by_reason)})
 
-      {t, result} ->
-        reply(t, result)
-    end)
+          {t, result} ->
+            reply(t, result)
+        end)
+
+      out_of_range ->
+        reply(t, {:error, {:key_out_of_range, out_of_range}})
+    end
   end
 
   @impl true
@@ -226,6 +252,28 @@ defmodule Bedrock.Internal.TransactionBuilder do
 
   @impl true
   def handle_info(:timeout, t), do: {:stop, :normal, t}
+
+  # FDB's getMaxReadKey(): normalKeys.end, or systemKeys.end once
+  # READ_SYSTEM_KEYS is set (ReadYourWrites.actor.cpp:2760). Like the commit
+  # mode, the option is asserted by the caller - it guards against reaching
+  # into `\xFF` by accident, not against a hostile client.
+  defp max_read_key(false), do: Bedrock.end_of_user_keyspace()
+  defp max_read_key(true), do: Bedrock.end_of_keyspace()
+
+  # Reads are bounded HERE, in the client's transaction object, ahead of any
+  # routing lookup or storage call - FDB checks the same bound in
+  # ReadYourWritesTransaction (get :1682, getKey :1704, getRange :1741) and
+  # throws key_outside_legal_range. Serving a `\xFF` read as a routing miss
+  # instead would be worse than merely wrong: the Repo classifies
+  # :layout_lookup_failed as retryable, so the caller would spend its whole
+  # deadline chasing a key it may not address, then raise something generic.
+  #
+  # A value read must address a key strictly below the bound; a selector
+  # anchor or a range endpoint IS a bound and may sit at it -
+  # firstGreaterOrEqual(\xFF) is how a scan reaches the last user key, the
+  # same reason a clear_range may end there.
+  defp unreadable_key(t, key), do: if(key >= t.max_read_key, do: key)
+  defp unreadable_bound(t, key), do: if(key > t.max_read_key, do: key)
 
   defp choose_a_reason(%{timeout: _}), do: :timeout
   defp choose_a_reason(%{unavailable: _}), do: :unavailable

--- a/lib/bedrock/internal/transaction_builder/state.ex
+++ b/lib/bedrock/internal/transaction_builder/state.ex
@@ -17,6 +17,8 @@ defmodule Bedrock.Internal.TransactionBuilder.State do
           read_version: Bedrock.version() | nil,
           commit_version: Bedrock.version() | nil,
           #
+          max_read_key: Bedrock.key(),
+          #
           tx: Tx.t(),
           stack: [Tx.t()],
           fastest_storage_servers: %{Bedrock.key_range() => pid()},
@@ -29,6 +31,10 @@ defmodule Bedrock.Internal.TransactionBuilder.State do
             #
             read_version: nil,
             commit_version: nil,
+            # FDB's getMaxReadKey(): the exclusive bound every read address
+            # is checked against, widened to the end of the keyspace only
+            # for a transaction opened with read_system_keys: true.
+            max_read_key: Bedrock.end_of_user_keyspace(),
             #
             tx: Tx.new(),
             stack: [],

--- a/lib/bedrock/repo.ex
+++ b/lib/bedrock/repo.ex
@@ -19,6 +19,13 @@ defmodule Bedrock.Repo do
   - `:retry_limit` - Maximum number of retries on transaction conflicts (default: nil for unlimited)
   - `:timeout_in_ms` - End-to-end transaction timeout, including retries
     (default: 5000; use `:infinity` to disable)
+  - `:read_system_keys` - Allow the transaction to read the `\\xFF` system
+    keyspace (default: false). Without it, any read addressed at or above
+    `Bedrock.end_of_user_keyspace/0` fails the transaction immediately with
+    `{:error, {:key_out_of_range, key}}` rather than being attempted; with
+    it the bound moves to `Bedrock.end_of_keyspace/0`. FDB parity:
+    `READ_SYSTEM_KEYS`, checked client-side. It does not grant system
+    WRITES - those are reserved to system-mode commits.
 
   ## Examples
 
@@ -47,7 +54,8 @@ defmodule Bedrock.Repo do
               | (module() -> :ok | {:ok, result} | {:error, reason}),
               opts :: [
                 retry_limit: non_neg_integer() | nil,
-                timeout_in_ms: Bedrock.timeout_in_ms()
+                timeout_in_ms: Bedrock.timeout_in_ms(),
+                read_system_keys: boolean()
               ]
             ) :: :ok | {:ok, result} | {:error, reason}
             when result: term(), reason: any()

--- a/lib/bedrock/repo.ex
+++ b/lib/bedrock/repo.ex
@@ -137,7 +137,14 @@ defmodule Bedrock.Repo do
   @doc """
   Gets a value for the given key, returning the value or `nil` if not found.
 
-  Keys must be binary and no larger than 16KiB.
+  Keys must be binary and no larger than 16KiB. Reads are bounded below
+  `Bedrock.end_of_user_keyspace/0` (`0xFF`) unless the transaction was opened
+  with `read_system_keys: true`; a read at or above the bound fails the
+  transaction with `{:error, {:key_out_of_range, key}}` instead of being
+  attempted. The same bound applies to `select/1` and `get_range/1` — note
+  that a range built with the `:end` sentinel ends at
+  `Bedrock.end_of_keyspace/0` and is therefore out of range for an ordinary
+  read; use `Bedrock.end_of_user_keyspace/0` as the widest legal end.
 
   ## Options
 

--- a/test/bedrock/data_plane/commit_proxy/finalization/ingress_rejection_test.exs
+++ b/test/bedrock/data_plane/commit_proxy/finalization/ingress_rejection_test.exs
@@ -18,6 +18,12 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization.IngressRejectionTest do
   parity; they never enter the metadata stream (metadata_mutation?/1 admits
   only sets and clears, exactly FDB's isMetadataMutation), so no view can
   diverge from one.
+
+  The conflict sections are bounded by the same rule (bedrock-q67.26). They
+  are DECLARED, not derived: an encoded transaction can name ranges it never
+  mutates, and a user commit naming a system range would abort every system
+  transaction that touches it. Range endpoints may sit AT the bound, because
+  an exclusive end there covers the whole legal range.
   """
   use ExUnit.Case, async: true
 
@@ -33,6 +39,14 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization.IngressRejectionTest do
       mutations: mutations,
       read_conflicts: nil,
       write_conflicts: [{conflict_key, conflict_key <> <<0>>}]
+    })
+  end
+
+  defp encode_conflicts(read_ranges, write_ranges) do
+    Transaction.encode(%{
+      mutations: [{:set, "a", "1"}],
+      read_conflicts: if(read_ranges == [], do: nil, else: {Version.from_integer(1), read_ranges}),
+      write_conflicts: write_ranges
     })
   end
 
@@ -250,6 +264,81 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization.IngressRejectionTest do
           assert_receive {^name, {:error, ^error}}
       end
     end
+  end
+
+  test "a user commit cannot declare a read conflict over the system keyspace" do
+    # The mutations are unimpeachable; the read-conflict range is the whole
+    # attack. Left unchecked it enters resolver history and aborts the next
+    # system transaction that writes there.
+    system_range = {<<0xFF, "/system/shard/">>, <<0xFF, "/system/shard0">>}
+    {system_start, _} = system_range
+
+    batch = batch_of([{reply_to_self(:tx), encode_conflicts([system_range], [{"a", "a\0"}]), :user}])
+
+    assert {:ok, 1, 0} = finalize(batch)
+    assert_receive {:tx, {:error, {:key_out_of_range, ^system_start}}}
+  end
+
+  test "a user commit cannot declare a write conflict over the system keyspace" do
+    eok = Bedrock.end_of_keyspace()
+
+    batch =
+      batch_of([
+        {reply_to_self(:tx), encode_conflicts([], [{"a", "a\0"}, {Bedrock.end_of_user_keyspace(), eok}]), :user}
+      ])
+
+    assert {:ok, 1, 0} = finalize(batch)
+    assert_receive {:tx, {:error, {:key_out_of_range, ^eok}}}
+  end
+
+  test "a system commit may declare the conflict ranges a user commit may not" do
+    system_range = {<<0xFF, "/system/shard/">>, <<0xFF, "/system/shard0">>}
+
+    batch =
+      batch_of([
+        {reply_to_self(:system_tx), encode_conflicts([system_range], [system_range]), :system},
+        {reply_to_self(:user_tx), encode_conflicts([system_range], [system_range]), :user}
+      ])
+
+    assert {:ok, 1, 1} = finalize(batch)
+
+    assert_receive {:system_tx, {:ok, _version, _index}}
+    assert_receive {:user_tx, {:error, {:key_out_of_range, _}}}
+  end
+
+  test "even a system commit cannot declare a conflict range past the end of the keyspace" do
+    past = Bedrock.end_of_keyspace() <> <<0x01>>
+
+    batch = batch_of([{reply_to_self(:tx), encode_conflicts([], [{<<0xFF, "/system/x">>, past}]), :system}])
+
+    assert {:ok, 1, 0} = finalize(batch)
+    assert_receive {:tx, {:error, {:key_out_of_range, ^past}}}
+  end
+
+  test "a conflict range ending exactly at the mode's bound is legal" do
+    boundary = Bedrock.end_of_user_keyspace()
+
+    batch = batch_of([{reply_to_self(:tx), encode_conflicts([{"a", boundary}], [{"a", boundary}]), :user}])
+
+    assert {:ok, 0, 1} = finalize(batch)
+    assert_receive {:tx, {:ok, _version, _index}}
+  end
+
+  test "a poisoned conflict range never reaches the resolver" do
+    system_range = {<<0xFF, "/system/shard/">>, <<0xFF, "/system/shard0">>}
+
+    batch =
+      batch_of([
+        {reply_to_self(:ok_tx), encode([{:set, "a", "1"}], "a"), :user},
+        {reply_to_self(:bad_tx), encode_conflicts([system_range], [system_range]), :user}
+      ])
+
+    assert {:ok, 1, 1} = finalize(batch)
+
+    empty_sections = Transaction.extract_sections!(Transaction.empty_transaction(), [:read_conflicts, :write_conflicts])
+
+    assert_receive {:resolved, [_ok_sections, rejected_sections]}
+    assert rejected_sections == empty_sections
   end
 
   test "a batch of only rejected transactions still completes" do

--- a/test/bedrock/data_plane/commit_proxy/finalization/ingress_rejection_test.exs
+++ b/test/bedrock/data_plane/commit_proxy/finalization/ingress_rejection_test.exs
@@ -19,11 +19,16 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization.IngressRejectionTest do
   only sets and clears, exactly FDB's isMetadataMutation), so no view can
   diverge from one.
 
-  The conflict sections are bounded by the same rule (bedrock-q67.26). They
-  are DECLARED, not derived: an encoded transaction can name ranges it never
-  mutates, and a user commit naming a system range would abort every system
-  transaction that touches it. Range endpoints may sit AT the bound, because
-  an exclusive end there covers the whole legal range.
+  The conflict sections are bounded too (bedrock-q67.26). They are DECLARED,
+  not derived: an encoded transaction can name ranges it never mutates. The
+  two sections get different bounds, as they do in FDB (getMaxWriteKey vs
+  getMaxReadKey): a WRITE conflict enters resolver history and aborts
+  everyone who read that range, so it is bounded by the commit's mode; a READ
+  conflict is only checked against history and can abort nothing but its own
+  transaction, so it is bounded only by the end of the keyspace - which is
+  also what makes a legitimate read_system_keys transaction committable in
+  :user mode. Range endpoints may sit AT the bound, because an exclusive end
+  there covers the whole legal range.
   """
   use ExUnit.Case, async: true
 
@@ -32,6 +37,7 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization.IngressRejectionTest do
   alias Bedrock.DataPlane.CommitProxy.ResolverLayout
   alias Bedrock.DataPlane.Transaction
   alias Bedrock.DataPlane.Version
+  alias Bedrock.Internal.TransactionBuilder.Tx
   alias Bedrock.Test.DataPlane.FinalizationTestSupport, as: Support
 
   defp encode(mutations, conflict_key) do
@@ -266,33 +272,36 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization.IngressRejectionTest do
     end
   end
 
-  test "a user commit cannot declare a read conflict over the system keyspace" do
-    # The mutations are unimpeachable; the read-conflict range is the whole
-    # attack. Left unchecked it enters resolver history and aborts the next
-    # system transaction that writes there.
+  test "a user commit cannot declare a write conflict over the system keyspace" do
+    # The mutations are unimpeachable; the write-conflict range is the whole
+    # attack. Left unchecked it enters resolver history and aborts every
+    # system transaction that read there.
     system_range = {<<0xFF, "/system/shard/">>, <<0xFF, "/system/shard0">>}
     {system_start, _} = system_range
 
-    batch = batch_of([{reply_to_self(:tx), encode_conflicts([system_range], [{"a", "a\0"}]), :user}])
+    batch = batch_of([{reply_to_self(:tx), encode_conflicts([], [{"a", "a\0"}, system_range]), :user}])
 
     assert {:ok, 1, 0} = finalize(batch)
     assert_receive {:tx, {:error, {:key_out_of_range, ^system_start}}}
   end
 
-  test "a user commit cannot declare a write conflict over the system keyspace" do
-    eok = Bedrock.end_of_keyspace()
+  test "a user commit MAY declare a read conflict over the system keyspace" do
+    # A read conflict is only checked against history - it can abort nothing
+    # but its own transaction - and it is exactly what a legitimate
+    # read_system_keys transaction produces for every non-snapshot system
+    # read. Rejecting it here would make that option unusable, since a client
+    # commit is always :user. The narrower read bound is the client's.
+    system_range = {<<0xFF, "/system/config/">>, <<0xFF, "/system/config0">>}
 
-    batch =
-      batch_of([
-        {reply_to_self(:tx), encode_conflicts([], [{"a", "a\0"}, {Bedrock.end_of_user_keyspace(), eok}]), :user}
-      ])
+    batch = batch_of([{reply_to_self(:tx), encode_conflicts([system_range], [{"a", "a\0"}]), :user}])
 
-    assert {:ok, 1, 0} = finalize(batch)
-    assert_receive {:tx, {:error, {:key_out_of_range, ^eok}}}
+    assert {:ok, 0, 1} = finalize(batch)
+    assert_receive {:tx, {:ok, _version, _index}}
   end
 
-  test "a system commit may declare the conflict ranges a user commit may not" do
+  test "a system commit may declare the write conflicts a user commit may not" do
     system_range = {<<0xFF, "/system/shard/">>, <<0xFF, "/system/shard0">>}
+    {system_start, _} = system_range
 
     batch =
       batch_of([
@@ -303,16 +312,36 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization.IngressRejectionTest do
     assert {:ok, 1, 1} = finalize(batch)
 
     assert_receive {:system_tx, {:ok, _version, _index}}
-    assert_receive {:user_tx, {:error, {:key_out_of_range, _}}}
+    assert_receive {:user_tx, {:error, {:key_out_of_range, ^system_start}}}
   end
 
-  test "even a system commit cannot declare a conflict range past the end of the keyspace" do
+  test "no commit may declare a conflict range past the end of the keyspace" do
     past = Bedrock.end_of_keyspace() <> <<0x01>>
 
-    batch = batch_of([{reply_to_self(:tx), encode_conflicts([], [{<<0xFF, "/system/x">>, past}]), :system}])
+    for {name, mode, tx} <- [
+          {:write_tx, :system, encode_conflicts([], [{<<0xFF, "/system/x">>, past}])},
+          {:read_tx, :user, encode_conflicts([{<<0xFF, "/system/x">>, past}], [{"a", "a\0"}])}
+        ] do
+      assert {:ok, 1, 0} = finalize(batch_of([{reply_to_self(name), tx, mode}]))
+      assert_receive {^name, {:error, {:key_out_of_range, ^past}}}
+    end
+  end
 
-    assert {:ok, 1, 0} = finalize(batch)
-    assert_receive {:tx, {:error, {:key_out_of_range, ^past}}}
+  test "a real read_system_keys transaction commits in user mode" do
+    # The shape the client actually produces: a non-snapshot system read
+    # registers its read-conflict key, and the transaction still commits as
+    # :user because read_system_keys widens reads only. Built through Tx
+    # rather than hand-encoded so the two gates are tested against each
+    # other, not against a fixture.
+    tx =
+      Tx.new()
+      |> Tx.add_read_conflict_key(<<0xFF, "/system/config/desired_commit_proxies">>)
+      |> Tx.set("user/a", "1", [])
+
+    batch = batch_of([{reply_to_self(:tx), Tx.commit(tx, Version.from_integer(1)), :user}])
+
+    assert {:ok, 0, 1} = finalize(batch)
+    assert_receive {:tx, {:ok, _version, _index}}
   end
 
   test "a conflict range ending exactly at the mode's bound is legal" do
@@ -330,7 +359,7 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization.IngressRejectionTest do
     batch =
       batch_of([
         {reply_to_self(:ok_tx), encode([{:set, "a", "1"}], "a"), :user},
-        {reply_to_self(:bad_tx), encode_conflicts([system_range], [system_range]), :user}
+        {reply_to_self(:bad_tx), encode_conflicts([], [system_range]), :user}
       ])
 
     assert {:ok, 1, 1} = finalize(batch)

--- a/test/bedrock/data_plane/commit_proxy/finalization/ingress_rejection_test.exs
+++ b/test/bedrock/data_plane/commit_proxy/finalization/ingress_rejection_test.exs
@@ -344,10 +344,15 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization.IngressRejectionTest do
     assert_receive {:tx, {:ok, _version, _index}}
   end
 
-  test "a conflict range ending exactly at the mode's bound is legal" do
+  test "a conflict range ending exactly at its bound is legal" do
+    # Each section against its own ceiling. The read conflict ending at
+    # end_of_keyspace/0 is the exact shape a read_system_keys range read of
+    # the system shard produces: a > that slipped to >= would silently break
+    # that feature.
     boundary = Bedrock.end_of_user_keyspace()
+    eok = Bedrock.end_of_keyspace()
 
-    batch = batch_of([{reply_to_self(:tx), encode_conflicts([{"a", boundary}], [{"a", boundary}]), :user}])
+    batch = batch_of([{reply_to_self(:tx), encode_conflicts([{boundary, eok}], [{"a", boundary}]), :user}])
 
     assert {:ok, 0, 1} = finalize(batch)
     assert_receive {:tx, {:ok, _version, _index}}

--- a/test/bedrock/internal/repo_transact_test.exs
+++ b/test/bedrock/internal/repo_transact_test.exs
@@ -315,9 +315,10 @@ defmodule Bedrock.Internal.RepoTransactTest do
 
     test "select and get_range surface the bound the same way get does" do
       # Three entry points, one classification. `{:key_out_of_range, key}` has
-      # a TUPLE reason, so without its own clause each of these would have
-      # taken a different wrong path: get/select fall through to the
-      # is_atom(reason) arm, and the range stream raises "Range query failed".
+      # a TUPLE reason, so without its own clause each of these takes a
+      # different wrong path: get/select match no arm at all (CaseClauseError,
+      # since the catch-all requires is_atom(reason)), and the range stream
+      # raises "Range query failed".
       selector_result =
         Repo.transact(
           NoCluster,

--- a/test/bedrock/internal/repo_transact_test.exs
+++ b/test/bedrock/internal/repo_transact_test.exs
@@ -20,6 +20,7 @@ defmodule Bedrock.Internal.RepoTransactTest do
   use ExUnit.Case, async: true
 
   alias Bedrock.Cluster.Link.RoutingCache
+  alias Bedrock.DataPlane.Version
   alias Bedrock.Internal.Repo
   alias Bedrock.Internal.Repo.TransactionContext
 
@@ -285,6 +286,58 @@ defmodule Bedrock.Internal.RepoTransactTest do
       assert TransactionContext.builder(TestRepo) == nil
     end
 
+    test "surfaces a system-key read as a permanent error instead of retrying" do
+      # A read the transaction is not allowed to address fails the same way a
+      # rejected commit does: once, with the offending key, at the client. Its
+      # old shape was :layout_lookup_failed - a RETRYABLE routing miss - so
+      # the caller burned its whole deadline and then raised something
+      # generic about a retry limit.
+      attempts = :counters.new(1, [])
+      key = <<0xFF, "/system/config/desired_commit_proxies">>
+
+      result =
+        Repo.transact(
+          NoCluster,
+          TestRepo,
+          fn ->
+            :counters.add(attempts, 1, 1)
+            Repo.get(TestRepo, key, next_read_version_fn: fn _t -> {:ok, Version.from_integer(1)} end)
+          end,
+          transaction_system_layout: @minimal_tsl,
+          retry_limit: 3
+        )
+
+      assert result == {:error, {:key_out_of_range, key}}
+      assert :counters.get(attempts, 1) == 1
+      assert TransactionContext.builder(TestRepo) == nil
+    end
+
+    test "read_system_keys: true lets the same read through to routing" do
+      # With no routing_fn (a caller-provided layout is wiring only), the
+      # read fails as :layout_lookup_failed - proof it passed the bound and
+      # went looking for the shard, rather than being refused at the client.
+      attempts = :counters.new(1, [])
+
+      assert_raise RuntimeError, ~r/retry limit exceeded/, fn ->
+        Repo.transact(
+          NoCluster,
+          TestRepo,
+          fn ->
+            :counters.add(attempts, 1, 1)
+
+            Repo.get(TestRepo, <<0xFF, "/system/config/desired_commit_proxies">>,
+              next_read_version_fn: fn _t -> {:ok, Version.from_integer(1)} end
+            )
+          end,
+          transaction_system_layout: @minimal_tsl,
+          read_system_keys: true,
+          retry_limit: 1
+        )
+      end
+
+      assert :counters.get(attempts, 1) == 2
+    end
+
     test "raises after exhausting the retry limit when commit keeps failing" do
       # A put makes the transaction non-empty; with no commit proxies in the
       # layout, commit fails with :unavailable, a retryable failure.
@@ -447,7 +500,7 @@ defmodule Bedrock.Internal.RepoTransactTest do
     defp sequencer_loop do
       receive do
         {:"$gen_call", from, {:next_read_version, _epoch}} ->
-          GenServer.reply(from, {:ok, Bedrock.DataPlane.Version.from_integer(1)})
+          GenServer.reply(from, {:ok, Version.from_integer(1)})
           sequencer_loop()
       end
     end

--- a/test/bedrock/internal/repo_transact_test.exs
+++ b/test/bedrock/internal/repo_transact_test.exs
@@ -23,6 +23,7 @@ defmodule Bedrock.Internal.RepoTransactTest do
   alias Bedrock.DataPlane.Version
   alias Bedrock.Internal.Repo
   alias Bedrock.Internal.Repo.TransactionContext
+  alias Bedrock.KeySelector
 
   defmodule TestRepo do
     use Bedrock.Repo, cluster: MockCluster
@@ -310,6 +311,32 @@ defmodule Bedrock.Internal.RepoTransactTest do
       assert result == {:error, {:key_out_of_range, key}}
       assert :counters.get(attempts, 1) == 1
       assert TransactionContext.builder(TestRepo) == nil
+    end
+
+    test "select and get_range surface the bound the same way get does" do
+      # Three entry points, one classification. `{:key_out_of_range, key}` has
+      # a TUPLE reason, so without its own clause each of these would have
+      # taken a different wrong path: get/select fall through to the
+      # is_atom(reason) arm, and the range stream raises "Range query failed".
+      selector_result =
+        Repo.transact(
+          NoCluster,
+          TestRepo,
+          fn -> Repo.select(TestRepo, KeySelector.first_greater_or_equal(<<0xFF, "/system/x">>)) end,
+          transaction_system_layout: @minimal_tsl
+        )
+
+      assert selector_result == {:error, {:key_out_of_range, <<0xFF, "/system/x">>}}
+
+      range_result =
+        Repo.transact(
+          NoCluster,
+          TestRepo,
+          fn -> TestRepo |> Repo.get_range("a", <<0xFF, 0x00>>) |> Enum.to_list() end,
+          transaction_system_layout: @minimal_tsl
+        )
+
+      assert range_result == {:error, {:key_out_of_range, <<0xFF, 0x00>>}}
     end
 
     test "read_system_keys: true lets the same read through to routing" do

--- a/test/bedrock/internal/transaction_builder/system_key_read_gate_test.exs
+++ b/test/bedrock/internal/transaction_builder/system_key_read_gate_test.exs
@@ -1,0 +1,154 @@
+defmodule Bedrock.Internal.TransactionBuilder.SystemKeyReadGateTest do
+  @moduledoc """
+  Pins the client-side read bound (bedrock-q67.26).
+
+  FoundationDB bounds reads in the client transaction object, not at a
+  server: `ReadYourWritesTransaction` compares every read address against
+  `getMaxReadKey()` — `normalKeys.end` (`\\xFF`) normally, `systemKeys.end`
+  (`\\xFF\\xFF`) once `READ_SYSTEM_KEYS` is set — and throws
+  `key_outside_legal_range` before any location lookup
+  (ReadYourWrites.actor.cpp:1682, 1704, 1741). Bedrock's transaction
+  builder is that object, so the bound lives here, ahead of routing.
+
+  The routing fn reports every key it is asked for: a gated read must never
+  reach it.
+  """
+  use ExUnit.Case, async: true
+
+  alias Bedrock.DataPlane.Version
+  alias Bedrock.Internal.TransactionBuilder
+  alias Bedrock.KeySelector
+
+  @boundary Bedrock.end_of_user_keyspace()
+  @end_of_keyspace Bedrock.end_of_keyspace()
+
+  # Reads need a read version and a routing answer; both are supplied
+  # in-process so a read that passes the bound fails with a shape no gate
+  # could produce.
+  defp read_opts, do: [next_read_version_fn: fn _t -> {:ok, Version.from_integer(1)} end]
+
+  defp start_builder(opts) do
+    test_pid = self()
+
+    routing_fn = fn key ->
+      send(test_pid, {:routing_asked, key})
+      {:error, :unavailable}
+    end
+
+    start_supervised!(
+      {TransactionBuilder,
+       Keyword.merge(
+         [transaction_system_layout: %{epoch: 1, proxies: []}, routing_fn: routing_fn],
+         opts
+       )}
+    )
+  end
+
+  describe "reads without the system-read option" do
+    setup do
+      {:ok, builder: start_builder([])}
+    end
+
+    test "a value read at the boundary is rejected before routing is asked", %{builder: builder} do
+      assert {:error, {:key_out_of_range, @boundary}} =
+               GenServer.call(builder, {:get, @boundary, read_opts()})
+
+      refute_received {:routing_asked, _}
+    end
+
+    test "a value read inside the system keyspace is rejected, naming the key", %{builder: builder} do
+      key = <<0xFF, "/system/config/desired_commit_proxies">>
+
+      assert {:error, {:key_out_of_range, ^key}} = GenServer.call(builder, {:get, key, read_opts()})
+
+      refute_received {:routing_asked, _}
+    end
+
+    test "the highest user key still reaches routing", %{builder: builder} do
+      key = <<0xFE, 0xFF, 0xFF, 0xFF>>
+
+      assert {:failure, :unavailable} = GenServer.call(builder, {:get, key, read_opts()})
+
+      assert_received {:routing_asked, ^key}
+    end
+
+    test "a range read past the boundary is rejected at whichever end escapes", %{builder: builder} do
+      assert {:error, {:key_out_of_range, <<0xFF, 0x00>>}} =
+               GenServer.call(builder, {:get_range, "a", <<0xFF, 0x00>>, 10, read_opts()})
+
+      assert {:error, {:key_out_of_range, <<0xFF, 0x01>>}} =
+               GenServer.call(builder, {:get_range, <<0xFF, 0x01>>, @end_of_keyspace, 10, read_opts()})
+
+      refute_received {:routing_asked, _}
+    end
+
+    test "a range read ending exactly AT the boundary is legal", %{builder: builder} do
+      # The end is exclusive, so `\xFF` is how a scan reaches the last user
+      # key - the same reason a clear_range may end there.
+      assert {:failure, :unavailable} = GenServer.call(builder, {:get_range, "a", @boundary, 10, read_opts()})
+
+      assert_received {:routing_asked, "a"}
+    end
+
+    test "a key selector anchored past the boundary is rejected", %{builder: builder} do
+      key = <<0xFF, "/system/shard/">>
+      selector = KeySelector.first_greater_or_equal(key)
+
+      assert {:error, {:key_out_of_range, ^key}} =
+               GenServer.call(builder, {:get_key_selector, selector, read_opts()})
+
+      refute_received {:routing_asked, _}
+    end
+
+    test "a key selector anchored AT the boundary is legal", %{builder: builder} do
+      # firstGreaterOrEqual(\xFF) is how a selector addresses the end of the
+      # user keyspace; the anchor is a bound, not a key being read.
+      selector = KeySelector.first_greater_or_equal(@boundary)
+
+      assert {:failure, :unavailable} = GenServer.call(builder, {:get_key_selector, selector, read_opts()})
+
+      assert_received {:routing_asked, @boundary}
+    end
+
+    test "a selector range is rejected on either escaping endpoint", %{builder: builder} do
+      inside = KeySelector.first_greater_or_equal("a")
+      outside = KeySelector.first_greater_or_equal(<<0xFF, 0x00>>)
+
+      assert {:error, {:key_out_of_range, <<0xFF, 0x00>>}} =
+               GenServer.call(builder, {:get_range_selectors, inside, outside, read_opts()})
+
+      assert {:error, {:key_out_of_range, <<0xFF, 0x00>>}} =
+               GenServer.call(builder, {:get_range_selectors, outside, inside, read_opts()})
+
+      refute_received {:routing_asked, _}
+    end
+  end
+
+  describe "reads with read_system_keys: true" do
+    setup do
+      {:ok, builder: start_builder(read_system_keys: true)}
+    end
+
+    test "the same system read reaches routing", %{builder: builder} do
+      key = <<0xFF, "/system/config/desired_commit_proxies">>
+
+      assert {:failure, :unavailable} = GenServer.call(builder, {:get, key, read_opts()})
+
+      assert_received {:routing_asked, ^key}
+    end
+
+    test "the bound moves to the end of the keyspace, it does not vanish", %{builder: builder} do
+      # Privatized keys live past end_of_keyspace/0 and belong to no shard;
+      # the system-read option admits `\xFF`, never `\xFF\xFF`.
+      assert {:error, {:key_out_of_range, @end_of_keyspace}} =
+               GenServer.call(builder, {:get, @end_of_keyspace, read_opts()})
+
+      past = @end_of_keyspace <> "/materializers/7"
+
+      assert {:error, {:key_out_of_range, ^past}} =
+               GenServer.call(builder, {:get_range, <<0xFF>>, past, 10, read_opts()})
+
+      refute_received {:routing_asked, _}
+    end
+  end
+end


### PR DESCRIPTION
Nothing bounded reads of `\xFF` system keys on the client, and nothing bounded the conflict ranges an encoded transaction declares at commit. The transaction builder now checks every read against a per-transaction ceiling, widened by a new `read_system_keys` option, and commit-proxy ingress now bounds the read and write conflict sections alongside the mutations.

Ticket: bedrock-q67.26

## Why

A system-key read in a user transaction went straight to routing. On a live cluster it was served like any other key; with a caller-supplied layout it failed as `:layout_lookup_failed`, a retryable failure, so the retry loop burned the whole deadline and then raised a generic retry-limit error. FoundationDB refuses such reads in the client transaction object.

Conflict sections are declared, not derived from mutations, so a transaction with harmless mutations could carry a write conflict over `\xFF/system/shard/...`. The mutation gate from #153 never looked at those sections; the range entered resolver history and aborted every system transaction that had read the shard map at an older version.

## What changed

- `transact` accepts `read_system_keys: true` (default `false`), FDB's `READ_SYSTEM_KEYS`. It widens reads only; the commit still runs in `:user` mode.
- Every builder read path checks the bound first and returns `{:error, {:key_out_of_range, key}}` before touching the sequencer or routing. The Repo returns it from `transact` without retrying.
- Ingress rejects a commit whose conflict sections escape their bound with the same error, and an undecodable conflict section as `:invalid_transaction`.
- `Bedrock.key_range(x, :end)` ends at `end_of_keyspace/0` and now fails the read gate in an ordinary transaction; `end_of_user_keyspace/0` is the widest legal end.

## How it works

The client bound. The builder fixes `max_read_key` at start: `<<0xFF>>` by default, `<<0xFF, 0xFF>>` with the option. A value read must sit strictly below it; a selector anchor or range endpoint is itself a bound and may sit exactly at it, which is how a scan reaches the last user key. Privatized keys past `end_of_keyspace/0` belong to no shard and are refused even with the option.

The ingress bound. The proxy walks mutations, then read conflicts, then write conflicts, and replaces a rejected transaction with an empty one so its ranges never reach the resolver. A write conflict enters resolver history and can abort other transactions, so it is bounded by the commit mode. A read conflict is only checked against history and can abort nothing but itself, so it is bounded by `end_of_keyspace/0` in both modes. The split is load-bearing: a non-snapshot system read registers a read-conflict key and a client commit is always `:user`, so a mode-bounded read section would reject what the builder had permitted.

```
:user commit, mutations [{:set, "a", "1"}]
  write conflict {\xFF/system/shard/, \xFF/system/shard0}    -> rejected
  read  conflict {\xFF/system/config/, \xFF/system/config0}  -> committed
  any conflict ending past \xFF\xFF, either mode              -> rejected
```

## Verification

Builder tests use a routing fn that reports every key it is asked for, so a gated read is distinguishable from one that reached routing; they cover value reads, range endpoints, selectors, and both settings of the option. Repo tests prove the error surfaces once from `get`, `select` and `get_range`. Ingress tests through the real `finalize_batch/2` prove the rows above, endpoints exactly at the bound, and a `Tx`-built system read plus user write committing in `:user` mode. CI is green on OTP 27, 28, 29 and the MinIO job. Two cold-audit rounds; the first found the read/write split necessary.
