### PR TITLE
292: Make Foreman lifecycle messages incarnation-aware

### DIFF
--- a/guides/deep-dives/architecture/infrastructure/foreman.md
+++ b/guides/deep-dives/architecture/infrastructure/foreman.md
@@ -112,6 +112,12 @@ Foremanprocesses coordinate with cluster service discovery:
 :ok = Foreman.report_health(foreman, worker_id, {:error, :unavailable})
 ```
 
+Health reports and retirement calls must originate in the worker process. The
+Foreman checks the calling PID against the current registered worker, so delayed
+messages from an older incarnation cannot change its replacement. Internal legacy
+health messages are accepted only when they carry the current registered PID;
+unattributed health and retirement messages are ignored.
+
 ### Service Registration Support
 
 ```elixir
@@ -135,6 +141,12 @@ Foremanprocesses coordinate with cluster service discovery:
 results = Foreman.remove_workers(foreman, ["materializer_1", "materializer_2", "log_1"])
 # Returns: %{"materializer_1" => :ok, "materializer_2" => :ok, "log_1" => :ok}
 ```
+
+Removal returns `{:error, :worker_shutdown_unresolved}` if bounded termination
+attempts cannot prove the DynamicSupervisor has released the worker's restart
+ownership. Membership and disk are retained for a later retry. A filesystem
+cleanup failure after successful shutdown retains stopped membership for retry.
+Single removal, batch removal, and accepted worker retirement share this policy.
 
 ## Working Directory Management
 

--- a/lib/bedrock/service/foreman.ex
+++ b/lib/bedrock/service/foreman.ex
@@ -47,6 +47,10 @@ defmodule Bedrock.Service.Foreman do
   @doc """
   Remove a worker and clean up its resources.
 
+  Returns `{:error, :worker_shutdown_unresolved}` and preserves membership and
+  disk when supervisor ownership cannot be conclusively removed. Retry after
+  the worker supervisor settles. Filesystem errors retain stopped membership.
+
   This will:
   1. Terminate the worker process
   2. Remove it from the supervisor
@@ -59,7 +63,7 @@ defmodule Bedrock.Service.Foreman do
           opts :: [{:timeout, timeout()}]
         ) ::
           :ok
-          | {:error, :worker_not_found}
+          | {:error, :worker_not_found | :worker_shutdown_unresolved}
           | {:error, {:failed_to_remove_directory, File.posix(), Path.t()}}
           | {:error, :unavailable | :timeout | :unknown}
   def remove_worker(foreman, worker_id, opts \\ []),
@@ -85,14 +89,18 @@ defmodule Bedrock.Service.Foreman do
     do: call(foreman, {:remove_workers, worker_ids}, opts[:timeout] || 30_000)
 
   @doc """
-  Called by a worker to report it's health to the foreman.
+  Called by a worker to report its own health to the foreman.
+
+  The internal message carries the calling PID. Reports from an absent or
+  superseded incarnation are ignored. Legacy successful reports are checked
+  against the current registered PID; legacy reports without a PID are ignored.
   """
   @spec report_health(
           foreman :: ref(),
           Worker.id(),
           Worker.health()
         ) :: :ok
-  def report_health(foreman, worker_id, health), do: cast(foreman, {:worker_health, worker_id, health})
+  def report_health(foreman, worker_id, health), do: cast(foreman, {:worker_health, worker_id, self(), health})
 
   @doc """
   Called by a hosted worker that has decided its own retirement (it found
@@ -102,7 +110,7 @@ defmodule Bedrock.Service.Foreman do
   component decides another process's retirement.
   """
   @spec worker_retired(foreman :: ref(), Worker.id()) :: :ok
-  def worker_retired(foreman, worker_id), do: cast(foreman, {:worker_retired, worker_id})
+  def worker_retired(foreman, worker_id), do: cast(foreman, {:worker_retired, worker_id, self()})
 
   @doc """
   Return a list of all running services with information needed for coordinator registration.

--- a/lib/bedrock/service/foreman/impl.ex
+++ b/lib/bedrock/service/foreman/impl.ex
@@ -18,6 +18,7 @@ defmodule Bedrock.Service.Foreman.Impl do
   alias Bedrock.Cluster.Link
   alias Bedrock.ControlPlane.Config.TransactionSystemLayout
   alias Bedrock.ControlPlane.Coordinator
+  alias Bedrock.Service.Foreman.Removal
   alias Bedrock.Service.Foreman.State
   alias Bedrock.Service.Foreman.WorkerInfo
   alias Bedrock.Service.Worker
@@ -78,9 +79,34 @@ defmodule Bedrock.Service.Foreman.Impl do
   @spec do_worker_retired(State.t(), Worker.id()) :: State.t()
   def do_worker_retired(t, worker_id) do
     Logger.info("Bedrock foreman: worker #{worker_id} retired itself; disposing")
-    {t, _result} = do_remove_worker(t, worker_id)
+    {t, result} = do_remove_worker(t, worker_id)
+
+    if result != :ok,
+      do: Logger.warning("Bedrock foreman: retirement cleanup for #{worker_id} deferred: #{inspect(result)}")
+
     t
   end
+
+  @spec do_worker_retired(State.t(), Worker.id(), pid()) :: State.t()
+  def do_worker_retired(t, worker_id, reporter) do
+    case Map.get(t.workers, worker_id) do
+      %WorkerInfo{} = info ->
+        registered = registered_worker(info)
+
+        if is_pid(reporter) and
+             (registered == reporter or
+                (is_nil(registered) and incarnation(info) == reporter)), do: do_worker_retired(t, worker_id), else: t
+
+      nil ->
+        t
+    end
+  end
+
+  defp registered_worker(%{otp_name: name}) when is_atom(name) and not is_nil(name), do: Process.whereis(name)
+  defp registered_worker(_), do: nil
+  defp incarnation(%{incarnation_pid: pid}) when is_pid(pid), do: pid
+  defp incarnation(%{health: {:ok, pid}}), do: pid
+  defp incarnation(_), do: nil
 
   @spec do_new_worker(State.t(), Worker.id(), :log | :materializer, params :: map()) ::
           {State.t(), Worker.ref()}
@@ -109,21 +135,25 @@ defmodule Bedrock.Service.Foreman.Impl do
   @spec do_remove_worker(State.t(), Worker.id()) ::
           {State.t(),
            :ok
-           | {:error, :worker_not_found | {:failed_to_remove_directory, File.posix(), Path.t()}}}
+           | {:error,
+              :worker_not_found | :worker_shutdown_unresolved | {:failed_to_remove_directory, File.posix(), Path.t()}}}
   def do_remove_worker(t, worker_id) do
     case Map.get(t.workers, worker_id) do
       nil ->
         {t, {:error, :worker_not_found}}
 
       worker_info ->
-        result = remove_worker_completely(worker_info, t.cluster, t.path)
+        case remove_worker_completely(worker_info, t) do
+          :ok ->
+            {t |> update_workers(&Map.delete(&1, worker_id)) |> recompute_health(), :ok}
 
-        t =
-          t
-          |> update_workers(&Map.delete(&1, worker_id))
-          |> recompute_health()
+          {:error, :worker_shutdown_unresolved} = error ->
+            {t, error}
 
-        {t, result}
+          error ->
+            stopped = worker_info |> WorkerInfo.put_health(:stopped) |> WorkerInfo.put_monitor_ref(nil)
+            {t |> update_workers(&Map.put(&1, worker_id, stopped)) |> recompute_health(), error}
+        end
     end
   end
 
@@ -132,7 +162,10 @@ defmodule Bedrock.Service.Foreman.Impl do
            %{
              Worker.id() =>
                :ok
-               | {:error, :worker_not_found | {:failed_to_remove_directory, File.posix(), Path.t()}}
+               | {:error,
+                  :worker_not_found
+                  | :worker_shutdown_unresolved
+                  | {:failed_to_remove_directory, File.posix(), Path.t()}}
            }}
   def do_remove_workers(t, worker_ids) do
     {updated_state, results} = process_worker_removals(t, worker_ids)
@@ -145,19 +178,8 @@ defmodule Bedrock.Service.Foreman.Impl do
   end
 
   defp remove_single_worker(worker_id, {state, acc_results}) do
-    case Map.get(state.workers, worker_id) do
-      nil ->
-        {state, Map.put(acc_results, worker_id, {:error, :worker_not_found})}
-
-      worker_info ->
-        result = remove_worker_completely(worker_info, state.cluster, state.path)
-        updated_state = remove_worker_from_state(state, worker_id)
-        {updated_state, Map.put(acc_results, worker_id, result)}
-    end
-  end
-
-  defp remove_worker_from_state(state, worker_id) do
-    update_workers(state, &Map.delete(&1, worker_id))
+    {state, result} = do_remove_worker(state, worker_id)
+    {state, Map.put(acc_results, worker_id, result)}
   end
 
   @spec advertise_running_workers([WorkerInfo.t()], Cluster.t()) :: [WorkerInfo.t()]
@@ -193,17 +215,13 @@ defmodule Bedrock.Service.Foreman.Impl do
   @spec advertise_running_worker(WorkerInfo.t(), module()) :: WorkerInfo.t()
   def advertise_running_worker(worker_info, _), do: worker_info
 
-  @spec remove_worker_completely(WorkerInfo.t(), module(), String.t()) ::
-          :ok | {:error, {:failed_to_remove_directory, File.posix(), Path.t()}}
-  defp remove_worker_completely(worker_info, cluster, base_path) do
-    # Release the monitor before terminating, with :flush so an already
-    # queued :DOWN is discarded. A deliberate removal is not a death, and
-    # must not be reported as one.
-    release_monitor(worker_info)
-
-    with :ok <- terminate_worker_process(worker_info, cluster),
-         :ok <- unadvertise_worker(worker_info, cluster) do
-      cleanup_worker_directory(worker_info, base_path)
+  @spec remove_worker_completely(WorkerInfo.t(), State.t()) ::
+          :ok | {:error, :worker_shutdown_unresolved | {:failed_to_remove_directory, File.posix(), Path.t()}}
+  defp remove_worker_completely(worker_info, t) do
+    with :ok <- Removal.stop(t, worker_info) do
+      release_monitor(worker_info)
+      :ok = unadvertise_worker(worker_info, t.cluster)
+      cleanup_worker_directory(worker_info, t.path)
     end
   end
 
@@ -215,19 +233,6 @@ defmodule Bedrock.Service.Foreman.Impl do
     Process.demonitor(ref, [:flush])
     :ok
   end
-
-  @spec terminate_worker_process(WorkerInfo.t(), module()) :: :ok | {:error, :not_found}
-  defp terminate_worker_process(%{health: {:ok, pid}, otp_name: _otp_name}, cluster) do
-    worker_supervisor = cluster.otp_name(:worker_supervisor)
-
-    case DynamicSupervisor.terminate_child(worker_supervisor, pid) do
-      :ok -> :ok
-      {:error, :not_found} -> :ok
-    end
-  end
-
-  defp terminate_worker_process(%{health: :stopped}, _cluster), do: :ok
-  defp terminate_worker_process(%{health: {:failed_to_start, _}}, _cluster), do: :ok
 
   # Best-effort: a ghost directory entry is tolerable (locking a gone
   # service fails and is skipped), but leaving one behind on every
@@ -325,6 +330,10 @@ defmodule Bedrock.Service.Foreman.Impl do
   @spec do_worker_recheck(State.t(), Worker.id(), non_neg_integer()) ::
           {State.t(), :done | :retry}
   def do_worker_recheck(t, worker_id, attempts_left) do
+    if Map.has_key?(t.workers, worker_id), do: recheck_existing_worker(t, worker_id, attempts_left), else: {t, :done}
+  end
+
+  defp recheck_existing_worker(t, worker_id, attempts_left) do
     with %{health: :stopped, otp_name: otp_name} <- Map.get(t.workers, worker_id),
          pid when is_pid(pid) <- Process.whereis(otp_name) do
       Logger.info("Bedrock foreman: worker #{worker_id} was replaced; adopting #{inspect(pid)}")
@@ -344,6 +353,21 @@ defmodule Bedrock.Service.Foreman.Impl do
       _ -> {t, :done}
     end
   end
+
+  @spec do_worker_health(State.t(), Worker.id(), pid(), WorkerInfo.health()) :: State.t()
+  def do_worker_health(t, worker_id, reporter, health) do
+    with %WorkerInfo{} = info <- Map.get(t.workers, worker_id),
+         true <- is_pid(reporter) and registered_worker(info) == reporter,
+         true <- reported_pid_matches?(health, reporter) do
+      t = update_workers(t, &Map.update!(&1, worker_id, fn info -> %{info | incarnation_pid: reporter} end))
+      do_worker_health(t, worker_id, health)
+    else
+      _ -> t
+    end
+  end
+
+  defp reported_pid_matches?({:ok, pid}, reporter), do: pid == reporter
+  defp reported_pid_matches?(_health, _reporter), do: true
 
   @spec do_worker_health(State.t(), Worker.id(), WorkerInfo.health()) :: State.t()
   def do_worker_health(t, worker_id, health) do

--- a/lib/bedrock/service/foreman/removal.ex
+++ b/lib/bedrock/service/foreman/removal.ex
@@ -1,0 +1,51 @@
+defmodule Bedrock.Service.Foreman.Removal do
+  @moduledoc false
+
+  alias Bedrock.Service.Foreman.State
+  alias Bedrock.Service.Foreman.WorkerInfo
+
+  @spec stop(State.t(), WorkerInfo.t()) :: :ok | {:error, :worker_shutdown_unresolved}
+  def stop(state, worker), do: attempt(state, worker, 3)
+
+  defp attempt(state, worker, remaining) do
+    supervisor = state.cluster.otp_name(:worker_supervisor)
+    pid = registered(worker) || incarnation(worker)
+    result = if is_pid(pid), do: DynamicSupervisor.terminate_child(supervisor, pid), else: {:error, :not_found}
+
+    case result do
+      result when result in [:ok, {:error, :not_found}] ->
+        if ownership_removed?(supervisor, state.workers, worker) do
+          :ok
+        else
+          retry(state, worker, remaining)
+        end
+
+      _ ->
+        {:error, :worker_shutdown_unresolved}
+    end
+  catch
+    :exit, _ -> {:error, :worker_shutdown_unresolved}
+  end
+
+  defp retry(state, worker, remaining) when remaining > 1, do: attempt(state, worker, remaining - 1)
+  defp retry(_state, _worker, _remaining), do: {:error, :worker_shutdown_unresolved}
+
+  # DynamicSupervisor serializes this snapshot with EXIT/restart/start callbacks.
+  # A nil name is insufficient: unaccounted children or :restarting retain ownership.
+  # Foreman serializes explicit starts/removals; all normal worker specs have fixed
+  # registered names and are direct children. Timed-out external starts are outside
+  # this guarantee and must never be guessed away as unrelated children.
+  defp ownership_removed?(supervisor, workers, target) do
+    other_pids = for {id, info} <- workers, id != target.id, pid = incarnation(info), is_pid(pid), do: pid
+    children = DynamicSupervisor.which_children(supervisor)
+
+    is_nil(registered(target)) and
+      Enum.all?(children, fn {_id, pid, _type, _modules} -> is_pid(pid) and pid in other_pids end)
+  end
+
+  defp registered(%{otp_name: name}) when is_atom(name) and not is_nil(name), do: Process.whereis(name)
+  defp registered(_), do: nil
+  defp incarnation(%{incarnation_pid: pid}) when is_pid(pid), do: pid
+  defp incarnation(%{health: {:ok, pid}}), do: pid
+  defp incarnation(_), do: nil
+end

--- a/lib/bedrock/service/foreman/server.ex
+++ b/lib/bedrock/service/foreman/server.ex
@@ -77,11 +77,18 @@ defmodule Bedrock.Service.Foreman.Server do
   def handle_call(_, _from, t), do: reply(t, {:error, :unknown_command})
 
   @impl true
-  def handle_cast({:worker_health, worker_id, health}, t), do: t |> do_worker_health(worker_id, health) |> noreply()
+  def handle_cast({:worker_health, worker_id, reporter, health}, t),
+    do: t |> do_worker_health(worker_id, reporter, health) |> noreply()
+
+  # The PID-bearing legacy form still establishes registration authority.
+  # Unattributed nonhealthy reports and retirement fall through unchanged.
+  def handle_cast({:worker_health, worker_id, {:ok, pid}}, t),
+    do: t |> do_worker_health(worker_id, pid, {:ok, pid}) |> noreply()
 
   # A hosted worker decided its own retirement; the foreman only janitors.
   @impl true
-  def handle_cast({:worker_retired, worker_id}, t), do: t |> do_worker_retired(worker_id) |> noreply()
+  def handle_cast({:worker_retired, worker_id, reporter}, t),
+    do: t |> do_worker_retired(worker_id, reporter) |> noreply()
 
   @impl true
   def handle_cast(_, t), do: noreply(t)

--- a/lib/bedrock/service/foreman/worker_info.ex
+++ b/lib/bedrock/service/foreman/worker_info.ex
@@ -17,10 +17,13 @@ defmodule Bedrock.Service.Foreman.WorkerInfo do
     :health,
     :manifest,
     :otp_name,
-    :monitor_ref
+    :monitor_ref,
+    :incarnation_pid
   ]
 
   @spec put_health(t(), health()) :: t()
+  def put_health(t, {:ok, pid}) when is_pid(pid), do: %{t | health: {:ok, pid}, incarnation_pid: pid}
+
   def put_health(t, health), do: %{t | health: health}
 
   @spec put_monitor_ref(t(), reference() | nil) :: t()

--- a/lib/mix/tasks/bedrock.dump_storage.ex
+++ b/lib/mix/tasks/bedrock.dump_storage.ex
@@ -126,7 +126,7 @@ defmodule Mix.Tasks.Bedrock.DumpStorage do
 
     # Wait for health report from the storage worker
     receive do
-      {:"$gen_cast", {:worker_health, ^worker_id, {:ok, ^storage_pid}}} -> :ok
+      {:"$gen_cast", {:worker_health, ^worker_id, ^storage_pid, {:ok, ^storage_pid}}} -> :ok
     after
       5000 ->
         Mix.shell().error("Error: Storage worker failed to start within timeout")

--- a/test/bedrock/data_plane/log/shale/displacement_test.exs
+++ b/test/bedrock/data_plane/log/shale/displacement_test.exs
@@ -27,7 +27,8 @@ defmodule Bedrock.DataPlane.Log.Shale.DisplacementTest do
       assert {:stop, {:shutdown, :displaced}, _t} =
                Server.handle_info({:tsl_updated, tsl(5, %{"log-2" => []})}, state([]))
 
-      assert_received {:"$gen_cast", {:worker_retired, "log-1"}}
+      assert_received {:"$gen_cast", {:worker_retired, "log-1", reporter}}
+      assert reporter == self()
     end)
   end
 
@@ -36,13 +37,14 @@ defmodule Bedrock.DataPlane.Log.Shale.DisplacementTest do
       assert {:stop, {:shutdown, :displaced}, _t} =
                Server.handle_info({:tsl_updated, tsl(6, %{"log-2" => []})}, state([]))
 
-      assert_received {:"$gen_cast", {:worker_retired, "log-1"}}
+      assert_received {:"$gen_cast", {:worker_retired, "log-1", reporter}}
+      assert reporter == self()
     end)
   end
 
   test "membership in the pushed epoch keeps the worker" do
     assert {:noreply, _t} = Server.handle_info({:tsl_updated, tsl(6, %{"log-1" => []})}, state([]))
-    refute_received {:"$gen_cast", {:worker_retired, _}}
+    refute_received {:"$gen_cast", {:worker_retired, _, _}}
   end
 
   test "a push older than our lock is not displacement" do
@@ -51,7 +53,7 @@ defmodule Bedrock.DataPlane.Log.Shale.DisplacementTest do
     # chance to include us and must never retire us.
     assert {:noreply, _t} = Server.handle_info({:tsl_updated, tsl(4, %{"log-2" => []})}, state([]))
     assert {:noreply, _t} = Server.handle_info({:tsl_updated, tsl(3, %{})}, state([]))
-    refute_received {:"$gen_cast", {:worker_retired, _}}
+    refute_received {:"$gen_cast", {:worker_retired, _, _}}
   end
 
   test "a never-locked resurrection is judged by any completed layout" do
@@ -62,7 +64,8 @@ defmodule Bedrock.DataPlane.Log.Shale.DisplacementTest do
       assert {:stop, {:shutdown, :displaced}, _t} =
                Server.handle_info({:tsl_updated, tsl(2, %{"log-2" => []})}, state(epoch: nil))
 
-      assert_received {:"$gen_cast", {:worker_retired, "log-1"}}
+      assert_received {:"$gen_cast", {:worker_retired, "log-1", reporter}}
+      assert reporter == self()
     end)
   end
 

--- a/test/bedrock/data_plane/materializer/olivine/compaction_cutover_test.exs
+++ b/test/bedrock/data_plane/materializer/olivine/compaction_cutover_test.exs
@@ -79,7 +79,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.CompactionCutoverTest do
 
   defp wait_for_health_report(worker_id, pid, timeout \\ 5_000) do
     receive do
-      {:"$gen_cast", {:worker_health, ^worker_id, {:ok, ^pid}}} -> :ok
+      {:"$gen_cast", {:worker_health, ^worker_id, ^pid, {:ok, ^pid}}} -> :ok
     after
       timeout -> flunk("Did not receive health report within #{timeout}ms")
     end

--- a/test/bedrock/data_plane/materializer/olivine/displacement_test.exs
+++ b/test/bedrock/data_plane/materializer/olivine/displacement_test.exs
@@ -62,7 +62,8 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.DisplacementTest do
       assert {:stop, {:shutdown, :displaced}, _t} =
                Server.handle_info({:tsl_updated, tsl(3, [proxy])}, state([]))
 
-      assert_received {:"$gen_cast", {:worker_retired, "mat-1"}}
+      assert_received {:"$gen_cast", {:worker_retired, "mat-1", reporter}}
+      assert reporter == self()
     end)
   end
 
@@ -73,7 +74,8 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.DisplacementTest do
       assert {:stop, {:shutdown, :displaced}, _t} =
                Server.handle_info({:tsl_updated, tsl(3, [proxy])}, state([]))
 
-      assert_received {:"$gen_cast", {:worker_retired, "mat-1"}}
+      assert_received {:"$gen_cast", {:worker_retired, "mat-1", reporter}}
+      assert reporter == self()
     end)
   end
 
@@ -81,14 +83,14 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.DisplacementTest do
     {:ok, proxy} = StubProxy.start_link({:ok, %{"mat-1" => "node@host"}})
 
     assert {:noreply, _t} = Server.handle_info({:tsl_updated, tsl(3, [proxy])}, state([]))
-    refute_received {:"$gen_cast", {:worker_retired, _}}
+    refute_received {:"$gen_cast", {:worker_retired, _, _}}
   end
 
   test "a locked proxy is not a verdict — revalidate on the next push" do
     {:ok, proxy} = StubProxy.start_link({:error, :locked})
 
     assert {:noreply, _t} = Server.handle_info({:tsl_updated, tsl(3, [proxy])}, state([]))
-    refute_received {:"$gen_cast", {:worker_retired, _}}
+    refute_received {:"$gen_cast", {:worker_retired, _, _}}
   end
 
   test "an unreachable proxy is not a verdict" do
@@ -96,7 +98,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.DisplacementTest do
     GenServer.stop(proxy)
 
     assert {:noreply, _t} = Server.handle_info({:tsl_updated, tsl(3, [proxy])}, state([]))
-    refute_received {:"$gen_cast", {:worker_retired, _}}
+    refute_received {:"$gen_cast", {:worker_retired, _, _}}
   end
 
   test "the completing push of our own locked epoch validates — strays are judged, not immortal" do
@@ -110,13 +112,14 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.DisplacementTest do
       assert {:stop, {:shutdown, :displaced}, _t} =
                Server.handle_info({:tsl_updated, tsl(2, [proxy])}, state([]))
 
-      assert_received {:"$gen_cast", {:worker_retired, "mat-1"}}
+      assert_received {:"$gen_cast", {:worker_retired, "mat-1", reporter}}
+      assert reporter == self()
     end)
   end
 
   test "a push older than our lock never validates — an in-flight recovery's past may not judge us" do
     assert {:noreply, _t} = Server.handle_info({:tsl_updated, tsl(1, [])}, state([]))
-    refute_received {:"$gen_cast", {:worker_retired, _}}
+    refute_received {:"$gen_cast", {:worker_retired, _, _}}
   end
 
   test "a never-locked resurrection is judged by any completed layout" do
@@ -126,7 +129,8 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.DisplacementTest do
       assert {:stop, {:shutdown, :displaced}, _t} =
                Server.handle_info({:tsl_updated, tsl(1, [proxy])}, state(epoch: nil))
 
-      assert_received {:"$gen_cast", {:worker_retired, "mat-1"}}
+      assert_received {:"$gen_cast", {:worker_retired, "mat-1", reporter}}
+      assert reporter == self()
     end)
   end
 
@@ -159,7 +163,8 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.DisplacementTest do
 
       capture_log(fn ->
         assert {:stop, {:shutdown, :displaced}, _t} = Server.handle_continue(:process_transactions, t)
-        assert_received {:"$gen_cast", {:worker_retired, "mat-1"}}
+        assert_received {:"$gen_cast", {:worker_retired, "mat-1", reporter}}
+        assert reporter == self()
       end)
     end
 

--- a/test/bedrock/data_plane/materializer/olivine/genserver_integration_test.exs
+++ b/test/bedrock/data_plane/materializer/olivine/genserver_integration_test.exs
@@ -17,7 +17,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.GenServerIntegrationTest do
 
   defp wait_for_health_report(worker_id, pid, timeout \\ 5000) do
     receive do
-      {:"$gen_cast", {:worker_health, ^worker_id, {:ok, ^pid}}} -> :ok
+      {:"$gen_cast", {:worker_health, ^worker_id, ^pid, {:ok, ^pid}}} -> :ok
     after
       timeout -> flunk("Did not receive health report within #{timeout}ms")
     end
@@ -136,7 +136,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.GenServerIntegrationTest do
       assert_receive {:DOWN, ^ref, :process, ^worker_pid, :killed}
 
       # Supervisor restarts worker - wait for new health report
-      assert_receive {:"$gen_cast", {:worker_health, ^worker_id, {:ok, new_worker_pid}}}, 1000
+      assert_receive {:"$gen_cast", {:worker_health, ^worker_id, new_worker_pid, {:ok, new_worker_pid}}}, 1000
 
       assert [{_child_id2, ^new_worker_pid, :worker, [GenServer]}] = Supervisor.which_children(supervisor_pid)
       assert new_worker_pid != worker_pid and Process.alive?(new_worker_pid)
@@ -206,7 +206,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.GenServerIntegrationTest do
       mock_foreman =
         spawn_link(fn ->
           receive do
-            {:"$gen_cast", {:worker_health, worker_id, health}} ->
+            {:"$gen_cast", {:worker_health, worker_id, _reporter, health}} ->
               send(:test_coordinator, {:mock_foreman_received, worker_id, health})
               :timer.sleep(:infinity)
           end

--- a/test/bedrock/data_plane/materializer/olivine/idle_spindown_test.exs
+++ b/test/bedrock/data_plane/materializer/olivine/idle_spindown_test.exs
@@ -58,7 +58,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.IdleSpindownTest do
     {:ok, pid} = apply(GenServer, :start, args)
 
     receive do
-      {:"$gen_cast", {:worker_health, ^worker_id, {:ok, ^pid}}} -> :ok
+      {:"$gen_cast", {:worker_health, ^worker_id, ^pid, {:ok, ^pid}}} -> :ok
     after
       5_000 -> flunk("no health report")
     end

--- a/test/bedrock/data_plane/materializer/olivine/ingest_test.exs
+++ b/test/bedrock/data_plane/materializer/olivine/ingest_test.exs
@@ -7,7 +7,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.IngestTest do
 
   defp wait_for_health_report(worker_id, pid, timeout \\ 5_000) do
     receive do
-      {:"$gen_cast", {:worker_health, ^worker_id, {:ok, ^pid}}} -> :ok
+      {:"$gen_cast", {:worker_health, ^worker_id, ^pid, {:ok, ^pid}}} -> :ok
     after
       timeout -> flunk("Did not receive health report within #{timeout}ms")
     end

--- a/test/bedrock/data_plane/materializer/olivine/stream_read_test.exs
+++ b/test/bedrock/data_plane/materializer/olivine/stream_read_test.exs
@@ -49,7 +49,7 @@ defmodule Bedrock.DataPlane.Materializer.Olivine.StreamReadTest do
 
   defp wait_for_health_report(worker_id, pid, timeout \\ 5_000) do
     receive do
-      {:"$gen_cast", {:worker_health, ^worker_id, {:ok, ^pid}}} -> :ok
+      {:"$gen_cast", {:worker_health, ^worker_id, ^pid, {:ok, ^pid}}} -> :ok
     after
       timeout -> flunk("no health report within #{timeout}ms")
     end

--- a/test/bedrock/service/foreman/recompute_health_test.exs
+++ b/test/bedrock/service/foreman/recompute_health_test.exs
@@ -50,6 +50,14 @@ defmodule Bedrock.Service.Foreman.RecomputeHealthTest do
   end
 
   describe "do_remove_worker/2" do
+    setup do
+      start_supervised!(
+        {DynamicSupervisor, strategy: :one_for_one, name: RecomputeTestCluster.otp_name(:worker_supervisor)}
+      )
+
+      :ok
+    end
+
     test "removing the last failing worker makes the foreman healthy" do
       state = state_with([healthy_worker("aaaa"), failed_worker("bbbb")])
 
@@ -74,6 +82,14 @@ defmodule Bedrock.Service.Foreman.RecomputeHealthTest do
   end
 
   describe "do_remove_workers/2" do
+    setup do
+      start_supervised!(
+        {DynamicSupervisor, strategy: :one_for_one, name: RecomputeTestCluster.otp_name(:worker_supervisor)}
+      )
+
+      :ok
+    end
+
     test "a batch removal that clears every failure makes the foreman healthy" do
       state = state_with([healthy_worker("aaaa"), failed_worker("bbbb"), failed_worker("cccc")])
 

--- a/test/bedrock/service/foreman/stale_health_test.exs
+++ b/test/bedrock/service/foreman/stale_health_test.exs
@@ -1,0 +1,547 @@
+defmodule Bedrock.Service.Foreman.StaleHealthTest do
+  use ExUnit.Case, async: false
+
+  alias Bedrock.ObjectStorage.LocalFilesystem
+  alias Bedrock.Service.Foreman
+  alias Bedrock.Service.Foreman.Server
+
+  @moduletag :tmp_dir
+  @worker_id "aaaaaaaa"
+
+  defmodule Cluster do
+    @moduledoc false
+    def name, do: "stale_health_test"
+    def otp_name_for_worker(id), do: :"stale_health_worker_#{id}"
+    def otp_name(role), do: :"stale_health_#{role}"
+  end
+
+  defmodule ControlledWorker do
+    @moduledoc false
+    use GenServer
+    use Bedrock.Service.WorkerBehaviour, kind: :materializer
+
+    def start_link(opts), do: GenServer.start_link(__MODULE__, opts, name: opts[:otp_name])
+    def child_spec(opts), do: %{id: __MODULE__, start: {__MODULE__, :start_link, [opts]}, restart: :transient}
+
+    @impl true
+    def init(opts) do
+      send(:stale_health_controller, {:started, self(), opts})
+      {:ok, opts, {:continue, :gate_startup}}
+    end
+
+    @impl true
+    def handle_continue(:gate_startup, opts) do
+      receive do
+        :report_startup -> report(opts, {:ok, self()})
+      end
+
+      {:noreply, opts}
+    end
+
+    @impl true
+    def handle_info({:report, health}, opts) do
+      report(opts, health)
+      {:noreply, opts}
+    end
+
+    def handle_info({:capture, :health}, opts) do
+      Foreman.report_health(:stale_health_controller, opts[:id], {:ok, self()})
+      {:noreply, opts}
+    end
+
+    def handle_info({:capture, :retirement}, opts) do
+      Foreman.worker_retired(:stale_health_controller, opts[:id])
+      {:noreply, opts}
+    end
+
+    def handle_info(:retire_and_exit, opts) do
+      Foreman.worker_retired(opts[:foreman], opts[:id])
+      {:stop, :normal, opts}
+    end
+
+    def handle_info(:retire, opts) do
+      Foreman.worker_retired(opts[:foreman], opts[:id])
+      send(:stale_health_controller, {:retired, self()})
+      {:noreply, opts}
+    end
+
+    defp report(opts, health) do
+      Foreman.report_health(opts[:foreman], opts[:id], health)
+      send(:stale_health_controller, {:reported, self(), health})
+    end
+  end
+
+  defmodule TerminationGate do
+    @moduledoc false
+    use GenServer
+
+    def start_link(opts), do: GenServer.start_link(__MODULE__, opts, name: opts[:name])
+    @impl true
+    def init(opts), do: {:ok, opts}
+    @impl true
+    def handle_call({:terminate_child, pid} = request, _from, opts) do
+      if opts[:gate] do
+        token = make_ref()
+        send(opts[:controller], {:termination_resolved, self(), token, pid})
+
+        receive do
+          {:forward_termination, ^token} -> :ok
+        end
+      end
+
+      result = GenServer.call(opts[:backing], request, :infinity)
+      send(opts[:controller], {:termination_result, pid, result})
+      {:reply, result, Keyword.put(opts, :gate, if(opts[:gate] == :always, do: :always, else: false))}
+    end
+
+    def handle_call({:gate, value}, _from, opts), do: {:reply, :ok, Keyword.put(opts, :gate, value)}
+
+    def handle_call(request, _from, opts), do: {:reply, GenServer.call(opts[:backing], request, :infinity), opts}
+  end
+
+  setup %{tmp_dir: path} do
+    Process.register(self(), :stale_health_controller)
+    worker_path = Path.join(path, @worker_id)
+    File.mkdir_p!(worker_path)
+
+    File.write!(
+      Path.join(worker_path, "manifest.json"),
+      Jason.encode!(%{
+        id: @worker_id,
+        cluster: Cluster.name(),
+        worker: ControlledWorker |> Atom.to_string() |> String.trim_leading("Elixir."),
+        params: %{}
+      })
+    )
+
+    supervisor =
+      start_supervised!(
+        {DynamicSupervisor, strategy: :one_for_one, name: Cluster.otp_name(:worker_supervisor), max_restarts: 100}
+      )
+
+    foreman =
+      start_supervised!(
+        {Server,
+         cluster: Cluster,
+         path: path,
+         capabilities: [:materializer],
+         otp_name: Cluster.otp_name(:foreman),
+         object_storage: {LocalFilesystem, root: Path.join(path, "objects")}}
+      )
+
+    assert_receive {:started, worker, opts}, 5_000
+    send(worker, :report_startup)
+    assert_receive {:reported, ^worker, {:ok, ^worker}}, 5_000
+    assert :pong = GenServer.call(foreman, :ping)
+    %{foreman: foreman, worker: worker, opts: opts, supervisor: supervisor, worker_path: worker_path}
+  end
+
+  test "removal queued before automatic restart health leaves no membership and the same Foreman alive", ctx do
+    :ok = :sys.suspend(ctx.foreman)
+    reply_ref = make_ref()
+
+    try do
+      send(ctx.foreman, {:"$gen_call", {self(), reply_ref}, {:remove_worker, @worker_id}})
+      Process.exit(ctx.worker, :kill)
+      assert_receive {:started, replacement, _}, 5_000
+      send(replacement, :report_startup)
+      assert_receive {:reported, ^replacement, {:ok, ^replacement}}, 5_000
+      {:messages, queued} = Process.info(ctx.foreman, :messages)
+
+      assert Enum.find_index(queued, &match?({:"$gen_call", _, {:remove_worker, @worker_id}}, &1)) <
+               Enum.find_index(queued, &match?({:"$gen_cast", {:worker_health, @worker_id, _, _}}, &1))
+    after
+      :sys.resume(ctx.foreman)
+    end
+
+    assert_receive {^reply_ref, :ok}, 5_000
+    assert :pong = GenServer.call(ctx.foreman, :ping)
+    assert :sys.get_state(ctx.foreman).workers == %{}
+    refute File.exists?(ctx.worker_path)
+  end
+
+  test "explicit removal terminates an automatic replacement whose startup health is still gated", ctx do
+    :ok = :sys.suspend(ctx.foreman)
+    reply_ref = make_ref()
+
+    replacement =
+      try do
+        send(ctx.foreman, {:"$gen_call", {self(), reply_ref}, {:remove_worker, @worker_id}})
+        Process.exit(ctx.worker, :kill)
+        assert_receive {:started, replacement, _}, 5_000
+        replacement
+      after
+        :sys.resume(ctx.foreman)
+      end
+
+    assert_receive {^reply_ref, :ok}, 5_000
+    refute Process.alive?(replacement), "removal must target the current registered child, not its dead predecessor"
+    assert :sys.get_state(ctx.foreman).workers == %{}
+  end
+
+  test "restart after termination PID resolution never deletes a surviving replacement", ctx do
+    Process.unregister(Cluster.otp_name(:worker_supervisor))
+
+    gate =
+      start_supervised!(
+        {TerminationGate,
+         name: Cluster.otp_name(:worker_supervisor), backing: ctx.supervisor, controller: self(), gate: true}
+      )
+
+    task = Task.async(fn -> Foreman.remove_worker(ctx.foreman, @worker_id) end)
+    assert_receive {:termination_resolved, ^gate, token, resolved}, 5_000
+    assert resolved == ctx.worker
+    Process.exit(resolved, :kill)
+    assert_receive {:started, replacement, _}, 5_000
+    assert replacement != resolved
+    assert Process.whereis(Cluster.otp_name_for_worker(@worker_id)) == replacement
+    send(gate, {:forward_termination, token})
+    assert_receive {:termination_result, ^resolved, {:error, :not_found}}, 5_000
+    result = Task.await(task, 5_000)
+    state = :sys.get_state(ctx.foreman)
+
+    assert result != :ok or not Process.alive?(replacement),
+           "stale terminate_child returned not_found while its automatic replacement still owns the directory"
+
+    if result != :ok do
+      assert Map.has_key?(state.workers, @worker_id)
+      assert File.exists?(Path.join(ctx.worker_path, "manifest.json"))
+      assert :ok = Foreman.remove_worker(ctx.foreman, @worker_id)
+    end
+
+    refute Process.alive?(replacement)
+    refute File.exists?(ctx.worker_path)
+  end
+
+  test "unresolved repeated restarts retain retryable membership and disk", ctx do
+    Process.unregister(Cluster.otp_name(:worker_supervisor))
+
+    gate =
+      start_supervised!(
+        {TerminationGate,
+         name: Cluster.otp_name(:worker_supervisor), backing: ctx.supervisor, controller: self(), gate: :always}
+      )
+
+    task = Task.async(fn -> Foreman.remove_worker(ctx.foreman, @worker_id) end)
+    {result, replacement, attempts} = churn_until_removal_reply(task.ref, gate)
+    Process.demonitor(task.ref, [:flush])
+    assert attempts <= 3, "termination must have a bounded retry budget"
+    assert result == {:error, :worker_shutdown_unresolved}
+    assert Map.has_key?(:sys.get_state(ctx.foreman).workers, @worker_id)
+    assert File.exists?(Path.join(ctx.worker_path, "manifest.json"))
+    assert Process.alive?(replacement)
+    :ok = GenServer.call(gate, {:gate, false})
+    assert :ok = Foreman.remove_worker(ctx.foreman, @worker_id)
+    refute Process.alive?(replacement)
+    refute File.exists?(ctx.worker_path)
+  end
+
+  test "retirement while abnormal restart is pending preserves directory until supervisor ownership is removed", ctx do
+    :ok = :sys.suspend(ctx.supervisor)
+
+    on_exit(fn ->
+      safe_resume(ctx.supervisor)
+      safe_resume(ctx.foreman)
+    end)
+
+    :ok = :sys.suspend(ctx.foreman)
+    send(ctx.worker, :retire)
+    assert_receive {:retired, old} when old == ctx.worker
+    ref = Process.monitor(ctx.worker)
+    Process.exit(ctx.worker, :kill)
+    assert_receive {:DOWN, ^ref, :process, _, :killed}
+    assert Process.whereis(Cluster.otp_name_for_worker(@worker_id)) == nil
+    :ok = :sys.resume(ctx.foreman)
+    # Both the actual EXIT and the subsequent termination call are queued at the
+    # real DynamicSupervisor; EXIT precedes the call and creates a replacement.
+    wait_for_termination_call(ctx.supervisor)
+    :ok = :sys.resume(ctx.supervisor)
+    assert_receive {:started, replacement, _}, 5_000
+    assert :pong = GenServer.call(ctx.foreman, :ping)
+    state = :sys.get_state(ctx.foreman)
+
+    assert Map.has_key?(state.workers, @worker_id) or not Process.alive?(replacement),
+           "retirement must not discard membership while an abnormal restart owns the directory"
+
+    if Process.alive?(replacement), do: assert(File.exists?(ctx.worker_path))
+  end
+
+  for health <- [:healthy, :stopped, {:error, :unavailable}] do
+    test "a superseded but live worker cannot replace current health with #{inspect(health)}", ctx do
+      old_ref = :sys.get_state(ctx.foreman).workers[@worker_id].monitor_ref
+      replacement = replace_registered_worker(ctx)
+      current = :sys.get_state(ctx.foreman)
+      health = if unquote(Macro.escape(health)) == :healthy, do: {:ok, ctx.worker}, else: unquote(Macro.escape(health))
+      report(ctx.foreman, ctx.worker, health)
+      assert :sys.get_state(ctx.foreman) == current
+      assert Process.alive?(ctx.worker)
+      assert Process.whereis(Cluster.otp_name_for_worker(@worker_id)) == replacement
+      send(ctx.foreman, {:DOWN, old_ref, :process, ctx.worker, :killed})
+      assert :pong = GenServer.call(ctx.foreman, :ping)
+      assert :sys.get_state(ctx.foreman) == current
+    end
+  end
+
+  test "a stale dead PID cannot steal the current worker monitor", ctx do
+    replacement = replace_registered_worker(ctx)
+    current = :sys.get_state(ctx.foreman)
+    ref = Process.monitor(ctx.worker)
+    GenServer.stop(ctx.worker, :normal)
+    assert_receive {:DOWN, ^ref, :process, _, :normal}
+    Foreman.report_health(ctx.foreman, @worker_id, {:ok, ctx.worker})
+    assert :pong = GenServer.call(ctx.foreman, :ping)
+    assert :sys.get_state(ctx.foreman) == current
+    assert Process.alive?(replacement)
+  end
+
+  test "current reports update health and duplicate healthy reports retain exactly one monitor", ctx do
+    initial = :sys.get_state(ctx.foreman).workers[@worker_id].monitor_ref
+    report(ctx.foreman, ctx.worker, {:ok, ctx.worker})
+    assert :sys.get_state(ctx.foreman).workers[@worker_id].monitor_ref == initial
+    report(ctx.foreman, ctx.worker, :stopped)
+    assert :sys.get_state(ctx.foreman).health == :starting
+    report(ctx.foreman, ctx.worker, {:error, :unavailable})
+    assert :sys.get_state(ctx.foreman).health == :unknown
+    report(ctx.foreman, ctx.worker, {:ok, ctx.worker})
+    assert :sys.get_state(ctx.foreman).health == :ok
+    {:monitors, monitors} = Process.info(ctx.foreman, :monitors)
+    assert Enum.count(monitors, &(&1 == {:process, ctx.worker})) == 1
+  end
+
+  test "late retirement from a superseded worker preserves the replacement and its directory", ctx do
+    replacement = replace_registered_worker(ctx)
+    current = :sys.get_state(ctx.foreman)
+    send(ctx.worker, :retire)
+    assert_receive {:retired, old} when old == ctx.worker
+    assert :pong = GenServer.call(ctx.foreman, :ping)
+    assert :sys.get_state(ctx.foreman) == current
+    assert Process.alive?(replacement)
+    assert File.exists?(Path.join(ctx.worker_path, "manifest.json"))
+  end
+
+  test "old health cannot overwrite a removed and recreated worker ID", ctx do
+    replace_registered_worker(ctx)
+    send(ctx.worker, {:capture, :health})
+    assert_receive captured = {:"$gen_cast", {:worker_health, @worker_id, _, _}}
+    GenServer.stop(ctx.worker, :normal)
+    assert :ok = Foreman.remove_worker(ctx.foreman, @worker_id)
+    assert {:ok, name} = Foreman.new_worker(ctx.foreman, @worker_id, :log)
+    current = :sys.get_state(ctx.foreman)
+    assert current.workers[@worker_id].health == {:ok, Process.whereis(name)}
+    send(ctx.foreman, captured)
+    assert :pong = GenServer.call(ctx.foreman, :ping)
+    assert :sys.get_state(ctx.foreman) == current
+    assert File.exists?(Path.join(ctx.worker_path, "manifest.json"))
+  end
+
+  test "old retirement cannot delete a removed and recreated worker ID", ctx do
+    replace_registered_worker(ctx)
+    send(ctx.worker, {:capture, :retirement})
+    assert_receive captured = {:"$gen_cast", {:worker_retired, @worker_id, _}}
+    GenServer.stop(ctx.worker, :normal)
+    assert :ok = Foreman.remove_worker(ctx.foreman, @worker_id)
+    assert {:ok, name} = Foreman.new_worker(ctx.foreman, @worker_id, :log)
+    replacement = Process.whereis(name)
+    current = :sys.get_state(ctx.foreman)
+    send(ctx.foreman, captured)
+    assert :pong = GenServer.call(ctx.foreman, :ping)
+    assert :sys.get_state(ctx.foreman) == current
+    assert Process.alive?(replacement)
+    assert File.exists?(Path.join(ctx.worker_path, "manifest.json"))
+  end
+
+  test "late DOWN and recheck after explicit removal cannot recreate membership", ctx do
+    ref = :sys.get_state(ctx.foreman).workers[@worker_id].monitor_ref
+    assert :ok = Foreman.remove_worker(ctx.foreman, @worker_id)
+    send(ctx.foreman, {:DOWN, ref, :process, ctx.worker, :killed})
+    send(ctx.foreman, {:worker_recheck, @worker_id, 0})
+    assert :pong = GenServer.call(ctx.foreman, :ping)
+    assert :sys.get_state(ctx.foreman).workers == %{}
+  end
+
+  test "absent nonhealthy reports and legacy unattributed messages do not create membership", ctx do
+    assert :ok = Foreman.remove_worker(ctx.foreman, @worker_id)
+    Foreman.report_health(ctx.foreman, @worker_id, {:error, :unavailable})
+    GenServer.cast(ctx.foreman, {:worker_health, @worker_id, :stopped})
+    GenServer.cast(ctx.foreman, {:worker_retired, @worker_id})
+    assert :pong = GenServer.call(ctx.foreman, :ping)
+    assert :sys.get_state(ctx.foreman).workers == %{}
+  end
+
+  test "legacy healthy reports restore current monitoring but unattributed forms cannot claim identity", ctx do
+    report(ctx.foreman, ctx.worker, :stopped)
+    assert :sys.get_state(ctx.foreman).health == :starting
+    assert :sys.get_state(ctx.foreman).workers[@worker_id].monitor_ref == nil
+
+    GenServer.cast(ctx.foreman, {:worker_health, @worker_id, {:ok, ctx.worker}})
+    assert :pong = GenServer.call(ctx.foreman, :ping)
+    current = :sys.get_state(ctx.foreman)
+    assert current.health == :ok
+    assert current.workers[@worker_id].health == {:ok, ctx.worker}
+    assert is_reference(current.workers[@worker_id].monitor_ref)
+    {:monitors, monitors} = Process.info(ctx.foreman, :monitors)
+    assert Enum.count(monitors, &(&1 == {:process, ctx.worker})) == 1
+
+    GenServer.cast(ctx.foreman, {:worker_health, @worker_id, :stopped})
+    GenServer.cast(ctx.foreman, {:worker_retired, @worker_id})
+    assert :pong = GenServer.call(ctx.foreman, :ping)
+    assert :sys.get_state(ctx.foreman) == current
+    assert File.exists?(ctx.worker_path)
+  end
+
+  test "a current reporter cannot name another PID in successful health", ctx do
+    current = :sys.get_state(ctx.foreman)
+    report(ctx.foreman, ctx.worker, {:ok, self()})
+    assert :sys.get_state(ctx.foreman) == current
+  end
+
+  test "current retirement removes the worker and directory", ctx do
+    send(ctx.worker, :retire)
+    assert_receive {:retired, old} when old == ctx.worker
+    assert :pong = GenServer.call(ctx.foreman, :ping)
+    assert :sys.get_state(ctx.foreman).workers == %{}
+    refute Process.alive?(ctx.worker)
+    refute File.exists?(ctx.worker_path)
+  end
+
+  for prior_health <- [:healthy, :stopped] do
+    test "post-exit retirement after #{prior_health} health preserves another managed worker", ctx do
+      if unquote(prior_health) == :stopped, do: report(ctx.foreman, ctx.worker, :stopped)
+      assert {:ok, other_name} = Foreman.new_worker(ctx.foreman, "bbbbbbbb", :log)
+      other = Process.whereis(other_name)
+      :ok = :sys.suspend(ctx.foreman)
+
+      try do
+        ref = Process.monitor(ctx.worker)
+        send(ctx.worker, :retire_and_exit)
+        assert_receive {:DOWN, ^ref, :process, _, :normal}, 5_000
+        refute Enum.any?(DynamicSupervisor.which_children(ctx.supervisor), fn {_, pid, _, _} -> pid == ctx.worker end)
+        assert Process.whereis(Cluster.otp_name_for_worker(@worker_id)) == nil
+      after
+        :sys.resume(ctx.foreman)
+      end
+
+      assert :pong = GenServer.call(ctx.foreman, :ping)
+      assert Map.keys(:sys.get_state(ctx.foreman).workers) == ["bbbbbbbb"]
+      assert Process.alive?(other)
+      refute File.exists?(ctx.worker_path)
+    end
+  end
+
+  test "replacement startup health arriving before old DOWN installs the replacement monitor", ctx do
+    :ok = :sys.suspend(ctx.foreman)
+
+    replacement =
+      try do
+        Process.unregister(Cluster.otp_name_for_worker(@worker_id))
+        {:ok, replacement} = DynamicSupervisor.start_child(ctx.supervisor, {ControlledWorker, ctx.opts})
+        assert_receive {:started, ^replacement, _}, 5_000
+        send(replacement, :report_startup)
+        assert_receive {:reported, ^replacement, {:ok, ^replacement}}, 5_000
+        GenServer.stop(ctx.worker, :normal)
+        replacement
+      after
+        :sys.resume(ctx.foreman)
+      end
+
+    assert :pong = GenServer.call(ctx.foreman, :ping)
+    assert :sys.get_state(ctx.foreman).workers[@worker_id].health == {:ok, replacement}
+    {:monitors, monitors} = Process.info(ctx.foreman, :monitors)
+    assert {:process, replacement} in monitors
+    refute {:process, ctx.worker} in monitors
+  end
+
+  test "an absent target name does not prove ownership is gone while an unknown supervised child remains", ctx do
+    GenServer.stop(ctx.worker, :normal)
+    assert :pong = GenServer.call(ctx.foreman, :ping)
+    assert Process.whereis(Cluster.otp_name_for_worker(@worker_id)) == nil
+    {:ok, unknown} = DynamicSupervisor.start_child(ctx.supervisor, {Agent, fn -> :unaccounted end})
+    before = :sys.get_state(ctx.foreman)
+    assert before.workers[@worker_id].health == :stopped
+
+    assert {:error, :worker_shutdown_unresolved} = Foreman.remove_worker(ctx.foreman, @worker_id)
+    assert :sys.get_state(ctx.foreman) == before
+    assert File.exists?(Path.join(ctx.worker_path, "manifest.json"))
+    assert Process.alive?(unknown)
+    assert Agent.get(unknown, & &1) == :unaccounted
+
+    assert :ok = DynamicSupervisor.terminate_child(ctx.supervisor, unknown)
+    assert :ok = Foreman.remove_worker(ctx.foreman, @worker_id)
+    assert :sys.get_state(ctx.foreman).workers == %{}
+    refute File.exists?(ctx.worker_path)
+  end
+
+  test "a filesystem cleanup failure retains stopped membership for retry", ctx do
+    parent = Path.dirname(ctx.worker_path)
+    File.chmod!(parent, 0o555)
+
+    result =
+      try do
+        Foreman.remove_worker(ctx.foreman, @worker_id)
+      after
+        File.chmod!(parent, 0o755)
+      end
+
+    assert {:error, {:failed_to_remove_directory, _, _}} = result
+    assert :sys.get_state(ctx.foreman).workers[@worker_id].health == :stopped
+    refute Process.alive?(ctx.worker)
+    assert :ok = Foreman.remove_worker(ctx.foreman, @worker_id)
+    assert :sys.get_state(ctx.foreman).workers == %{}
+  end
+
+  defp safe_resume(pid) do
+    if Process.alive?(pid), do: :sys.resume(pid, 1_000)
+  catch
+    :exit, _ -> :ok
+  end
+
+  defp churn_until_removal_reply(ref, gate, attempts \\ 0, replacement \\ nil) do
+    receive do
+      {:termination_resolved, ^gate, token, pid} ->
+        assert attempts < 10, "unbounded termination retries"
+        Process.exit(pid, :kill)
+        assert_receive {:started, next, _}, 5_000
+        assert next != pid
+        send(gate, {:forward_termination, token})
+        churn_until_removal_reply(ref, gate, attempts + 1, next)
+
+      {^ref, result} ->
+        {result, replacement, attempts}
+    after
+      5_000 -> flunk("removal did not return a bounded result")
+    end
+  end
+
+  defp wait_for_termination_call(supervisor, remaining \\ 5_000) do
+    {:messages, messages} = Process.info(supervisor, :messages)
+
+    if Enum.any?(messages, &match?({:"$gen_call", _, {:terminate_child, _}}, &1)) do
+      :ok
+    else
+      if remaining == 0, do: flunk("Foreman never reached supervised termination")
+
+      receive do
+      after
+        1 -> wait_for_termination_call(supervisor, remaining - 1)
+      end
+    end
+  end
+
+  defp replace_registered_worker(ctx) do
+    # The old process remains alive deliberately: liveness alone is not identity.
+    Process.unregister(Cluster.otp_name_for_worker(@worker_id))
+    {:ok, replacement} = DynamicSupervisor.start_child(ctx.supervisor, {ControlledWorker, ctx.opts})
+    assert_receive {:started, ^replacement, _}, 5_000
+    send(replacement, :report_startup)
+    assert_receive {:reported, ^replacement, {:ok, ^replacement}}, 5_000
+    assert :pong = GenServer.call(ctx.foreman, :ping)
+    assert :sys.get_state(ctx.foreman).workers[@worker_id].health == {:ok, replacement}
+    replacement
+  end
+
+  defp report(foreman, worker, health) do
+    send(worker, {:report, health})
+    assert_receive {:reported, ^worker, ^health}, 5_000
+    assert :pong = GenServer.call(foreman, :ping)
+  end
+end

--- a/test/bedrock/service/foreman_test.exs
+++ b/test/bedrock/service/foreman_test.exs
@@ -91,6 +91,7 @@ defmodule Bedrock.Service.ForemanTest do
     end
 
     test "disposes the retired worker's directory and entry — and does not restart it" do
+      start_supervised!({DynamicSupervisor, strategy: :one_for_one, name: JanitorCluster.otp_name(:worker_supervisor)})
       path = Path.join(System.tmp_dir!(), "foreman_retired_#{System.unique_integer([:positive])}")
       File.mkdir_p!(Path.join(path, "gone"))
       File.mkdir_p!(Path.join(path, "stays"))

--- a/test/mix/tasks/bedrock_dump_storage_test.exs
+++ b/test/mix/tasks/bedrock_dump_storage_test.exs
@@ -1,0 +1,34 @@
+defmodule Mix.Tasks.Bedrock.DumpStorageTest do
+  use ExUnit.Case, async: false
+
+  @moduletag :tmp_dir
+
+  test "the task receives the reporter-bearing Olivine startup health and dumps storage", %{tmp_dir: path} do
+    storage = Path.join(path, "storage")
+    output = Path.join(path, "dump.json")
+    File.mkdir_p!(storage)
+
+    # The task deliberately halts on errors, so exercise it in an isolated VM.
+    {diagnostics, status} =
+      System.cmd(
+        "elixir",
+        [
+          "--erl",
+          "+S 2:2",
+          "-S",
+          "mix",
+          "bedrock.dump_storage",
+          "--path",
+          storage,
+          "--format",
+          "json",
+          "--output",
+          output
+        ],
+        stderr_to_stdout: true
+      )
+
+    assert status == 0, diagnostics
+    assert Jason.decode!(File.read!(output)) == %{"count" => 0, "entries" => []}
+  end
+end


### PR DESCRIPTION
The Foreman keyed worker lifecycle messages by worker id alone, so a late health report or retirement from a removed or replaced process was applied to whatever held that id; an absent id crashed the Foreman with a `KeyError`. Messages now carry the sending pid and are honoured only from the process registered under the worker's OTP name, and removal proves the supervisor has released the worker before deleting its directory.

Ticket: bedrock-gu0.5
Closes #292

## Why

Workers are transient children of a DynamicSupervisor, so an abnormal exit is restarted under the same name. Kill a materializer, call `remove_worker` before the restart's startup health is processed, and the removal deletes the map entry first. The late health cast then hit `Map.update!` on a missing key and took the Foreman down.

The same gap covered two quieter races: a superseded but still-live pid reporting `{:ok, old_pid}` overwrote the replacement's health and monitor, and a retirement from an old incarnation terminated the replacement and removed its directory.

Removal had its own hole: `terminate_child` returning `not_found` counted as success, so a child restarted between lookup and the call stayed alive, unmonitored, on a deleted directory.

## What changed

- `report_health` and `worker_retired` include `self()`; public arities are unchanged.
- Health is accepted only from the pid registered under the worker's name, and `{:ok, pid}` must name the reporter. Retirement also accepts the last accepted incarnation, remembered as `incarnation_pid`, once it has unregistered.
- Single, batch and self-retirement removal share the new `Removal.stop/2`; `remove_worker` can return `{:error, :worker_shutdown_unresolved}` with membership, monitor and disk intact.
- Legacy `{:worker_health, id, {:ok, pid}}` gets the same check; other legacy shapes are ignored. The `dump_storage` task matches the new envelope.

## How it works

Identity is resolved when the message is handled, with `Process.whereis` on the worker's OTP name. Any other sender leaves the state untouched: removed ids, superseded pids, and replays after recreation change nothing. A retiring worker has unregistered by the time its cast is read, which is why retirement also accepts the remembered incarnation when nothing is registered.

Removal makes at most three attempts. Each targets the registered pid or the remembered incarnation, calls `terminate_child`, then requires that the name is unregistered and every child the supervisor still lists belongs to another worker. If a restart slipped in, the next attempt targets the new pid; under continuous churn or an unattributable child the caller gets the retryable error. Only then does the Foreman demonitor, deregister and remove the directory; a filesystem failure keeps the entry as `:stopped` for retry.

```
remove_worker served -> whereis(name) = B, terminate B, children = [] -> ok
B's {:worker_health, id, B, {:ok, B}} arrives -> id absent -> ignored
```

## Verification

A new Foreman suite runs a real server over a real DynamicSupervisor with a gated worker and a pausable `terminate_child`. It proves the ticket's interleaving leaves an empty worker map and a live Foreman, that removal terminates the replacement rather than its dead predecessor, that a restart between lookup and termination is retried or reported, and that stale messages from superseded pids leave state unchanged. RED log `/tmp/bedrock-followups-20260905.zKTZxP/292-removal-red.log`, audit `/tmp/bedrock-followups-20260905.zKTZxP/292-final-audit.md`. CI green on OTP 27.3, 28.3, 29.0 and S3 MinIO.

Related, not addressed: bedrock-gu0.2, slow restart stays stopped. bedrock-jq8, start-task exit handling.
