### PR TITLE
bedrock-s9x: widen relay-class DOWN assertions in transaction_builder_test

### DIFF
--- a/test/bedrock/internal/transaction_builder_test.exs
+++ b/test/bedrock/internal/transaction_builder_test.exs
@@ -155,7 +155,10 @@ defmodule Bedrock.Internal.TransactionBuilderTest do
 
       send(pid, :timeout)
 
-      assert_receive {:DOWN, ^ref, :process, ^pid, :normal}
+      # Relay-class: the process must be scheduled to handle :timeout and stop
+      # before the DOWN exists, so the default 100ms flakes under full-suite
+      # load (bedrock-s9x). 5_000ms is free when the message is prompt.
+      assert_receive {:DOWN, ^ref, :process, ^pid, :normal}, 5_000
     end
 
     test "starts with custom configuration" do
@@ -248,7 +251,9 @@ defmodule Bedrock.Internal.TransactionBuilderTest do
 
       GenServer.cast(pid, :rollback)
 
-      assert_receive {:DOWN, ^ref, :process, ^pid, :normal}
+      # Relay-class (bedrock-s9x): the cast must be scheduled and processed
+      # before the DOWN exists.
+      assert_receive {:DOWN, ^ref, :process, ^pid, :normal}, 5_000
     end
 
     test ":rollback cast with non-empty stack pops stack frame" do
@@ -300,7 +305,8 @@ defmodule Bedrock.Internal.TransactionBuilderTest do
 
       GenServer.cast(pid, :unknown_cast)
 
-      assert_receive {:DOWN, ^ref, :process, ^pid, reason}, 1000
+      # Relay-class (bedrock-s9x): normalized to the class window (was 1_000).
+      assert_receive {:DOWN, ^ref, :process, ^pid, reason}, 5_000
       assert match?({:function_clause, _}, reason)
     end
   end
@@ -324,8 +330,11 @@ defmodule Bedrock.Internal.TransactionBuilderTest do
       # Send unknown info message - will crash due to no catch-all clause
       send(pid, :unknown_message)
 
-      # Process should crash with FunctionClauseError
-      assert_receive {:DOWN, ^ref, :process, ^pid, reason}
+      # Process should crash with FunctionClauseError. Relay-class
+      # (bedrock-s9x): the process must be scheduled to receive and crash on
+      # the message before the DOWN exists, so the default 100ms flakes under
+      # full-suite load.
+      assert_receive {:DOWN, ^ref, :process, ^pid, reason}, 5_000
       assert match?({:function_clause, _}, reason)
     end
   end
@@ -459,7 +468,9 @@ defmodule Bedrock.Internal.TransactionBuilderTest do
 
       GenServer.cast(pid, :rollback)
 
-      assert_receive {:DOWN, ^ref, :process, ^pid, :normal}
+      # Relay-class (bedrock-s9x): the cast must be scheduled and processed
+      # before the DOWN exists.
+      assert_receive {:DOWN, ^ref, :process, ^pid, :normal}, 5_000
     end
   end
 


### PR DESCRIPTION
Several `TransactionBuilder` tests monitor the process, send it a message that makes it crash or stop, and wait for the `:DOWN` with ExUnit's default 100ms window. Under full-suite load the process is not always scheduled, run, and torn down in time, so the assertion times out on an empty mailbox. Five of those sites now use a 5 second window, the class rule PR #228 applied to sibling files. Test-only change.

Ticket: bedrock-s9x

## Why

The ticket's named test, `"unknown info messages crash the process"`, failed on the S3 MinIO CI job and was reproduced twice on OTP 27.3.3 in full-suite runs with seed 346337. Each time the expected `FunctionClauseError` was logged, so the crash happened; the test reported "no matching message after 100ms". The same seed passed in isolation.

`send/2` returns immediately. Before the `:DOWN` can exist the builder must be scheduled, dispatch to `handle_info/2` (no catch-all clause by design), raise, report the crash, and exit, all competing with an `async: true` suite for scheduler time. A spike that suspended the builder for 150ms after the send reproduced the CI failure text exactly and passed with the widened window.

## What changed

Five `assert_receive {:DOWN, ...}` sites gained a `5_000` window and a comment naming the mechanism: two empty-stack `:rollback` casts, the lifecycle `:timeout` send, the unknown-cast crash (normalized from an ad hoc 1000), and the unknown-info crash. The `catch_exit(GenServer.call(...))` site stays bare because the call already blocks until the callee exits; the 10ms `refute_receive` absence check is untouched.

## How it works

The window changes only the maximum wait; on an idle machine each test still finishes in milliseconds. Crash tests still require a `{:function_clause, _}` reason and stop tests still pin `:normal`, so a wrong exit or a live process still fails.

## Verification

No new tests; five assertions widened, none weakened. The suspend/resume spike is not part of the branch. CI is green on all four jobs including S3 MinIO. Known gap: the `:timeout` send in the info-handling block (test file line 321) is the same relay-class pattern and still uses the default window.
