### PR TITLE
bedrock-wxf.7: disk cache backend in front of ObjectStorage reads

### DIFF
--- a/lib/bedrock/object_storage/config.ex
+++ b/lib/bedrock/object_storage/config.ex
@@ -2,6 +2,7 @@ defmodule Bedrock.ObjectStorage.Config do
   @moduledoc "Configuration helpers for ObjectStorage backends."
 
   alias Bedrock.ObjectStorage
+  alias Bedrock.ObjectStorage.DiskCache
   alias Bedrock.ObjectStorage.LocalFilesystem
   alias Bedrock.ObjectStorage.S3
 
@@ -42,12 +43,27 @@ defmodule Bedrock.ObjectStorage.Config do
     ObjectStorage.backend(LocalFilesystem, Keyword.get(app_config, :local_filesystem, []))
   end
 
+  defp normalize_backend({:disk_cache, backend_config}, app_config) when is_list(backend_config) do
+    normalize_backend({DiskCache, backend_config}, app_config)
+  end
+
+  defp normalize_backend(:disk_cache, app_config) do
+    normalize_backend({DiskCache, Keyword.get(app_config, :disk_cache, [])}, app_config)
+  end
+
   defp normalize_backend({module, backend_config}, app_config) when is_atom(module) and is_list(backend_config) do
     ObjectStorage.backend(module, normalize_module_config(module, backend_config, app_config))
   end
 
   defp normalize_backend(module, app_config) when is_atom(module) do
     normalize_backend({module, []}, app_config)
+  end
+
+  # The cache wraps a backend, so its `:inner` is itself something to
+  # normalize — that is what lets `inner: :s3` pick up the top-level `:s3`
+  # config rather than having to be spelled out again.
+  defp normalize_module_config(DiskCache, backend_config, app_config) do
+    Keyword.update!(backend_config, :inner, &normalize_backend(&1, app_config))
   end
 
   defp normalize_module_config(S3, backend_config, app_config) do

--- a/lib/bedrock/object_storage/disk_cache.ex
+++ b/lib/bedrock/object_storage/disk_cache.ex
@@ -2,11 +2,14 @@ defmodule Bedrock.ObjectStorage.DiskCache do
   @moduledoc """
   A local disk cache in front of another ObjectStorage backend.
 
-  A materializer that restarts on a node it has already run on pays for
-  the same bytes twice: `Snapshot.read_latest/1` downloads the shard's
-  baseline again, and `ChunkReader.read_from_version/3` re-fetches every
-  chunk it replays. Neither object ever changed. This backend keeps a
-  copy in a local directory so the second cold start reads it from disk.
+  A node that restarts pays for the same bytes twice. A materializer's
+  cold start downloads the shard's baseline again
+  (`Snapshot.read_latest/1`, reached from
+  `Olivine.Logic.maybe_load_snapshot/2`), and a restarted
+  `Demux.ShardServer` re-reads every chunk it serves back out of history
+  (`ChunkReader.read_from_version/3`, reached from `get_from_storage/3`).
+  Neither object ever changed. This backend keeps a copy in a local
+  directory so the second read of one comes off local disk.
 
   It is a decorator: it holds another backend as `:inner` and forwards
   every operation to it. The inner backend remains the authority for what
@@ -15,44 +18,59 @@ defmodule Bedrock.ObjectStorage.DiskCache do
 
   ## What is cached, and why nothing needs invalidating
 
-  Only chunks (`c/`) and snapshots (`s/`). Both are written once under a
-  key naming the version they end at, and are never rewritten, so a copy
-  cannot go stale.
+  Only keys of the shape `Keys.chunk_path/2` and `Keys.snapshot_path/2`
+  build: `c/{tag}/{version}` and `s/{tag}/{version}`. Both are written
+  once under a key naming the version they end at, and are never
+  rewritten, so a copy cannot go stale.
 
   The other keys in the store are not like that. The bootstrap record is
   read with `get/2` (`Coordinator.Server`, recovery's `PersistencePhase`)
   and REWRITTEN in place by `put_if_version_matches/5`; serving a cached
   copy would hand a coordinator a cluster layout another node has already
-  replaced. Those keys pass straight through.
+  replaced. Those keys pass straight through. It is the whole SHAPE that
+  is tested rather than the leading `c/` or `s/`, because the bootstrap
+  key is free-form application config: a cluster named `c` would
+  otherwise put its mutable record inside the cached namespace.
 
   Immutable is not eternal, though — consolidation reclaims chunks
-  (bedrock-wxf.6) and retention drops old snapshots. Every operation that
-  removes or replaces an object at a cached key drops the entry with it,
-  so an entry never outlives the object it copies. A removal performed
-  from ANOTHER node is invisible here, but so is the key: `list/3` is
-  never served from the cache, so nothing names an object the store no
-  longer lists, and the entry ages out.
+  (bedrock-wxf.6) and retention drops old snapshots. Every operation
+  through THIS backend that removes or replaces an object at a cached key
+  drops the entry with it. Removals from another node are invisible here,
+  and so is the racing case where a `get/2` already in flight repopulates
+  a key a `delete/2` has just dropped. What makes those harmless is that
+  nothing can name the object any more: `list/3` is never served from the
+  cache, so a key the store no longer lists is never asked for again, and
+  the entry is only ever dead weight against the bound.
 
   ## Bound
 
-  `:max_bytes` caps what the directory holds. A populate that carries the
-  total over the cap deletes entries oldest-mtime-first until it fits, and
-  emits `[:bedrock, :object_storage, :disk_cache, :evicted]` with the
-  count and bytes dropped. mtime IS the recency clock: a hit touches its
-  entry, so eviction is least-recently-USED rather than
-  least-recently-written.
+  `:max_bytes` caps what the directory holds. A sweep deletes entries
+  oldest-mtime-first until the total fits, and emits
+  `[:bedrock, :object_storage, :disk_cache, :evicted]` with the count and
+  bytes dropped. mtime IS the recency clock: a hit touches its entry, so
+  eviction is least-recently-USED rather than least-recently-written.
 
-  The sweep walks the directory, which is O(entries). It runs only on a
-  populate — the path that just paid for a fetch from the inner backend,
-  which dwarfs a directory walk — and staying stateless is what lets a
-  backend remain a plain `{module, config}` term that any process can
-  hold without registering anything.
+  The sweep walks the directory, so it costs O(entries) — and sweeping on
+  every populate would make the cache slower than no cache at all, since
+  a warm 1 GiB of 522-byte chunks is two million `stat` calls to save one
+  GET. Instead a populate sweeps with probability `bytes / (slack ×
+  max_bytes)`, so one sweep falls due for every `slack × max_bytes` bytes
+  admitted however large the objects are. The expected work per populate
+  is then `1 / slack` stats no matter how big the cache grows, and the
+  cap is soft by that same fraction: the directory drifts above it
+  between sweeps, and is pulled back at the next one. Nothing is
+  registered anywhere to make this work, which is what lets a backend
+  stay a plain `{module, config}` term any process can hold.
+
+  An object larger than the whole cap is never written: it could only
+  make room for itself by evicting everything, and would then be evicted
+  in turn on the very next populate.
 
   ## Configuration
 
   - `:inner` - Required. The backend to wrap, as `{module, config}`.
   - `:root` - Required. Local directory holding the cached copies.
-  - `:max_bytes` - Cap on the bytes held (default: 1 GiB).
+  - `:max_bytes` - Soft cap on the bytes held (default: 1 GiB).
 
   Not wired in by default: `ObjectStorage.Config` reaches this backend
   only when it is asked for.
@@ -70,9 +88,17 @@ defmodule Bedrock.ObjectStorage.DiskCache do
 
   @default_max_bytes 1024 * 1024 * 1024
 
-  # `Keys` builds every chunk key under `c/` and every snapshot key under
-  # `s/`. Nothing else in the store is write-once.
-  @immutable_prefixes ["c/", "s/"]
+  # How far the directory is allowed to drift above the cap between
+  # sweeps, as a fraction of it. It is also the reciprocal of the
+  # expected `stat` calls a populate pays: 10% slack, ~10 stats.
+  @sweep_slack 0.1
+
+  # Exactly what `Keys.chunk_path/2` and `Keys.snapshot_path/2` build:
+  # a namespace, a base36 shard tag, and a 13-character base36 inverted
+  # version. Nothing else in the store is write-once. (The pattern lives
+  # here rather than in `Keys` because it is this module's question —
+  # "may I keep a copy of this forever?" — not a key-formatting one.)
+  @immutable_key ~r"^[cs]/[0-9a-z]+/[0-9a-z]{13}$"
 
   @impl true
   def get(config, key) do
@@ -127,6 +153,14 @@ defmodule Bedrock.ObjectStorage.DiskCache do
 
   @impl true
   def put_if_version_matches(config, key, version_token, data, opts \\ []) do
+    # In this cluster the only compare-and-swap is on the bootstrap
+    # record, which `cacheable?/1` never admits, so the discard below has
+    # nothing to do today. It stays because `put/4` and `delete/2` are
+    # the other two ways an object at a cached key can change, and both
+    # keep the entry honest; leaving the third as the exception would
+    # make "an entry never outlives the object it copies" conditional on
+    # a convention this module cannot enforce, for the price of one
+    # `File.rm` on a path that runs once per cluster reconfiguration.
     result = ObjectStorage.put_if_version_matches(inner(config), key, version_token, data, opts)
     discard(config, key)
     result
@@ -136,7 +170,7 @@ defmodule Bedrock.ObjectStorage.DiskCache do
   defp root(config), do: Keyword.fetch!(config, :root)
   defp max_bytes(config), do: Keyword.get(config, :max_bytes, @default_max_bytes)
 
-  defp cacheable?(key), do: String.starts_with?(key, @immutable_prefixes)
+  defp cacheable?(key), do: Regex.match?(@immutable_key, key)
 
   defp entry_path(config, key), do: Path.join(root(config), key)
 
@@ -176,14 +210,34 @@ defmodule Bedrock.ObjectStorage.DiskCache do
   # misses; it is never a reason to fail an operation the store completed.
   @spec populate(keyword(), ObjectStorage.key(), ObjectStorage.data()) :: :ok
   defp populate(config, key, data) do
-    if cacheable?(key) do
+    bytes = IO.iodata_length(data)
+    max_bytes = max_bytes(config)
+
+    if cacheable?(key) and bytes <= max_bytes do
       # LocalFilesystem writes to a scratch file in the target's own
       # directory, fsyncs it and renames, so an entry is whole or absent.
       # A short entry would be served as if it were the object.
       case LocalFilesystem.put([root: root(config)], key, data) do
-        :ok -> evict_to_fit(config)
+        :ok -> maybe_sweep(config, bytes, max_bytes)
         {:error, _reason} -> :ok
       end
+    else
+      :ok
+    end
+  end
+
+  # One sweep per `@sweep_slack * max_bytes` bytes admitted, decided by a
+  # coin weighted by the size of THIS object so the rate holds whatever
+  # the objects weigh. An independent draw per populate, not a hash of
+  # the key: a workload that cycles a handful of keys must still
+  # accumulate its way to a sweep rather than deterministically never
+  # reaching one.
+  @spec maybe_sweep(keyword(), pos_integer(), pos_integer()) :: :ok
+  defp maybe_sweep(config, bytes, max_bytes) do
+    interval = max(1, div(trunc(@sweep_slack * max_bytes), max(1, bytes)))
+
+    if :rand.uniform(interval) == 1 do
+      evict_to_fit(config, max_bytes)
     else
       :ok
     end
@@ -198,10 +252,9 @@ defmodule Bedrock.ObjectStorage.DiskCache do
     :ok
   end
 
-  @spec evict_to_fit(keyword()) :: :ok
-  defp evict_to_fit(config) do
+  @spec evict_to_fit(keyword(), pos_integer()) :: :ok
+  defp evict_to_fit(config, max_bytes) do
     root = root(config)
-    max_bytes = max_bytes(config)
     entries = entries(root)
     total = Enum.reduce(entries, 0, fn {_path, size, _mtime}, sum -> sum + size end)
 
@@ -212,20 +265,24 @@ defmodule Bedrock.ObjectStorage.DiskCache do
     end
   end
 
-  @spec evict(Path.t(), [{Path.t(), non_neg_integer(), integer()}], non_neg_integer(), non_neg_integer()) :: :ok
+  @spec evict(Path.t(), [{Path.t(), non_neg_integer(), integer()}], non_neg_integer(), pos_integer()) :: :ok
   defp evict(root, entries, total, max_bytes) do
-    {victims, freed} =
+    {victims, _condemned} =
       entries
-      |> Enum.sort_by(fn {_path, _size, mtime} -> mtime end)
-      |> Enum.reduce_while({[], 0}, fn {path, size, _mtime}, {victims, freed} ->
-        if total - freed > max_bytes do
-          {:cont, {[path | victims], freed + size}}
+      |> Enum.sort(&least_recently_used?/2)
+      |> Enum.reduce_while({[], 0}, fn {path, size, _mtime}, {victims, condemned} ->
+        if total - condemned > max_bytes do
+          {:cont, {[{path, size} | victims], condemned + size}}
         else
-          {:halt, {victims, freed}}
+          {:halt, {victims, condemned}}
         end
       end)
 
-    Enum.each(victims, &File.rm/1)
+    # Only bytes actually removed are freed bytes: a removal that failed
+    # left the entry, and the report must not claim room that is still
+    # occupied.
+    freed =
+      Enum.reduce(victims, 0, fn {path, size}, freed -> if File.rm(path) == :ok, do: freed + size, else: freed end)
 
     Telemetry.execute(
       [:bedrock, :object_storage, :disk_cache, :evicted],
@@ -233,6 +290,18 @@ defmodule Bedrock.ObjectStorage.DiskCache do
       %{root: root}
     )
   end
+
+  # mtime is whole seconds, so a replay populates a whole run of entries
+  # that tie. The tie-break has to break SOMEWHERE, and reverse key order
+  # is the least harmful direction: both cached namespaces are named by
+  # inverted version, so the greatest key is the oldest object, and the
+  # oldest object is the one a reader is least likely to want next.
+  # Without it the order is whatever `Path.wildcard/1` returned —
+  # ascending, i.e. newest object first, precisely backwards.
+  @spec least_recently_used?({Path.t(), non_neg_integer(), integer()}, {Path.t(), non_neg_integer(), integer()}) ::
+          boolean()
+  defp least_recently_used?({path_a, _size_a, mtime}, {path_b, _size_b, mtime}), do: path_a > path_b
+  defp least_recently_used?({_path_a, _size_a, mtime_a}, {_path_b, _size_b, mtime_b}), do: mtime_a < mtime_b
 
   # `Path.wildcard/1` skips dot-prefixed names, which is exactly right
   # here: a LocalFilesystem scratch file is a write in progress, not an

--- a/lib/bedrock/object_storage/disk_cache.ex
+++ b/lib/bedrock/object_storage/disk_cache.ex
@@ -1,0 +1,253 @@
+defmodule Bedrock.ObjectStorage.DiskCache do
+  @moduledoc """
+  A local disk cache in front of another ObjectStorage backend.
+
+  A materializer that restarts on a node it has already run on pays for
+  the same bytes twice: `Snapshot.read_latest/1` downloads the shard's
+  baseline again, and `ChunkReader.read_from_version/3` re-fetches every
+  chunk it replays. Neither object ever changed. This backend keeps a
+  copy in a local directory so the second cold start reads it from disk.
+
+  It is a decorator: it holds another backend as `:inner` and forwards
+  every operation to it. The inner backend remains the authority for what
+  exists — the cache only ever answers a `get/2` that it can satisfy from
+  a copy of something the inner backend already gave it.
+
+  ## What is cached, and why nothing needs invalidating
+
+  Only chunks (`c/`) and snapshots (`s/`). Both are written once under a
+  key naming the version they end at, and are never rewritten, so a copy
+  cannot go stale.
+
+  The other keys in the store are not like that. The bootstrap record is
+  read with `get/2` (`Coordinator.Server`, recovery's `PersistencePhase`)
+  and REWRITTEN in place by `put_if_version_matches/5`; serving a cached
+  copy would hand a coordinator a cluster layout another node has already
+  replaced. Those keys pass straight through.
+
+  Immutable is not eternal, though — consolidation reclaims chunks
+  (bedrock-wxf.6) and retention drops old snapshots. Every operation that
+  removes or replaces an object at a cached key drops the entry with it,
+  so an entry never outlives the object it copies. A removal performed
+  from ANOTHER node is invisible here, but so is the key: `list/3` is
+  never served from the cache, so nothing names an object the store no
+  longer lists, and the entry ages out.
+
+  ## Bound
+
+  `:max_bytes` caps what the directory holds. A populate that carries the
+  total over the cap deletes entries oldest-mtime-first until it fits, and
+  emits `[:bedrock, :object_storage, :disk_cache, :evicted]` with the
+  count and bytes dropped. mtime IS the recency clock: a hit touches its
+  entry, so eviction is least-recently-USED rather than
+  least-recently-written.
+
+  The sweep walks the directory, which is O(entries). It runs only on a
+  populate — the path that just paid for a fetch from the inner backend,
+  which dwarfs a directory walk — and staying stateless is what lets a
+  backend remain a plain `{module, config}` term that any process can
+  hold without registering anything.
+
+  ## Configuration
+
+  - `:inner` - Required. The backend to wrap, as `{module, config}`.
+  - `:root` - Required. Local directory holding the cached copies.
+  - `:max_bytes` - Cap on the bytes held (default: 1 GiB).
+
+  Not wired in by default: `ObjectStorage.Config` reaches this backend
+  only when it is asked for.
+
+      config :bedrock, Bedrock.ObjectStorage,
+        backend: {:disk_cache, root: "/var/cache/bedrock", inner: :s3},
+        s3: [bucket: "bedrock"]
+  """
+
+  @behaviour Bedrock.ObjectStorage
+
+  alias Bedrock.ObjectStorage
+  alias Bedrock.ObjectStorage.LocalFilesystem
+  alias Bedrock.Telemetry
+
+  @default_max_bytes 1024 * 1024 * 1024
+
+  # `Keys` builds every chunk key under `c/` and every snapshot key under
+  # `s/`. Nothing else in the store is write-once.
+  @immutable_prefixes ["c/", "s/"]
+
+  @impl true
+  def get(config, key) do
+    if cacheable?(key) do
+      read_through(config, key)
+    else
+      ObjectStorage.get(inner(config), key)
+    end
+  end
+
+  @impl true
+  def put(config, key, data, opts \\ []) do
+    with :ok <- ObjectStorage.put(inner(config), key, data, opts) do
+      populate(config, key, data)
+    end
+  end
+
+  @impl true
+  def put_if_not_exists(config, key, data, opts \\ []) do
+    # The inner backend decides. A cache entry proves only that this node
+    # once read the object; answering `:already_exists` from it would let
+    # a local file veto a write the store would have accepted, and the
+    # callers that read `:already_exists` as success
+    # (`Demux.ShardServer`, `Snapshot.write/3`) would never learn the
+    # object is not there.
+    with :ok <- ObjectStorage.put_if_not_exists(inner(config), key, data, opts) do
+      populate(config, key, data)
+    end
+  end
+
+  @impl true
+  def delete(config, key) do
+    result = ObjectStorage.delete(inner(config), key)
+    discard(config, key)
+    result
+  end
+
+  @impl true
+  def list(config, prefix, opts \\ []) do
+    # Never cached. A listing is the answer to "what exists", which is the
+    # one question a copy of past bytes cannot speak to.
+    ObjectStorage.list(inner(config), prefix, opts)
+  end
+
+  @impl true
+  def get_with_version(config, key) do
+    # Passed through: the version token is the inner backend's (an ETag,
+    # a content hash), and it must describe the object in the store
+    # rather than the copy on this disk.
+    ObjectStorage.get_with_version(inner(config), key)
+  end
+
+  @impl true
+  def put_if_version_matches(config, key, version_token, data, opts \\ []) do
+    result = ObjectStorage.put_if_version_matches(inner(config), key, version_token, data, opts)
+    discard(config, key)
+    result
+  end
+
+  defp inner(config), do: Keyword.fetch!(config, :inner)
+  defp root(config), do: Keyword.fetch!(config, :root)
+  defp max_bytes(config), do: Keyword.get(config, :max_bytes, @default_max_bytes)
+
+  defp cacheable?(key), do: String.starts_with?(key, @immutable_prefixes)
+
+  defp entry_path(config, key), do: Path.join(root(config), key)
+
+  @spec read_through(keyword(), ObjectStorage.key()) :: {:ok, ObjectStorage.data()} | ObjectStorage.error()
+  defp read_through(config, key) do
+    case read_entry(config, key) do
+      {:ok, data} ->
+        {:ok, data}
+
+      :miss ->
+        with {:ok, data} <- ObjectStorage.get(inner(config), key) do
+          populate(config, key, data)
+          {:ok, data}
+        end
+    end
+  end
+
+  # A cache read that fails for ANY reason is a miss, never an error: the
+  # inner backend is still there to answer. An entry can be swept away by
+  # another process between one call and the next, and a local disk fault
+  # must not turn an object that IS in the store into `:not_found`.
+  @spec read_entry(keyword(), ObjectStorage.key()) :: {:ok, binary()} | :miss
+  defp read_entry(config, key) do
+    path = entry_path(config, key)
+
+    case File.read(path) do
+      {:ok, data} ->
+        _ = File.touch(path)
+        {:ok, data}
+
+      {:error, _reason} ->
+        :miss
+    end
+  end
+
+  # Populating is best effort. A cache that cannot write is a cache that
+  # misses; it is never a reason to fail an operation the store completed.
+  @spec populate(keyword(), ObjectStorage.key(), ObjectStorage.data()) :: :ok
+  defp populate(config, key, data) do
+    if cacheable?(key) do
+      # LocalFilesystem writes to a scratch file in the target's own
+      # directory, fsyncs it and renames, so an entry is whole or absent.
+      # A short entry would be served as if it were the object.
+      case LocalFilesystem.put([root: root(config)], key, data) do
+        :ok -> evict_to_fit(config)
+        {:error, _reason} -> :ok
+      end
+    else
+      :ok
+    end
+  end
+
+  @spec discard(keyword(), ObjectStorage.key()) :: :ok
+  defp discard(config, key) do
+    if cacheable?(key) do
+      _ = File.rm(entry_path(config, key))
+    end
+
+    :ok
+  end
+
+  @spec evict_to_fit(keyword()) :: :ok
+  defp evict_to_fit(config) do
+    root = root(config)
+    max_bytes = max_bytes(config)
+    entries = entries(root)
+    total = Enum.reduce(entries, 0, fn {_path, size, _mtime}, sum -> sum + size end)
+
+    if total > max_bytes do
+      evict(root, entries, total, max_bytes)
+    else
+      :ok
+    end
+  end
+
+  @spec evict(Path.t(), [{Path.t(), non_neg_integer(), integer()}], non_neg_integer(), non_neg_integer()) :: :ok
+  defp evict(root, entries, total, max_bytes) do
+    {victims, freed} =
+      entries
+      |> Enum.sort_by(fn {_path, _size, mtime} -> mtime end)
+      |> Enum.reduce_while({[], 0}, fn {path, size, _mtime}, {victims, freed} ->
+        if total - freed > max_bytes do
+          {:cont, {[path | victims], freed + size}}
+        else
+          {:halt, {victims, freed}}
+        end
+      end)
+
+    Enum.each(victims, &File.rm/1)
+
+    Telemetry.execute(
+      [:bedrock, :object_storage, :disk_cache, :evicted],
+      %{objects: length(victims), bytes: freed, retained_bytes: total - freed},
+      %{root: root}
+    )
+  end
+
+  # `Path.wildcard/1` skips dot-prefixed names, which is exactly right
+  # here: a LocalFilesystem scratch file is a write in progress, not an
+  # entry, and evicting one would corrupt the writer that owns it.
+  @spec entries(Path.t()) :: [{Path.t(), non_neg_integer(), integer()}]
+  defp entries(root) do
+    root
+    |> Path.join("**/*")
+    |> Path.wildcard()
+    |> Enum.flat_map(fn path ->
+      case File.stat(path, time: :posix) do
+        {:ok, %File.Stat{type: :regular, size: size, mtime: mtime}} -> [{path, size, mtime}]
+        # Directories, and entries a concurrent sweep already removed.
+        _not_an_entry -> []
+      end
+    end)
+  end
+end

--- a/lib/bedrock/object_storage/disk_cache.ex
+++ b/lib/bedrock/object_storage/disk_cache.ex
@@ -64,7 +64,9 @@ defmodule Bedrock.ObjectStorage.DiskCache do
 
   An object larger than the whole cap is never written: it could only
   make room for itself by evicting everything, and would then be evicted
-  in turn on the very next populate.
+  in turn on the very next populate. Below that size an entry always
+  survives the sweep its own populate triggers — a read that fetched an
+  object never throws it away again before returning it.
 
   ## Configuration
 
@@ -94,11 +96,16 @@ defmodule Bedrock.ObjectStorage.DiskCache do
   @sweep_slack 0.1
 
   # Exactly what `Keys.chunk_path/2` and `Keys.snapshot_path/2` build:
-  # a namespace, a base36 shard tag, and a 13-character base36 inverted
-  # version. Nothing else in the store is write-once. (The pattern lives
-  # here rather than in `Keys` because it is this module's question —
-  # "may I keep a copy of this forever?" — not a key-formatting one.)
-  @immutable_key ~r"^[cs]/[0-9a-z]+/[0-9a-z]{13}$"
+  # a namespace, a shard tag, and a 13-character base36 inverted version.
+  # Nothing else in the store is write-once. The version segment carries
+  # the discrimination — `Keys.format_inverted_version/1` always emits 13
+  # lowercase base36 characters — while the tag stays permissive, because
+  # `Olivine.Logic.normalize_shard/1` passes a configured tag through
+  # verbatim rather than round-tripping it through `Keys.shard_tag/1`.
+  # (The pattern lives here rather than in `Keys` because it answers this
+  # module's question — "may I keep a copy of this forever?" — not a
+  # key-formatting one.)
+  @immutable_key ~r"^[cs]/[0-9A-Za-z]+/[0-9a-z]{13}\z"
 
   @impl true
   def get(config, key) do
@@ -218,7 +225,7 @@ defmodule Bedrock.ObjectStorage.DiskCache do
       # directory, fsyncs it and renames, so an entry is whole or absent.
       # A short entry would be served as if it were the object.
       case LocalFilesystem.put([root: root(config)], key, data) do
-        :ok -> maybe_sweep(config, bytes, max_bytes)
+        :ok -> maybe_sweep(config, entry_path(config, key), bytes, max_bytes)
         {:error, _reason} -> :ok
       end
     else
@@ -232,12 +239,12 @@ defmodule Bedrock.ObjectStorage.DiskCache do
   # the key: a workload that cycles a handful of keys must still
   # accumulate its way to a sweep rather than deterministically never
   # reaching one.
-  @spec maybe_sweep(keyword(), pos_integer(), pos_integer()) :: :ok
-  defp maybe_sweep(config, bytes, max_bytes) do
+  @spec maybe_sweep(keyword(), Path.t(), non_neg_integer(), pos_integer()) :: :ok
+  defp maybe_sweep(config, admitted, bytes, max_bytes) do
     interval = max(1, div(trunc(@sweep_slack * max_bytes), max(1, bytes)))
 
     if :rand.uniform(interval) == 1 do
-      evict_to_fit(config, max_bytes)
+      evict_to_fit(config, admitted, max_bytes)
     else
       :ok
     end
@@ -252,23 +259,31 @@ defmodule Bedrock.ObjectStorage.DiskCache do
     :ok
   end
 
-  @spec evict_to_fit(keyword(), pos_integer()) :: :ok
-  defp evict_to_fit(config, max_bytes) do
+  @spec evict_to_fit(keyword(), Path.t(), pos_integer()) :: :ok
+  defp evict_to_fit(config, admitted, max_bytes) do
     root = root(config)
     entries = entries(root)
     total = Enum.reduce(entries, 0, fn {_path, size, _mtime}, sum -> sum + size end)
 
     if total > max_bytes do
-      evict(root, entries, total, max_bytes)
+      evict(root, entries, admitted, total, max_bytes)
     else
       :ok
     end
   end
 
-  @spec evict(Path.t(), [{Path.t(), non_neg_integer(), integer()}], non_neg_integer(), pos_integer()) :: :ok
-  defp evict(root, entries, total, max_bytes) do
+  @spec evict(Path.t(), [{Path.t(), non_neg_integer(), integer()}], Path.t(), non_neg_integer(), pos_integer()) :: :ok
+  defp evict(root, entries, admitted, total, max_bytes) do
     {victims, _condemned} =
       entries
+      # The entry whose populate triggered this sweep is spared. Its size
+      # still counts against the total, so the rest yield until the cap
+      # is met — which they always can, since nothing larger than the cap
+      # is admitted. Recency alone would not spare it: mtime is whole
+      # seconds, so a snapshot written in the same tick as a run of
+      # chunks ties with them, and the tie-break below would take the
+      # `s/` key first.
+      |> Enum.reject(fn {path, _size, _mtime} -> path == admitted end)
       |> Enum.sort(&least_recently_used?/2)
       |> Enum.reduce_while({[], 0}, fn {path, size, _mtime}, {victims, condemned} ->
         if total - condemned > max_bytes do

--- a/test/bedrock/object_storage/config_test.exs
+++ b/test/bedrock/object_storage/config_test.exs
@@ -3,6 +3,7 @@ defmodule Bedrock.ObjectStorage.ConfigTest do
 
   alias Bedrock.ObjectStorage
   alias Bedrock.ObjectStorage.Config
+  alias Bedrock.ObjectStorage.DiskCache
   alias Bedrock.ObjectStorage.LocalFilesystem
   alias Bedrock.ObjectStorage.S3
 
@@ -101,6 +102,26 @@ defmodule Bedrock.ObjectStorage.ConfigTest do
       )
 
       assert {LocalFilesystem, [root: "/tmp/bedrock-local"]} = Config.backend()
+    end
+
+    test "normalizes :disk_cache shorthand and the backend it wraps" do
+      Application.put_env(:bedrock, ObjectStorage,
+        backend: {:disk_cache, root: "/tmp/bedrock-cache", inner: :s3},
+        s3: [bucket: "bedrock", access_key_id: "minio_key"]
+      )
+
+      assert {DiskCache, backend_config} = Config.backend()
+      assert backend_config[:root] == "/tmp/bedrock-cache"
+
+      assert {S3, inner_config} = backend_config[:inner]
+      assert inner_config[:bucket] == "bedrock"
+      assert inner_config[:config][:access_key_id] == "minio_key"
+    end
+
+    test "a disk cache without an inner backend is a configuration error" do
+      Application.put_env(:bedrock, ObjectStorage, backend: {:disk_cache, root: "/tmp/bedrock-cache"})
+
+      assert_raise KeyError, fn -> Config.backend() end
     end
   end
 

--- a/test/bedrock/object_storage/disk_cache_test.exs
+++ b/test/bedrock/object_storage/disk_cache_test.exs
@@ -294,6 +294,21 @@ defmodule Bedrock.ObjectStorage.DiskCacheTest do
       refute File.exists?(entry_path(cache_root, "bootstrap"))
       assert gets(inner_config) == ["bootstrap", "bootstrap"]
     end
+
+    test "a mutable record that happens to sit under c/ or s/ is still not cached", %{
+      inner: inner,
+      cached: cached,
+      cache_root: cache_root
+    } do
+      # The bootstrap key is free-form application config. A cluster
+      # named `c` puts its record inside the cached namespace without
+      # ever being shaped like a chunk key.
+      for key <- ["c/bootstrap", "c/x/bootstrap", "s/a/not-a-version"] do
+        :ok = ObjectStorage.put(inner, key, "v1")
+        assert {:ok, "v1"} = ObjectStorage.get(cached, key)
+        refute File.exists?(entry_path(cache_root, key))
+      end
+    end
   end
 
   describe "bounded size" do
@@ -347,6 +362,48 @@ defmodule Bedrock.ObjectStorage.DiskCacheTest do
 
       {:ok, %File.Stat{mtime: mtime}} = File.stat(path, time: :posix)
       assert mtime > 1_000
+    end
+
+    test "entries that share an mtime give up the oldest object first", %{
+      inner: inner,
+      cache_root: cache_root
+    } do
+      cached = ObjectStorage.backend(DiskCache, inner: inner, root: cache_root, max_bytes: 200)
+      [older, newer, trigger] = for version <- [200, 300, 100], do: Keys.chunk_path("a", version)
+
+      for key <- [older, newer] do
+        :ok = ObjectStorage.put(inner, key, String.duplicate("x", 100))
+        {:ok, _data} = ObjectStorage.get(cached, key)
+        # A replay populates a run of chunks inside one mtime tick.
+        File.touch!(entry_path(cache_root, key), 1_000)
+      end
+
+      :ok = ObjectStorage.put(inner, trigger, String.duplicate("x", 100))
+      {:ok, _data} = ObjectStorage.get(cached, trigger)
+
+      refute File.exists?(entry_path(cache_root, older))
+      assert File.exists?(entry_path(cache_root, newer))
+    end
+
+    test "an object bigger than the cap is never written, and does not take the cache with it", %{
+      inner: inner,
+      cache_root: cache_root
+    } do
+      cached = ObjectStorage.backend(DiskCache, inner: inner, root: cache_root, max_bytes: 200)
+      warm = Keys.chunk_path("a", 100)
+      oversized = Keys.snapshot_path("a", 100)
+
+      :ok = ObjectStorage.put(inner, warm, String.duplicate("x", 100))
+      {:ok, _data} = ObjectStorage.get(cached, warm)
+      # Older than anything the oversized read could write, so a sweep
+      # would take it first.
+      File.touch!(entry_path(cache_root, warm), 1_000)
+
+      :ok = ObjectStorage.put(inner, oversized, String.duplicate("x", 500))
+      assert {:ok, _data} = ObjectStorage.get(cached, oversized)
+
+      refute File.exists?(entry_path(cache_root, oversized))
+      assert File.exists?(entry_path(cache_root, warm))
     end
 
     test "a writer's scratch file is neither counted nor evicted", %{

--- a/test/bedrock/object_storage/disk_cache_test.exs
+++ b/test/bedrock/object_storage/disk_cache_test.exs
@@ -385,6 +385,25 @@ defmodule Bedrock.ObjectStorage.DiskCacheTest do
       assert File.exists?(entry_path(cache_root, newer))
     end
 
+    test "a read never evicts the object it just fetched", %{inner: inner, cache_root: cache_root} do
+      cached = ObjectStorage.backend(DiskCache, inner: inner, root: cache_root, max_bytes: 150)
+      warm = Keys.chunk_path("a", 100)
+      fetched = Keys.snapshot_path("a", 100)
+
+      :ok = ObjectStorage.put(inner, warm, String.duplicate("x", 100))
+      {:ok, _data} = ObjectStorage.get(cached, warm)
+      # Recency alone would spend the fetched object to keep this one:
+      # mtime is whole seconds, so entries routinely tie, and here the
+      # scales are tipped the whole way.
+      File.touch!(entry_path(cache_root, warm), System.os_time(:second) + 10_000)
+
+      :ok = ObjectStorage.put(inner, fetched, String.duplicate("x", 100))
+      {:ok, _data} = ObjectStorage.get(cached, fetched)
+
+      assert File.exists?(entry_path(cache_root, fetched))
+      refute File.exists?(entry_path(cache_root, warm))
+    end
+
     test "an object bigger than the cap is never written, and does not take the cache with it", %{
       inner: inner,
       cache_root: cache_root

--- a/test/bedrock/object_storage/disk_cache_test.exs
+++ b/test/bedrock/object_storage/disk_cache_test.exs
@@ -1,0 +1,369 @@
+defmodule Bedrock.ObjectStorage.DiskCacheTest do
+  use ExUnit.Case, async: true
+
+  import Bedrock.Test.TelemetryTestHelper
+
+  alias Bedrock.ObjectStorage
+  alias Bedrock.ObjectStorage.Chunk
+  alias Bedrock.ObjectStorage.ChunkReader
+  alias Bedrock.ObjectStorage.DiskCache
+  alias Bedrock.ObjectStorage.Keys
+  alias Bedrock.ObjectStorage.LocalFilesystem
+  alias Bedrock.ObjectStorage.Snapshot
+
+  @eviction_event [:bedrock, :object_storage, :disk_cache, :evicted]
+
+  # A LocalFilesystem that remembers what was asked of it, so a test can
+  # count how many times an object actually left the inner store.
+  defmodule RecordingBackend do
+    @moduledoc false
+    @behaviour ObjectStorage
+
+    @spec keys_for(keyword(), atom()) :: [String.t()]
+    def keys_for(config, op) do
+      config
+      |> Keyword.fetch!(:calls)
+      |> Agent.get(&Enum.reverse/1)
+      |> Enum.flat_map(fn
+        {^op, key} -> [key]
+        _other_op -> []
+      end)
+    end
+
+    @impl true
+    def get(config, key) do
+      record(config, {:get, key})
+      LocalFilesystem.get(config, key)
+    end
+
+    @impl true
+    def put(config, key, data, opts \\ []) do
+      record(config, {:put, key})
+      LocalFilesystem.put(config, key, data, opts)
+    end
+
+    @impl true
+    def delete(config, key) do
+      record(config, {:delete, key})
+      LocalFilesystem.delete(config, key)
+    end
+
+    @impl true
+    def list(config, prefix, opts \\ []) do
+      record(config, {:list, prefix})
+      LocalFilesystem.list(config, prefix, opts)
+    end
+
+    @impl true
+    def put_if_not_exists(config, key, data, opts \\ []) do
+      record(config, {:put_if_not_exists, key})
+      LocalFilesystem.put_if_not_exists(config, key, data, opts)
+    end
+
+    @impl true
+    def get_with_version(config, key) do
+      record(config, {:get_with_version, key})
+      LocalFilesystem.get_with_version(config, key)
+    end
+
+    @impl true
+    def put_if_version_matches(config, key, version_token, data, opts \\ []) do
+      record(config, {:put_if_version_matches, key})
+      LocalFilesystem.put_if_version_matches(config, key, version_token, data, opts)
+    end
+
+    defp record(config, call), do: config |> Keyword.fetch!(:calls) |> Agent.update(&[call | &1])
+  end
+
+  setup do
+    tmp = Path.join(System.tmp_dir!(), "disk_cache_test_#{:erlang.unique_integer([:positive])}")
+    store_root = Path.join(tmp, "store")
+    cache_root = Path.join(tmp, "cache")
+    File.mkdir_p!(store_root)
+    File.mkdir_p!(cache_root)
+    on_exit(fn -> File.rm_rf!(tmp) end)
+
+    {:ok, calls} = Agent.start_link(fn -> [] end)
+
+    inner_config = [root: store_root, calls: calls]
+    inner = ObjectStorage.backend(RecordingBackend, inner_config)
+    cached = ObjectStorage.backend(DiskCache, inner: inner, root: cache_root)
+
+    {:ok, inner: inner, inner_config: inner_config, cached: cached, cache_root: cache_root}
+  end
+
+  defp gets(inner_config), do: RecordingBackend.keys_for(inner_config, :get)
+
+  defp entry_path(cache_root, key), do: Path.join(cache_root, key)
+
+  defp write_chunk(backend, shard_tag, transactions) do
+    {:ok, binary} = Chunk.encode(transactions)
+    {max_version, _data} = List.last(transactions)
+    key = Keys.chunk_path(shard_tag, max_version)
+    :ok = ObjectStorage.put(backend, key, binary)
+    key
+  end
+
+  # What a materializer does on a cold start: build a fresh reader and
+  # replay the shard's chunks from the beginning.
+  defp replay(backend, shard_tag) do
+    backend
+    |> ChunkReader.new(shard_tag)
+    |> ChunkReader.read_from_version(0)
+    |> Enum.to_list()
+  end
+
+  describe "cold restart on the same node" do
+    test "the bare backend re-fetches the same chunk on every cold start", %{
+      inner: inner,
+      inner_config: inner_config
+    } do
+      key = write_chunk(inner, "a", [{100, "txn"}])
+
+      assert replay(inner, "a") == [{100, "txn"}]
+      assert replay(inner, "a") == [{100, "txn"}]
+
+      assert gets(inner_config) == [key, key]
+    end
+
+    test "a disk cache serves the second cold start without reading the chunk again", %{
+      inner: inner,
+      inner_config: inner_config,
+      cached: cached
+    } do
+      key = write_chunk(inner, "a", [{100, "txn"}])
+
+      assert replay(cached, "a") == [{100, "txn"}]
+      assert replay(cached, "a") == [{100, "txn"}]
+
+      assert gets(inner_config) == [key]
+    end
+
+    test "a disk cache downloads a shard's snapshot once", %{
+      inner: inner,
+      inner_config: inner_config,
+      cached: cached
+    } do
+      key = Keys.snapshot_path("a", 700)
+      :ok = ObjectStorage.put(inner, key, "bundle-bytes")
+
+      snapshot = Snapshot.new(cached, "a")
+      assert {:ok, 700, "bundle-bytes"} = Snapshot.read_latest(snapshot)
+      assert {:ok, 700, "bundle-bytes"} = Snapshot.read_latest(snapshot)
+
+      assert gets(inner_config) == [key]
+    end
+  end
+
+  describe "writes" do
+    test "a write populates the cache, so reading it back never touches the inner backend", %{
+      inner_config: inner_config,
+      cached: cached,
+      cache_root: cache_root
+    } do
+      key = Keys.chunk_path("a", 100)
+      :ok = ObjectStorage.put(cached, key, "v1")
+
+      assert File.exists?(entry_path(cache_root, key))
+      assert {:ok, "v1"} = ObjectStorage.get(cached, key)
+      assert gets(inner_config) == []
+    end
+
+    test "a create-only write populates the cache when it wins", %{
+      inner_config: inner_config,
+      cached: cached
+    } do
+      key = Keys.chunk_path("a", 100)
+      :ok = ObjectStorage.put_if_not_exists(cached, key, "v1")
+
+      assert {:ok, "v1"} = ObjectStorage.get(cached, key)
+      assert gets(inner_config) == []
+    end
+
+    test "a rewrite replaces the cached copy", %{cached: cached} do
+      key = Keys.chunk_path("a", 100)
+      :ok = ObjectStorage.put(cached, key, "v1")
+      :ok = ObjectStorage.put(cached, key, "v2")
+
+      assert {:ok, "v2"} = ObjectStorage.get(cached, key)
+    end
+
+    test "a failed write leaves nothing cached", %{
+      inner_config: inner_config,
+      cached: cached,
+      cache_root: cache_root
+    } do
+      key = Keys.chunk_path("a", 100)
+      # A directory under the object's key makes the inner write fail.
+      File.mkdir_p!(Path.join(Keyword.fetch!(inner_config, :root), key))
+
+      assert {:error, _reason} = ObjectStorage.put(cached, key, "v1")
+      refute File.exists?(entry_path(cache_root, key))
+    end
+  end
+
+  describe "the inner backend is the authority" do
+    test "a cached entry cannot make a create-only write report :already_exists", %{
+      inner: inner,
+      cached: cached,
+      cache_root: cache_root
+    } do
+      key = Keys.chunk_path("a", 100)
+      :ok = ObjectStorage.put(cached, key, "v1")
+      # Removed behind the cache's back, the way another node's
+      # consolidation or retention sweep would remove it.
+      :ok = ObjectStorage.delete(inner, key)
+      assert File.exists?(entry_path(cache_root, key))
+
+      assert :ok = ObjectStorage.put_if_not_exists(cached, key, "v1")
+    end
+
+    test "a create-only write still loses to an object it has never read", %{inner: inner, cached: cached} do
+      key = Keys.chunk_path("a", 100)
+      :ok = ObjectStorage.put(inner, key, "v1")
+
+      assert {:error, :already_exists} = ObjectStorage.put_if_not_exists(cached, key, "v2")
+    end
+
+    test "listing is answered by the inner backend, never by the cache", %{
+      inner: inner,
+      cached: cached,
+      cache_root: cache_root
+    } do
+      key = Keys.chunk_path("a", 100)
+      :ok = ObjectStorage.put(cached, key, "v1")
+      :ok = ObjectStorage.delete(inner, key)
+
+      assert File.exists?(entry_path(cache_root, key))
+      assert cached |> ObjectStorage.list("c/a/") |> Enum.to_list() == []
+    end
+
+    test "an unreadable cache entry falls through instead of failing the read", %{
+      inner: inner,
+      cached: cached,
+      cache_root: cache_root
+    } do
+      key = Keys.chunk_path("a", 100)
+      :ok = ObjectStorage.put(inner, key, "v1")
+      File.mkdir_p!(entry_path(cache_root, key))
+
+      assert {:ok, "v1"} = ObjectStorage.get(cached, key)
+    end
+
+    test "a missing object is still missing", %{cached: cached} do
+      assert {:error, :not_found} = ObjectStorage.get(cached, Keys.chunk_path("a", 100))
+    end
+  end
+
+  describe "entries never outlive their object" do
+    test "delete drops the cached copy", %{inner_config: inner_config, cached: cached, cache_root: cache_root} do
+      key = Keys.chunk_path("a", 100)
+      :ok = ObjectStorage.put(cached, key, "v1")
+      assert {:ok, "v1"} = ObjectStorage.get(cached, key)
+      assert gets(inner_config) == []
+
+      :ok = ObjectStorage.delete(cached, key)
+
+      refute File.exists?(entry_path(cache_root, key))
+      assert {:error, :not_found} = ObjectStorage.get(cached, key)
+      assert gets(inner_config) == [key]
+    end
+
+    test "a conditional update drops the cached copy", %{cached: cached} do
+      key = Keys.chunk_path("a", 100)
+      :ok = ObjectStorage.put(cached, key, "v1")
+      {:ok, "v1", token} = ObjectStorage.get_with_version(cached, key)
+
+      :ok = ObjectStorage.put_if_version_matches(cached, key, token, "v2")
+
+      assert {:ok, "v2"} = ObjectStorage.get(cached, key)
+    end
+
+    test "keys outside the chunk and snapshot namespaces are never cached", %{
+      inner: inner,
+      inner_config: inner_config,
+      cached: cached,
+      cache_root: cache_root
+    } do
+      :ok = ObjectStorage.put(inner, "bootstrap", "v1")
+      assert {:ok, "v1"} = ObjectStorage.get(cached, "bootstrap")
+
+      :ok = ObjectStorage.put(inner, "bootstrap", "v2")
+      assert {:ok, "v2"} = ObjectStorage.get(cached, "bootstrap")
+
+      refute File.exists?(entry_path(cache_root, "bootstrap"))
+      assert gets(inner_config) == ["bootstrap", "bootstrap"]
+    end
+  end
+
+  describe "bounded size" do
+    test "the cache evicts least-recently-used entries to stay under its cap and reports what it dropped", %{
+      inner: inner,
+      inner_config: inner_config,
+      cache_root: cache_root
+    } do
+      cached = ObjectStorage.backend(DiskCache, inner: inner, root: cache_root, max_bytes: 200)
+
+      attach_telemetry_reflector(
+        self(),
+        [@eviction_event],
+        "disk-cache-eviction-#{:erlang.unique_integer([:positive])}"
+      )
+
+      [oldest, middle, newest] = for version <- [100, 200, 300], do: Keys.chunk_path("a", version)
+
+      for {key, mtime} <- [{oldest, 1_000}, {middle, 2_000}] do
+        :ok = ObjectStorage.put(inner, key, String.duplicate("x", 100))
+        {:ok, _data} = ObjectStorage.get(cached, key)
+        File.touch!(entry_path(cache_root, key), mtime)
+      end
+
+      :ok = ObjectStorage.put(inner, newest, String.duplicate("x", 100))
+      {:ok, _data} = ObjectStorage.get(cached, newest)
+
+      refute File.exists?(entry_path(cache_root, oldest))
+      assert File.exists?(entry_path(cache_root, middle))
+      assert File.exists?(entry_path(cache_root, newest))
+
+      {measurements, metadata} = expect_telemetry(@eviction_event)
+      assert measurements.objects == 1
+      assert measurements.bytes == 100
+      assert measurements.retained_bytes == 200
+      assert metadata.root == cache_root
+
+      # The evicted object is still an object; it just costs a fetch again.
+      assert {:ok, _data} = ObjectStorage.get(cached, oldest)
+      assert gets(inner_config) == [oldest, middle, newest, oldest]
+    end
+
+    test "a hit refreshes an entry's recency", %{inner: inner, cached: cached, cache_root: cache_root} do
+      key = Keys.chunk_path("a", 100)
+      :ok = ObjectStorage.put(inner, key, "v1")
+      {:ok, "v1"} = ObjectStorage.get(cached, key)
+
+      path = entry_path(cache_root, key)
+      File.touch!(path, 1_000)
+      assert {:ok, "v1"} = ObjectStorage.get(cached, key)
+
+      {:ok, %File.Stat{mtime: mtime}} = File.stat(path, time: :posix)
+      assert mtime > 1_000
+    end
+
+    test "a writer's scratch file is neither counted nor evicted", %{
+      inner: inner,
+      cache_root: cache_root
+    } do
+      cached = ObjectStorage.backend(DiskCache, inner: inner, root: cache_root, max_bytes: 200)
+      scratch = Path.join(cache_root, ".bedrock-tmp.in-flight")
+      File.write!(scratch, String.duplicate("x", 1_000))
+      File.touch!(scratch, 1_000)
+
+      key = Keys.chunk_path("a", 100)
+      :ok = ObjectStorage.put(inner, key, String.duplicate("x", 100))
+      {:ok, _data} = ObjectStorage.get(cached, key)
+
+      assert File.exists?(scratch)
+      assert File.exists?(entry_path(cache_root, key))
+    end
+  end
+end


### PR DESCRIPTION
A node that restarts downloads the same objects again: a materializer's cold start fetches the shard's snapshot bundle, and a restarted shard server re-fetches every chunk it replays, though neither object changes once written. This change adds an opt-in `DiskCache` backend that wraps another backend and keeps local copies of chunks and snapshots under a soft byte cap with least-recently-used eviction. Nothing selects it by default.

Ticket: bedrock-wxf.7

## Why

Chunks and snapshots are write-once: each is created under a key naming the version it ends at, through a create-only put that is never followed by a rewrite. A local copy can never go stale, yet both cold-start paths go to the store on every start. On S3 that is billed per request; bedrock-wxf.6 measured 698 objects for one 8.3 hour replay.

## What changed

- New backend `Bedrock.ObjectStorage.DiskCache` with keys `:inner` (the wrapped backend), `:root` (local directory) and `:max_bytes` (default 1 GiB).
- `ObjectStorage.Config` accepts `:disk_cache` and `{:disk_cache, opts}`; `:inner` is normalized the same way, so `inner: :s3` picks up the top-level `s3:` config. A missing `:inner` raises `KeyError`.
- Eviction emits `[:bedrock, :object_storage, :disk_cache, :evicted]` with `objects`, `bytes` and `retained_bytes`.

The app-env setting reaches the materializer and bootstrap discovery; Demux shard servers take their backend from the foreman's `:object_storage` option, so covering chunk replay means passing a cache term there too. No hit-rate telemetry; guides untouched.

## How it works

The cache is a decorator: every operation forwards to the inner backend, which stays the authority for what exists. Only keys of the exact shape `c/{tag}/{version}` or `s/{tag}/{version}`, with a 13-character base36 version, are cached. The whole shape matters because the bootstrap key is free-form config; a cluster named `c` would put its rewritten-in-place record at `c/bootstrap`.

A get on a cacheable key reads the local file and touches its mtime on a hit. Any read failure is a miss, never an error. On a miss the inner get runs and its bytes are written locally through the scratch-and-rename path, so an entry is whole or absent. Writes populate only once the inner backend accepts them; `put_if_not_exists` never answers already-exists from a local file, since callers read that as durable. Listings and version tokens pass through. Delete and compare-and-swap drop the entry.

No size counter, no process. Each populate sweeps with probability `bytes / (0.1 * max_bytes)`, so one directory walk falls due per 100 MiB admitted at the default cap, and the cap is soft by that fraction. A sweep evicts oldest mtime first, breaks second-granular ties by reverse key order (the greatest inverted-version key is the oldest object), and spares the entry whose populate triggered it. Objects larger than the cap are never written.

```elixir
config :bedrock, Bedrock.ObjectStorage,
  backend: {:disk_cache, root: "/var/cache/bedrock", inner: :s3},
  s3: [bucket: "bedrock"]
```

## Verification

The new tests wrap a recording backend: the bare backend fetches a chunk on both of two replays, the cache once, and likewise for the latest snapshot. Others pin each rule above: inner authority, fall-through on unreadable entries, key filtering, eviction order and telemetry, the just-fetched entry surviving a sweep, oversized objects and scratch files. CI is green on OTP 27.3, 28.3, 29.0 and S3 MinIO. Audit fixes landed in `c7380e56` and `840449b5`.

Follow-up: bedrock-k9k, sweep runs inline, unbounded.
Follow-up: bedrock-5tq.7, document backend in guides.
