### PR TITLE
bedrock-ngl: honour allow_window_advancement on Olivine's :timeout path

### DIFF
--- a/lib/bedrock/data_plane/materializer/olivine/server.ex
+++ b/lib/bedrock/data_plane/materializer/olivine/server.ex
@@ -280,14 +280,19 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Server do
     end
   end
 
-  def handle_continue(:advance_window, %State{} = t) do
-    if t.allow_window_advancement do
-      {:ok, state_after_window} = Logic.advance_window(t)
-      noreply(state_after_window)
-    else
-      # Compaction in progress - skip window advancement
-      noreply(t)
-    end
+  def handle_continue(:advance_window, %State{} = t), do: noreply(maybe_advance_window(t))
+
+  # A compaction labels its output with the durable version it captured at
+  # start_compaction/1, and the cutover looks exactly that version up in
+  # `versions` to recover the index's paging parameters. Advancing the
+  # window evicts every entry below the new eviction point and carries
+  # index_db.durable_version up with it, so an advance while a compaction is
+  # open takes the cutover's anchor away. Both advance sites defer.
+  defp maybe_advance_window(%State{allow_window_advancement: false} = t), do: t
+
+  defp maybe_advance_window(%State{} = t) do
+    {:ok, state_after_window} = Logic.advance_window(t)
+    state_after_window
   end
 
   defp do_finish_startup(otp_name, foreman, id, path, opts) do
@@ -392,8 +397,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Server do
         state_after_txns = notify_waiting_fetches(state_with_txns, version)
 
         # Now advance window after processing transactions
-        {:ok, final_state} = Logic.advance_window(state_after_txns)
-        noreply(final_state, continue: :maybe_process_transactions)
+        noreply(maybe_advance_window(state_after_txns), continue: :maybe_process_transactions)
     end
   end
 

--- a/test/bedrock/data_plane/materializer/olivine/compaction_cutover_test.exs
+++ b/test/bedrock/data_plane/materializer/olivine/compaction_cutover_test.exs
@@ -214,7 +214,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.CompactionCutoverTest do
   describe "window advancement while a compaction is open" do
     # start_compaction/1 labels its output with the durable version at the
     # moment it starts, and the cutover looks exactly that version up in
-    # `versions` to recover the index's paging parameters (server.ex:479).
+    # `versions` to recover the index's paging parameters.
     # A window advance evicts every entry below the new eviction point and
     # carries index_db.durable_version up with it, so an advance while a
     # compaction is open takes the cutover's anchor away.

--- a/test/bedrock/data_plane/materializer/olivine/compaction_cutover_test.exs
+++ b/test/bedrock/data_plane/materializer/olivine/compaction_cutover_test.exs
@@ -8,9 +8,15 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.CompactionCutoverTest do
   bookkeeping, but the same way recovery restores a suffix: the stream
   puller is stopped and restarted from the durable boundary, and the
   stream re-delivers everything after it.
+
+  It also guards the cutover's precondition (bedrock-ngl): the durable
+  version the compaction captured must still be in `versions` when the
+  cutover arrives, so no window advance may run while a compaction is open.
   """
   use ExUnit.Case, async: true
 
+  alias Bedrock.DataPlane.Materializer.Olivine.Database
+  alias Bedrock.DataPlane.Materializer.Olivine.IntakeQueue
   alias Bedrock.DataPlane.Materializer.Olivine.Logic
   alias Bedrock.DataPlane.Materializer.Olivine.Server
   alias Bedrock.DataPlane.Transaction
@@ -204,6 +210,89 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.CompactionCutoverTest do
     :ok = ReplayShardServer.append(shard_server, v2000, slice(v2000, "b"))
     await_value(pid, v2000, "b")
   end
+
+  describe "window advancement while a compaction is open" do
+    # start_compaction/1 labels its output with the durable version at the
+    # moment it starts, and the cutover looks exactly that version up in
+    # `versions` to recover the index's paging parameters (server.ex:479).
+    # A window advance evicts every entry below the new eviction point and
+    # carries index_db.durable_version up with it, so an advance while a
+    # compaction is open takes the cutover's anchor away.
+    #
+    # handle_continue(:advance_window, ...) has always deferred on
+    # allow_window_advancement; the :timeout path applies a batch and then
+    # advances, and must defer for the same reason.
+    test "the :timeout path defers the advance, leaving the compaction's durable version in place",
+         %{tmp_dir: tmp_dir} do
+      state = flushed_state(tmp_dir, "ngl_deferred")
+
+      # What start_compaction/1 captured when the operator asked to compact.
+      compaction_version = Database.durable_version(state.database)
+      assert Version.to_integer(compaction_version) > 0
+
+      {:noreply, after_timeout, _continue} =
+        Server.handle_info(:timeout, queue_third_transaction(%{state | allow_window_advancement: false}))
+
+      assert version_present?(after_timeout, compaction_version)
+      assert Database.durable_version(after_timeout.database) == compaction_version
+
+      # The batch still landed — compaction pauses the window, not ingest.
+      assert after_timeout.index_manager.current_version == Version.from_integer(30_000_000)
+
+      Logic.shutdown(after_timeout)
+    end
+
+    test "with no compaction open the :timeout path still advances the window", %{tmp_dir: tmp_dir} do
+      state = flushed_state(tmp_dir, "ngl_allowed")
+      durable_before = Database.durable_version(state.database)
+
+      {:noreply, after_timeout, _continue} = Server.handle_info(:timeout, queue_third_transaction(state))
+
+      assert Database.durable_version(after_timeout.database) == Version.from_integer(20_000_000)
+      refute version_present?(after_timeout, durable_before)
+
+      Logic.shutdown(after_timeout)
+    end
+  end
+
+  # Two applies five seconds (in version-time) apart: the second's window
+  # advance evicts the first, so the durable version is v10_000_000 and is
+  # the oldest entry still in `versions`.
+  defp flushed_state(tmp_dir, name) do
+    dir = Path.join(tmp_dir, name)
+    File.mkdir_p!(dir)
+
+    {:ok, state} = Logic.startup(:"olivine_#{name}_#{System.unique_integer([:positive])}", self(), name, dir, [])
+
+    state
+    |> apply_and_flush("k1", "v1", 10_000_000)
+    |> apply_and_flush("k2", "v2", 20_000_000)
+  end
+
+  defp apply_and_flush(state, key, value, version_int) do
+    {:ok, state, _version} = Logic.apply_transactions(state, [commit(key, value, version_int)])
+    {:ok, state} = Logic.advance_window(%{state | known_committed_version: Version.from_integer(version_int)})
+    state
+  end
+
+  # A third transaction, far enough above the second to make the window
+  # advanceable again, left in the intake queue so handle_info(:timeout, ...)
+  # takes the apply-then-advance branch rather than the empty-queue one.
+  defp queue_third_transaction(state) do
+    %{
+      state
+      | intake_queue: IntakeQueue.add_transactions(state.intake_queue, [commit("k3", "v3", 30_000_000)]),
+        known_committed_version: Version.from_integer(30_000_000)
+    }
+  end
+
+  defp commit(key, value, version_int) do
+    encoded = Transaction.encode(%{mutations: [{:set, key, value}], read_conflicts: {nil, []}, write_conflicts: []})
+    {:ok, with_version} = Transaction.add_commit_version(encoded, Version.from_integer(version_int))
+    with_version
+  end
+
+  defp version_present?(state, version), do: Enum.any?(state.index_manager.versions, fn {v, _} -> v == version end)
 
   defp flush_pulls do
     receive do


### PR DESCRIPTION
The Olivine materializer advances its durability window from two places, and only one checked whether a compaction was open. An advance mid-compaction evicts the index entry the cutover later looks up with a strict match, crashing the worker. Both advance sites now go through one guarded helper that defers while the compaction flag is set.

Ticket: bedrock-ngl

## Why

Olivine keeps a list of per-version index snapshots and periodically advances a durability window over them: versions below the window edge are flushed, dropped from the list, and the on-disk durable version moves up. This runs on the worker's idle `:timeout`. With an empty intake queue the handler took a guarded path that skips the advance while a compaction is open; with transactions waiting, it applied the batch and then advanced with no guard.

A compaction needs that guard. When an operator sends `:compact`, the server records the current durable version, hands the page map to a background task, and clears `allow_window_advancement`. The task reports back labelled with the version it captured, and the cutover finds that exact version in the live snapshot list to recover the index's paging parameters. One `:timeout` with transactions queued while the task ran evicted that entry; the cutover's lookup returned nil, the pinned match raised `MatchError`, and the GenServer went down.

Nothing in `lib/` drives `:compact` today, so the crash was reachable only from tests. It becomes live when compaction is scheduled (bedrock-947). The cold audit on #276 (bedrock-3v1) found the defect; it predates that work.

## What changed

The `:advance_window` continue and the apply-then-advance branch of the `:timeout` handler both call a new private `maybe_advance_window/1`. It returns the state untouched when the flag is false and otherwise runs the existing window advance.

The window advance, compaction start, and cutover are untouched, so this does not collide with #276. The ticket's alternative, guarding inside the persistence function, would put a server-lifecycle flag in a function tests call directly to build fixtures.

## How it works

With the flag false, the batch still lands and the continuation is unchanged: a compaction pauses the window, not ingest, and the stream re-delivers everything accepted during compaction after the cutover rewinds. Both compaction outcomes restore the flag, and the task is linked, so a crash cannot strand it.

The test fixture, with a five-second window lag:

```
apply k1@v10M, advance   -> no eviction
apply k2@v20M, advance   -> v10M evicted; durable = v10M, versions = [v20M, v10M]
:compact                 -> captures v10M, flag = false
queue k3@v30M, :timeout  -> base: durable = v20M, versions = [v30M, v20M], cutover crashes
                            head: durable = v10M, versions = [v30M, v20M, v10M], cutover finds it
```

## Verification

Two new tests build that state on disk and call the `:timeout` handler directly. With the flag false, v10M stays in the snapshot list, the durable version is unchanged, and the current version is v30M, so the fix cannot pass by dropping the batch. With the flag at its default, durable moves to v20M and v10M is gone, so the fix cannot degenerate into never advancing. The first is red on develop; a cold audit confirmed neither test is vacuous.

CI green on OTP 27.3, 28.3, and 29.0 plus S3 MinIO. Stale line citation removed in `de9ff3ab`.

Follow-up: bedrock-947, schedule compaction from lib.
