### PR TITLE
bedrock-q67.35: Remove write-only Batch.finalized_at field

### DIFF
--- a/lib/bedrock/data_plane/commit_proxy/batch.ex
+++ b/lib/bedrock/data_plane/commit_proxy/batch.ex
@@ -16,7 +16,6 @@ defmodule Bedrock.DataPlane.CommitProxy.Batch do
 
   @type t :: %__MODULE__{
           started_at: Bedrock.timestamp_in_ms(),
-          finalized_at: Bedrock.timestamp_in_ms() | nil,
           last_commit_version: Bedrock.version(),
           commit_version: Bedrock.version(),
           known_committed_version: Bedrock.version() | nil,
@@ -24,7 +23,6 @@ defmodule Bedrock.DataPlane.CommitProxy.Batch do
           buffer: [{index :: non_neg_integer(), reply_fn(), Transaction.encoded(), commit_mode()}]
         }
   defstruct started_at: nil,
-            finalized_at: nil,
             last_commit_version: nil,
             commit_version: nil,
             known_committed_version: nil,
@@ -65,7 +63,4 @@ defmodule Bedrock.DataPlane.CommitProxy.Batch do
 
   @spec transaction_count(t()) :: non_neg_integer()
   def transaction_count(t), do: t.n_transactions
-
-  @spec set_finalized_at(t(), Bedrock.timestamp_in_ms()) :: t()
-  def set_finalized_at(t, finalized_at), do: %{t | finalized_at: finalized_at}
 end

--- a/lib/bedrock/data_plane/commit_proxy/batching.ex
+++ b/lib/bedrock/data_plane/commit_proxy/batching.ex
@@ -1,9 +1,7 @@
 defmodule Bedrock.DataPlane.CommitProxy.Batching do
   @moduledoc false
 
-  import Bedrock.DataPlane.CommitProxy.Batch,
-    only: [new_batch: 4, add_transaction: 4, set_finalized_at: 2]
-
+  import Bedrock.DataPlane.CommitProxy.Batch, only: [new_batch: 4, add_transaction: 4]
   import Bedrock.DataPlane.Sequencer, only: [next_commit_version: 2]
 
   alias Bedrock.DataPlane.CommitProxy.Batch
@@ -30,8 +28,7 @@ defmodule Bedrock.DataPlane.CommitProxy.Batching do
         {:ok,
          timestamp()
          |> new_batch(last_commit_version, commit_version, known_committed_version)
-         |> add_transaction(transaction, reply_fn, :user)
-         |> set_finalized_at(timestamp())}
+         |> add_transaction(transaction, reply_fn, :user)}
 
       {:error, reason} ->
         {:error, {:sequencer_unavailable, reason}}
@@ -95,7 +92,7 @@ defmodule Bedrock.DataPlane.CommitProxy.Batching do
 
     if max_latency?(t.batch, now, t.max_latency_in_ms) or
          max_transactions?(t.batch, t.max_per_batch) do
-      {%{t | batch: nil}, set_finalized_at(t.batch, now)}
+      {%{t | batch: nil}, t.batch}
     else
       {t, nil}
     end

--- a/test/bedrock/data_plane/commit_proxy/batch_test.exs
+++ b/test/bedrock/data_plane/commit_proxy/batch_test.exs
@@ -16,7 +16,6 @@ defmodule Bedrock.DataPlane.CommitProxy.BatchTest do
       assert batch.commit_version == commit_version
       assert batch.n_transactions == 0
       assert batch.buffer == []
-      assert batch.finalized_at == nil
     end
   end
 
@@ -97,16 +96,6 @@ defmodule Bedrock.DataPlane.CommitProxy.BatchTest do
 
       batch = Batch.add_transaction(batch, <<2>>, fn _ -> :ok end, :user)
       assert Batch.transaction_count(batch) == 2
-    end
-  end
-
-  describe "set_finalized_at/2" do
-    test "sets the finalized timestamp" do
-      batch = Batch.new_batch(1000, <<1::64>>, <<2::64>>)
-      assert batch.finalized_at == nil
-
-      batch = Batch.set_finalized_at(batch, 2000)
-      assert batch.finalized_at == 2000
     end
   end
 end

--- a/test/bedrock/data_plane/commit_proxy/batching_test.exs
+++ b/test/bedrock/data_plane/commit_proxy/batching_test.exs
@@ -100,7 +100,6 @@ defmodule Bedrock.DataPlane.CommitProxy.BatchingTest do
       assert batch.n_transactions == 1
       assert batch.last_commit_version == Version.from_integer(100)
       assert batch.commit_version == Version.from_integer(101)
-      assert batch.finalized_at
     end
 
     test "returns error when sequencer is nil" do
@@ -288,7 +287,6 @@ defmodule Bedrock.DataPlane.CommitProxy.BatchingTest do
       assert updated_state.batch == nil
       assert finalized_batch
       assert finalized_batch.n_transactions == 5
-      assert finalized_batch.finalized_at
     end
 
     test "triggers finalization when max_latency exceeded" do
@@ -309,7 +307,6 @@ defmodule Bedrock.DataPlane.CommitProxy.BatchingTest do
 
       assert updated_state.batch == nil
       assert finalized_batch
-      assert finalized_batch.finalized_at
     end
 
     test "does not trigger finalization when neither policy is met" do

--- a/test/bedrock/data_plane/commit_proxy/finalization/ingress_rejection_test.exs
+++ b/test/bedrock/data_plane/commit_proxy/finalization/ingress_rejection_test.exs
@@ -70,7 +70,6 @@ defmodule Bedrock.DataPlane.CommitProxy.Finalization.IngressRejectionTest do
 
     %Batch{
       started_at: 0,
-      finalized_at: 0,
       last_commit_version: Version.from_integer(99),
       commit_version: Version.from_integer(100),
       n_transactions: length(entries),

--- a/test/bedrock/data_plane/commit_proxy/finalization/private_mutation_test.exs
+++ b/test/bedrock/data_plane/commit_proxy/finalization/private_mutation_test.exs
@@ -72,7 +72,6 @@ defmodule Bedrock.DataPlane.CommitProxy.FinalizationPrivateMutationTest do
 
       batch = %Batch{
         started_at: 0,
-        finalized_at: 0,
         last_commit_version: Version.from_integer(99),
         commit_version: Version.from_integer(100),
         n_transactions: 1,


### PR DESCRIPTION
The commit proxy stamped a `finalized_at` timestamp onto every batch it closed, and nothing downstream ever read it. An earlier dead-state trim (PR #167) said it removed the field but did not. This change removes the field, its setter, both write sites, and the test assertions that only observed the write.

Ticket: bedrock-q67.35
Closes bedrock-q67.35.

## Why

The commit proxy accumulates transactions into a batch and closes it when it fills or has been open longer than `max_latency_in_ms`. The batch carried two timestamps. The first, `started_at`, is read by the latency check and the adaptive hold timer. The second was written at close and never consulted again.

Only three things consume a closed batch: the finalization pipeline, the batch-failed telemetry event, and the fill-rate estimator. The pipeline reads the version fields and the buffer, and measures its own duration with `:timer.tc`. Telemetry reads the buffer length and commit version. The estimator reads the transaction count. The close timestamp was computed on every batch, carried to the finalization task, and dropped.

The 2026-08-20 lib-diff re-read of #152 caught that #167's commit message listed the field among its removals while the code still set it. The ticket allowed naming a real reader or deleting the field; no reader exists.

## What changed

- The struct loses `finalized_at` from its type and defaults, and `set_finalized_at/2` is gone.
- The two write sites (the empty-transaction heartbeat batch and the close-the-batch policy) return the batch as it stands.
- Tests asserting the field, and two `%Batch{}` fixtures that named it, drop the reference; the fixtures would otherwise fail to compile.
- `started_at` is deliberately kept. No replacement metric was added; an open-to-hand-off latency would be new instrumentation and deserves its own ticket.

## How it works

The batch lifecycle is unchanged except for one assignment. On close, the policy still clears the batch slot and returns the batch in a single tuple, so a batch is closed at most once and handed to exactly one finalization task. Because the removed value was never read, no restart, retry, or concurrent path depended on it.

## Verification

`git grep -n finalized_at` finds 17 hits on `develop` and zero on the PR head across `lib/`, `test/`, `guides/`, and `docs/`. No tests were added; the surviving batching tests still assert the batch is returned, the slot is cleared, and the version and count fields are correct. CI is green on OTP 27.3, 28.3, 29.0, and the S3 MinIO job; the distributed durability job is scheduled and skipped as usual. A cold audit passed, noting an unrelated pre-existing flake in `tracing_test.exs:144`.
