### PR TITLE
bedrock-0lx: derive the id allocator from the index a rewind installs

### DIFF
--- a/lib/bedrock/data_plane/materializer/olivine/index.ex
+++ b/lib/bedrock/data_plane/materializer/olivine/index.ex
@@ -151,13 +151,13 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Index do
 
   @doc """
   Loads an Index from the database by traversing the page chain and building the tree structure.
-  Returns {:ok, index, max_id, free_ids, total_key_count} or an error.
+  Returns {:ok, index, id_allocator, total_key_count} or an error.
 
   ## Options
   - `max_keys_per_page` - Maximum keys per page (default: #{@default_max_keys_per_page})
   """
   @spec load_from(Database.t(), keyword()) ::
-          {:ok, t(), Page.id(), [Page.id()], non_neg_integer()}
+          {:ok, t(), IdAllocator.t(), non_neg_integer()}
           | {:error, :missing_pages | {:corrupt_index, term()}}
   def load_from({_data_db, index_db}, opts \\ []) do
     {:ok, durable_version} = IndexDatabase.load_durable_version(index_db)
@@ -165,7 +165,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Index do
     target_keys = div(max_keys * 3, 4)
 
     if durable_version == Version.zero() do
-      {:ok, new(opts), 0, [], 0}
+      {:ok, new(opts), IdAllocator.new(0, []), 0}
     else
       needed_page_ids = MapSet.new([0])
 
@@ -420,12 +420,11 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Index do
   end
 
   @spec build_index_from_page_map(%{Page.id() => {Page.t(), Page.id()}}, pos_integer(), pos_integer()) ::
-          {:ok, t(), Page.id(), [Page.id()], non_neg_integer()}
+          {:ok, t(), IdAllocator.t(), non_neg_integer()}
   defp build_index_from_page_map(page_map, max_keys_per_page, target_keys_per_page) do
     tree = Tree.from_page_map(page_map)
     page_ids = page_map |> Map.keys() |> MapSet.new()
     max_id = if MapSet.size(page_ids) > 0, do: Enum.max(page_ids), else: 0
-    free_ids = calculate_free_ids(max_id, page_ids)
 
     initial_page_map =
       if :gb_trees.is_empty(tree) and max_id == 0 do
@@ -442,7 +441,28 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Index do
       target_keys_per_page: target_keys_per_page
     }
 
-    {:ok, index, max_id, free_ids, key_count(index)}
+    {:ok, index, id_allocator(index), key_count(index)}
+  end
+
+  @doc """
+  The allocator implied by an index's page map: `max_id` is the largest page
+  id in use, and every id below it that no page holds is free.
+
+  This is the only allocator an index may be paired with. Anywhere an older
+  index is installed — a recovery rollback, the compaction cutover, a load
+  from disk — the allocator must be re-derived from the map going in rather
+  than carried across from the state being discarded. A clear above the
+  rewind point recycles the ids of the pages it empties; the rewind brings
+  those pages back to life, and a carried-over allocator would still list
+  their ids as free. The next split would take one and write a new page
+  straight over a live one.
+  """
+  @spec id_allocator(t()) :: IdAllocator.t()
+  def id_allocator(%__MODULE__{page_map: page_map}) do
+    # Page 0 always exists (invariant 1), so the set is never empty.
+    page_ids = page_map |> Map.keys() |> MapSet.new()
+    max_id = Enum.max(page_ids)
+    IdAllocator.new(max_id, calculate_free_ids(max_id, page_ids))
   end
 
   defp calculate_free_ids(0, _all_existing_page_ids), do: []

--- a/lib/bedrock/data_plane/materializer/olivine/index_manager.ex
+++ b/lib/bedrock/data_plane/materializer/olivine/index_manager.ex
@@ -75,14 +75,14 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.IndexManager do
     durable_version = Database.durable_version(database)
 
     case Index.load_from(database) do
-      {:ok, initial_index, max_id, free_ids, n_keys} ->
+      {:ok, initial_index, id_allocator, n_keys} ->
         {data_db, _index_db} = database
 
         index_manager = %__MODULE__{
           versions: [{durable_version, {initial_index, %{}}}],
           current_version: durable_version,
           window_size_in_microseconds: 5_000_000,
-          id_allocator: IdAllocator.new(max_id, free_ids),
+          id_allocator: id_allocator,
           last_version_ended_at_offset: data_db.file_offset,
           n_keys: n_keys
         }
@@ -518,6 +518,13 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.IndexManager do
   `n_keys` rewinds with the index: the resumed stream re-delivers the
   discarded suffix, and a count carried across the rollback would tally
   those transactions twice.
+
+  So does the id allocator, and for a sharper reason: a clear in the
+  discarded suffix recycled the ids of the pages it emptied, and the
+  rollback brings those pages back to life. A carried-over allocator would
+  still list their ids as free and the next split would write over a live
+  page — so the allocator is re-derived from the index being installed
+  (`Index.id_allocator/1`).
   """
   @spec rollback_to(t(), Bedrock.version()) :: t()
   def rollback_to(%{current_version: current} = index_manager, version) when current <= version, do: index_manager
@@ -536,6 +543,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.IndexManager do
       | versions: versions,
         current_version: new_current,
         output_queue: output_queue,
+        id_allocator: Index.id_allocator(new_index),
         n_keys: Index.key_count(new_index)
     }
   end

--- a/lib/bedrock/data_plane/materializer/olivine/server.ex
+++ b/lib/bedrock/data_plane/materializer/olivine/server.ex
@@ -490,7 +490,10 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.Server do
       versions: [{durable_version, {new_index, %{}}}],
       current_version: durable_version,
       window_size_in_microseconds: 5_000_000,
-      id_allocator: t.index_manager.id_allocator,
+      # The allocator rewinds with the index for the same reason the count
+      # does: the compacted map brings back pages whose ids the live
+      # allocator has since recycled, and a split would write over one.
+      id_allocator: Index.id_allocator(new_index),
       output_queue: :queue.new(),
       last_version_ended_at_offset: 0,
       window_lag_time_μs: 5_000_000,

--- a/lib/mix/tasks/bedrock.analyze_index.ex
+++ b/lib/mix/tasks/bedrock.analyze_index.ex
@@ -112,7 +112,7 @@ defmodule Mix.Tasks.Bedrock.AnalyzeIndex do
 
     # Use Index.load_from to properly load the index from disk
     case Index.load_from(db_tuple) do
-      {:ok, index, _version, _new_pages, _loaded_pages} ->
+      {:ok, index, _id_allocator, _n_keys} ->
         analyze_index_structure(index, config)
 
       {:error, :missing_pages} ->

--- a/test/bedrock/data_plane/materializer/olivine/compaction_cutover_test.exs
+++ b/test/bedrock/data_plane/materializer/olivine/compaction_cutover_test.exs
@@ -11,6 +11,9 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.CompactionCutoverTest do
   """
   use ExUnit.Case, async: true
 
+  alias Bedrock.DataPlane.Materializer.Olivine.Database
+  alias Bedrock.DataPlane.Materializer.Olivine.Index
+  alias Bedrock.DataPlane.Materializer.Olivine.IndexManager
   alias Bedrock.DataPlane.Materializer.Olivine.Logic
   alias Bedrock.DataPlane.Materializer.Olivine.Server
   alias Bedrock.DataPlane.Transaction
@@ -295,6 +298,67 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.CompactionCutoverTest do
     v2000 = Version.from_integer(2_000)
     :ok = ReplayShardServer.append(shard_server, v2000, slice(v2000, "b"))
     await_value(pid, v2000, "b")
+  end
+
+  # The cutover installs the DURABLE page map, and that map still holds
+  # pages the live allocator has since recycled. A carried-over allocator
+  # lists them as free; the replay then recycles the same ids a SECOND
+  # time, and a later multi-way split hands one id to two new pages —
+  # `add_pages_batch` keeps only the last, and the other page's keys are
+  # gone.
+  #
+  # Driven through Logic rather than a live server: the durable boundary
+  # has to advance past a recycling clear, which needs versions seconds
+  # apart and a known-committed version to uncap the window.
+  test "the id allocator rewinds with the compacted index", %{tmp_dir: tmp_dir} do
+    otp_name = :"olivine_cutover_alloc_#{System.unique_integer([:positive])}"
+    {:ok, state} = Logic.startup(otp_name, self(), "cutover-alloc-worker", tmp_dir)
+
+    # 300 keys overflow the 256-key page, splitting page 0 and allocating
+    # page 1. Nothing is evictable yet — the window edge underflows.
+    state = apply_and_flush(state, sets("k", 1..300), 10_000_000)
+
+    # Emptying page 1 recycles its id. This version's window advance makes
+    # the PREVIOUS one durable, so the durable page map still holds page 1.
+    state = apply_and_flush(state, [{:clear_range, "k0151", "l"}], 20_000_000)
+
+    durable = Database.durable_version(state.database)
+    assert Version.to_integer(durable) == 10_000_000
+    assert state.index_manager |> IndexManager.page_map_at(durable) |> Map.keys() |> Enum.sort() == [0, 1]
+    assert IndexManager.info(state.index_manager, :free_ids) == [1]
+
+    {:ok, task} = Logic.start_compaction(state)
+    assert_receive {:compaction_ready, _, _, _, _, _, _, _, ^durable, _, _, _} = cutover_msg, 10_000
+    Task.await(task)
+
+    {:noreply, state} = Server.handle_info(cutover_msg, state)
+    assert IndexManager.info(state.index_manager, :free_ids) == []
+
+    # The replay: the stream re-delivers the clear, and then a transaction
+    # whose split needs two new page ids at once.
+    state = apply_transaction(state, [{:clear_range, "k0151", "l"}], 20_000_000)
+    state = apply_transaction(state, sets("j", 1..400), 30_000_000)
+
+    [{_version, {index, _modified}} | _] = state.index_manager.versions
+    assert IndexManager.info(state.index_manager, :n_keys) == Index.key_count(index)
+    assert IndexManager.info(state.index_manager, :n_keys) == 550
+
+    Logic.shutdown(state)
+  end
+
+  defp sets(prefix, range),
+    do: Enum.map(range, &{:set, prefix <> String.pad_leading(Integer.to_string(&1), 4, "0"), "v"})
+
+  defp apply_transaction(state, mutations, version_int) do
+    encoded = Transaction.encode(%{mutations: mutations, commit_version: Version.from_integer(version_int)})
+    {:ok, state, _version} = Logic.apply_transactions(state, [encoded])
+    state
+  end
+
+  defp apply_and_flush(state, mutations, version_int) do
+    state = apply_transaction(state, mutations, version_int)
+    {:ok, state} = Logic.advance_window(%{state | known_committed_version: Version.from_integer(version_int)})
+    state
   end
 
   defp flush_pulls do

--- a/test/bedrock/data_plane/materializer/olivine/index_manager_test.exs
+++ b/test/bedrock/data_plane/materializer/olivine/index_manager_test.exs
@@ -5,6 +5,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.IndexManagerTest do
 
   alias Bedrock.DataPlane.Materializer.Olivine.Database
   alias Bedrock.DataPlane.Materializer.Olivine.IdAllocator
+  alias Bedrock.DataPlane.Materializer.Olivine.Index
   alias Bedrock.DataPlane.Materializer.Olivine.Index.Page
   alias Bedrock.DataPlane.Materializer.Olivine.IndexManager
   alias Bedrock.DataPlane.Transaction
@@ -49,6 +50,11 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.IndexManagerTest do
 
     Transaction.encode(transaction_map)
   end
+
+  defp sets(prefix, range),
+    do: Enum.map(range, &{:set, prefix <> String.pad_leading(Integer.to_string(&1), 4, "0"), "v"})
+
+  defp live_page_ids(%{versions: [{_version, {index, _modified}} | _]}), do: index.page_map |> Map.keys() |> Enum.sort()
 
   describe "rollback_to/2" do
     test "discards in-memory versions above the target — a pointer operation" do
@@ -109,6 +115,43 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.IndexManagerTest do
 
       assert IndexManager.info(rolled, :n_keys) == 1
       assert IndexManager.info(rolled, :key_ranges) == [{"a", "a"}]
+    end
+
+    # A clear above the rollback point empties pages and recycles their ids.
+    # The rollback brings those pages back to life, so an allocator carried
+    # across would still list a live page's id as free — and the next split
+    # would take it and write a new page straight over the live one.
+    test "the id allocator rewinds with the index" do
+      db = create_test_database()
+      im = IndexManager.new()
+
+      v1 = Version.from_integer(1_000)
+      v2 = Version.from_integer(2_000)
+      v3 = Version.from_integer(3_000)
+
+      # 300 keys overflow the 256-key page, splitting page 0 and allocating
+      # a second page id.
+      {im, db} = IndexManager.apply_transactions(im, [test_transaction(sets("k", 1..300), v1)], db)
+      page_ids_at_v1 = live_page_ids(im)
+      assert page_ids_at_v1 == [0, 1]
+
+      # Empty page 1 above the rollback point: its id goes on the free list.
+      {im, db} = IndexManager.apply_transactions(im, [test_transaction([{:clear_range, "k0151", "l"}], v2)], db)
+      assert live_page_ids(im) == [0]
+      assert IndexManager.info(im, :free_ids) == [1]
+
+      rolled = IndexManager.rollback_to(im, v1)
+
+      assert live_page_ids(rolled) == page_ids_at_v1
+      assert Enum.all?(IndexManager.info(rolled, :free_ids), &(&1 not in page_ids_at_v1))
+
+      # 120 more keys below the page boundary overflow page 0 again, so the
+      # replayed suffix asks the allocator for another id.
+      {rolled, _db} = IndexManager.apply_transactions(rolled, [test_transaction(sets("j", 1..120), v3)], db)
+
+      [{^v3, {index, _}} | _] = rolled.versions
+      assert IndexManager.info(rolled, :n_keys) == Index.key_count(index)
+      assert IndexManager.info(rolled, :n_keys) == 420
     end
 
     test "a rollback at or above the current version is a no-op" do

--- a/test/bedrock/data_plane/materializer/olivine/index_manager_test.exs
+++ b/test/bedrock/data_plane/materializer/olivine/index_manager_test.exs
@@ -143,7 +143,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.IndexManagerTest do
       rolled = IndexManager.rollback_to(im, v1)
 
       assert live_page_ids(rolled) == page_ids_at_v1
-      assert Enum.all?(IndexManager.info(rolled, :free_ids), &(&1 not in page_ids_at_v1))
+      assert IndexManager.info(rolled, :free_ids) == []
 
       # 120 more keys below the page boundary overflow page 0 again, so the
       # replayed suffix asks the allocator for another id.

--- a/test/bedrock/data_plane/materializer/olivine/index_test.exs
+++ b/test/bedrock/data_plane/materializer/olivine/index_test.exs
@@ -1,6 +1,7 @@
 defmodule Bedrock.DataPlane.Materializer.Olivine.IndexTest do
   use ExUnit.Case, async: true
 
+  alias Bedrock.DataPlane.Materializer.Olivine.IdAllocator
   alias Bedrock.DataPlane.Materializer.Olivine.Index
   alias Bedrock.DataPlane.Materializer.Olivine.Index.Page
   alias Bedrock.DataPlane.Materializer.Olivine.Index.Tree
@@ -27,6 +28,43 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.IndexTest do
       tree: tree,
       page_map: page_map
     }
+  end
+
+  describe "id_allocator/1" do
+    test "the free list is the gaps below the largest page id in use" do
+      index =
+        build_index_with_pages([
+          {0, [], 3},
+          {3, [{"key3", locator(3)}], 5},
+          {5, [{"key5", locator(5)}], 0}
+        ])
+
+      assert Index.id_allocator(index) == IdAllocator.new(5, [1, 2, 4])
+    end
+
+    test "an index whose ids are contiguous has nothing free" do
+      index = build_index_with_pages([{0, [], 1}, {1, [{"key1", locator(1)}], 0}])
+
+      assert Index.id_allocator(index) == IdAllocator.new(1, [])
+    end
+
+    # No page can be handed an id the index is already using: that is the
+    # whole reason a rewind re-derives the allocator instead of carrying
+    # the live one across.
+    test "no id it hands out is already in the page map" do
+      index =
+        build_index_with_pages([
+          {0, [], 2},
+          {2, [{"key2", locator(2)}], 7},
+          {7, [{"key7", locator(7)}], 0}
+        ])
+
+      {ids, allocator} = IdAllocator.allocate_ids(Index.id_allocator(index), 8)
+
+      assert Enum.all?(ids, &(not Map.has_key?(index.page_map, &1)))
+      assert ids == Enum.uniq(ids)
+      assert allocator.free_ids == []
+    end
   end
 
   describe "delete_pages/2" do


### PR DESCRIPTION
Two Olivine paths install an older in-memory index while keeping the newer page-id allocator: the recovery rollback and the compaction cutover. A clear above the rewind point had freed the ids of pages it emptied; the rewind revived those pages, the allocator still offered their ids, and the next split wrote over a live page. The allocator is now derived from the page map being installed.

Ticket: bedrock-0lx
Stacked on: #276 (bedrock-3v1/compaction-cutover-version-label)

## Why

The allocator is a high-water mark plus a free list. It does not know which ids the index holds; it trusts that an id is recycled only by the code that deletes the page. The forward path honors that, since both clear paths in `IndexUpdate` delete and recycle in one step; a rewind that leaves the allocator behind does not.

300 keys at v1 split page 0 and allocate page 1. A clear at v2 empties page 1 and frees its id. Rolling back to v1 revives page 1 with 150 keys, but the free list still says `[1]`. When the replay overflows page 0 again, the split is handed id 1 and the new page replaces the live one, keys and all.

The rollback has always had this shape. The cutover became exposed by #276, which switched compaction to the durable page map, so the compacted map can hold pages the live allocator has recycled; the replay then recycles the same id twice and a multi-way split hands it to two new pages. Nothing in lib issues `:compact` today, so the rollback is the production path.

## What changed

`Index.id_allocator/1` is new. Given an index, the high-water mark is the largest page id in the map and the free list is every gap below it, the derivation the disk loader already used. The rollback and the cutover take their allocator from it instead of carrying the live one, and `Index.load_from/2` returns the derived allocator directly, so its result tuple loses one element. The allocator struct and forward-path recycling are unchanged.

## How it works

The derived allocator holds one invariant: no free id and no id above the high-water mark is present in the page map. The forward path preserves that on its own, so realigning at each rewind is enough.

```
page map {0, 3, 5}  ->  max_id 5, free_ids [1, 2, 4]
page map {0, 1}     ->  max_id 1, free_ids []
```

The high-water mark can move down, so ids the discarded suffix allocated are reused. Every load from disk already does this. Eviction is clamped to the known-committed version, so nothing from the suffix reached disk, and the loader follows the chain from page 0 with the newest block winning, so a stale page under a reused id is never selected. Page 0 always exists, so the id set is never empty.

## Verification

A rollback test drives the sequence above: free list empty after the rollback, key count matching the index after the replayed split (420; reverted, 420 against 270). A cutover test pushes the durable boundary past a recycling clear through `Logic`, hands the ready message to the server, and checks the same after a three-way split (550; reverted, 367). Unit tests pin the derivation on gapped and contiguous maps. Author reports all gates green; no CI checks on the stacked branch. No follow-up tickets.
