### PR TITLE
bedrock-jsu: Fix ExpensiveEmptyEnumCheck and Nesting credo findings; re-enable checks

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -34,9 +34,6 @@
         # Specs required for lib code only; test helpers are exempt (bedrock-qjp)
         {Credo.Check.Readability.Specs, files: %{excluded: [~r"(^|/)test/"]}},
 
-        # Disabled pending cleanup of existing findings (bedrock-jsu)
-        {Credo.Check.Refactor.Nesting, false},
-        {Credo.Check.Warning.ExpensiveEmptyEnumCheck, false}
       ]
     }
   ]

--- a/lib/bedrock/control_plane/coordinator/server.ex
+++ b/lib/bedrock/control_plane/coordinator/server.ex
@@ -379,7 +379,7 @@ defmodule Bedrock.ControlPlane.Coordinator.Server do
       end)
       |> Enum.sort()
 
-    if length(already_committed_txns) > 0 do
+    if not Enum.empty?(already_committed_txns) do
       Logger.info(
         "Bedrock [#{t.cluster}]: Sending recovery consensus for #{length(already_committed_txns)} already-committed transactions: #{inspect(already_committed_txns)}"
       )

--- a/lib/bedrock/control_plane/director/recovery/log_recruitment_phase.ex
+++ b/lib/bedrock/control_plane/director/recovery/log_recruitment_phase.ex
@@ -302,22 +302,26 @@ defmodule Bedrock.ControlPlane.Director.Recovery.LogRecruitmentPhase do
     Enum.reduce_while(existing_log_ids, {:ok, %{}, []}, fn log_id, {:ok, locked_services, lock_failed} ->
       case Map.get(available_services, log_id) do
         {_kind, last_seen} = service ->
-          case lock_recruited_service(service, recovery_attempt.epoch, context) do
-            {:ok, pid, info} ->
-              locked_service = %{status: {:up, pid}, kind: info.kind, last_seen: last_seen}
-              {:cont, {:ok, Map.put(locked_services, log_id, locked_service), lock_failed}}
-
-            {:error, :newer_epoch_exists} = error ->
-              {:halt, error}
-
-            {:error, _reason} ->
-              {:cont, {:ok, locked_services, [log_id | lock_failed]}}
-          end
+          lock_or_fail(service, log_id, last_seen, locked_services, lock_failed, recovery_attempt, context)
 
         _ ->
           {:cont, {:ok, locked_services, [log_id | lock_failed]}}
       end
     end)
+  end
+
+  defp lock_or_fail(service, log_id, last_seen, locked_services, lock_failed, recovery_attempt, context) do
+    case lock_recruited_service(service, recovery_attempt.epoch, context) do
+      {:ok, pid, info} ->
+        locked_service = %{status: {:up, pid}, kind: info.kind, last_seen: last_seen}
+        {:cont, {:ok, Map.put(locked_services, log_id, locked_service), lock_failed}}
+
+      {:error, :newer_epoch_exists} = error ->
+        {:halt, error}
+
+      {:error, _reason} ->
+        {:cont, {:ok, locked_services, [log_id | lock_failed]}}
+    end
   end
 
   @spec replace_lock_failed_candidates(

--- a/lib/bedrock/control_plane/director/recovery/materializer_bootstrap_phase.ex
+++ b/lib/bedrock/control_plane/director/recovery/materializer_bootstrap_phase.ex
@@ -469,20 +469,38 @@ defmodule Bedrock.ControlPlane.Director.Recovery.MaterializerBootstrapPhase do
           {:cont, {:ok, acc, services}}
 
         :error ->
-          shard_tag
-          |> start_materializer_for_shard(existing_by_shard, recovery_version, recovery_attempt, context)
-          |> case do
-            {:ok, :absent, _created} ->
-              {:cont, {:ok, acc, services}}
-
-            {:ok, assignment, created} ->
-              {:cont, {:ok, Map.put(acc, shard_tag, assignment), Map.merge(services, created)}}
-
-            {:error, reason} ->
-              {:halt, {:error, {shard_tag, reason}}}
-          end
+          ensure_materializer_for_shard(
+            shard_tag,
+            existing_by_shard,
+            recovery_version,
+            recovery_attempt,
+            context,
+            acc,
+            services
+          )
       end
     end)
+  end
+
+  defp ensure_materializer_for_shard(
+         shard_tag,
+         existing_by_shard,
+         recovery_version,
+         recovery_attempt,
+         context,
+         acc,
+         services
+       ) do
+    case start_materializer_for_shard(shard_tag, existing_by_shard, recovery_version, recovery_attempt, context) do
+      {:ok, :absent, _created} ->
+        {:cont, {:ok, acc, services}}
+
+      {:ok, assignment, created} ->
+        {:cont, {:ok, Map.put(acc, shard_tag, assignment), Map.merge(services, created)}}
+
+      {:error, reason} ->
+        {:halt, {:error, {shard_tag, reason}}}
+    end
   end
 
   defp start_materializer_for_shard(shard_tag, existing_by_shard, recovery_version, recovery_attempt, context) do

--- a/lib/bedrock/control_plane/director/recovery/persistence_phase.ex
+++ b/lib/bedrock/control_plane/director/recovery/persistence_phase.ex
@@ -276,13 +276,16 @@ defmodule Bedrock.ControlPlane.Director.Recovery.PersistencePhase do
         # shard) keep their keys — the family is a set, so writing one
         # member never implies removing another.
         for {tag, members} <- materializers, {worker_id, node} <- members, reduce: tx do
-          tx ->
-            if prior |> Map.get(tag, %{}) |> Map.get(worker_id) == node do
-              tx
-            else
-              Tx.set(tx, SystemKeys.materializer_key(tag, worker_id), Values.encode_materializer_node(node))
-            end
+          tx -> maybe_set_materializer_key(tx, prior, tag, worker_id, node)
         end
+    end
+  end
+
+  defp maybe_set_materializer_key(tx, prior, tag, worker_id, node) do
+    if prior |> Map.get(tag, %{}) |> Map.get(worker_id) == node do
+      tx
+    else
+      Tx.set(tx, SystemKeys.materializer_key(tag, worker_id), Values.encode_materializer_node(node))
     end
   end
 

--- a/lib/bedrock/data_plane/demux/persistence_worker.ex
+++ b/lib/bedrock/data_plane/demux/persistence_worker.ex
@@ -123,14 +123,18 @@ defmodule Bedrock.DataPlane.Demux.PersistenceWorker do
             %{state | queue: queue}
 
           {:dropped, queue} ->
-            if state.on_drop, do: state.on_drop.(payload, reason)
-            send(self(), :drain)
-            %{state | queue: queue}
+            handle_dropped(state, queue, payload, reason)
 
           {:error, :unknown_token, queue} ->
             %{state | queue: queue}
         end
     end
+  end
+
+  defp handle_dropped(state, queue, payload, reason) do
+    if state.on_drop, do: state.on_drop.(payload, reason)
+    send(self(), :drain)
+    %{state | queue: queue}
   end
 
   defp maybe_schedule_retry_tick(queue, retry_tick_ms, now_ms) do

--- a/lib/bedrock/data_plane/demux/shard_server.ex
+++ b/lib/bedrock/data_plane/demux/shard_server.ex
@@ -252,17 +252,7 @@ defmodule Bedrock.DataPlane.Demux.ShardServer do
           # requested position: say so, and let the puller advance.
           {:reply, {:ok, [], currency(state)}, state}
         else
-          # Nothing known at or after the requested position yet: park, and
-          # subscribe to the demux's next currency advance. Event-driven —
-          # the reply arrives when the next push does, not when a timer
-          # fires.
-          reply_fn = fn response -> GenServer.reply(from, response) end
-
-          {waiting_list, _timeout} =
-            WaitingList.insert(state.waiting_list, from_version, {from_version, limit}, reply_fn, timeout)
-
-          state = request_currency(%{state | waiting_list: waiting_list})
-          {:noreply, state, next_timeout(state)}
+          park_pull_request(state, from, from_version, limit, timeout)
         end
 
       {:error, _reason} = error ->
@@ -371,6 +361,19 @@ defmodule Bedrock.DataPlane.Demux.ShardServer do
 
   defp known_current_past?(%{high_water: nil}, _from_version), do: false
   defp known_current_past?(state, from_version), do: not Version.newer?(from_version, state.high_water)
+
+  # Nothing known at or after the requested position yet: park, and
+  # subscribe to the demux's next currency advance. Event-driven — the
+  # reply arrives when the next push does, not when a timer fires.
+  defp park_pull_request(state, from, from_version, limit, timeout) do
+    reply_fn = fn response -> GenServer.reply(from, response) end
+
+    {waiting_list, _timeout} =
+      WaitingList.insert(state.waiting_list, from_version, {from_version, limit}, reply_fn, timeout)
+
+    state = request_currency(%{state | waiting_list: waiting_list})
+    {:noreply, state, next_timeout(state)}
+  end
 
   # One-shot currency subscription: tell the demux what we've seen; it
   # replies now if it knows more, otherwise on its next push. Duplicate

--- a/lib/bedrock/data_plane/log/shale/cold_starting.ex
+++ b/lib/bedrock/data_plane/log/shale/cold_starting.ex
@@ -15,12 +15,7 @@ defmodule Bedrock.DataPlane.Log.Shale.ColdStarting do
         files
         |> Enum.filter(&String.starts_with?(&1, Segment.file_prefix()))
         |> Enum.sort(:desc)
-        |> Enum.reduce_while({:ok, []}, fn file_name, {:ok, segments} ->
-          case Segment.from_path(Path.join(segment_dir, file_name)) do
-            {:ok, segment} -> {:cont, {:ok, [segment | segments]}}
-            {:error, reason} -> {:halt, {:error, reason}}
-          end
-        end)
+        |> Enum.reduce_while({:ok, []}, &accumulate_segment(&1, segment_dir, &2))
         |> case do
           {:ok, segments} -> {:ok, Enum.sort_by(segments, & &1.min_version, :desc)}
           error -> error
@@ -28,6 +23,13 @@ defmodule Bedrock.DataPlane.Log.Shale.ColdStarting do
 
       {:error, posix} ->
         {:error, {:wal_io, segment_dir, posix}}
+    end
+  end
+
+  defp accumulate_segment(file_name, segment_dir, {:ok, segments}) do
+    case Segment.from_path(Path.join(segment_dir, file_name)) do
+      {:ok, segment} -> {:cont, {:ok, [segment | segments]}}
+      {:error, reason} -> {:halt, {:error, reason}}
     end
   end
 end

--- a/lib/bedrock/data_plane/materializer/olivine/index_database.ex
+++ b/lib/bedrock/data_plane/materializer/olivine/index_database.ex
@@ -272,15 +272,19 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.IndexDatabase do
           <<@magic_number::32, version::binary-size(8), ^payload_size::32, payload::binary-size(^payload_size),
             ^payload_size::32>>} <- :file.pread(file, record_offset, record_size) do
       if version == target_version do
-        {previous_version, pages_map} = :erlang.binary_to_term(payload)
-        next_version = if previous_version == version, do: nil, else: previous_version
-        {:ok, pages_map, next_version}
+        version_found(payload, version)
       else
         scan_backward_for_version(file, record_offset, target_version)
       end
     else
       _ -> {:error, :not_found}
     end
+  end
+
+  defp version_found(payload, version) do
+    {previous_version, pages_map} = :erlang.binary_to_term(payload)
+    next_version = if previous_version == version, do: nil, else: previous_version
+    {:ok, pages_map, next_version}
   end
 
   defp count_records(_file, file_size) when file_size < @min_record_size, do: 0

--- a/lib/bedrock/directory.ex
+++ b/lib/bedrock/directory.ex
@@ -289,12 +289,14 @@ defmodule Bedrock.Directory do
   def create_or_open(%Layer{repo: repo} = layer, path, opts) do
     with :ok <- validate_path(path),
          true <- not root?(path) || {:error, :cannot_create_or_open_root} do
-      repo.transact(fn ->
-        case do_open(layer, nil, path) do
-          {:ok, node} -> {:ok, node}
-          {:error, :directory_does_not_exist} -> do_create(layer, nil, path, opts)
-        end
-      end)
+      repo.transact(fn -> open_or_create(layer, path, opts) end)
+    end
+  end
+
+  defp open_or_create(layer, path, opts) do
+    case do_open(layer, nil, path) do
+      {:ok, node} -> {:ok, node}
+      {:error, :directory_does_not_exist} -> do_create(layer, nil, path, opts)
     end
   end
 
@@ -604,18 +606,19 @@ defmodule Bedrock.Directory do
       existing_value = repo.get(layer.node_keyspace, path)
 
       case existing_value do
-        nil ->
-          if parent_exists?(layer, path) do
-            create_directory(layer, txn, path, opts)
-          else
-            {:error, :parent_directory_does_not_exist}
-          end
-
-        _value ->
-          {:error, :directory_already_exists}
+        nil -> create_if_parent_exists(layer, txn, path, opts)
+        _value -> {:error, :directory_already_exists}
       end
     else
       {:error, _} = error -> error
+    end
+  end
+
+  defp create_if_parent_exists(layer, txn, path, opts) do
+    if parent_exists?(layer, path) do
+      create_directory(layer, txn, path, opts)
+    else
+      {:error, :parent_directory_does_not_exist}
     end
   end
 

--- a/lib/bedrock/object_storage/snapshot_bundle.ex
+++ b/lib/bedrock/object_storage/snapshot_bundle.ex
@@ -102,20 +102,24 @@ defmodule Bedrock.ObjectStorage.SnapshotBundle do
       data_end_offset = file_size - idx_size
 
       if data_end_offset >= 0 do
-        # Read header to validate magic number
-        case read_bytes_at(path, data_end_offset, @header_size) do
-          {:ok, <<@magic_number::32, _rest::binary>>} ->
-            {:ok, data_end_offset, idx_size}
-
-          {:ok, _} ->
-            {:error, :no_index_record}
-
-          error ->
-            error
-        end
+        validate_header(path, data_end_offset, idx_size)
       else
         {:error, :invalid_bundle}
       end
+    end
+  end
+
+  # Read header to validate magic number
+  defp validate_header(path, data_end_offset, idx_size) do
+    case read_bytes_at(path, data_end_offset, @header_size) do
+      {:ok, <<@magic_number::32, _rest::binary>>} ->
+        {:ok, data_end_offset, idx_size}
+
+      {:ok, _} ->
+        {:error, :no_index_record}
+
+      error ->
+        error
     end
   end
 

--- a/lib/mix/tasks/bedrock.analyze_index.ex
+++ b/lib/mix/tasks/bedrock.analyze_index.ex
@@ -209,7 +209,7 @@ defmodule Mix.Tasks.Bedrock.AnalyzeIndex do
       display_histogram(key_counts, page_count)
     end
 
-    if length(extra_key_pages) > 0 do
+    if not Enum.empty?(extra_key_pages) do
       display_extra_keys_analysis(extra_key_pages)
     end
 

--- a/test/bedrock/data_plane/demux/shard_server_test.exs
+++ b/test/bedrock/data_plane/demux/shard_server_test.exs
@@ -776,7 +776,7 @@ defmodule Bedrock.DataPlane.Demux.ShardServerTest do
 
       # Should receive the data
       assert_receive {:pull_result, {:ok, transactions, _}}, 1_000
-      assert length(transactions) >= 1
+      refute Enum.empty?(transactions)
     end
 
     test "a woken waiter receives data from its own start position, not from zero", %{

--- a/test/bedrock/data_plane/log/shale/pushing_test.exs
+++ b/test/bedrock/data_plane/log/shale/pushing_test.exs
@@ -444,14 +444,14 @@ defmodule Bedrock.DataPlane.Log.Shale.PushingTest do
     defp controlled_sync do
       {:ok, control} = Agent.start_link(fn -> %{fail: false, calls: 0} end)
 
-      sync_fun = fn _fd ->
-        Agent.get_and_update(control, fn state ->
-          result = if state.fail, do: {:error, :eio}, else: :ok
-          {result, %{state | calls: state.calls + 1}}
-        end)
-      end
+      sync_fun = fn _fd -> Agent.get_and_update(control, &sync_step/1) end
 
       {control, sync_fun}
+    end
+
+    defp sync_step(state) do
+      result = if state.fail, do: {:error, :eio}, else: :ok
+      {result, %{state | calls: state.calls + 1}}
     end
 
     defp state_with(dir, recycler, writer_opts) do

--- a/test/bedrock/data_plane/log/shale/wal_segment_issues_test.exs
+++ b/test/bedrock/data_plane/log/shale/wal_segment_issues_test.exs
@@ -98,7 +98,7 @@ defmodule Bedrock.DataPlane.Log.Shale.WalSegmentIssuesTest do
       assert {:ok, stream} = TransactionStreams.from_segments(segments, middle_version)
       transactions = Enum.take(stream, 10)
 
-      assert length(transactions) > 0, """
+      assert not Enum.empty?(transactions), """
       Expected transactions after version #{inspect(middle_version)} with large version gaps,
       but got empty stream. This indicates from_segments can't handle large version ranges.
       """

--- a/test/bedrock/data_plane/materializer/olivine/incremental_loading_test.exs
+++ b/test/bedrock/data_plane/materializer/olivine/incremental_loading_test.exs
@@ -168,7 +168,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.IncrementalLoadingTest do
 
       # Verify pages contain the expected keys
       page_0_keys = Page.keys(page_0)
-      assert length(page_0_keys) > 0, "Page 0 should contain keys"
+      assert not Enum.empty?(page_0_keys), "Page 0 should contain keys"
 
       # Verify we can locate keys using the index and get correct locators
       {:ok, page_for_key1, locator1} = Index.locator_for_key(recovered_index, "key_00001")

--- a/test/bedrock/data_plane/materializer/olivine/index_manager_property_test.exs
+++ b/test/bedrock/data_plane/materializer/olivine/index_manager_property_test.exs
@@ -176,7 +176,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.IndexManagerPropertyTest do
 
   property "tree maintains sorted order invariant" do
     check all(pages <- non_overlapping_pages_generator()) do
-      if length(pages) > 0 do
+      if not Enum.empty?(pages) do
         tree = build_tree_from_pages(pages)
 
         tree_entries = extract_tree_entries(tree)
@@ -200,7 +200,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.IndexManagerPropertyTest do
 
   property "page_for_key returns correct page for keys in range" do
     check all(pages <- non_overlapping_pages_generator()) do
-      if length(pages) > 0 do
+      if not Enum.empty?(pages) do
         tree = build_tree_from_pages(pages)
 
         # Verify page_for_key returns correct page for each key
@@ -219,7 +219,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.IndexManagerPropertyTest do
             pages <- non_overlapping_pages_generator(),
             test_key <- binary_key_generator()
           ) do
-      if length(pages) > 0 do
+      if not Enum.empty?(pages) do
         tree = build_tree_from_pages(pages)
 
         found_page_id = Tree.page_for_key(tree, test_key)
@@ -233,7 +233,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.IndexManagerPropertyTest do
 
   property "find_rightmost_page returns page with highest last_key" do
     check all(pages <- non_overlapping_pages_generator()) do
-      if length(pages) > 0 do
+      if not Enum.empty?(pages) do
         tree = build_tree_from_pages(pages)
 
         rightmost_page_id = find_rightmost_page(tree)
@@ -290,7 +290,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.IndexManagerPropertyTest do
 
         tree_entries = extract_tree_entries(updated_tree)
 
-        if length(tree_entries) > 0 do
+        if not Enum.empty?(tree_entries) do
           expected_page_id = Page.id(page)
           _expected_first_key = List.first(new_keys)
           expected_last_key = List.last(new_keys)

--- a/test/bedrock/data_plane/materializer/olivine/index_manager_test.exs
+++ b/test/bedrock/data_plane/materializer/olivine/index_manager_test.exs
@@ -432,14 +432,14 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.IndexManagerTest do
                IndexManager.pages_for_range(vm_updated, start_key, end_key, Version.from_integer(1000))
 
       assert is_list(pages)
-      assert length(pages) > 0
+      refute Enum.empty?(pages)
 
       # All pages should contain keys in the requested range
       all_keys = Enum.flat_map(pages, &Page.keys/1)
       range_keys = Enum.filter(all_keys, fn key -> key >= start_key and key <= end_key end)
 
       # Should find keys in the range
-      assert length(range_keys) > 0
+      refute Enum.empty?(range_keys)
 
       Database.close(db)
     end

--- a/test/bedrock/data_plane/materializer/olivine/intake_queue_test.exs
+++ b/test/bedrock/data_plane/materializer/olivine/intake_queue_test.exs
@@ -333,9 +333,9 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.IntakeQueueTest do
       {batch, last_version, updated_queue} = IntakeQueue.take_batch_by_size(queue, max_size)
 
       # Should always take at least one transaction
-      assert length(batch) >= 1 or IntakeQueue.empty?(queue)
+      assert not Enum.empty?(batch) or IntakeQueue.empty?(queue)
 
-      if length(batch) > 0 do
+      if not Enum.empty?(batch) do
         assert last_version == <<version::64>>
         assert IntakeQueue.empty?(updated_queue)
       end

--- a/test/bedrock/data_plane/materializer/olivine/key_selector_property_test.exs
+++ b/test/bedrock/data_plane/materializer/olivine/key_selector_property_test.exs
@@ -91,24 +91,25 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.KeySelectorPropertyTest do
     2..5
     |> StreamData.integer()
     |> StreamData.map(fn page_count ->
-      pages =
-        for page_id <- 0..(page_count - 1) do
-          base_key_num = page_id * 100
-
-          keys =
-            Enum.map(1..50, fn i ->
-              "page#{page_id}_key#{String.pad_leading(to_string(base_key_num + i), 3, "0")}"
-            end)
-
-          versions = List.duplicate(<<0, 0, 0, 0, 0, 0, 0, 1>>, 50)
-          key_locators = Enum.zip(keys, versions)
-          next_id = if page_id == page_count - 1, do: 0, else: page_id + 1
-          page = Page.new(page_id, key_locators)
-          {page, next_id}
-        end
+      pages = for page_id <- 0..(page_count - 1), do: build_page_entry(page_id, page_count)
 
       create_index_from_pages(pages)
     end)
+  end
+
+  defp build_page_entry(page_id, page_count) do
+    base_key_num = page_id * 100
+
+    keys =
+      Enum.map(1..50, fn i ->
+        "page#{page_id}_key#{String.pad_leading(to_string(base_key_num + i), 3, "0")}"
+      end)
+
+    versions = List.duplicate(<<0, 0, 0, 0, 0, 0, 0, 1>>, 50)
+    key_locators = Enum.zip(keys, versions)
+    next_id = if page_id == page_count - 1, do: 0, else: page_id + 1
+    page = Page.new(page_id, key_locators)
+    {page, next_id}
   end
 
   defp create_index_from_pages(page_tuples) do
@@ -177,7 +178,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.KeySelectorPropertyTest do
     check all(
             index <- multi_page_index_generator(),
             all_keys = get_all_keys_from_index(index),
-            length(all_keys) > 0
+            not Enum.empty?(all_keys)
           ) do
       existing_key = Enum.random(all_keys)
       selector = existing_key |> KeySelector.first_greater_or_equal() |> KeySelector.add(0)

--- a/test/bedrock/data_plane/materializer/olivine/persistence_integration_test.exs
+++ b/test/bedrock/data_plane/materializer/olivine/persistence_integration_test.exs
@@ -173,7 +173,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.PersistenceIntegrationTest do
 
         {:evict, batch, updated_manager} ->
           # Eviction occurred - verify the batch contains versions
-          assert length(batch) > 0
+          refute Enum.empty?(batch)
           # Each batch entry should be {version, data_size_in_bytes, bytes}
           Enum.each(batch, fn {version, _data_size_in_bytes, _bytes} ->
             assert Version.valid?(version)

--- a/test/bedrock/data_plane/transaction_property_test.exs
+++ b/test/bedrock/data_plane/transaction_property_test.exs
@@ -170,7 +170,7 @@ defmodule Bedrock.DataPlane.TransactionPropertyTest do
       base_tx = %{
         mutations: mutations,
         read_conflicts:
-          if(has_read_conflicts and not is_nil(read_version) and length(read_conflict_ranges) > 0,
+          if(has_read_conflicts and not is_nil(read_version) and not Enum.empty?(read_conflict_ranges),
             do: {read_version, read_conflict_ranges},
             else: {nil, []}
           ),
@@ -333,7 +333,7 @@ defmodule Bedrock.DataPlane.TransactionPropertyTest do
 
     property "produces minimal size for given data" do
       check all(mutations <- mutation_list_generator()) do
-        if length(mutations) > 0 do
+        if not Enum.empty?(mutations) do
           transaction = mutations_transaction(mutations)
           encoded = Transaction.encode(transaction)
 
@@ -423,7 +423,7 @@ defmodule Bedrock.DataPlane.TransactionPropertyTest do
   describe "header structure" do
     property "decoded opcodes are in valid ranges" do
       check all(mutations <- mutation_list_generator()) do
-        if length(mutations) > 0 do
+        if not Enum.empty?(mutations) do
           transaction = mutations_transaction(mutations)
           encoded = Transaction.encode(transaction)
 
@@ -544,7 +544,7 @@ defmodule Bedrock.DataPlane.TransactionPropertyTest do
   describe "streaming and section extraction" do
     property "mutation streaming produces identical results to decode" do
       check all(mutations <- mutation_list_generator()) do
-        if length(mutations) > 0 do
+        if not Enum.empty?(mutations) do
           transaction = mutations_transaction(mutations)
           encoded = Transaction.encode(transaction)
 

--- a/test/bedrock/directory/property_test.exs
+++ b/test/bedrock/directory/property_test.exs
@@ -60,7 +60,7 @@ defmodule Bedrock.Directory.PropertyTest do
             layer_name <- valid_layer_name()
           ) do
       # Use keyspace-aware stubs
-      parent_path = if length(path) > 0, do: Enum.drop(path, -1)
+      parent_path = if not Enum.empty?(path), do: Enum.drop(path, -1)
 
       stub(MockRepo, :get, fn _keyspace, key ->
         case key do

--- a/test/bedrock/internal/transaction_builder/transaction_builder/tx_key_selector_test.exs
+++ b/test/bedrock/internal/transaction_builder/transaction_builder/tx_key_selector_test.exs
@@ -102,7 +102,7 @@ defmodule Bedrock.Internal.TransactionBuilder.Tx.KeySelectorTest do
       # The exact merge result depends on add_or_merge implementation
       assert is_list(range_reads)
       # Could be 1 if merged, or 2 if kept separate
-      assert length(range_reads) >= 1
+      refute Enum.empty?(range_reads)
     end
   end
 

--- a/test/support/control_plane/recovery_test_support.ex
+++ b/test/support/control_plane/recovery_test_support.ex
@@ -254,7 +254,7 @@ defmodule Bedrock.Test.ControlPlane.RecoveryTestSupport do
           context.node_capabilities
 
         count when is_integer(count) ->
-          nodes = if count > 0, do: for(i <- 1..count, do: :"node#{i}@host"), else: []
+          nodes = node_names(count)
           %{log: nodes, storage: nodes}
 
         nodes when is_list(nodes) ->
@@ -263,6 +263,9 @@ defmodule Bedrock.Test.ControlPlane.RecoveryTestSupport do
 
     Map.put(context, :node_capabilities, node_capabilities)
   end
+
+  defp node_names(count) when count > 0, do: for(i <- 1..count, do: :"node#{i}@host")
+  defp node_names(_count), do: []
 
   @doc """
   Creates a simple mock node capabilities for testing.


### PR DESCRIPTION
Two credo checks, `Refactor.Nesting` and `Warning.ExpensiveEmptyEnumCheck`, have been disabled in `.credo.exs` since the credo 1.7.19 bump in PR #81 flagged pre-existing sites that were out of scope there. This change fixes every site the checks flag on current develop (22 empty-list comparisons and 13 nesting violations, up from 7 while the check was off) and deletes the two disable entries, so both run again with credo's defaults. No behaviour changes.

Ticket: bedrock-jsu

## Why

`length/1` is a BIF that walks every cons cell to produce a count, so `length(list) > 0` does O(n) work to answer a question that is settled by looking at the first cell. `Enum.empty?/1` on a list is a constant-time comparison against `[]`. The lists here are small, but the pattern also misstates intent: the code wants "is there anything here", not a count.

The nesting check flags any function body where `if`, `case`, `cond`, `with`, `for` or `fn` sit more than two deep. At depth three a reader holds three live branch conditions to know which line runs, and the innermost block has no name saying what it is for. Every such block here is a self-contained step (lock one service, park one pull request, validate one header) that reads better as a named function.

## What changed

- The two `{check, false}` entries and their comment are removed from `.credo.exs`.
- Every `length(x) > 0` and `length(x) >= 1` becomes `not Enum.empty?(x)`; where that is the sole argument of `assert`, the formatter rewrites it to `refute Enum.empty?(x)`. Calls to `length/1` that need the actual count (a coordinator log line) are untouched.
- Each nesting site moves its innermost block verbatim into a private helper taking exactly the variables it closed over; the original line becomes a single call. No `credo:disable` markers were added.

## How it works

Credo counts nesting per function definition and treats a function call as transparent, so moving a block into a helper lowers the depth at the call site without changing evaluation order. The directory layer's create-or-open path is representative:

```elixir
# before: with > fn > case
repo.transact(fn ->
  case do_open(layer, nil, path) do
    {:ok, node} -> {:ok, node}
    {:error, :directory_does_not_exist} -> do_create(layer, nil, path, opts)
  end
end)

# after: with > fn > call
repo.transact(fn -> open_or_create(layer, path, opts) end)
```

The `case` still runs inside the same transaction closure, so `do_open` and `do_create` see the same transaction as before. Two extractions changed shape slightly: the Shale cold-start reducer became a capture that matches `{:ok, segments}` in its accumulator (safe because the reducer halts on the first error), and a test helper's `if count > 0` became two clauses with a guard.

## Verification

With only the disable entries removed, `mix credo --strict` reports 35 issues; with the fixes, none. An independent audit re-derived the same 35 sites, checked each rewrite for equivalence, and reverted one site of each kind to confirm credo re-flags it. Format, dialyzer and the full suite (2892 tests, 0 failures) are clean; CI is green on all four matrix jobs. No tests were added: existing tests cover every touched function.

From a worktree nested under the main checkout, pass `--config-file .credo.exs`; credo otherwise also reads the parent config, which disables both checks until this lands. No follow-up tickets.
